### PR TITLE
remove one-jar usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ WIKI_PRG := atlas-wiki/runMain com.netflix.atlas.wiki.Main
 WIKI_DIR := target/atlas.wiki
 
 IVY_CACHE_URL := https://www.dropbox.com/s/zx5yq86nk6q19w1/ivy2.tar.gz?dl=0
+LAUNCHER_JAR_URL := https://repo1.maven.org/maven2/com/netflix/iep/iep-launcher/0.1.7/iep-launcher-0.1.7.jar
 
 .PHONY: build clean coverage license update-wiki publish-wiki
 
@@ -38,3 +39,10 @@ publish-wiki: update-wiki
 get-ivy-cache:
 	curl -L $(IVY_CACHE_URL) -o $(HOME)/ivy.tar.gz
 	tar -C $(HOME) -xzf $(HOME)/ivy.tar.gz
+
+one-jar:
+	mkdir -p target
+	curl -L $(LAUNCHER_JAR_URL) -o target/iep-launcher.jar
+	java -classpath target/iep-launcher.jar com.netflix.iep.launcher.JarBuilder \
+		target/standalone.jar com.netflix.atlas.standalone.Main \
+		`$(SBT) "export atlas-standalone/runtime:fullClasspath" | tail -n1 | sed 's/:/ /g'`

--- a/atlas-standalone/src/main/resources/META-INF/services/com.netflix.spectator.api.Registry
+++ b/atlas-standalone/src/main/resources/META-INF/services/com.netflix.spectator.api.Registry
@@ -1,1 +1,0 @@
-com.netflix.spectator.metrics2.MetricsRegistry

--- a/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/Main.scala
+++ b/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/Main.scala
@@ -71,6 +71,7 @@ object Main extends StrictLogging {
   }
 
   def shutdown(): Unit = {
+    logger.info("starting shutdown")
     server.shutdown()
     Governator.getInstance.shutdown()
   }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,7 +1,6 @@
 import sbt._
 import sbt.Keys._
 import com.typesafe.sbt.pgp.PgpKeys._
-import com.github.retronym.SbtOneJar._
 
 object MainBuild extends Build {
 
@@ -111,15 +110,12 @@ object MainBuild extends Build {
   lazy val `atlas-standalone` = project
     .dependsOn(`atlas-webapi`)
     .settings(buildSettings: _*)
-    .settings(oneJarSettings: _*)
-    .settings(mainClass in oneJar := Some("com.netflix.atlas.standalone.Main"))
     .settings(libraryDependencies ++= Seq(
       Dependencies.iepGovernator,
       Dependencies.log4jApi,
       Dependencies.log4jCore,
       Dependencies.log4jSlf4j,
-      Dependencies.spectatorLog4j,
-      Dependencies.spectatorM2
+      Dependencies.spectatorLog4j
     ))
 
   lazy val `atlas-test` = project
@@ -142,8 +138,6 @@ object MainBuild extends Build {
   lazy val `atlas-wiki` = project
     .dependsOn(`atlas-core`, `atlas-webapi`)
     .settings(buildSettings: _*)
-    .settings(oneJarSettings: _*)
-    .settings(mainClass in oneJar := Some("com.netflix.atlas.wiki.Main"))
     .settings(libraryDependencies ++= Seq(
       Dependencies.scalaCompiler
     ))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   object Versions {
     val akka       = "2.3.8"
     val aws        = "1.9.16"
-    val iep        = "0.1.6"
+    val iep        = "0.1.7"
     val jackson    = "2.5.0"
     val log4j      = "2.1"
     val lucene     = "4.10.2"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,5 +12,3 @@ addSbtPlugin("com.sksamuel.sbt-versions" % "sbt-versions" % "0.2.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.8")
-
-addSbtPlugin("org.scala-sbt.plugins" % "sbt-onejar" % "0.8")


### PR DESCRIPTION
One-JAR's class loader is causing a problems with
other libraries.

```
WARNING: Could not load Finalizer in its own class loader. Loading Finalizer in the current class loader instead. As a result, you will not be able to garbage collect this class loader. To support reclaiming this class loader, either resolve the underlying issue, or move Google Collections to your system class path.
```

Might be related to: http://sourceforge.net/p/one-jar/bugs/74/

We mainly want a simple way to package so the end-user
can just run `java -jar atlas.jar ...`, so using a simple
launcher that creates a self-extracting jar. After
extracting it uses the built-in URLClassLoader for the
set of jars and invokes a specfied main class.

So far this seems to be working well. The standalone jar
is built with a target in the makefile:

```
$ make one-jar
$ java -jar target/standalone.jar
```

If it still looks like the best approach after some more
testing, I'll create a better sbt task that should be
less system dependent than the current shell commands in
the make file.