### PR TITLE
allow formats for graph api to be configured

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/CommaSepGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/CommaSepGraphEngine.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.chart
+
+/**
+ * Simple text output using comma as separators.
+ */
+class CommaSepGraphEngine extends CsvGraphEngine("csv", "text/csv", ",")

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/CsvGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/CsvGraphEngine.scala
@@ -20,7 +20,7 @@ import java.io.OutputStreamWriter
 import java.time.Instant
 import java.time.ZonedDateTime
 
-class CsvGraphEngine(val contentType: String, sep: String) extends GraphEngine {
+class CsvGraphEngine(val name: String, val contentType: String, sep: String) extends GraphEngine {
 
   def write(config: GraphDef, output: OutputStream) {
     val writer = new OutputStreamWriter(output, "UTF-8")

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/GraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/GraphEngine.scala
@@ -128,6 +128,7 @@ object GraphEngine {
 }
 
 trait GraphEngine {
+  def name: String
   def contentType: String
   def write(config: GraphDef, output: OutputStream)
 }

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonGraphEngine.scala
@@ -22,7 +22,8 @@ class JsonGraphEngine extends GraphEngine {
 
   import com.netflix.atlas.chart.GraphEngine._
 
-  val contentType: String = "application/json"
+  def name: String = "json"
+  def contentType: String = "application/json"
 
   def write(config: GraphDef, output: OutputStream) {
     val writer = new OutputStreamWriter(output, "UTF-8")

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/Rrd4jGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/Rrd4jGraphEngine.scala
@@ -77,6 +77,7 @@ class Rrd4jGraphEngine extends PngGraphEngine {
   private val isoDateFmt = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm z")
   private val isoPeriodFmt = ISOPeriodFormat.standard
 
+  def name: String = "png"
 
   private def dashedStroke: Stroke = {
     new BasicStroke(

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/StatsJsonGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/StatsJsonGraphEngine.scala
@@ -31,7 +31,8 @@ class StatsJsonGraphEngine extends GraphEngine {
 
 import com.netflix.atlas.chart.GraphEngine._
 
-  val contentType: String = "application/json"
+  def name: String = "stats.json"
+  def contentType: String = "application/json"
 
   private def writeRawField(gen: JsonGenerator, name: String, value: String) {
     gen.writeFieldName(name)

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/TabSepGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/TabSepGraphEngine.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.chart
+
+/**
+ * Simple text output using tab as separators. The content-type is also set to `text/plain` to
+ * make it more likely to render locally in a browser rather than treated as a download.
+ */
+class TabSepGraphEngine extends CsvGraphEngine("txt", "text/plain", "\t")

--- a/atlas-webapi/src/main/resources/reference.conf
+++ b/atlas-webapi/src/main/resources/reference.conf
@@ -53,6 +53,15 @@ atlas {
 
       // Don't permit more that 1440 datapoints (1 day at minute resolution) for a single graph
       max-datapoints = 1440
+
+      // Set of output formats to support via the graph API
+      engines = [
+        "com.netflix.atlas.chart.CommaSepGraphEngine",
+        "com.netflix.atlas.chart.TabSepGraphEngine",
+        "com.netflix.atlas.chart.JsonGraphEngine",
+        "com.netflix.atlas.chart.StatsJsonGraphEngine",
+        "com.netflix.atlas.chart.Rrd4jGraphEngine"
+      ]
     }
   }
 

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
@@ -17,6 +17,7 @@ package com.netflix.atlas.webapi
 
 import java.util.concurrent.TimeUnit
 
+import com.netflix.atlas.chart.GraphEngine
 import com.netflix.atlas.core.db.Database
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
@@ -52,4 +53,12 @@ object ApiSettings {
   def palette: String = config.getString("graph.palette")
 
   def maxDatapoints: Int = config.getInt("graph.max-datapoints")
+
+  def engines: List[GraphEngine] = {
+    import scala.collection.JavaConversions._
+    config.getStringList("graph.engines").toList.map { cname =>
+      val cls = Class.forName(cname)
+      cls.newInstance().asInstanceOf[GraphEngine]
+    }
+  }
 }

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
@@ -21,12 +21,8 @@ import java.time.ZoneId
 import akka.actor.ActorRefFactory
 import akka.actor.Props
 import com.netflix.atlas.akka.WebApi
-import com.netflix.atlas.chart.CsvGraphEngine
 import com.netflix.atlas.chart.GraphDef
 import com.netflix.atlas.chart.GraphEngine
-import com.netflix.atlas.chart.JsonGraphEngine
-import com.netflix.atlas.chart.Rrd4jGraphEngine
-import com.netflix.atlas.chart.StatsJsonGraphEngine
 import com.netflix.atlas.chart.VisionType
 import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.EvalContext
@@ -117,21 +113,11 @@ object GraphApi {
 
   private val interpreter = new Interpreter(StyleVocabulary.words ::: StandardVocabulary.words)
 
-  import spray.http.MediaTypes._
+  private val engines = ApiSettings.engines.map(e => e.name -> e).toMap
 
-  private val engines = Map(
-    "png" -> new Rrd4jGraphEngine,
-    "csv" -> new CsvGraphEngine("text/csv", ","),
-    "txt" -> new CsvGraphEngine("text/plain", "\t"),
-    "json" -> new JsonGraphEngine,
-    "stats.json" -> new StatsJsonGraphEngine)
-
-  private val contentTypes = Map(
-    "png" -> `image/png`,
-    "csv" -> `text/csv`,
-    "txt" -> `text/plain`,
-    "json" -> `application/json`,
-    "stats.json" -> `application/json`)
+  private val contentTypes = engines.map { case (k, e) =>
+    k -> MediaType.custom(e.contentType)
+  }
 
   case class Request(
       query: String,


### PR DESCRIPTION
For some legacy backward compatibility use-cases
internally we need to support a number of additional
formats. This can potentially be useful for others
that might want to provide a custom output format.

This change adds a config setting:

`atlas.webapi.graph.engines`

The value is a list of class names that implement the
GraphEngine trait. Another consideration we will
table for now is source compatibility between versions.
Internally we only try to maintain compatibility of the
webapi and make no guarantees about compatibility of
source built against the app.