### PR TITLE
more script friendly time format for txt output

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/CsvGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/CsvGraphEngine.scala
@@ -19,6 +19,7 @@ import java.io.OutputStream
 import java.io.OutputStreamWriter
 import java.time.Instant
 import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 
 class CsvGraphEngine(val name: String, val contentType: String, sep: String) extends GraphEngine {
 
@@ -39,7 +40,7 @@ class CsvGraphEngine(val name: String, val contentType: String, sep: String) ext
     var timestamp = config.startTime.toEpochMilli
     while (timestamp <= endTime) {
       val t = ZonedDateTime.ofInstant(Instant.ofEpochMilli(timestamp), config.timezone)
-      writer.append(t.toString)
+      writer.append(t.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
       seriesList.foreach { series =>
         val v = series.data.data(timestamp)
         val vstr = numberFmt.format(v)


### PR DESCRIPTION
Previously it was using the default associated with
the ZonedDateTime.toString call:

```
2015-01-16T23:40:59-08:00[US/Pacific]   562916.031424
2015-01-16T23:41-08:00[US/Pacific]      575008.038403
2015-01-16T23:41:01-08:00[US/Pacific]   569944.697917
```

This change removes the zone ID from the output and
always includes the seconds in the timestamp.

```
2015-01-16T23:40:59-08:00   562916.031424
2015-01-16T23:41:00-08:00   575008.038403
2015-01-16T23:41:01-08:00   569944.697917
```

UTC will show a Z:

```
2015-01-17T07:40:59Z   562916.031424
2015-01-17T07:41:00Z   575008.038403
2015-01-17T07:41:01Z   569944.697917
```