### PR TITLE
update resolver list

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -18,8 +18,7 @@ object MainBuild extends Build {
            sourcesInBase := false,
             fork in Test := true,   // Needed to avoid ClassNotFoundException with equalsverifier
               exportJars := true,   // Needed for one-jar, with multi-project
-               resolvers += Resolver.sonatypeRepo("snapshots"),
-               resolvers += "rrd4j" at "https://raw.githubusercontent.com/brharrington/rrd4j/repo",
+       externalResolvers := BuildSettings.resolvers,
      checkLicenseHeaders := License.checkLicenseHeaders(streams.value.log, sourceDirectory.value),
     formatLicenseHeaders := License.formatLicenseHeaders(streams.value.log, sourceDirectory.value)
   )

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -12,6 +12,13 @@ object BuildSettings {
     "-feature",
     "-target:jvm-1.8")
 
+  val resolvers = Seq(
+    Resolver.mavenLocal,
+    Resolver.jcenterRepo,
+    DefaultMavenRepository,
+    "jfrog" at "http://oss.jfrog.org/oss-snapshot-local",
+    "rrd4j" at "https://raw.githubusercontent.com/brharrington/rrd4j/repo")
+
   // Don't create root.jar, from:
   // http://stackoverflow.com/questions/20747296/producing-no-artifact-for-root-project-with-package-under-multi-project-build-in
   lazy val noPackaging = Seq(


### PR DESCRIPTION
Nebula builds use jcenter by default. These are sync'd with
maven central, but that can take some time. This changes the
default resolver order to be:

1. local
2. jcenter
3. maven
4. jfrog snapshot repo
5. hack for custom rrd4j

We should try to remove the need for 5 in the future.