### PR TITLE
re-resolve config on update

### DIFF
--- a/atlas-config/src/test/scala/com/netflix/atlas/config/ConfigManagerSuite.scala
+++ b/atlas-config/src/test/scala/com/netflix/atlas/config/ConfigManagerSuite.scala
@@ -51,5 +51,16 @@ class ConfigManagerSuite extends FunSuite {
     ConfigManager.set(ConfigFactory.empty())
     intercept[ConfigException] { ConfigManager.current.getString("user.home") }
   }
+
+  test("re-resolve with update") {
+    ConfigManager.update(ConfigFactory.parseString("""
+      test.foo = 1
+      test.bar = ${test.foo}
+      """))
+    assert(ConfigManager.current.getInt("test.bar") === 1)
+
+    ConfigManager.update(ConfigFactory.parseString("test.foo = 2"))
+    assert(ConfigManager.current.getInt("test.bar") === 2)
+  }
 }
 

--- a/atlas-core/src/main/resources/reference.conf
+++ b/atlas-core/src/main/resources/reference.conf
@@ -9,8 +9,6 @@ atlas {
       class = "com.netflix.atlas.core.db.StaticDatabase"
       dataset = "alert"
 
-      step = ${atlas.core.model.step}
-
       // 1h
       block-size = 60
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/DataSet.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/DataSet.scala
@@ -178,7 +178,7 @@ private[db] object DataSet {
     ds.withTags(tags)
   }
 
-  val step = 60000
+  val step = DefaultSettings.stepSize
 
   def constant(v: Double): TimeSeries = {
     TimeSeries(Map("name" -> v.toString), new FunctionTimeSeq(DsType.Gauge, step, _ => v))

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
@@ -17,7 +17,6 @@ package com.netflix.atlas.core.db
 
 import java.math.BigInteger
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.TimeUnit
 
 import com.netflix.atlas.config.ConfigManager
 import com.netflix.atlas.core.index.BatchUpdateTagIndex
@@ -25,6 +24,7 @@ import com.netflix.atlas.core.index.TagQuery
 import com.netflix.atlas.core.model.Block
 import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.core.model.DefaultSettings
 import com.netflix.atlas.core.model.EvalContext
 import com.netflix.atlas.core.model.TimeSeries
 import com.netflix.spectator.api.Spectator
@@ -52,7 +52,7 @@ class MemoryDatabase(config: Config) extends Database {
   /** How many output datapoints are being processed for transform queries. */
   private val queryOutputDatapoints = Spectator.registry.counter("atlas.db.queryOutputDatapoints")
 
-  private val step = config.getDuration("step", TimeUnit.MILLISECONDS)
+  private val step = DefaultSettings.stepSize
   private val blockSize = config.getInt("block-size")
   private val numBlocks = config.getInt("num-blocks")
   private val testMode = config.getBoolean("test-mode")

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/StaticDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/StaticDatabase.scala
@@ -19,6 +19,7 @@ import com.netflix.atlas.core.index.LazyTagIndex
 import com.netflix.atlas.core.index.TagIndex
 import com.netflix.atlas.core.index.TagQuery
 import com.netflix.atlas.core.model.DataExpr
+import com.netflix.atlas.core.model.DefaultSettings
 import com.netflix.atlas.core.model.DsType
 import com.netflix.atlas.core.model.EvalContext
 import com.netflix.atlas.core.model.FunctionTimeSeq
@@ -56,7 +57,8 @@ object StaticDatabase {
       tagsBuilder += "class" -> (if (i % 2 == 1) "odd" else "even")
       if (probablyPrime(i))
         tagsBuilder += "prime" -> "probably"
-      TimeSeries(tagsBuilder.result(), new FunctionTimeSeq(DsType.Gauge, 60000, _ => i))
+      val seq = new FunctionTimeSeq(DsType.Gauge, DefaultSettings.stepSize, _ => i)
+      TimeSeries(tagsBuilder.result(), seq)
     }
     new StaticDatabase(ts.toList)
   }

--- a/atlas-webapi/src/main/resources/reference.conf
+++ b/atlas-webapi/src/main/resources/reference.conf
@@ -43,7 +43,6 @@ atlas {
     }
 
     graph {
-      step = ${atlas.core.model.step}
       start-time = e-3h
       end-time = now
       timezone = US/Pacific

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
@@ -15,11 +15,10 @@
  */
 package com.netflix.atlas.webapi
 
-import java.util.concurrent.TimeUnit
-
 import com.netflix.atlas.chart.GraphEngine
 import com.netflix.atlas.config.ConfigManager
 import com.netflix.atlas.core.db.Database
+import com.netflix.atlas.core.model.DefaultSettings
 import com.typesafe.config.Config
 
 object ApiSettings {
@@ -38,7 +37,7 @@ object ApiSettings {
 
   def maxTagLimit: Int = config.getInt("tags.max-limit")
 
-  def stepSize: Long = config.getDuration("graph.step", TimeUnit.MILLISECONDS)
+  def stepSize: Long = DefaultSettings.stepSize
 
   def startTime: String = config.getString("graph.start-time")
 


### PR DESCRIPTION
Primary change is to re-resolve the config on
subsequent updates so vars can be updated. Note
that the reference conf files are resolved on
load so configs applied via update cannot change
a var in the reference conf.

Also removes duplicate step settings.