### PR TITLE
add option to restrict jmx port

### DIFF
--- a/atlas-webapi/src/main/resources/reference.conf
+++ b/atlas-webapi/src/main/resources/reference.conf
@@ -36,6 +36,14 @@ atlas {
   webapi {
     main {
       port = 7101
+
+      jmx {
+        // Restrict the ports used so access can easily be granted through a firewall
+        restrict-port = false
+
+        // Port to use if the restrict-port setting is true
+        port = 7500
+      }
     }
 
     tags {

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
@@ -35,6 +35,10 @@ object ApiSettings {
 
   def port: Int = config.getInt("main.port")
 
+  def shouldRestrictJmxPort: Boolean = config.getBoolean("main.jmx.restrict-port")
+
+  def jmxPort: Int = config.getInt("main.jmx.port")
+
   def maxTagLimit: Int = config.getInt("tags.max-limit")
 
   def stepSize: Long = DefaultSettings.stepSize

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -119,6 +119,7 @@ object MainBuild extends Build {
     .settings(mainClass in oneJar := Some("com.netflix.atlas.webapi.Main"))
     .settings(libraryDependencies ++= commonDeps)
     .settings(libraryDependencies ++= Seq(
+      Dependencies.iepJmxPort,
       Dependencies.slf4jSimple,
       Dependencies.akkaTestkit % "test",
       Dependencies.sprayTestkit % "test"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,6 +4,7 @@ object Dependencies {
   object Versions {
     val akka       = "2.3.8"
     val aws        = "1.9.13"
+    val iep        = "0.1.0-SNAPSHOT"
     val jackson    = "2.4.4"
     val lucene     = "4.10.2"
     val scala      = "2.11.5"
@@ -26,6 +27,7 @@ object Dependencies {
   val frigga          = "com.netflix.frigga" % "frigga" % "0.13"
   val guava           = "com.google.guava" % "guava" % "15.0"
   val hadoopCommon    = "org.apache.hadoop" % "hadoop-common" % "2.5.1"
+  val iepJmxPort      = "com.netflix.iep" % "iep-jmxport" % iep
   val jacksonAnno2    = "com.fasterxml.jackson.core" % "jackson-annotations" % jackson
   val jacksonCore2    = "com.fasterxml.jackson.core" % "jackson-core" % jackson
   val jacksonJoda2    = "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % jackson


### PR DESCRIPTION
When running on AWS instances it is convenient to
be able to open up a single port on the security group
to allow for JMX access. The option is disabled by
default since it tries to access the on instance
metadata service.