### PR TITLE
fixes #16

### DIFF
--- a/project/sbt
+++ b/project/sbt
@@ -12,7 +12,7 @@ java \
   -Xmx2g \
   -XX:ReservedCodeCacheSize=128m \
   -XX:+UseCodeCacheFlushing \
-  -Dsbt.boot.directory=$WORKSPACE/.sbt \
-  -Dsbt.ivy.home=$WORKSPACE/.ivy2 \
+  -Dsbt.boot.directory=${WORKSPACE:-$HOME}/.sbt \
+  -Dsbt.ivy.home=${WORKSPACE:-$HOME}/.ivy2 \
   $OPTIONS \
   -jar `dirname $0`/sbt-launch.jar "$@"


### PR DESCRIPTION
Because of the way we set the `sbt.boot.directory`
it was trying to store the .sbt directory in /
if the `$WORKSPACE` environment variable was not
set. Now it will use the user's home directory
if `$WORKSPACE` is not set.
