### PR TITLE
pin the end time of ref charts

### DIFF
--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/GraphHelper.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/GraphHelper.scala
@@ -46,6 +46,8 @@ class GraphHelper(webApi: ActorRef, dir: File, path: String) extends StrictLoggi
 
   private val wordLinkBaseUri = "https://github.com/Netflix/atlas/wiki/Stack-Language-Reference"
 
+  override def toString: String = s"GraphHelper($dir, $path)"
+
   def image(uri: String, showQuery: Boolean = true): String = {
     logger.info(s"creating image for: $uri")
     val fname = imageFileName(uri)


### PR DESCRIPTION
Pins the end time of the charts generated for the
stack language reference examples so we don't change
all images on every run.