### PR TITLE
support initializing a set of modules on startup

### DIFF
--- a/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/Main.scala
+++ b/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/Main.scala
@@ -24,7 +24,7 @@ import com.netflix.atlas.core.db.MemoryDatabase
 import com.netflix.atlas.webapi.ApiSettings
 import com.netflix.atlas.webapi.LocalDatabaseActor
 import com.netflix.atlas.webapi.LocalPublishActor
-import com.netflix.iep.jmxport.JmxPort
+import com.netflix.iep.gov.Governator
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
 
@@ -47,12 +47,6 @@ object Main extends StrictLogging {
     }
   }
 
-  private def restrictJmxPort(): Unit = {
-    if (ApiSettings.shouldRestrictJmxPort) {
-      JmxPort.configure(null, ApiSettings.jmxPort)
-    }
-  }
-
   private def startServer(): Unit = {
     server = new WebServer("atlas") {
       override protected def configure(): Unit = {
@@ -71,11 +65,13 @@ object Main extends StrictLogging {
 
   def main(args: Array[String]) {
     loadAdditionalConfigFiles(args)
-    restrictJmxPort()
+    Governator.getInstance().start()
     startServer()
+    Governator.addShutdownHook(() => shutdown())
   }
 
   def shutdown(): Unit = {
     server.shutdown()
+    Governator.getInstance.shutdown()
   }
 }

--- a/atlas-webapi/src/main/resources/reference.conf
+++ b/atlas-webapi/src/main/resources/reference.conf
@@ -36,14 +36,6 @@ atlas {
   webapi {
     main {
       port = 7101
-
-      jmx {
-        // Restrict the ports used so access can easily be granted through a firewall
-        restrict-port = false
-
-        // Port to use if the restrict-port setting is true
-        port = 7500
-      }
     }
 
     tags {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -114,6 +114,7 @@ object MainBuild extends Build {
     .settings(oneJarSettings: _*)
     .settings(mainClass in oneJar := Some("com.netflix.atlas.standalone.Main"))
     .settings(libraryDependencies ++= Seq(
+      Dependencies.iepGovernator,
       Dependencies.log4jApi,
       Dependencies.log4jCore,
       Dependencies.log4jSlf4j,
@@ -133,7 +134,6 @@ object MainBuild extends Build {
     .settings(buildSettings: _*)
     .settings(libraryDependencies ++= commonDeps)
     .settings(libraryDependencies ++= Seq(
-      Dependencies.iepJmxPort,
       Dependencies.spectatorSandbox,
       Dependencies.akkaTestkit % "test",
       Dependencies.sprayTestkit % "test"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,6 +28,7 @@ object Dependencies {
   val frigga          = "com.netflix.frigga" % "frigga" % "0.13"
   val guava           = "com.google.guava" % "guava" % "15.0"
   val hadoopCommon    = "org.apache.hadoop" % "hadoop-common" % "2.5.1"
+  val iepGovernator   = "com.netflix.iep" % "iep-governator" % iep
   val iepJmxPort      = "com.netflix.iep" % "iep-jmxport" % iep
   val jacksonAnno2    = "com.fasterxml.jackson.core" % "jackson-annotations" % jackson
   val jacksonCore2    = "com.fasterxml.jackson.core" % "jackson-core" % jackson


### PR DESCRIPTION
Uses helper to manage a set of modules with governator. This
allows us to package with eureka, archaius, and karyon admin
for use internally.

It seems governator (guice probably) doesn't play well with
one-jar. When running standalone single jar we get:

```
WARNING: Could not load Finalizer in its own class loader. Loading Finalizer in the current class loader instead. As a result, you will not be able to garbage collect this class loader. To support reclaiming this class loader, either resolve the underlying issue, or move Google Collections to your system class path.
```

Need to look into the best option there. One-jar is also known
to prevent the ServiceLoader from finding providers.