### PR TITLE
allow additional config files on command line

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/ConfigApi.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/ConfigApi.scala
@@ -19,6 +19,7 @@ import java.io.StringWriter
 import java.util.Properties
 
 import akka.actor.ActorRefFactory
+import com.netflix.atlas.config.ConfigManager
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
@@ -58,7 +59,7 @@ class ConfigApi(val actorRefFactory: ActorRefFactory) extends WebApi {
   private def doGet(ctx: RequestContext, path: Option[String]): Unit = {
     val format = ctx.request.uri.query.get("format").getOrElse("json")
     if (formats.contains(format)) {
-      val config = ConfigFactory.load
+      val config = ConfigManager.current
       path match {
         case Some(p) if !config.hasPath(p) =>
           sendError(ctx, NotFound, s"no matching path '$p'")

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/Paths.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/Paths.scala
@@ -16,11 +16,11 @@
 package com.netflix.atlas.akka
 
 import akka.actor.ActorPath
-import com.typesafe.config.ConfigFactory
+import com.netflix.atlas.config.ConfigManager
 
 
 object Paths {
-  private val config = ConfigFactory.load()
+  private val config = ConfigManager.current
   private val Path = config.getString("atlas.akka.pathPattern").r
 
   /**

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/RequestHandlerActor.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/RequestHandlerActor.scala
@@ -16,8 +16,8 @@
 package com.netflix.atlas.akka
 
 import akka.actor._
+import com.netflix.atlas.config.ConfigManager
 import com.netflix.spectator.api.Spectator
-import com.typesafe.config.ConfigFactory
 import spray.can.Http
 import spray.can.server.Stats
 import spray.http.HttpMethods._
@@ -74,7 +74,7 @@ class RequestHandlerActor extends Actor with ActorLogging with HttpService {
 
   private def loadRoutesFromConfig(): List[WebApi] = {
     import scala.collection.JavaConversions._
-    val config = ConfigFactory.load()
+    val config = ConfigManager.current
     val routeClasses = config.getStringList("atlas.akka.api-endpoints").toList
     routeClasses.map { cls =>
       val c = Class.forName(cls)

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/ConfigApiSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/ConfigApiSuite.scala
@@ -18,6 +18,7 @@ package com.netflix.atlas.akka
 import java.io.StringReader
 import java.util.Properties
 
+import com.netflix.atlas.config.ConfigManager
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import org.scalatest.FunSuite
@@ -28,7 +29,7 @@ import spray.testkit.ScalatestRouteTest
 class ConfigApiSuite extends FunSuite with ScalatestRouteTest {
 
   val endpoint = new ConfigApi(system)
-  val sysConfig = ConfigFactory.load()
+  val sysConfig = ConfigManager.current
 
   test("/config") {
     Get("/api/v2/config") ~> endpoint.routes ~> check {

--- a/atlas-aws/src/main/scala/com/netflix/atlas/aws/AwsClientFactory.scala
+++ b/atlas-aws/src/main/scala/com/netflix/atlas/aws/AwsClientFactory.scala
@@ -21,8 +21,8 @@ import com.amazonaws.AmazonWebServiceClient
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.Protocol
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import com.netflix.atlas.config.ConfigManager
 import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
 
 
 /**
@@ -30,7 +30,7 @@ import com.typesafe.config.ConfigFactory
  */
 object AwsClientFactory {
 
-  private val defaultConfig = ConfigFactory.load().getConfig("atlas.aws")
+  private val defaultConfig = ConfigManager.current.getConfig("atlas.aws")
 
   def default: AwsClientFactory = {
     new DefaultAwsClientFactory(new DefaultAWSCredentialsProviderChain, defaultConfig)

--- a/atlas-aws/src/test/scala/com/netflix/atlas/aws/AwsClientFactorySuite.scala
+++ b/atlas-aws/src/test/scala/com/netflix/atlas/aws/AwsClientFactorySuite.scala
@@ -16,12 +16,13 @@
 package com.netflix.atlas.aws
 
 import com.amazonaws.ClientConfiguration
+import com.netflix.atlas.config.ConfigManager
 import com.typesafe.config.ConfigFactory
 import org.scalatest.FunSuite
 
 class AwsClientFactorySuite extends FunSuite {
 
-  val config = ConfigFactory.load()
+  val config = ConfigManager.current
 
   test("client config") {
     val awsDflt = new ClientConfiguration

--- a/atlas-aws/src/test/scala/com/netflix/atlas/aws/DefaultAwsClientFactorySuite.scala
+++ b/atlas-aws/src/test/scala/com/netflix/atlas/aws/DefaultAwsClientFactorySuite.scala
@@ -18,14 +18,14 @@ package com.netflix.atlas.aws
 import java.net.InetAddress
 
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
-import com.typesafe.config.ConfigFactory
+import com.netflix.atlas.config.ConfigManager
 import org.scalatest.FunSuite
 
 class DefaultAwsClientFactorySuite extends FunSuite {
 
   import scala.collection.JavaConversions._
 
-  val config = ConfigFactory.load()
+  val config = ConfigManager.current
 
   // Double check that the endpoints can be resolved, helps catch silly mistakes and typos
   val endpoints = config.getConfig("atlas.aws.endpoint").entrySet.toList

--- a/atlas-config/src/main/scala/com/netflix/atlas/config/ConfigManager.scala
+++ b/atlas-config/src/main/scala/com/netflix/atlas/config/ConfigManager.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.config
+
+import java.util.concurrent.atomic.AtomicReference
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+
+/**
+ * Keeps reference to global config object that can updated during application initialization.
+ */
+object ConfigManager {
+
+  private val configRef: AtomicReference[Config] = new AtomicReference(ConfigFactory.load())
+
+  /** Return the current global config object. */
+  def current: Config = configRef.get
+
+  /** Set the global config to `c`. */
+  def set(c: Config): Unit = configRef.set(c)
+
+  /** Update the global config object setting it to `c.withFallback(current)`. */
+  def update(c: Config): Unit = {
+    var tmp = configRef.get
+    while (!configRef.compareAndSet(tmp, c.withFallback(tmp).resolve())) {
+      tmp = configRef.get
+    }
+  }
+}

--- a/atlas-config/src/test/scala/com/netflix/atlas/config/ConfigManagerSuite.scala
+++ b/atlas-config/src/test/scala/com/netflix/atlas/config/ConfigManagerSuite.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.config
+
+import com.typesafe.config.ConfigException
+import com.typesafe.config.ConfigFactory
+import org.scalatest.FunSuite
+
+
+class ConfigManagerSuite extends FunSuite {
+  private val home = System.getProperty("user.home")
+
+  test("init") {
+    assert(ConfigManager.current === ConfigFactory.load())
+  }
+
+  test("home is set") {
+    assert(home !== null)
+    assert(ConfigManager.current.getString("user.home") === home)
+  }
+
+  test("update") {
+    ConfigManager.update(ConfigFactory.parseString(s"user.home = foo$home"))
+    assert(ConfigManager.current.getString("user.home") === s"foo$home")
+  }
+
+  test("update empty") {
+    ConfigManager.update(ConfigFactory.empty())
+    assert(ConfigManager.current.getString("user.home") === s"foo$home")
+  }
+
+  test("update with var") {
+    ConfigManager.update(ConfigFactory.parseString("foo = ${user.home}"))
+    assert(ConfigManager.current.getString("foo") === s"foo$home")
+  }
+
+  test("set") {
+    ConfigManager.set(ConfigFactory.empty())
+    intercept[ConfigException] { ConfigManager.current.getString("user.home") }
+  }
+}
+

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/Limits.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/Limits.scala
@@ -15,14 +15,12 @@
  */
 package com.netflix.atlas.core.db
 
-import java.util.concurrent.TimeUnit
-
-import com.typesafe.config.ConfigFactory
+import com.netflix.atlas.config.ConfigManager
 
 
 object Limits {
 
-  private val config = ConfigFactory.load.getConfig("atlas.core.db")
+  private val config = ConfigManager.current.getConfig("atlas.core.db")
 
   def maxLines: Int = config.getInt("max-lines")
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
@@ -19,9 +19,8 @@ import java.math.BigInteger
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
+import com.netflix.atlas.config.ConfigManager
 import com.netflix.atlas.core.index.BatchUpdateTagIndex
-import com.netflix.atlas.core.index.LazyTagIndex
-import com.netflix.atlas.core.index.TagIndex
 import com.netflix.atlas.core.index.TagQuery
 import com.netflix.atlas.core.model.Block
 import com.netflix.atlas.core.model.DataExpr
@@ -30,10 +29,8 @@ import com.netflix.atlas.core.model.EvalContext
 import com.netflix.atlas.core.model.TimeSeries
 import com.netflix.spectator.api.Spectator
 import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
 import org.slf4j.LoggerFactory
 
-import scala.collection.SeqView
 
 class MemoryDatabase(config: Config) extends Database {
 
@@ -229,7 +226,7 @@ class MemoryDatabase(config: Config) extends Database {
 
 object MemoryDatabase {
   def apply(k: String): MemoryDatabase = {
-    val cfg = ConfigFactory.load()
+    val cfg = ConfigManager.current
     new MemoryDatabase(cfg.getConfig(k))
   }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DefaultSettings.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DefaultSettings.scala
@@ -17,12 +17,12 @@ package com.netflix.atlas.core.model
 
 import java.util.concurrent.TimeUnit
 
-import com.typesafe.config.ConfigFactory
+import com.netflix.atlas.config.ConfigManager
 
 
 object DefaultSettings {
 
-  private val config = ConfigFactory.load.getConfig("atlas.core")
+  private val config = ConfigManager.current.getConfig("atlas.core")
 
   def stepSize: Long = config.getDuration("model.step", TimeUnit.MILLISECONDS)
 }

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
@@ -18,14 +18,14 @@ package com.netflix.atlas.webapi
 import java.util.concurrent.TimeUnit
 
 import com.netflix.atlas.chart.GraphEngine
+import com.netflix.atlas.config.ConfigManager
 import com.netflix.atlas.core.db.Database
 import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
 
 object ApiSettings {
 
-  private val root = ConfigFactory.load
-  private val config = root.getConfig("atlas.webapi")
+  private def root = ConfigManager.current
+  private def config = root.getConfig("atlas.webapi")
 
   def newDbInstance: Database = {
     val db = root.getConfig("atlas.core.db")

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/Main.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/Main.scala
@@ -15,15 +15,32 @@
  */
 package com.netflix.atlas.webapi
 
+import java.io.File
+
 import akka.actor.Props
 import com.netflix.atlas.akka.WebServer
-import com.netflix.atlas.core.db.StaticDatabase
+import com.netflix.atlas.config.ConfigManager
+import com.typesafe.config.ConfigFactory
+import com.typesafe.scalalogging.StrictLogging
 
-object Main {
+/**
+ * Provides a simple way to start up a standalone server. Usage:
+ *
+ * ```
+ * $ java -jar atlas.jar config1.conf config2.conf
+ * ```
+ */
+object Main extends StrictLogging {
 
   var server: WebServer = _
 
   def main(args: Array[String]) {
+    args.foreach { f =>
+      logger.info(s"loading config file: $f")
+      val c = ConfigFactory.parseFileAnySyntax(new File(f))
+      ConfigManager.update(c)
+    }
+
     server = new WebServer("atlas") {
       override protected def configure(): Unit = {
         val db = ApiSettings.newDbInstance

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/RequestId.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/RequestId.scala
@@ -18,7 +18,7 @@ package com.netflix.atlas.webapi
 import java.lang.management.ManagementFactory
 import java.util.concurrent.atomic.AtomicLong
 
-import com.typesafe.config.ConfigFactory
+import com.netflix.atlas.config.ConfigManager
 
 /**
  * Identifier for a request to another instance. The identifier consists of a unique string for
@@ -33,7 +33,7 @@ import com.typesafe.config.ConfigFactory
  */
 object RequestId {
 
-  private val config = ConfigFactory.load()
+  private val config = ConfigManager.current
 
   private val instanceId = {
     val prop = "atlas.environment.instanceId"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -30,6 +30,7 @@ object MainBuild extends Build {
       `atlas-akka`,
       `atlas-aws`,
       `atlas-chart`,
+      `atlas-config`,
       `atlas-core`,
       `atlas-jmh`,
       `atlas-json`,
@@ -39,7 +40,7 @@ object MainBuild extends Build {
     .settings(BuildSettings.noPackaging: _*)
 
   lazy val `atlas-akka` = project
-    .dependsOn(`atlas-json`)
+    .dependsOn(`atlas-config`, `atlas-json`)
     .settings(buildSettings: _*)
     .settings(libraryDependencies ++= commonDeps)
     .settings(libraryDependencies ++= Seq(
@@ -53,6 +54,7 @@ object MainBuild extends Build {
     ))
 
   lazy val `atlas-aws` = project
+    .dependsOn(`atlas-config`)
     .settings(buildSettings: _*)
     .settings(libraryDependencies ++= commonDeps)
     .settings(libraryDependencies ++= Seq(
@@ -70,7 +72,12 @@ object MainBuild extends Build {
       Dependencies.rrd4j
     ))
 
+  lazy val `atlas-config` = project
+    .settings(buildSettings: _*)
+    .settings(libraryDependencies ++= commonDeps)
+
   lazy val `atlas-core` = project
+    .dependsOn(`atlas-config`)
     .settings(buildSettings: _*)
     .settings(libraryDependencies ++= commonDeps)
     .settings(libraryDependencies ++= Seq(


### PR DESCRIPTION
To make it easier to run the standalone jar in different
modes, this change allows additional config files to be
specified as command line arguments. Example:

```
$ java -jar atlas-standalone.jar c1.conf c2.conf
```