### PR TITLE
additional stack manipulation operators

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataVocabulary.scala
@@ -21,7 +21,7 @@ import com.netflix.atlas.core.stacklang.Vocabulary
 import com.netflix.atlas.core.stacklang.Word
 
 object DataVocabulary extends Vocabulary {
-  import com.netflix.atlas.core.model.Extractors._
+  import com.netflix.atlas.core.model.ModelExtractors._
 
   val name: String = "data"
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterVocabulary.scala
@@ -22,7 +22,7 @@ import com.netflix.atlas.core.stacklang.Word
 
 object FilterVocabulary extends Vocabulary {
 
-  import com.netflix.atlas.core.model.Extractors._
+  import com.netflix.atlas.core.model.ModelExtractors._
 
   val name: String = "filter"
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -23,7 +23,7 @@ import com.netflix.atlas.core.stacklang.Word
 
 object MathVocabulary extends Vocabulary {
 
-  import com.netflix.atlas.core.model.Extractors._
+  import com.netflix.atlas.core.model.ModelExtractors._
 
   val name: String = "math"
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/ModelExtractors.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/ModelExtractors.scala
@@ -22,22 +22,7 @@ import com.netflix.atlas.core.util.Strings
 
 import scala.util.Try
 
-object Extractors {
-  case object IntType {
-    def unapply(value: Any): Option[Int] = value match {
-      case v: String         => Some(v.toInt)
-      case v: Int            => Some(v)
-      case _                 => None
-    }
-  }
-
-  case object DoubleType {
-    def unapply(value: Any): Option[Double] = value match {
-      case v: String         => Some(v.toDouble)
-      case v: Double         => Some(v)
-      case _                 => None
-    }
-  }
+object ModelExtractors {
 
   case object DurationType {
     def unapply(value: Any): Option[Duration] = value match {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/QueryVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/QueryVocabulary.scala
@@ -23,7 +23,7 @@ import com.netflix.atlas.core.stacklang.Word
 
 object QueryVocabulary extends Vocabulary {
 
-  import com.netflix.atlas.core.model.Extractors._
+  import com.netflix.atlas.core.model.ModelExtractors._
 
   val name: String = "query"
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
@@ -23,7 +23,8 @@ import com.netflix.atlas.core.util.Strings
 
 object StatefulVocabulary extends Vocabulary {
 
-  import com.netflix.atlas.core.model.Extractors._
+  import com.netflix.atlas.core.model.ModelExtractors._
+  import com.netflix.atlas.core.stacklang.Extractors._
 
   val name: String = "stateful"
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
@@ -75,7 +75,7 @@ object StyleExpr {
   private val interpreter = new Interpreter(StandardVocabulary.allWords)
 
   private def parseDurationList(s: String): List[Duration] = {
-    import Extractors._
+    import ModelExtractors._
     val ctxt = interpreter.execute(s)
     ctxt.stack match {
       case StringListType(vs) :: Nil => vs.map { v => Strings.parseDuration(v) }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleVocabulary.scala
@@ -23,7 +23,7 @@ import com.netflix.atlas.core.stacklang.Word
 
 object StyleVocabulary extends Vocabulary {
 
-  import com.netflix.atlas.core.model.Extractors._
+  import com.netflix.atlas.core.model.ModelExtractors._
 
   val name: String = "style"
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Extractors.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Extractors.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.stacklang
+
+import scala.util.Try
+
+object Extractors {
+  case object IntType {
+    def unapply(value: Any): Option[Int] = value match {
+      case v: String         => Try(v.toInt).toOption
+      case v: Int            => Some(v)
+      case _                 => None
+    }
+  }
+
+  case object DoubleType {
+    def unapply(value: Any): Option[Double] = value match {
+      case v: String         => Try(v.toDouble).toOption
+      case v: Double         => Some(v)
+      case _                 => None
+    }
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
@@ -175,7 +175,7 @@ class TimeSeriesExprSuite extends FunSuite {
     test(s"eval global: $prg") {
       val c = interpreter.execute(prg)
       assert(c.stack.size === 1)
-      val expr = c.stack.collect { case Extractors.TimeSeriesType(t) => t } head
+      val expr = c.stack.collect { case ModelExtractors.TimeSeriesType(t) => t } head
       val rs = expr.eval(p.ctxt, p.input)
       assert(rs.expr === expr)
       assert(bounded(rs.data, p.ctxt) === bounded(p.output, p.ctxt))
@@ -185,7 +185,7 @@ class TimeSeriesExprSuite extends FunSuite {
       test(s"eval incremental $label: $prg") {
         val c = interpreter.execute(prg)
         assert(c.stack.size === 1)
-        val expr = c.stack.collect { case Extractors.TimeSeriesType(t) => t} head
+        val expr = c.stack.collect { case ModelExtractors.TimeSeriesType(t) => t} head
         val rs = expr.eval(p.ctxt, p.input)
         val ctxts = p.ctxt.partition(step, ChronoUnit.MINUTES)
         var state = Map.empty[StatefulExpr, Any]
@@ -213,7 +213,7 @@ class TimeSeriesExprSuite extends FunSuite {
     test(s"eval global: $prg") {
       val c = interpreter.execute(prg)
       assert(c.stack.size === 1)
-      val expr = c.stack.collect { case Extractors.TimeSeriesType(t) => t} head
+      val expr = c.stack.collect { case ModelExtractors.TimeSeriesType(t) => t} head
       val rs = expr.eval(p.ctxt, p.input)
       assert(rs.expr === expr)
       assert(bounded(rs.data, p.ctxt) === bounded(p.output, p.ctxt))

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/NDropSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/NDropSuite.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.stacklang
+
+class NDropSuite extends BaseWordSuite {
+
+  def interpreter: Interpreter = Interpreter(StandardVocabulary.allWords)
+
+  def word: Word = StandardVocabulary.NDrop
+
+  def shouldMatch: List[(String, List[Any])] = List(
+    "a,0" -> List("a"),
+    "a,b,1" -> List("a"),
+    "a,b,2" -> Nil
+  )
+
+  def shouldNotMatch: List[String] = List("", "a", "a,b")
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/NListSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/NListSuite.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.stacklang
+
+class NListSuite extends BaseWordSuite {
+
+  def interpreter: Interpreter = Interpreter(StandardVocabulary.allWords)
+
+  def word: Word = StandardVocabulary.NList
+
+  def shouldMatch: List[(String, List[Any])] = List(
+    "a,0" -> List(Nil, "a"),
+    "a,b,1" -> List(List("b"), "a"),
+    "a,b,2" -> List(List("a", "b"))
+  )
+
+  def shouldNotMatch: List[String] = List("", "a", "a,b")
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/PickSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/PickSuite.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.stacklang
+
+class PickSuite extends BaseWordSuite {
+
+  def interpreter: Interpreter = Interpreter(StandardVocabulary.allWords)
+
+  def word: Word = StandardVocabulary.Pick
+
+  def shouldMatch: List[(String, List[Any])] = List(
+    "a,0" -> List("a", "a"),
+    "a,b,0" -> List("b", "b", "a"),
+    "a,b,1" -> List("a", "b", "a")
+  )
+
+  def shouldNotMatch: List[String] = List("", "a", "a,b")
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/RollSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/RollSuite.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.stacklang
+
+class RollSuite extends BaseWordSuite {
+
+  def interpreter: Interpreter = Interpreter(StandardVocabulary.allWords)
+
+  def word: Word = StandardVocabulary.Roll
+
+  def shouldMatch: List[(String, List[Any])] = List(
+    "a,0" -> List("a"),
+    "a,b,0" -> List("b", "a"),
+    "a,b,1" -> List("a", "b")
+  )
+
+  def shouldNotMatch: List[String] = List("", "a", "a,b")
+}

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
@@ -26,7 +26,7 @@ import com.netflix.atlas.chart.GraphEngine
 import com.netflix.atlas.chart.VisionType
 import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.EvalContext
-import com.netflix.atlas.core.model.Extractors
+import com.netflix.atlas.core.model.ModelExtractors
 import com.netflix.atlas.core.model.StyleExpr
 import com.netflix.atlas.core.model.StyleVocabulary
 import com.netflix.atlas.core.model.TimeSeries
@@ -184,7 +184,7 @@ object GraphApi {
 
     def exprs: List[StyleExpr] = {
       interpreter.execute(query).stack.reverse.flatMap {
-        case Extractors.PresentationType(s) => s.perOffset
+        case ModelExtractors.PresentationType(s) => s.perOffset
       }
     }
 

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Main.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Main.scala
@@ -68,7 +68,7 @@ import scala.util.Try
  */
 object Main extends StrictLogging {
 
-  import com.netflix.atlas.core.model.Extractors._
+  import com.netflix.atlas.core.model.ModelExtractors._
 
   class UseForDefaults
 


### PR DESCRIPTION
Adds depth, pick, roll, nip, and tuck to make the
standard set more complete for those used to languages
like forth.

For convenience adds ndrop and nlist to select a subset
of the stack for those operations.