### PR TITLE
filtering group by results

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterExpr.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.atlas.core.util.Math
+
+trait FilterExpr extends TimeSeriesExpr
+
+object FilterExpr {
+
+  case class Stat(expr: TimeSeriesExpr, stat: String) extends FilterExpr {
+
+    override def toString: String = s"$expr,$stat,:stat"
+
+    def dataExprs: List[DataExpr] = expr.dataExprs
+
+    def isGrouped: Boolean = expr.isGrouped
+
+    def groupByKey(tags: Map[String, String]): Option[String] = expr.groupByKey(tags)
+
+    private def value(s: SummaryStats): Double = stat match {
+      case "max"   => s.max
+      case "min"   => s.min
+      case "total" => s.total
+      case "avg"   => s.avg
+    }
+
+    def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
+      val rs = expr.eval(context, data)
+      val newData = rs.data.map { t =>
+        val v = value(SummaryStats(t, context.start, context.end))
+        val seq = new FunctionTimeSeq(DsType.Gauge, context.step, _ => v)
+        TimeSeries(t.tags, s"stat-$stat(${t.label})", seq)
+      }
+      ResultSet(this, newData, rs.state)
+    }
+  }
+
+  trait StatExpr extends FilterExpr {
+    def name: String
+
+    override def toString: String = s":stat-$name"
+
+    def dataExprs: List[DataExpr] = Nil
+
+    def isGrouped: Boolean = false
+
+    def groupByKey(tags: Map[String, String]): Option[String] = None
+
+    def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
+      ResultSet(this, Nil, context.state)
+    }
+  }
+
+  case object StatMax extends StatExpr {
+    def name: String = "max"
+  }
+
+  case object StatMin extends StatExpr {
+    def name: String = "min"
+  }
+
+  case object StatAvg extends StatExpr {
+    def name: String = "avg"
+  }
+
+  case object StatTotal extends StatExpr {
+    def name: String = "total"
+  }
+
+  case class Filter(expr1: TimeSeriesExpr, expr2: TimeSeriesExpr) extends FilterExpr {
+
+    if (!expr1.isGrouped) require(!expr2.isGrouped, "filter grouping must match expr grouping")
+
+    override def toString: String = s"$expr1,$expr2,:filter"
+
+    def dataExprs: List[DataExpr] = expr1.dataExprs ::: expr2.dataExprs
+
+    def isGrouped: Boolean = expr1.isGrouped
+
+    def groupByKey(tags: Map[String, String]): Option[String] = expr1.groupByKey(tags)
+
+    def matches(context: EvalContext, ts: TimeSeries): Boolean = {
+      var m = false
+      ts.data.foreach(context.start, context.end) { (_, v) =>
+        m = m || Math.toBoolean(v)
+      }
+      m
+    }
+
+    def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
+      val rs1 = expr1.eval(context, data)
+      val rs2 = expr2.eval(context, data)
+      val result = (expr1.isGrouped, expr2.isGrouped) match {
+        case (_, false) =>
+          require(rs2.data.size == 1)
+          if (matches(context, rs2.data.head)) rs1.data else Nil
+        case (false, _) =>
+          // Shouldn't be able to get here
+          Nil
+        case (true, true) =>
+          val g2 = rs2.data.groupBy(t => groupByKey(t.tags))
+          rs1.data.filter { t1 =>
+            val k = groupByKey(t1.tags)
+            g2.get(k).fold(false) {
+              case t2 :: Nil => matches(context, t2)
+              case _         => false
+            }
+          }
+      }
+      ResultSet(this, result, rs1.state ++ rs2.state)
+    }
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterVocabulary.scala
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.atlas.core.stacklang.SimpleWord
+import com.netflix.atlas.core.stacklang.Vocabulary
+import com.netflix.atlas.core.stacklang.Word
+
+object FilterVocabulary extends Vocabulary {
+
+  import com.netflix.atlas.core.model.Extractors._
+
+  val words: List[Word] = StatefulVocabulary.words ::: List(
+    Stat, StatMax, StatMin, StatAvg, StatTotal, Filter
+  )
+
+  object Stat extends SimpleWord {
+    override def name: String = "stat"
+
+    protected def matcher: PartialFunction[List[Any], Boolean] = {
+      case (_: String) :: TimeSeriesType(_) :: _ => true
+    }
+
+    protected def executor: PartialFunction[List[Any], List[Any]] = {
+      case (s: String) :: TimeSeriesType(t) :: stack => FilterExpr.Stat(t, s) :: stack
+    }
+
+    override def signature: String = "TimeSeriesExpr String -- FilterExpr"
+
+    override def summary: String =
+      """
+        |Create a summary line showing the value of the specified statistic for the input line.
+        |Valid statistic values are `min`, `max`, `avg`, and `total`. For example:
+        |
+        || Input          |  0 |  5 |  1 |  3 |  1 |
+        ||----------------|----|----|----|----|----|
+        || `max,:stat`    |  5 |  5 |  5 |  5 |  5 |
+        || `min,:stat`    |  0 |  0 |  0 |  0 |  0 |
+        || `avg,:stat`    |  2 |  2 |  2 |  2 |  2 |
+        || `total,:stat`  | 10 | 10 | 10 | 10 | 10 |
+        |
+        |When used with [filter](#filter) the corresponding `stat-$(name)` operation can be used
+        |to simplify filtering based on stats.
+        |
+        |```
+        |name,requestsPerSecond,:eq,:sum,
+        |:dup,max,:stat,50,:lt,
+        |:over,min,:stat,100,:gt,
+        |:or,:filter
+        |```
+        |
+        |Could be rewritten as:
+        |
+        |```
+        |name,requestsPerSecond,:eq,:sum,
+        |:stat-max,50,:lt,:stat-min,100,:gt,:or,:filter
+        |```
+        |
+        |The `stat-min` and `stat-max` operations will get rewritten to be the corresponding
+        |call to `stat` on the first expression passed to `filter`.
+      """.stripMargin.trim
+
+    override def examples: List[String] = List("a,b,:eq,max")
+  }
+
+  trait StatWord extends SimpleWord {
+
+    protected def matcher: PartialFunction[List[Any], Boolean] = { case _ => true }
+
+    protected def executor: PartialFunction[List[Any], List[Any]] = {
+      case stack => value :: stack
+    }
+
+    override def signature: String = " -- FilterExpr"
+
+    override def examples: List[String] = List("", "a,b,:eq")
+
+    def value: FilterExpr
+  }
+
+  object StatMax extends StatWord {
+    override def name: String = "stat-max"
+
+    def value: FilterExpr = FilterExpr.StatMax
+
+    override def summary: String =
+      """
+        |Represents the `max,:stat` line when used with the filter operation.
+      """.stripMargin.trim
+  }
+
+  object StatMin extends StatWord {
+    override def name: String = "stat-min"
+
+    def value: FilterExpr = FilterExpr.StatMin
+
+    override def summary: String =
+      """
+        |Represents the `min,:stat` line when used with the filter operation.
+      """.stripMargin.trim
+  }
+
+  object StatAvg extends StatWord {
+    override def name: String = "stat-avg"
+
+    def value: FilterExpr = FilterExpr.StatAvg
+
+    override def summary: String =
+      """
+        |Represents the `avg,:stat` line when used with the filter operation.
+      """.stripMargin.trim
+  }
+
+  object StatTotal extends StatWord {
+    override def name: String = "stat-total"
+
+    def value: FilterExpr = FilterExpr.StatTotal
+
+    override def summary: String =
+      """
+        |Represents the `total,:stat` line when used with the filter operation.
+      """.stripMargin.trim
+  }
+
+  object Filter extends SimpleWord {
+    override def name: String = "filter"
+
+    protected def matcher: PartialFunction[List[Any], Boolean] = {
+      case TimeSeriesType(_) :: TimeSeriesType(_) :: _ => true
+    }
+
+    protected def executor: PartialFunction[List[Any], List[Any]] = {
+      case TimeSeriesType(t2) :: TimeSeriesType(t1) :: stack =>
+        FilterExpr.Filter(t1, rewriteStatExprs(t1, t2)) :: stack
+    }
+
+    private def rewriteStatExprs(t1: TimeSeriesExpr, t2: TimeSeriesExpr): TimeSeriesExpr = {
+      val r = t2.rewrite {
+        case s: FilterExpr.StatExpr => FilterExpr.Stat(t1, s.name)
+      }
+      r.asInstanceOf[TimeSeriesExpr]
+    }
+
+    override def signature: String = "TimeSeriesExpr TimeSeriesExpr -- FilterExpr"
+
+    override def summary: String =
+      """
+        |Filter the output based on another expression. For example, only show lines that have
+        |a value greater than 50.
+      """.stripMargin.trim
+
+    override def examples: List[String] = List("a,b,:eq,:dup,:stat-max,50,:gt")
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterVocabulary.scala
@@ -16,6 +16,7 @@
 package com.netflix.atlas.core.model
 
 import com.netflix.atlas.core.stacklang.SimpleWord
+import com.netflix.atlas.core.stacklang.StandardVocabulary.Macro
 import com.netflix.atlas.core.stacklang.Vocabulary
 import com.netflix.atlas.core.stacklang.Word
 
@@ -24,7 +25,10 @@ object FilterVocabulary extends Vocabulary {
   import com.netflix.atlas.core.model.Extractors._
 
   val words: List[Word] = StatefulVocabulary.words ::: List(
-    Stat, StatMax, StatMin, StatAvg, StatTotal, Filter
+    Stat, StatMax, StatMin, StatAvg, StatTotal, Filter,
+
+    // Legacy operation equivalent to `max,:stat`
+    Macro("stat-max-mf", List("max", ":stat"), List("42"))
   )
 
   object Stat extends SimpleWord {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleVocabulary.scala
@@ -25,7 +25,7 @@ object StyleVocabulary extends Vocabulary {
 
   import com.netflix.atlas.core.model.Extractors._
 
-  val words: List[Word] = StatefulVocabulary.words ::: List(
+  val words: List[Word] = FilterVocabulary.words ::: List(
     Alpha, Color, LineStyle, LineWidth, Legend, Axis, Offset,
     Macro("area", List("area", ":ls"), List("42")),
     Macro("line", List("line", ":ls"), List("42")),

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/FilterExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/FilterExamplesSuite.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.atlas.core.stacklang.BaseExamplesSuite
+import com.netflix.atlas.core.stacklang.Word
+
+class FilterExamplesSuite extends BaseExamplesSuite {
+  override def vocabulary: List[Word] = FilterVocabulary.words
+}


### PR DESCRIPTION
Moving filter expressions from internal to OSS. This
also generalizes them a bit to work using an arbitrary
line.