### PR TITLE
initial import of publish webapi

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/DiagnosticMessage.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/DiagnosticMessage.scala
@@ -16,6 +16,7 @@
 package com.netflix.atlas.akka
 
 import akka.actor.ActorRef
+import com.fasterxml.jackson.core.JsonParseException
 import com.netflix.atlas.json.JsonSupport
 import spray.http.HttpEntity
 import spray.http.HttpResponse
@@ -51,9 +52,7 @@ object DiagnosticMessage {
   }
 
   def handleException(ref: ActorRef): PartialFunction[Throwable, Unit] = {
-    case e: IllegalArgumentException =>
-      sendError(ref, StatusCodes.BadRequest, e)
-    case e: IllegalStateException =>
+    case e @ (_: IllegalArgumentException | _: IllegalStateException | _: JsonParseException) =>
       sendError(ref, StatusCodes.BadRequest, e)
     case e: NoSuchElementException =>
       sendError(ref, StatusCodes.NotFound, e)

--- a/atlas-core/src/main/resources/reference.conf
+++ b/atlas-core/src/main/resources/reference.conf
@@ -9,6 +9,9 @@ atlas {
       class = "com.netflix.atlas.core.db.StaticDatabase"
       dataset = "alert"
 
+      // How often to rebuild the index for the memory database
+      rebuild-frequency = 40s
+
       // 1h
       block-size = 60
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
@@ -17,6 +17,7 @@ package com.netflix.atlas.core.db
 
 import java.math.BigInteger
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
 
 import com.netflix.atlas.config.ConfigManager
 import com.netflix.atlas.core.index.BatchUpdateTagIndex
@@ -62,7 +63,7 @@ class MemoryDatabase(config: Config) extends Database {
   val index = BatchUpdateTagIndex.newLazyIndex[BlockStoreItem]
 
   // If the last update time for the index is older than the rebuild age force an update
-  private val rebuildAge = 40000L
+  private val rebuildAge = config.getDuration("rebuild-frequency", TimeUnit.MILLISECONDS)
 
   private val data = new ConcurrentHashMap[BigInteger, BlockStore]
 

--- a/atlas-webapi/src/main/resources/reference.conf
+++ b/atlas-webapi/src/main/resources/reference.conf
@@ -62,6 +62,11 @@ atlas {
         "com.netflix.atlas.chart.Rrd4jGraphEngine"
       ]
     }
+
+    publish {
+      // Should we try to intern strings and tag values while parsing the request?
+      intern-while-parsing = true
+    }
   }
 
   akka {

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalPublishActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalPublishActor.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.webapi
+
+import akka.actor.Actor
+import akka.actor.ActorLogging
+import com.netflix.atlas.core.db.MemoryDatabase
+import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.core.model.DefaultSettings
+import com.netflix.atlas.core.model.TagKey
+import com.netflix.atlas.core.norm.NormalizationCache
+import com.netflix.spectator.api.Spectator
+
+
+class LocalPublishActor(db: MemoryDatabase) extends Actor with ActorLogging {
+
+  import com.netflix.atlas.webapi.PublishApi._
+
+  private val numReceived = Spectator.registry.distributionSummary("atlas.db.numMetricsReceived")
+
+  private val cache = new NormalizationCache(DefaultSettings.stepSize, db.update)
+
+  def receive = {
+    case PublishRequest(vs) => update(vs)
+  }
+
+  private def update(vs: List[Datapoint]): Unit = {
+    val now = System.currentTimeMillis()
+    vs.foreach { v =>
+      numReceived.record(now - v.timestamp)
+      v.tags.get(TagKey.dsType) match {
+        case Some("counter") => cache.updateCounter(v)
+        case Some("gauge")   => cache.updateGauge(v)
+        case Some("rate")    => cache.updateRate(v)
+        case _               => cache.updateRate(v)
+      }
+    }
+  }
+}
+

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/Main.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/Main.scala
@@ -20,6 +20,7 @@ import java.io.File
 import akka.actor.Props
 import com.netflix.atlas.akka.WebServer
 import com.netflix.atlas.config.ConfigManager
+import com.netflix.atlas.core.db.MemoryDatabase
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
 
@@ -45,6 +46,12 @@ object Main extends StrictLogging {
       override protected def configure(): Unit = {
         val db = ApiSettings.newDbInstance
         actorSystem.actorOf(Props(new LocalDatabaseActor(db)), "db")
+        db match {
+          case mem: MemoryDatabase =>
+            logger.info("enabling local publish to memory database")
+            actorSystem.actorOf(Props(new LocalPublishActor(mem)), "publish")
+          case _ =>
+        }
       }
     }
     server.start(ApiSettings.port)

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
@@ -15,8 +15,13 @@
  */
 package com.netflix.atlas.webapi
 
+import akka.actor.ActorRefFactory
+import akka.actor.Props
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.core.JsonParser
+import com.netflix.atlas.akka.WebApi
+import com.netflix.atlas.chart.VisionType
+import com.netflix.atlas.config.ConfigManager
 import com.netflix.atlas.core.model.Datapoint
 import com.netflix.atlas.core.model.DefaultSettings
 import com.netflix.atlas.core.model.TaggedItem
@@ -24,6 +29,59 @@ import com.netflix.atlas.core.util.Interner
 import com.netflix.atlas.core.util.SmallHashMap
 import com.netflix.atlas.core.util.Streams
 import com.netflix.atlas.json.Json
+import spray.http.HttpRequest
+import spray.http.HttpResponse
+import spray.http.StatusCodes
+import spray.http.Uri
+import spray.routing.RequestContext
+
+class PublishApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi {
+
+  import com.netflix.atlas.webapi.PublishApi._
+
+  private val publishRef = actorRefFactory.actorSelection("/user/publish")
+
+  private val config = ConfigManager.current.getConfig("atlas.webapi.publish")
+
+  private val internWhileParsing = config.getBoolean("intern-while-parsing")
+
+  def routes: RequestContext => Unit = {
+    post {
+      path("api" / "v1" / "publish") { ctx =>
+        handleReq(ctx)
+      } ~
+      path("api" / "v1" / "publish-fast") { ctx =>
+        // Legacy path from when there was more than one publish mode
+        handleReq(ctx)
+      }
+    }
+  }
+
+  private def handleReq(ctx: RequestContext): Unit = {
+    try {
+      getJsonParser(ctx.request) match {
+        case Some(parser) =>
+          val data = decodeBatch(parser, internWhileParsing)
+          validate(data)
+          publishRef ! PublishRequest(data)
+          ctx.responder ! HttpResponse(StatusCodes.OK)
+        case None =>
+          throw new IllegalArgumentException("empty request body")
+      }
+    } catch handleException(ctx)
+  }
+
+  private def validate(vs: List[Datapoint]): Unit = {
+    // Temporary until rules get moved to oss. Just include basic sanity check on timestamps
+    val now = System.currentTimeMillis()
+    val step = DefaultSettings.stepSize
+    vs.foreach { v =>
+      val diff = now - v.timestamp
+      if (diff > step)
+        throw new IllegalArgumentException("data is too old")
+    }
+  }
+}
 
 object PublishApi {
   private final val step = DefaultSettings.stepSize
@@ -101,7 +159,14 @@ object PublishApi {
         foreachItem(parser) { builder += decode(parser, tags, intern) }
         metrics = builder.result
     }
-    if (tagsLoadedFirst || tags == null) metrics else metrics.map(d => d.copy(tags = d.tags ++ tags))
+
+    // If the tags were loaded first they got merged with the datapoints while parsing. Otherwise
+    // they need to be merged here.
+    if (tagsLoadedFirst || tags == null) {
+      if (metrics == null) Nil else metrics
+    } else {
+      metrics.map(d => d.copy(tags = d.tags ++ tags))
+    }
   }
 
   def decodeBatch(json: String): List[Datapoint] = {
@@ -159,4 +224,6 @@ object PublishApi {
       Streams.scope(Json.newJsonGenerator(w)) { gen => encodeBatch(gen, tags, values) }
     }
   }
+
+  case class PublishRequest(values: List[Datapoint])
 }

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
@@ -16,11 +16,9 @@
 package com.netflix.atlas.webapi
 
 import akka.actor.ActorRefFactory
-import akka.actor.Props
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.core.JsonParser
 import com.netflix.atlas.akka.WebApi
-import com.netflix.atlas.chart.VisionType
 import com.netflix.atlas.config.ConfigManager
 import com.netflix.atlas.core.model.Datapoint
 import com.netflix.atlas.core.model.DefaultSettings
@@ -29,10 +27,8 @@ import com.netflix.atlas.core.util.Interner
 import com.netflix.atlas.core.util.SmallHashMap
 import com.netflix.atlas.core.util.Streams
 import com.netflix.atlas.json.Json
-import spray.http.HttpRequest
 import spray.http.HttpResponse
 import spray.http.StatusCodes
-import spray.http.Uri
 import spray.routing.RequestContext
 
 class PublishApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi {

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishApiJsonSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishApiJsonSuite.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.webapi
+
+import com.netflix.atlas.core.model.Datapoint
+import org.scalatest.FunSuite
+
+
+class PublishApiJsonSuite extends FunSuite {
+
+  test("encode and decode datapoint") {
+    val original = Datapoint(Map("name" -> "foo", "id" -> "bar"), 42L, 1024.0)
+    val decoded = PublishApi.decodeDatapoint(PublishApi.encodeDatapoint(original))
+    assert(original === decoded)
+  }
+
+  test("encode and decode batch") {
+    val commonTags = Map("id" -> "bar")
+    val original = List(Datapoint(Map("name" -> "foo"), 42L, 1024.0))
+    val decoded = PublishApi.decodeBatch(PublishApi.encodeBatch(commonTags, original))
+    assert(original.map(d => d.copy(tags = d.tags ++ commonTags)) === decoded)
+  }
+
+  test("decode batch empty") {
+    val decoded = PublishApi.decodeBatch("{}")
+    assert(decoded.size === 0)
+  }
+
+  test("decode with legacy array value") {
+    val expected = Datapoint(Map("name" -> "foo"), 42L, 1024.0)
+    val decoded = PublishApi.decodeDatapoint(
+      """{"tags":{"name":"foo"},"timestamp":42,"values":[1024.0]}""")
+    assert(expected === decoded)
+  }
+
+  test("decode legacy batch empty") {
+    val decoded = PublishApi.decodeBatch("""
+      {
+        "tags": {},
+        "metrics": []
+      }
+      """)
+    assert(decoded.size === 0)
+  }
+
+  test("decode legacy batch no tags") {
+    val decoded = PublishApi.decodeBatch("""
+      {
+        "metrics": []
+      }
+      """)
+    assert(decoded.size === 0)
+  }
+
+  test("decode legacy batch with tags before") {
+    val decoded = PublishApi.decodeBatch("""
+      {
+        "tags": {
+          "foo": "bar"
+        },
+        "metrics": [
+          {
+            "tags": {"name": "test"},
+            "start": 123456789,
+            "values": [1.0]
+          }
+        ]
+      }
+      """)
+    assert(decoded.size === 1)
+    assert(decoded.head.tags === Map("name" -> "test", "foo" -> "bar"))
+  }
+
+  test("decode legacy batch with tags after") {
+    val decoded = PublishApi.decodeBatch("""
+      {
+        "metrics": [
+          {
+            "tags": {"name": "test"},
+            "start": 123456789,
+            "values": [1.0]
+          }
+        ],
+        "tags": {
+          "foo": "bar"
+        }
+      }
+      """)
+    assert(decoded.size === 1)
+    assert(decoded.head.tags === Map("name" -> "test", "foo" -> "bar"))
+  }
+
+  test("decode legacy batch no tags metric") {
+    val decoded = PublishApi.decodeBatch("""
+      {
+        "metrics": [
+          {
+            "tags": {"name": "test"},
+            "start": 123456789,
+            "values": [1.0]
+          }
+        ]
+      }
+      """)
+    assert(decoded.size === 1)
+  }
+
+  test("decode list empty") {
+    val decoded = PublishApi.decodeList("""
+      []
+      """)
+    assert(decoded.size === 0)
+  }
+
+  test("decode list") {
+    val decoded = PublishApi.decodeList("""
+      [
+        {
+          "tags": {"name": "test"},
+          "timestamp": 123456789,
+          "values": 1.0
+        }
+      ]
+      """)
+    assert(decoded.size === 1)
+  }
+}

--- a/conf/memory.conf
+++ b/conf/memory.conf
@@ -1,0 +1,41 @@
+
+atlas {
+
+  core {
+    model {
+      step = 10s
+    }
+
+    db {
+      class = "com.netflix.atlas.core.db.MemoryDatabase"
+      //class = "com.netflix.atlas.core.db.StaticDatabase"
+
+      // How often to rebuild the index for the memory database
+      rebuild-frequency = 8s
+
+      // 1h with 10s step
+      block-size = 360
+
+      // 3h of data overall
+      num-blocks = 3
+    }
+  }
+
+  webapi {
+    main {
+      port = 7101
+    }
+
+    graph {
+      // Change default start time on graph to smaller range more typical for testing
+      start-time = e-30m
+    }
+  }
+
+  akka {
+    api-endpoints = ${?atlas.akka.api-endpoints} [
+      "com.netflix.atlas.webapi.PublishApi"
+    ]
+  }
+}
+

--- a/scripts/publish-test.sh
+++ b/scripts/publish-test.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+#
+# Simple example for testing publish. Usage:
+#
+# 1. Run a server:
+#    $ java -jar atlas-standalone.jar conf/memory.conf
+# 2. Kick off the test script:
+#    $ scripts/publish-test.sh
+#
+
+# URL, this is assuming settings in conf/memory.conf
+url="http://localhost:7101/api/v1/publish"
+
+# How often to send data, typically a little bit more frequent than the step
+frequency=8
+
+# Use hostname to for tag
+node=$(hostname)
+
+while true; do
+  # Times are expected to be in milliseconds since the epoch
+  timestamp="$(date +%s)000"
+  curl -s $url \
+    -w"  $(date +%Y-%m-%dT%H:%M:%S)\t%{http_code}\t%{time_total}\n" \
+    -H'Content-Type: application/json' \
+    --data-binary "
+      {
+        \"tags\": {
+          \"nf.node\": \"$node\"
+        },
+        \"metrics\": [
+          {
+            \"tags\": {
+              \"name\": \"anwserToEverything\",
+              \"atlas.dstype\": \"gauge\"
+            },
+            \"timestamp\": $timestamp,
+            \"value\": 42
+          },
+          {
+            \"tags\": {
+              \"name\": \"randomValue\",
+              \"atlas.dstype\": \"gauge\"
+            },
+            \"timestamp\": $timestamp,
+            \"value\": $RANDOM
+          }
+        ]
+      }"
+  sleep $frequency
+done


### PR DESCRIPTION
Includes sample conf and a test script to show
and example of how to send data. To try it:

```
$ cd $REPO_DIR
$ sbt one-jar
$ java -jar atlas-webapi/target/atlas-webapi-1.4.2-SNAPSHOT-one-jar.jar conf/memory.conf
```

From another terminal:

```
$ scripts/publish-test.sh
```