### PR TITLE
simple access log when running standalone

### DIFF
--- a/atlas-akka/src/main/resources/reference.conf
+++ b/atlas-akka/src/main/resources/reference.conf
@@ -61,6 +61,10 @@ spray.can {
     request-timeout = 10 s
     pipelining-limit = 20
 
+    # Add the remote address into the request, useful for trying to figure out where traffic
+    # is coming from.
+    remote-address-header = on
+
     verbose-error-messages = on
 
     # https://groups.google.com/forum/#!msg/spray-user/TqkPlxjDlm8/fl33xVIlnIcJ

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/RequestHandlerActor.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/RequestHandlerActor.scala
@@ -39,9 +39,11 @@ class RequestHandlerActor extends Actor with ActorLogging with HttpService {
     if (endpoints.isEmpty) default else {
       default.orElse {
         runRoute {
-          compressResponseIfRequested() {
-            corsFilter {
-              endpoints.tail.foldLeft(endpoints.head.routes) { case (acc, r) => acc ~ r.routes }
+          accessLog {
+            compressResponseIfRequested() {
+              corsFilter {
+                endpoints.tail.foldLeft(endpoints.head.routes) { case (acc, r) => acc ~ r.routes}
+              }
             }
           }
         }

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/CustomDirectivesSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/CustomDirectivesSuite.scala
@@ -27,37 +27,39 @@ class CustomDirectivesSuite extends FunSuite with ScalatestRouteTest {
   class TestService(val actorRefFactory: ActorRefFactory) extends HttpService {
 
     def routes: RequestContext => Unit = {
-      CustomDirectives.corsFilter {
-        CustomDirectives.jsonpFilter {
-          path("text") {
-            get { ctx =>
-              val entity = HttpEntity(MediaTypes.`text/plain`, "text response")
-              ctx.responder ! HttpResponse(status = StatusCodes.OK, entity = entity)
-            }
-          } ~
-          path("json") {
-            get { ctx =>
-              val entity = HttpEntity(MediaTypes.`application/json`, "[1,2,3]")
-              ctx.responder ! HttpResponse(status = StatusCodes.OK, entity = entity)
-            }
-          } ~
-          path("binary") {
-            get { ctx =>
-              val entity = HttpEntity(MediaTypes.`application/octet-stream`, "text response")
-              ctx.responder ! HttpResponse(status = StatusCodes.OK, entity = entity)
-            }
-          } ~
-          path("error") {
-            get { ctx =>
-              val entity = HttpEntity(MediaTypes.`text/plain`, "error")
-              ctx.responder ! HttpResponse(status = StatusCodes.BadRequest, entity = entity)
-            }
-          } ~
-          path("empty") {
-            get { ctx =>
-              val headers = List(HttpHeaders.RawHeader("foo", "bar"))
-              ctx.responder ! HttpResponse(status = StatusCodes.OK, headers = headers)
-            }
+      CustomDirectives.accessLog {
+        CustomDirectives.corsFilter {
+          CustomDirectives.jsonpFilter {
+            path("text") {
+              get { ctx =>
+                val entity = HttpEntity(MediaTypes.`text/plain`, "text response")
+                ctx.responder ! HttpResponse(status = StatusCodes.OK, entity = entity)
+              }
+            } ~
+              path("json") {
+                get { ctx =>
+                  val entity = HttpEntity(MediaTypes.`application/json`, "[1,2,3]")
+                  ctx.responder ! HttpResponse(status = StatusCodes.OK, entity = entity)
+                }
+              } ~
+              path("binary") {
+                get { ctx =>
+                  val entity = HttpEntity(MediaTypes.`application/octet-stream`, "text response")
+                  ctx.responder ! HttpResponse(status = StatusCodes.OK, entity = entity)
+                }
+              } ~
+              path("error") {
+                get { ctx =>
+                  val entity = HttpEntity(MediaTypes.`text/plain`, "error")
+                  ctx.responder ! HttpResponse(status = StatusCodes.BadRequest, entity = entity)
+                }
+              } ~
+              path("empty") {
+                get { ctx =>
+                  val headers = List(HttpHeaders.RawHeader("foo", "bar"))
+                  ctx.responder ! HttpResponse(status = StatusCodes.OK, headers = headers)
+                }
+              }
           }
         }
       }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -46,6 +46,7 @@ object MainBuild extends Build {
     .settings(libraryDependencies ++= Seq(
       Dependencies.akkaActor,
       Dependencies.akkaSlf4j,
+      Dependencies.spectatorSandbox,
       Dependencies.sprayCan,
       Dependencies.sprayRouting,
       Dependencies.typesafeConfig,


### PR DESCRIPTION
When using the Netflix baseami we often rely on the
apache access.log and reporting. This change adds a
basic directive to generate an access log with basic
metrics when running standalone.