### PR TITLE
json codec for publish payload

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/Rrd4jGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/Rrd4jGraphEngine.scala
@@ -376,7 +376,7 @@ class Rrd4jGraphEngine extends PngGraphEngine {
 
   private class SeriesPlottable(s: SeriesDef) extends Plottable {
 
-    val ts = if (s.style == STACK) s.data.copy(_.mapValues(v => Math.addNaN(v, 0.0))) else s.data
+    val ts = if (s.style == STACK) s.data.mapTimeSeq(_.mapValues(v => Math.addNaN(v, 0.0))) else s.data
 
     override def getValue(timestamp: Long): Double = {
       ts.data(timestamp * 1000)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TaggedItem.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TaggedItem.scala
@@ -123,7 +123,7 @@ object TaggedItem {
     tagsInterner.intern(smallMap)
   }
 
-  private[model] def internTagsShallow(tags: Map[String, String]): Map[String, String] = {
+  def internTagsShallow(tags: Map[String, String]): Map[String, String] = {
     tagsInterner.intern(tags)
   }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TimeSeries.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TimeSeries.scala
@@ -98,7 +98,7 @@ trait TimeSeries extends TaggedItem {
   }
 
   // Create a copy with a modified time sequence.
-  def copy(f: TimeSeq => TimeSeq): TimeSeries = {
+  def mapTimeSeq(f: TimeSeq => TimeSeq): TimeSeries = {
     LazyTimeSeries(tags, label, f(data))
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
@@ -162,7 +162,7 @@ class TimeSeriesExprSuite extends FunSuite {
           val c = ctxt.copy(state = state)
           val results = expr.eval(c, bounded(p.input, ctxt))
           state = results.state
-          val boundedResults = results.data.map(_.copy(_.bounded(ctxt.start, ctxt.end)))
+          val boundedResults = results.data.map(_.mapTimeSeq(_.bounded(ctxt.start, ctxt.end)))
           boundedResults.groupBy(_.id)
         }
         val incrRS = ResultSet(expr, rs.data.map { t =>
@@ -228,7 +228,7 @@ class TimeSeriesExprSuite extends FunSuite {
   }
 
   def bounded(data: List[TimeSeries], ctxt: EvalContext): List[TimeSeries] = {
-    data.sortWith(_.label < _.label).map { ts => ts.copy(_.bounded(ctxt.start, ctxt.end)) }
+    data.sortWith(_.label < _.label).map { ts => ts.mapTimeSeq(_.bounded(ctxt.start, ctxt.end)) }
   }
 
   def constants: List[TimeSeries] = {

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.webapi
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.JsonParser
+import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.core.model.DefaultSettings
+import com.netflix.atlas.core.model.TaggedItem
+import com.netflix.atlas.core.util.Interner
+import com.netflix.atlas.core.util.SmallHashMap
+import com.netflix.atlas.core.util.Streams
+import com.netflix.atlas.json.Json
+
+object PublishApi {
+  private final val step = DefaultSettings.stepSize
+
+  import com.netflix.atlas.json.JsonParserHelper._
+
+  type TagMap = Map[String, String]
+
+  private final val maxPermittedTags = 30
+
+  private def decodeTags(parser: JsonParser, commonTags: TagMap, intern: Boolean): TagMap = {
+    val strInterner = Interner.forStrings
+    val b = new SmallHashMap.Builder[String, String](2 * maxPermittedTags)
+    if (commonTags != null) b.addAll(commonTags)
+    foreachField(parser) { case key =>
+      val value = parser.nextTextValue()
+      if (value == null || value.isEmpty) {
+        val loc = parser.getCurrentLocation
+        val line = loc.getLineNr
+        val col = loc.getColumnNr
+        val msg = s"tag value cannot be null or empty (key=$key, line=$line, col=$col)"
+        throw new IllegalArgumentException(msg)
+      }
+      if (intern)
+        b.add(strInterner.intern(key), strInterner.intern(value))
+      else
+        b.add(key, value)
+    }
+    if (intern) TaggedItem.internTagsShallow(b.compact) else b.result
+  }
+
+  private def getValue(parser: JsonParser): Double = {
+    import com.fasterxml.jackson.core.JsonToken._
+    parser.nextToken() match {
+      case START_ARRAY        => nextDouble(parser)
+      case VALUE_NUMBER_FLOAT => parser.getValueAsDouble()
+      case VALUE_STRING       => java.lang.Double.valueOf(parser.getText())
+      case t                  => fail(parser, s"expected VALUE_NUMBER_FLOAT but received $t")
+    }
+  }
+
+  private def decode(parser: JsonParser, commonTags: TagMap, intern: Boolean): Datapoint = {
+    var tags: TagMap = null
+    var timestamp: Long = -1L
+    var value: Double = Double.NaN
+    foreachField(parser) {
+      case "tags"      => tags = decodeTags(parser, commonTags, intern)
+      case "timestamp" => timestamp = nextLong(parser)
+      case "value"     => value = nextDouble(parser)
+      case "start"     => timestamp = nextLong(parser) // Legacy support
+      case "values"    => value = getValue(parser)
+      case _           => // Ignore unknown fields
+    }
+    Datapoint(tags, timestamp, value)
+  }
+
+  def decodeDatapoint(parser: JsonParser, intern: Boolean = false): Datapoint = {
+    decode(parser, null, intern)
+  }
+
+  def decodeDatapoint(json: String): Datapoint = {
+    val parser = Json.newJsonParser(json)
+    try decodeDatapoint(parser, false) finally parser.close()
+  }
+
+  def decodeBatch(parser: JsonParser, intern: Boolean = false): List[Datapoint] = {
+    var tags: Map[String, String] = null
+    var metrics: List[Datapoint] = null
+    var tagsLoadedFirst = false
+    foreachField(parser) {
+      case "tags"    => tags = decodeTags(parser, null, intern)
+      case "metrics" =>
+        tagsLoadedFirst = (tags != null)
+        val builder = List.newBuilder[Datapoint]
+        foreachItem(parser) { builder += decode(parser, tags, intern) }
+        metrics = builder.result
+    }
+    if (tagsLoadedFirst || tags == null) metrics else metrics.map(d => d.copy(tags = d.tags ++ tags))
+  }
+
+  def decodeBatch(json: String): List[Datapoint] = {
+    val parser = Json.newJsonParser(json)
+    try decodeBatch(parser, false) finally parser.close()
+  }
+
+  def decodeList(parser: JsonParser, intern: Boolean = false): List[Datapoint] = {
+    val builder = List.newBuilder[Datapoint]
+    foreachItem(parser) {
+      builder += decode(parser, null, intern)
+    }
+    builder.result
+  }
+
+  def decodeList(json: String): List[Datapoint] = {
+    val parser = Json.newJsonParser(json)
+    try decodeList(parser, false) finally parser.close()
+  }
+
+  private def encodeTags(gen: JsonGenerator, tags: Map[String, String]) {
+    gen.writeObjectFieldStart("tags")
+    tags match {
+      case m: SmallHashMap[String, String] => m.foreachItem { (k, v) => gen.writeStringField(k, v) }
+      case m: Map[String, String]          => m.foreach { t => gen.writeStringField(t._1, t._2) }
+    }
+    gen.writeEndObject()
+  }
+
+  def encodeDatapoint(gen: JsonGenerator, d: Datapoint) {
+    gen.writeStartObject()
+    encodeTags(gen, d.tags)
+    gen.writeNumberField("timestamp", d.timestamp)
+    gen.writeNumberField("value", d.value)
+    gen.writeEndObject()
+  }
+
+  def encodeDatapoint(d: Datapoint): String = {
+    Streams.string { w =>
+      Streams.scope(Json.newJsonGenerator(w)) { gen => encodeDatapoint(gen, d) }
+    }
+  }
+
+  def encodeBatch(gen: JsonGenerator, tags: Map[String, String], values: List[Datapoint]) {
+    gen.writeStartObject()
+    encodeTags(gen, tags)
+    gen.writeArrayFieldStart("metrics")
+    values.foreach(v => encodeDatapoint(gen, v))
+    gen.writeEndArray()
+    gen.writeEndObject()
+  }
+
+  def encodeBatch(tags: Map[String, String], values: List[Datapoint]): String = {
+    Streams.string { w =>
+      Streams.scope(Json.newJsonGenerator(w)) { gen => encodeBatch(gen, tags, values) }
+    }
+  }
+}

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishApiSuite.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.webapi
+
+import com.netflix.atlas.core.model.Datapoint
+import org.scalatest.FunSuite
+
+
+class PublishApiSuite extends FunSuite {
+
+  test("encode and decode datapoint") {
+    val original = Datapoint(Map("name" -> "foo", "id" -> "bar"), 42L, 1024.0)
+    val decoded = PublishApi.decodeDatapoint(PublishApi.encodeDatapoint(original))
+    assert(original === decoded)
+  }
+
+  test("encode and decode batch") {
+    val commonTags = Map("id" -> "bar")
+    val original = List(Datapoint(Map("name" -> "foo"), 42L, 1024.0))
+    val decoded = PublishApi.decodeBatch(PublishApi.encodeBatch(commonTags, original))
+    assert(original.map(d => d.copy(tags = d.tags ++ commonTags)) === decoded)
+  }
+
+  test("decode with legacy array value") {
+    val expected = Datapoint(Map("name" -> "foo"), 42L, 1024.0)
+    val decoded = PublishApi.decodeDatapoint(
+      """{"tags":{"name":"foo"},"timestamp":42,"values":[1024.0]}""")
+    assert(expected === decoded)
+  }
+
+  test("decode legacy batch empty") {
+    val decoded = PublishApi.decodeBatch("""
+      {
+        "tags": {},
+        "metrics": []
+      }
+      """)
+    assert(decoded.size === 0)
+  }
+
+  test("decode legacy batch no tags") {
+    val decoded = PublishApi.decodeBatch("""
+      {
+        "metrics": []
+      }
+      """)
+    assert(decoded.size === 0)
+  }
+
+  test("decode legacy batch with tags before") {
+    val decoded = PublishApi.decodeBatch("""
+      {
+        "tags": {
+          "foo": "bar"
+        },
+        "metrics": [
+          {
+            "tags": {"name": "test"},
+            "start": 123456789,
+            "values": [1.0]
+          }
+        ]
+      }
+      """)
+    assert(decoded.size === 1)
+    assert(decoded.head.tags === Map("name" -> "test", "foo" -> "bar"))
+  }
+
+  test("decode legacy batch with tags after") {
+    val decoded = PublishApi.decodeBatch("""
+      {
+        "metrics": [
+          {
+            "tags": {"name": "test"},
+            "start": 123456789,
+            "values": [1.0]
+          }
+        ],
+        "tags": {
+          "foo": "bar"
+        }
+      }
+      """)
+    assert(decoded.size === 1)
+    assert(decoded.head.tags === Map("name" -> "test", "foo" -> "bar"))
+  }
+
+  test("decode legacy batch no tags metric") {
+    val decoded = PublishApi.decodeBatch("""
+      {
+        "metrics": [
+          {
+            "tags": {"name": "test"},
+            "start": 123456789,
+            "values": [1.0]
+          }
+        ]
+      }
+      """)
+    assert(decoded.size === 1)
+  }
+
+  test("decode list empty") {
+    val decoded = PublishApi.decodeList("""
+      []
+      """)
+    assert(decoded.size === 0)
+  }
+
+  test("decode list") {
+    val decoded = PublishApi.decodeList("""
+      [
+        {
+          "tags": {"name": "test"},
+          "timestamp": 123456789,
+          "values": 1.0
+        }
+      ]
+      """)
+    assert(decoded.size === 1)
+  }
+}


### PR DESCRIPTION
Supports legacy formats and field labels that are
still needed internally. It will likely be a long time
before we can fully deprecate and simplify those
paths.

Also has some to make it more efficient when working
with SmallHashMap values.