### PR TITLE
re-enable tests that were failing on jenkins

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
@@ -263,7 +263,9 @@ class StringsSuite extends FunSuite {
     assert(parseDate("2012-02-01") === expected)
   }
 
-  /*test("parseDate, iso date with time no seconds") {
+  // Note: will fail prior to 8u20:
+  // https://github.com/Netflix/atlas/issues/9
+  test("parseDate, iso date with time no seconds") {
     val expected = ZonedDateTime.of(2012, 2, 1, 4, 5, 0, 0, ZoneOffset.UTC)
     assert(parseDate("2012-02-01T04:05") === expected)
     assert(parseDate("2012-02-01T04:05Z") === expected)
@@ -272,10 +274,12 @@ class StringsSuite extends FunSuite {
     assert(result === expected)
   }
 
+  // Note: will fail prior to 8u20:
+  // https://github.com/Netflix/atlas/issues/9
   test("parseDate, iso date with time") {
     val expected = ZonedDateTime.of(2012, 2, 1, 4, 5, 6, 0, ZoneOffset.UTC)
     assert(parseDate("2012-02-01T04:05:06") === expected)
-  }*/
+  }
 
   test("parseDate, iso date with time and zone") {
     val expected = ZonedDateTime.of(2012, 1, 31, 20, 5, 6, 0, ZoneOffset.UTC)

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
@@ -74,11 +74,11 @@ class GraphApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi {
       width = params.get("w").fold(ApiSettings.width)(_.toInt),
       height = params.get("h").fold(ApiSettings.height)(_.toInt),
       axes = axes,
-      axisPerLine = params.get("axis_per_line") == Some("1"),
-      showLegend = params.get("no_legend") != Some("1"),
-      showLegendStats = params.get("no_legend_stats") != Some("1"),
-      showBorder = params.get("no_border") != Some("1"),
-      showOnlyGraph = params.get("only_graph") == Some("1"),
+      axisPerLine = params.get("axis_per_line").contains("1"),
+      showLegend = !params.get("no_legend").contains("1"),
+      showLegendStats = !params.get("no_legend_stats").contains("1"),
+      showBorder = !params.get("no_border").contains("1"),
+      showOnlyGraph = params.get("only_graph").contains("1"),
       vision = vision.getOrElse(VisionType.normal),
       palette = params.get("palette").getOrElse(ApiSettings.palette)
     )


### PR DESCRIPTION
The failures were due to a bug in java.time
that was fixed in 8u20. See #9 for details.

This change also adds some assertions on the
status code for the response in the graph
api test so we don't get the confusing exception
about png headers.
