### PR TITLE
reduce use of guava

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/Colors.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/Colors.scala
@@ -16,9 +16,8 @@
 package com.netflix.atlas.chart
 
 import java.awt.Color
-import java.nio.charset.Charset
 
-import com.google.common.io.Resources
+import com.netflix.atlas.core.util.Streams
 import com.netflix.atlas.core.util.Strings
 
 
@@ -27,9 +26,8 @@ object Colors {
    * Load a list of colors from a resource file.
    */
   def load(name: String): List[Color] = {
-    import scala.collection.JavaConversions._
-    val url = Resources.getResource(name)
-    val data = Resources.readLines(url, Charset.forName("UTF-8"))
-    data.toList.map(Strings.parseColor)
+    Streams.scope(Streams.resource(name)) { in =>
+      Streams.lines(in).map(Strings.parseColor).toList
+    }
   }
 }

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/GraphAssertions.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/GraphAssertions.scala
@@ -21,8 +21,7 @@ import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.InputStream
 
-import com.google.common.io.ByteStreams
-import com.google.common.io.Files
+import com.netflix.atlas.core.util.Streams
 import org.scalatest.Assertions
 
 
@@ -40,8 +39,9 @@ class GraphAssertions(goldenDir: String, targetDir: String) extends Assertions {
   }
 
   private def getString(file: String): String = {
-    val in = getInputStream(file)
-    try new String(ByteStreams.toByteArray(in), "UTF-8") finally in.close()
+    Streams.scope(getInputStream(file)) { in =>
+      new String(Streams.byteArray(in), "UTF-8")
+    }
   }
 
   def generateReport(clazz: Class[_]) {
@@ -68,7 +68,9 @@ class GraphAssertions(goldenDir: String, targetDir: String) extends Assertions {
       } </body>
     </html>
 
-    Files.write(report.toString.getBytes("UTF-8"), new File(s"$targetDir/report.html"))
+    Streams.scope(Streams.fileOut(new File(s"$targetDir/report.html"))) { out =>
+      out.write(report.toString.getBytes("UTF-8"))
+    }
   }
 
   def assertEquals(v1: Double, v2: Double, delta: Double) {

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/PngImageSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/PngImageSuite.scala
@@ -17,7 +17,7 @@ package com.netflix.atlas.chart
 
 import java.io.InputStream
 
-import com.google.common.io.Resources
+import com.netflix.atlas.core.util.Streams
 import org.scalatest.FunSuite
 
 
@@ -42,7 +42,7 @@ class PngImageSuite extends FunSuite {
   """.stripMargin
 
   def getInputStream(file: String): InputStream = {
-    Resources.getResource("pngimage/" + file).openStream()
+    Streams.resource("pngimage/" + file)
   }
 
   def getImage(file: String): PngImage = {

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphAssertions.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphAssertions.scala
@@ -21,9 +21,8 @@ import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.InputStream
 
-import com.google.common.io.ByteStreams
-import com.google.common.io.Files
 import com.netflix.atlas.chart.PngImage
+import com.netflix.atlas.core.util.Streams
 import org.scalatest.Assertions
 
 
@@ -41,8 +40,9 @@ class GraphAssertions(goldenDir: String, targetDir: String) extends Assertions {
   }
 
   private def getString(file: String): String = {
-    val in = getInputStream(file)
-    try new String(ByteStreams.toByteArray(in), "UTF-8") finally in.close()
+    Streams.scope(getInputStream(file)) { in =>
+      new String(Streams.byteArray(in), "UTF-8")
+    }
   }
 
   def generateReport(clazz: Class[_]) {
@@ -69,7 +69,9 @@ class GraphAssertions(goldenDir: String, targetDir: String) extends Assertions {
         } </body>
     </html>
 
-    Files.write(report.toString.getBytes("UTF-8"), new File(s"$targetDir/report.html"))
+    Streams.scope(Streams.fileOut(new File(s"$targetDir/report.html"))) { out =>
+      out.write(report.toString.getBytes("UTF-8"))
+    }
   }
 
   def assertEquals(v1: Double, v2: Double, delta: Double) {
@@ -134,4 +136,3 @@ class GraphAssertions(goldenDir: String, targetDir: String) extends Assertions {
     try stream.write(s.getBytes("UTF-8")) finally stream.close()
   }
 }
-

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -17,6 +17,7 @@ object MainBuild extends Build {
            scalacOptions ++= BuildSettings.compilerFlags,
               crossPaths := false,
            sourcesInBase := false,
+            fork in Test := true,   // Needed to avoid ClassNotFoundException with equalsverifier
               exportJars := true,   // Needed for one-jar, with multi-project
                resolvers += Resolver.sonatypeRepo("snapshots"),
                resolvers += "rrd4j" at "https://raw.githubusercontent.com/brharrington/rrd4j/repo",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
   val awsCore         = "com.amazonaws" % "aws-java-sdk-core" % aws
   val awsEC2          = "com.amazonaws" % "aws-java-sdk-ec2" % aws
   val awsS3           = "com.amazonaws" % "aws-java-sdk-s3" % aws
-  val equalsVerifier  = "nl.jqno.equalsverifier" % "equalsverifier" % "1.4.1"
+  val equalsVerifier  = "nl.jqno.equalsverifier" % "equalsverifier" % "1.5.1"
   val eureka          = "com.netflix.eureka" % "eureka-client" % "1.1.142"
   val frigga          = "com.netflix.frigga" % "frigga" % "0.13"
   val guava           = "com.google.guava" % "guava" % "15.0"


### PR DESCRIPTION
Removes some of the simple uses of guava.

Not sure why, but something about the
TimeSeriesBuffer class triggers a
ClassNotFoundException with the
equalsverifier library:

```
[info]   Cause: java.lang.NoClassDefFoundError: nl/jqno/equalsverifier/internal/cglib/proxy/Factory
[info]   at java.lang.ClassLoader.defineClass1(Native Method)
[info]   at java.lang.ClassLoader.defineClass(ClassLoader.java:760)
[info]   at sun.reflect.GeneratedMethodAccessor7.invoke(Unknown Source)
[info]   at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[info]   at java.lang.reflect.Method.invoke(Method.java:483)
[info]   at nl.jqno.equalsverifier.internal.cglib.core.ReflectUtils.defineClass(ReflectUtils.java:384)
[info]   at nl.jqno.equalsverifier.internal.cglib.core.AbstractClassGenerator.create(AbstractClassGenerator.java:219)
[info]   at nl.jqno.equalsverifier.internal.cglib.proxy.Enhancer.createHelper(Enhancer.java:377)
[info]   at nl.jqno.equalsverifier.internal.cglib.proxy.Enhancer.createClass(Enhancer.java:317)
[info]   at nl.jqno.equalsverifier.util.Instantiator.createDynamicSubclass(Instantiator.java:104)
[info]   ...
[info]   Cause: java.lang.ClassNotFoundException: nl.jqno.equalsverifier.internal.cglib.proxy.Factory
[info]   at java.net.URLClassLoader$1.run(URLClassLoader.java:372)
[info]   at java.net.URLClassLoader$1.run(URLClassLoader.java:361)
[info]   at java.security.AccessController.doPrivileged(Native Method)
[info]   at java.net.URLClassLoader.findClass(URLClassLoader.java:360)
[info]   at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
[info]   at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
[info]   at java.lang.ClassLoader.defineClass1(Native Method)
[info]   at java.lang.ClassLoader.defineClass(ClassLoader.java:760)
[info]   at sun.reflect.GeneratedMethodAccessor7.invoke(Unknown Source)
[info]   at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[info]   ...
```

Current workaround is to set `fork in Test := true`
for the sbt build.