### PR TITLE
explicit timeout for tags suite

### DIFF
--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/ConfigApiSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/ConfigApiSuite.scala
@@ -28,6 +28,10 @@ import spray.testkit.ScalatestRouteTest
 
 class ConfigApiSuite extends FunSuite with ScalatestRouteTest {
 
+  import scala.concurrent.duration._
+
+  implicit val routeTestTimeout = RouteTestTimeout(5.second)
+
   val endpoint = new ConfigApi(system)
   val sysConfig = ConfigManager.current
 

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/TagsApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/TagsApiSuite.scala
@@ -24,6 +24,10 @@ import spray.testkit.ScalatestRouteTest
 
 class TagsApiSuite extends FunSuite with ScalatestRouteTest {
 
+  import scala.concurrent.duration._
+
+  implicit val routeTestTimeout = RouteTestTimeout(5.second)
+
   val db = StaticDatabase.range(0, 11)
   system.actorOf(Props(new LocalDatabaseActor(db)), "db")
 


### PR DESCRIPTION
There have been a few spurious failures due to
default 1s timeout being exceeded. Changing to 5s.