### PR TITLE
docs: update generated stacklang reference

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
@@ -73,7 +73,9 @@ object DataExpr {
 
     override def eval(context: EvalContext, data: List[TimeSeries]): ResultSet = {
       val filtered = data.filter(t => query.matches(t.tags))
-      val aggr = TimeSeries.aggregate(filtered.iterator, context.start, context.end, this)
+      val aggr = if (filtered.isEmpty) TimeSeries.noData(context.step) else {
+        TimeSeries.aggregate(filtered.iterator, context.start, context.end, this)
+      }
       val rs = consolidate(context.step, List(aggr))
       ResultSet(this, rs, context.state)
     }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataVocabulary.scala
@@ -23,7 +23,11 @@ import com.netflix.atlas.core.stacklang.Word
 object DataVocabulary extends Vocabulary {
   import com.netflix.atlas.core.model.Extractors._
 
-  val words: List[Word] = QueryVocabulary.words ::: List(
+  val name: String = "data"
+
+  val dependsOn: List[Vocabulary] = List(QueryVocabulary)
+
+  val words: List[Word] = List(
     All,
     Sum, Count, Min, Max,
     GroupBy,
@@ -44,7 +48,7 @@ object DataVocabulary extends Vocabulary {
 
     override def signature: String = "Query -- DataExpr"
 
-    override def examples: List[String] = List("a,b,:eq")
+    override def examples: List[String] = List("name,sps,:eq")
   }
 
   object All extends DataWord {
@@ -57,7 +61,7 @@ object DataVocabulary extends Vocabulary {
         |Fetch all time series that match the query.
         |
         |> :warning: This operation is primarily intended for debugging and can have strange
-        |behaviour when used with rollups. Most users should use [:by](#by) instead.
+        |behaviour when used with rollups. Most users should use [:by](data-by) instead.
       """.stripMargin.trim
   }
 
@@ -68,7 +72,8 @@ object DataVocabulary extends Vocabulary {
 
     override def summary: String =
       """
-        |Compute the sum of all the time series that match the query.
+        |Compute the sum of all the time series that match the query. Sum is the default aggregate
+        |used if a query is specified with no explicit aggregate function.
       """.stripMargin.trim
   }
 
@@ -130,8 +135,9 @@ object DataVocabulary extends Vocabulary {
     override def signature: String = "af:AggregateFunction keys:List -- DataExpr"
 
     override def examples: List[String] = List(
-      "a,b,:eq,(,name,)",
-      "a,b,:eq,:max,(,name,)")
+      "name,sps,:eq,(,name,)",
+      "name,sps,:eq,:max,(,nf.cluster,)",
+      "name,sps,:eq,nf.cluster,nccp-silverlight,:eq,:and,(,nf.asg,nf.zone,)")
   }
 
   object Offset extends SimpleWord {
@@ -154,8 +160,8 @@ object DataVocabulary extends Vocabulary {
     override def signature: String = "TimeSeriesExpr Duration -- TimeSeriesExpr"
 
     override def examples: List[String] = List(
-      "a,b,:eq,(,name,),:by,1w",
-      "a,b,:eq,:max,PT1H")
+      "name,sps,:eq,(,name,),:by,1w",
+      "name,sps,:eq,:max,PT1H")
   }
 
   sealed trait CfWord extends SimpleWord {
@@ -171,11 +177,11 @@ object DataVocabulary extends Vocabulary {
     override def signature: String = "AggregateFunction -- DataExpr"
 
     override def examples: List[String] = List(
-      "a,b,:eq",
-      "a,b,:eq,:min",
-      "a,b,:eq,:max",
-      "a,b,:eq,:sum",
-      "a,b,:eq,:count")
+      "name,sps,:eq",
+      "name,sps,:eq,:min",
+      "name,sps,:eq,:max",
+      "name,sps,:eq,:sum",
+      "name,sps,:eq,:count")
   }
 
   object CfSum extends CfWord {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Extractors.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Extractors.scala
@@ -20,6 +20,8 @@ import java.time.Duration
 import com.netflix.atlas.core.model.DataExpr.AggregateFunction
 import com.netflix.atlas.core.util.Strings
 
+import scala.util.Try
+
 object Extractors {
   case object IntType {
     def unapply(value: Any): Option[Int] = value match {
@@ -62,10 +64,10 @@ object Extractors {
 
   case object TimeSeriesType {
     def unapply(value: Any): Option[TimeSeriesExpr] = value match {
-      case v: String         => Some(MathExpr.Constant(v.toDouble))
-      case v: Query          => Some(DataExpr.Sum(v))
-      case v: TimeSeriesExpr => Some(v)
-      case _                 => None
+      case v: String if Try(v.toDouble).isSuccess => Some(MathExpr.Constant(v.toDouble))
+      case v: Query                               => Some(DataExpr.Sum(v))
+      case v: TimeSeriesExpr                      => Some(v)
+      case _                                      => None
     }
   }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterVocabulary.scala
@@ -24,7 +24,11 @@ object FilterVocabulary extends Vocabulary {
 
   import com.netflix.atlas.core.model.Extractors._
 
-  val words: List[Word] = StatefulVocabulary.words ::: List(
+  val name: String = "filter"
+
+  val dependsOn: List[Vocabulary] = List(StatefulVocabulary)
+
+  val words: List[Word] = List(
     Stat, StatMax, StatMin, StatAvg, StatTotal, Filter,
 
     // Legacy operations equivalent to `max,:stat`

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/QueryVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/QueryVocabulary.scala
@@ -18,13 +18,18 @@ package com.netflix.atlas.core.model
 import com.netflix.atlas.core.stacklang.SimpleWord
 import com.netflix.atlas.core.stacklang.StandardVocabulary
 import com.netflix.atlas.core.stacklang.Vocabulary
+import com.netflix.atlas.core.stacklang.Word
 
 
 object QueryVocabulary extends Vocabulary {
 
   import com.netflix.atlas.core.model.Extractors._
 
-  val words = StandardVocabulary.words ::: List(
+  val name: String = "query"
+
+  val dependsOn: List[Vocabulary] = List(StandardVocabulary)
+
+  val words: List[Word] = List(
     True,
     False,
     HasKey,
@@ -97,7 +102,7 @@ object QueryVocabulary extends Vocabulary {
 
     override def signature: String = "k:String -- Query"
 
-    override def examples: List[String] = List("a", "ERROR:")
+    override def examples: List[String] = List("a", "name", "ERROR:")
   }
 
   trait KeyValueWord extends SimpleWord {
@@ -113,7 +118,10 @@ object QueryVocabulary extends Vocabulary {
 
     override def signature: String = "k:String v:String -- Query"
 
-    override def examples: List[String] = List("a,b", "ERROR:a")
+    override def examples: List[String] = List(
+      "a,b",
+      "nf.node,silverlight-003e",
+      "ERROR:name")
   }
 
   object Equal extends KeyValueWord {
@@ -183,6 +191,11 @@ object QueryVocabulary extends Vocabulary {
         |> :warning: Regular expressions without a clear prefix force a full scan and should be
         |avoided.
       """.stripMargin.trim
+
+    override def examples: List[String] = List(
+      "name,DiscoveryStatus_(UP|DOWN)",
+      "name,discoverystatus_(Up|Down)",
+      "ERROR:name")
   }
 
   object RegexIgnoreCase extends KeyValueWord {
@@ -197,6 +210,11 @@ object QueryVocabulary extends Vocabulary {
         |> :warning: This operation requires a full scan and should be avoided it at all
         |possible.
       """.stripMargin.trim
+
+    override def examples: List[String] = List(
+      "name,DiscoveryStatus_(UP|DOWN)",
+      "name,discoverystatus_(Up|Down)",
+      "ERROR:name")
   }
 
   object In extends SimpleWord {
@@ -219,7 +237,11 @@ object QueryVocabulary extends Vocabulary {
 
     override def signature: String = "k:String vs:List -- Query"
 
-    override def examples: List[String] = List("a,(,b,c,d,)", "a,(,b,)", "a,(,)", "ERROR:a,b")
+    override def examples: List[String] = List(
+      "name,(,sps,)",
+      "name,(,requestsPerSecond,sps,)",
+      "name,(,)",
+      "ERROR:name,sps")
   }
 
   object And extends SimpleWord {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
@@ -25,7 +25,11 @@ object StatefulVocabulary extends Vocabulary {
 
   import com.netflix.atlas.core.model.Extractors._
 
-  val words: List[Word] = MathVocabulary.words ::: List(
+  val name: String = "stateful"
+
+  val dependsOn: List[Vocabulary] = List(MathVocabulary)
+
+  val words: List[Word] = List(
     RollingCount, Des, Trend, Integral, Derivative,
     Macro("des-simple", List("10", "0.1",  "0.5",  ":des"), List("42")),
     Macro("des-fast",   List("10", "0.1",  "0.02", ":des"), List("42")),
@@ -53,7 +57,7 @@ object StatefulVocabulary extends Vocabulary {
 
     override def signature: String = "TimeSeriesExpr n:Int -- TimeSeriesExpr"
 
-    override def examples: List[String] = List("a,b,:eq,:sum,5")
+    override def examples: List[String] = List(":random,0.4,:gt,5")
   }
 
   object Des extends SimpleWord {
@@ -76,7 +80,7 @@ object StatefulVocabulary extends Vocabulary {
     override def signature: String =
       "TimeSeriesExpr training:Int alpha:Double beta:Double -- TimeSeriesExpr"
 
-    override def examples: List[String] = List("a,b,:eq,:sum,5,0.1,0.5")
+    override def examples: List[String] = List("name,requestsPerSecond,:eq,:sum,5,0.1,0.5")
   }
 
   object Trend extends SimpleWord {
@@ -99,7 +103,7 @@ object StatefulVocabulary extends Vocabulary {
     override def signature: String =
       "TimeSeriesExpr window:Duration -- TimeSeriesExpr"
 
-    override def examples: List[String] = List("a,b,:eq,:sum,PT5M", "a,b,:eq,:sum,5m")
+    override def examples: List[String] = List(":random,PT5M", ":random,20m")
   }
 
   object Integral extends SimpleWord {
@@ -121,7 +125,9 @@ object StatefulVocabulary extends Vocabulary {
     override def signature: String =
       "TimeSeriesExpr -- TimeSeriesExpr"
 
-    override def examples: List[String] = List("a,b,:eq,:sum")
+    override def examples: List[String] = List(
+      "1",
+      "name,requestsPerSecond,:eq,:sum,:per-step")
   }
 
   object Derivative extends SimpleWord {
@@ -144,7 +150,7 @@ object StatefulVocabulary extends Vocabulary {
     override def signature: String =
       "TimeSeriesExpr -- TimeSeriesExpr"
 
-    override def examples: List[String] = List("a,b,:eq,:sum")
+    override def examples: List[String] = List("1", "1,:integral")
   }
 
   private def desEpicSignal = List(

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
@@ -72,7 +72,7 @@ case class StyleExpr(expr: TimeSeriesExpr, settings: Map[String, String]) extend
 }
 
 object StyleExpr {
-  private val interpreter = new Interpreter(StandardVocabulary.words)
+  private val interpreter = new Interpreter(StandardVocabulary.allWords)
 
   private def parseDurationList(s: String): List[Duration] = {
     import Extractors._

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleVocabulary.scala
@@ -25,7 +25,11 @@ object StyleVocabulary extends Vocabulary {
 
   import com.netflix.atlas.core.model.Extractors._
 
-  val words: List[Word] = FilterVocabulary.words ::: List(
+  val name: String = "style"
+
+  val dependsOn: List[Vocabulary] = List(FilterVocabulary)
+
+  val words: List[Word] = List(
     Alpha, Color, LineStyle, LineWidth, Legend, Axis, Offset,
     Macro("area", List("area", ":ls"), List("42")),
     Macro("line", List("line", ":ls"), List("42")),
@@ -55,7 +59,7 @@ object StyleVocabulary extends Vocabulary {
         |where `00` is transparent and `ff` is opague.
       """.stripMargin.trim
 
-    override def examples: List[String] = List("a,b,:eq,:sum,40")
+    override def examples: List[String] = List("name,sps,:eq,:sum,:stack,40")
   }
 
   case object Color extends StyleWord {
@@ -72,7 +76,7 @@ object StyleVocabulary extends Vocabulary {
         |  to use with the color.
       """.stripMargin.trim
 
-    override def examples: List[String] = List("a,b,:eq,:sum,ff0000", "a,b,:eq,:sum,f00")
+    override def examples: List[String] = List("name,sps,:eq,:sum,ff0000", "name,sps,:eq,:sum,f00")
   }
 
   case object LineStyle extends StyleWord {
@@ -83,7 +87,7 @@ object StyleVocabulary extends Vocabulary {
         |Set the line style. The value should be one of `line`, `area`, `stack`, or `vspan`.
       """.stripMargin.trim
 
-    override def examples: List[String] = List("a,b,:eq,:sum,(,name,),:by,area")
+    override def examples: List[String] = List("name,sps,:eq,:sum,(,name,),:by,area")
   }
 
   case object LineWidth extends StyleWord {
@@ -94,7 +98,7 @@ object StyleVocabulary extends Vocabulary {
         |The width of the stroke used when drawing the line.
       """.stripMargin.trim
 
-    override def examples: List[String] = List("a,b,:eq,:sum,(,name,),:by,2")
+    override def examples: List[String] = List("name,sps,:eq,:sum,(,name,),:by,2")
   }
 
   case object Legend extends StyleWord {
@@ -105,7 +109,7 @@ object StyleVocabulary extends Vocabulary {
         |Set the legend text.
       """.stripMargin.trim
 
-    override def examples: List[String] = List("a,b,:eq,:sum,(,name,),:by,$name")
+    override def examples: List[String] = List("name,sps,:eq,:sum,(,name,),:by,$name")
   }
 
   case object Axis extends StyleWord {
@@ -116,7 +120,7 @@ object StyleVocabulary extends Vocabulary {
         |Specify which Y-axis to use for the line.
       """.stripMargin.trim
 
-    override def examples: List[String] = List("a,b,:eq,:sum,1")
+    override def examples: List[String] = List("name,sps,:eq,:sum,1")
   }
 
   case object Offset extends SimpleWord {
@@ -143,7 +147,7 @@ object StyleVocabulary extends Vocabulary {
         |each shift value in the list.
       """.stripMargin.trim
 
-    override def examples: List[String] = List("a,b,:eq,:sum,(,0h,1d,1w,)")
+    override def examples: List[String] = List("name,sps,:eq,:sum,(,0h,1d,1w,)")
   }
 
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/StandardVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/StandardVocabulary.scala
@@ -18,7 +18,11 @@ package com.netflix.atlas.core.stacklang
 
 object StandardVocabulary extends Vocabulary {
 
-  val words = List(
+  val name: String = "std"
+
+  val dependsOn: List[Vocabulary] = Nil
+
+  val words: List[Word] = List(
     Call,
     Clear,
     Drop,

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/AndWordSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/AndWordSuite.scala
@@ -23,7 +23,7 @@ import com.netflix.atlas.core.stacklang.Word
 class AndWordSuite extends BaseWordSuite {
 
   def interpreter: Interpreter = Interpreter(
-    QueryVocabulary.words ::: StandardVocabulary.words)
+    QueryVocabulary.allWords ::: StandardVocabulary.allWords)
 
   def word: Word = QueryVocabulary.And
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataExamplesSuite.scala
@@ -16,8 +16,8 @@
 package com.netflix.atlas.core.model
 
 import com.netflix.atlas.core.stacklang.BaseExamplesSuite
-import com.netflix.atlas.core.stacklang.Word
+import com.netflix.atlas.core.stacklang.Vocabulary
 
 class DataExamplesSuite extends BaseExamplesSuite {
-  override def vocabulary: List[Word] = DataVocabulary.words
+  override def vocabulary: Vocabulary = DataVocabulary
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/FilterExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/FilterExamplesSuite.scala
@@ -16,8 +16,8 @@
 package com.netflix.atlas.core.model
 
 import com.netflix.atlas.core.stacklang.BaseExamplesSuite
-import com.netflix.atlas.core.stacklang.Word
+import com.netflix.atlas.core.stacklang.Vocabulary
 
 class FilterExamplesSuite extends BaseExamplesSuite {
-  override def vocabulary: List[Word] = FilterVocabulary.words
+  override def vocabulary: Vocabulary = FilterVocabulary
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/InWordSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/InWordSuite.scala
@@ -23,7 +23,7 @@ import com.netflix.atlas.core.stacklang.Word
 class InWordSuite extends BaseWordSuite {
 
   def interpreter: Interpreter = Interpreter(
-    QueryVocabulary.words ::: StandardVocabulary.words)
+    QueryVocabulary.allWords ::: StandardVocabulary.allWords)
 
   def word: Word = QueryVocabulary.In
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathExamplesSuite.scala
@@ -16,9 +16,8 @@
 package com.netflix.atlas.core.model
 
 import com.netflix.atlas.core.stacklang.BaseExamplesSuite
-import com.netflix.atlas.core.stacklang.StandardVocabulary
-import com.netflix.atlas.core.stacklang.Word
+import com.netflix.atlas.core.stacklang.Vocabulary
 
 class MathExamplesSuite extends BaseExamplesSuite {
-  override def vocabulary: List[Word] = MathVocabulary.words
+  override def vocabulary: Vocabulary = MathVocabulary
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/NotWordSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/NotWordSuite.scala
@@ -23,7 +23,7 @@ import com.netflix.atlas.core.stacklang.Word
 class NotWordSuite extends BaseWordSuite {
 
   def interpreter: Interpreter = Interpreter(
-    QueryVocabulary.words ::: StandardVocabulary.words)
+    QueryVocabulary.allWords ::: StandardVocabulary.allWords)
 
   def word: Word = QueryVocabulary.Not
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/OrWordSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/OrWordSuite.scala
@@ -23,7 +23,7 @@ import com.netflix.atlas.core.stacklang.Word
 class OrWordSuite extends BaseWordSuite {
 
   def interpreter: Interpreter = Interpreter(
-    QueryVocabulary.words ::: StandardVocabulary.words)
+    QueryVocabulary.allWords ::: StandardVocabulary.allWords)
 
   def word: Word = QueryVocabulary.Or
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/QueryExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/QueryExamplesSuite.scala
@@ -16,8 +16,8 @@
 package com.netflix.atlas.core.model
 
 import com.netflix.atlas.core.stacklang.BaseExamplesSuite
-import com.netflix.atlas.core.stacklang.Word
+import com.netflix.atlas.core.stacklang.Vocabulary
 
 class QueryExamplesSuite extends BaseExamplesSuite {
-  override def vocabulary: List[Word] = QueryVocabulary.words
+  override def vocabulary: Vocabulary = QueryVocabulary
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/StatefulExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/StatefulExamplesSuite.scala
@@ -16,9 +16,8 @@
 package com.netflix.atlas.core.model
 
 import com.netflix.atlas.core.stacklang.BaseExamplesSuite
-import com.netflix.atlas.core.stacklang.StandardVocabulary
-import com.netflix.atlas.core.stacklang.Word
+import com.netflix.atlas.core.stacklang.Vocabulary
 
 class StatefulExamplesSuite extends BaseExamplesSuite {
-  override def vocabulary: List[Word] = StatefulVocabulary.words
+  override def vocabulary: Vocabulary = StatefulVocabulary
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleExamplesSuite.scala
@@ -16,9 +16,8 @@
 package com.netflix.atlas.core.model
 
 import com.netflix.atlas.core.stacklang.BaseExamplesSuite
-import com.netflix.atlas.core.stacklang.StandardVocabulary
-import com.netflix.atlas.core.stacklang.Word
+import com.netflix.atlas.core.stacklang.Vocabulary
 
 class StyleExamplesSuite extends BaseExamplesSuite {
-  override def vocabulary: List[Word] = StyleVocabulary.words
+  override def vocabulary: Vocabulary = StyleVocabulary
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
@@ -28,7 +28,7 @@ class TimeSeriesExprSuite extends FunSuite {
 
   import com.netflix.atlas.core.model.TimeSeriesExprSuite._
 
-  val interpreter = Interpreter(StyleVocabulary.words ::: StandardVocabulary.words)
+  val interpreter = Interpreter(StyleVocabulary.allWords ::: StandardVocabulary.allWords)
   val data = constants
 
   val noTags = Map.empty[String, String]
@@ -49,6 +49,7 @@ class TimeSeriesExprSuite extends FunSuite {
     ":true,:avg,:count"           -> const(ts(constTag, "count(type=constant)", 1)),
     ":true,:sum,:avg"             -> const(ts(constTag, "(type=constant / count(type=constant))", 55)),
     ":true,:avg,:avg"             -> const(ts(constTag, "(sum(type=constant) / count(type=constant))", 5)),
+    ":false,:sum"                 -> const(ts(Map("name" -> "NO_DATA"), "NO DATA", Double.NaN)),
     "name,:has"                   -> const(ts(constTag, 55)),
     "name,1,:eq"                  -> const(ts(Map("name" -> "1", constTag), 1)),
     "name,1,:re"                  -> const(ts(constTag, 11)),

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/BaseExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/BaseExamplesSuite.scala
@@ -19,11 +19,11 @@ import org.scalatest.FunSuite
 
 abstract class BaseExamplesSuite extends FunSuite {
 
-  def vocabulary: List[Word]
+  def vocabulary: Vocabulary
 
-  val i = new Interpreter(vocabulary)
+  val i = new Interpreter(vocabulary.allWords)
 
-  for (w <- vocabulary; ex <- w.examples) {
+  for (w <- vocabulary.words; ex <- w.examples) {
     if (ex.startsWith("UNK:")) {
       test(s"noException -- $ex,:${w.name}") {
         val prg = ex.substring("UNK:".length)

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/CallSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/CallSuite.scala
@@ -17,7 +17,7 @@ package com.netflix.atlas.core.stacklang
 
 class CallSuite extends BaseWordSuite {
 
-  def interpreter: Interpreter = Interpreter(StandardVocabulary.words)
+  def interpreter: Interpreter = Interpreter(StandardVocabulary.allWords)
 
   def word: Word = StandardVocabulary.Call
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/ClearSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/ClearSuite.scala
@@ -17,7 +17,7 @@ package com.netflix.atlas.core.stacklang
 
 class ClearSuite extends BaseWordSuite {
 
-  def interpreter: Interpreter = Interpreter(StandardVocabulary.words)
+  def interpreter: Interpreter = Interpreter(StandardVocabulary.allWords)
 
   def word: Word = StandardVocabulary.Clear
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/DropSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/DropSuite.scala
@@ -17,7 +17,7 @@ package com.netflix.atlas.core.stacklang
 
 class DropSuite extends BaseWordSuite {
 
-  def interpreter: Interpreter = Interpreter(StandardVocabulary.words)
+  def interpreter: Interpreter = Interpreter(StandardVocabulary.allWords)
 
   def word: Word = StandardVocabulary.Drop
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/DupSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/DupSuite.scala
@@ -17,7 +17,7 @@ package com.netflix.atlas.core.stacklang
 
 class DupSuite extends BaseWordSuite {
 
-  def interpreter: Interpreter = Interpreter(StandardVocabulary.words)
+  def interpreter: Interpreter = Interpreter(StandardVocabulary.allWords)
 
   def word: Word = StandardVocabulary.Dup
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/EachSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/EachSuite.scala
@@ -17,7 +17,7 @@ package com.netflix.atlas.core.stacklang
 
 class EachSuite extends BaseWordSuite {
 
-  def interpreter: Interpreter = Interpreter(StandardVocabulary.words)
+  def interpreter: Interpreter = Interpreter(StandardVocabulary.allWords)
 
   def word: Word = StandardVocabulary.Each
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/FormatSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/FormatSuite.scala
@@ -17,7 +17,7 @@ package com.netflix.atlas.core.stacklang
 
 class FormatSuite extends BaseWordSuite {
 
-  def interpreter: Interpreter = Interpreter(StandardVocabulary.words)
+  def interpreter: Interpreter = Interpreter(StandardVocabulary.allWords)
 
   def word: Word = StandardVocabulary.Format
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/GetSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/GetSuite.scala
@@ -17,7 +17,7 @@ package com.netflix.atlas.core.stacklang
 
 class GetSuite extends BaseWordSuite {
 
-  def interpreter: Interpreter = Interpreter(StandardVocabulary.words)
+  def interpreter: Interpreter = Interpreter(StandardVocabulary.allWords)
 
   def word: Word = StandardVocabulary.Get
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/MapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/MapSuite.scala
@@ -17,7 +17,7 @@ package com.netflix.atlas.core.stacklang
 
 class MapSuite extends BaseWordSuite {
 
-  def interpreter: Interpreter = Interpreter(StandardVocabulary.words)
+  def interpreter: Interpreter = Interpreter(StandardVocabulary.allWords)
 
   def word: Word = StandardVocabulary.Map
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/OverSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/OverSuite.scala
@@ -17,7 +17,7 @@ package com.netflix.atlas.core.stacklang
 
 class OverSuite extends BaseWordSuite {
 
-  def interpreter: Interpreter = Interpreter(StandardVocabulary.words)
+  def interpreter: Interpreter = Interpreter(StandardVocabulary.allWords)
 
   def word: Word = StandardVocabulary.Over
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/ReverseRotSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/ReverseRotSuite.scala
@@ -17,7 +17,7 @@ package com.netflix.atlas.core.stacklang
 
 class ReverseRotSuite extends BaseWordSuite {
 
-  def interpreter: Interpreter = Interpreter(StandardVocabulary.words)
+  def interpreter: Interpreter = Interpreter(StandardVocabulary.allWords)
 
   def word: Word = StandardVocabulary.ReverseRot
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/RotSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/RotSuite.scala
@@ -17,7 +17,7 @@ package com.netflix.atlas.core.stacklang
 
 class RotSuite extends BaseWordSuite {
 
-  def interpreter: Interpreter = Interpreter(StandardVocabulary.words)
+  def interpreter: Interpreter = Interpreter(StandardVocabulary.allWords)
 
   def word: Word = StandardVocabulary.Rot
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/SetSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/SetSuite.scala
@@ -17,7 +17,7 @@ package com.netflix.atlas.core.stacklang
 
 class SetSuite extends BaseWordSuite {
 
-  def interpreter: Interpreter = Interpreter(StandardVocabulary.words)
+  def interpreter: Interpreter = Interpreter(StandardVocabulary.allWords)
 
   def word: Word = StandardVocabulary.Set
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/StandardExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/StandardExamplesSuite.scala
@@ -16,5 +16,5 @@
 package com.netflix.atlas.core.stacklang
 
 class StandardExamplesSuite extends BaseExamplesSuite {
-  override def vocabulary: List[Word] = StandardVocabulary.words
+  override def vocabulary: Vocabulary = StandardVocabulary
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/SwapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/SwapSuite.scala
@@ -17,7 +17,7 @@ package com.netflix.atlas.core.stacklang
 
 class SwapSuite extends BaseWordSuite {
 
-  def interpreter: Interpreter = Interpreter(StandardVocabulary.words)
+  def interpreter: Interpreter = Interpreter(StandardVocabulary.allWords)
 
   def word: Word = StandardVocabulary.Swap
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/VocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/VocabularySuite.scala
@@ -90,6 +90,8 @@ class VocabularySuite extends FunSuite {
 
 object VocabularySuite {
   object TestVocabulary extends Vocabulary {
+    def name: String = "test"
+    def dependsOn: List[Vocabulary] = Nil
     def words: List[Word] = List(
       StandardVocabulary.Call,
       StandardVocabulary.Dup

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
@@ -111,7 +111,7 @@ class GraphApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi {
 
 object GraphApi {
 
-  private val interpreter = new Interpreter(StyleVocabulary.words ::: StandardVocabulary.words)
+  private val interpreter = new Interpreter(StyleVocabulary.allWords ::: StandardVocabulary.allWords)
 
   private val engines = ApiSettings.engines.map(e => e.name -> e).toMap
 

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphRequestActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphRequestActor.scala
@@ -42,7 +42,7 @@ class GraphRequestActor extends Actor with ActorLogging {
 
   import com.netflix.atlas.webapi.GraphApi._
 
-  private def queryInterpreter = new Interpreter(QueryVocabulary.words ::: StandardVocabulary.words)
+  private def queryInterpreter = new Interpreter(QueryVocabulary.allWords ::: StandardVocabulary.allWords)
 
   private val errorId = Spectator.registry().createId("atlas.graph.errorImages")
 

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsApi.scala
@@ -66,7 +66,7 @@ object TagsApi {
 
   val offsetHeader = "x-nflx-atlas-next-offset"
 
-  private val queryInterpreter = new Interpreter(QueryVocabulary.words ::: StandardVocabulary.words)
+  private val queryInterpreter = new Interpreter(QueryVocabulary.allWords ::: StandardVocabulary.allWords)
 
   def databaseActor: Class[_] = classOf[TagsRequestActor]
 

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsRequestActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsRequestActor.scala
@@ -32,7 +32,7 @@ class TagsRequestActor extends Actor with ActorLogging {
 
   import com.netflix.atlas.webapi.TagsApi._
 
-  private def queryInterpreter = new Interpreter(QueryVocabulary.words ::: StandardVocabulary.words)
+  private def queryInterpreter = new Interpreter(QueryVocabulary.allWords ::: StandardVocabulary.allWords)
 
   val dbRef = context.actorSelection("/user/db")
 

--- a/atlas-wiki/src/main/resources/Stack-Language-Reference.md
+++ b/atlas-wiki/src/main/resources/Stack-Language-Reference.md
@@ -1,4 +1,0 @@
-```wiki.script
-import com.netflix.atlas.core.model.StyleVocabulary
-StyleVocabulary.toMarkdown
-```

--- a/atlas-wiki/src/main/resources/stacklang/Stack-Language-Reference.md
+++ b/atlas-wiki/src/main/resources/stacklang/Stack-Language-Reference.md
@@ -1,0 +1,2 @@
+
+Reference for operations available in the stack language. Use the sidebar to navigate.

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/GraphHelper.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/GraphHelper.scala
@@ -30,16 +30,19 @@ import spray.http.HttpRequest
 import spray.http.HttpResponse
 import spray.http.Uri
 
+import scala.concurrent.Await
 import scala.util.Failure
 import scala.util.Success
 
-class GraphHelper(webApi: ActorRef, dir: File) extends StrictLogging {
+class GraphHelper(webApi: ActorRef, dir: File, path: String) extends StrictLogging {
 
   import scala.concurrent.ExecutionContext.Implicits.global
+  import scala.concurrent.duration._
 
   implicit val timeout = akka.util.Timeout(1, TimeUnit.MINUTES)
+  private val askRef = akka.pattern.ask(webApi)
 
-  private val baseUri = "https://raw.githubusercontent.com/wiki/Netflix/atlas/gen-images"
+  private val baseUri = s"https://raw.githubusercontent.com/wiki/Netflix/atlas/$path"
 
   private val wordLinkBaseUri = "https://github.com/Netflix/atlas/wiki/Stack-Language-Reference"
 
@@ -47,19 +50,38 @@ class GraphHelper(webApi: ActorRef, dir: File) extends StrictLogging {
     logger.info(s"creating image for: $uri")
     val fname = imageFileName(uri)
     val req = HttpRequest(HttpMethods.GET, Uri(uri))
-    akka.pattern.ask(webApi, req).onComplete {
-      case Success(res: HttpResponse) =>
+    val future = askRef.ask(req)
+    Await.result(future, 1.minute) match {
+      case res: HttpResponse =>
         dir.mkdirs()
         val image = PngImage(res.entity.data.toByteArray)
         scope(fileOut(new File(dir, fname))) { out => image.write(out) }
-      case Success(v) => throw new IllegalStateException(s"unexpected response: $v")
-      case Failure(t) => throw t
+      case v => throw new IllegalStateException(s"unexpected response: $v")
     }
 
     if (showQuery)
       s"${formatQuery(uri)}\n![$fname]($baseUri/$fname)\n"
     else
       s"![$fname]($baseUri/$fname)\n"
+  }
+
+  def imageHtml(uri: String): String = {
+    logger.info(s"creating image for: $uri")
+    val fname = imageFileName(uri)
+    val file = new File(dir, fname)
+    if (!file.exists()) {
+      val req = HttpRequest(HttpMethods.GET, Uri(uri))
+      val future = askRef.ask(req)
+      Await.result(future, 1.minute) match {
+        case res: HttpResponse =>
+          dir.mkdirs()
+          val image = PngImage(res.entity.data.toByteArray)
+          scope(fileOut(file)) { out => image.write(out) }
+        case v => throw new IllegalStateException(s"unexpected response: $v")
+      }
+    }
+
+    s"""<img src="$baseUri/$fname"/>"""
   }
 
   private def imageFileName(uri: String): String = {


### PR DESCRIPTION
Change generated stacklang docs to generate a table
that is easier to read. Also where possible a sample
chart is shown for the examples instead of the string
representation of the expression.