### PR TITLE
add setting to customize vocabulary for graph api

### DIFF
--- a/atlas-webapi/src/main/resources/reference.conf
+++ b/atlas-webapi/src/main/resources/reference.conf
@@ -61,6 +61,10 @@ atlas {
         "com.netflix.atlas.chart.StatsJsonGraphEngine",
         "com.netflix.atlas.chart.Rrd4jGraphEngine"
       ]
+
+      // Vocabulary to use for the graph API. The value can be "default" or a class representing
+      // the vocabulary to use.
+      vocabulary = "default"
     }
 
     publish {

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
@@ -19,11 +19,14 @@ import com.netflix.atlas.chart.GraphEngine
 import com.netflix.atlas.config.ConfigManager
 import com.netflix.atlas.core.db.Database
 import com.netflix.atlas.core.model.DefaultSettings
+import com.netflix.atlas.core.model.StyleVocabulary
+import com.netflix.atlas.core.stacklang.Vocabulary
 import com.typesafe.config.Config
 
-object ApiSettings {
+object ApiSettings extends ApiSettings(ConfigManager.current)
 
-  private def root = ConfigManager.current
+class ApiSettings(root: => Config) {
+
   private def config = root.getConfig("atlas.webapi")
 
   def newDbInstance: Database = {
@@ -62,6 +65,13 @@ object ApiSettings {
     config.getStringList("graph.engines").toList.map { cname =>
       val cls = Class.forName(cname)
       cls.newInstance().asInstanceOf[GraphEngine]
+    }
+  }
+
+  def graphVocabulary: Vocabulary = {
+    config.getString("graph.vocabulary") match {
+      case "default" => StyleVocabulary
+      case cls       => Class.forName(cls).newInstance().asInstanceOf[Vocabulary]
     }
   }
 }

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
@@ -28,10 +28,8 @@ import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.EvalContext
 import com.netflix.atlas.core.model.ModelExtractors
 import com.netflix.atlas.core.model.StyleExpr
-import com.netflix.atlas.core.model.StyleVocabulary
 import com.netflix.atlas.core.model.TimeSeries
 import com.netflix.atlas.core.stacklang.Interpreter
-import com.netflix.atlas.core.stacklang.StandardVocabulary
 import com.netflix.atlas.core.util.Step
 import com.netflix.atlas.core.util.Strings
 import spray.http.HttpRequest
@@ -111,7 +109,7 @@ class GraphApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi {
 
 object GraphApi {
 
-  private val interpreter = new Interpreter(StyleVocabulary.allWords ::: StandardVocabulary.allWords)
+  private val interpreter = new Interpreter(ApiSettings.graphVocabulary.allWords)
 
   private val engines = ApiSettings.engines.map(e => e.name -> e).toMap
 

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphRequestActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphRequestActor.scala
@@ -28,7 +28,6 @@ import com.netflix.atlas.chart.PlotDef
 import com.netflix.atlas.chart.SeriesDef
 import com.netflix.atlas.core.model._
 import com.netflix.atlas.core.stacklang.Interpreter
-import com.netflix.atlas.core.stacklang.StandardVocabulary
 import com.netflix.atlas.core.util.PngImage
 import com.netflix.atlas.core.util.Strings
 import com.netflix.atlas.json.Json
@@ -42,7 +41,7 @@ class GraphRequestActor extends Actor with ActorLogging {
 
   import com.netflix.atlas.webapi.GraphApi._
 
-  private def queryInterpreter = new Interpreter(QueryVocabulary.allWords ::: StandardVocabulary.allWords)
+  private def queryInterpreter = new Interpreter(QueryVocabulary.allWords)
 
   private val errorId = Spectator.registry().createId("atlas.graph.errorImages")
 

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsApi.scala
@@ -23,7 +23,6 @@ import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.QueryVocabulary
 import com.netflix.atlas.core.model.Tag
 import com.netflix.atlas.core.stacklang.Interpreter
-import com.netflix.atlas.core.stacklang.StandardVocabulary
 import spray.routing.RequestContext
 
 class TagsApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi {
@@ -66,7 +65,7 @@ object TagsApi {
 
   val offsetHeader = "x-nflx-atlas-next-offset"
 
-  private val queryInterpreter = new Interpreter(QueryVocabulary.allWords ::: StandardVocabulary.allWords)
+  private val queryInterpreter = new Interpreter(QueryVocabulary.allWords)
 
   def databaseActor: Class[_] = classOf[TagsRequestActor]
 

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsRequestActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsRequestActor.scala
@@ -21,7 +21,6 @@ import akka.actor.ActorRef
 import com.netflix.atlas.akka.DiagnosticMessage
 import com.netflix.atlas.core.model._
 import com.netflix.atlas.core.stacklang.Interpreter
-import com.netflix.atlas.core.stacklang.StandardVocabulary
 import com.netflix.atlas.json.Json
 import spray.can.Http
 import spray.http.MediaTypes._
@@ -32,7 +31,7 @@ class TagsRequestActor extends Actor with ActorLogging {
 
   import com.netflix.atlas.webapi.TagsApi._
 
-  private def queryInterpreter = new Interpreter(QueryVocabulary.allWords ::: StandardVocabulary.allWords)
+  private def queryInterpreter = new Interpreter(QueryVocabulary.allWords)
 
   val dbRef = context.actorSelection("/user/db")
 

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ApiSettingsSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ApiSettingsSuite.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.webapi
+
+import com.netflix.atlas.core.model.StyleVocabulary
+import com.netflix.atlas.core.stacklang.Vocabulary
+import com.netflix.atlas.core.stacklang.Word
+import com.typesafe.config.ConfigFactory
+import org.scalatest.FunSuite
+
+class ApiSettingsSuite extends FunSuite {
+
+  test("graphVocabulary default") {
+    val cfg = new ApiSettings(ConfigFactory.parseString("atlas.webapi.graph.vocabulary=default"))
+    assert(cfg.graphVocabulary === StyleVocabulary)
+  }
+
+  test("graphVocabulary class") {
+    val cls = classOf[TestVocabulary].getName
+    val cfg = new ApiSettings(ConfigFactory.parseString(s"atlas.webapi.graph.vocabulary=$cls"))
+    assert(cfg.graphVocabulary.isInstanceOf[TestVocabulary])
+  }
+}
+
+class TestVocabulary extends Vocabulary {
+  override def name: String = "test"
+  override def words: List[Word] = Nil
+  override def dependsOn: List[Vocabulary] = Nil
+}
+


### PR DESCRIPTION
There are a number of use-cases where it is convenient
to be able to change the vocabulary used by the graph
api via configuration. Main uses:

1. Experiments such as current work looking at better
   support for percentiles. This could be true of other
   extensions that likely will never be part of core.
2. Internal extensions that only make sense with our
   infrastructure.

This change allows the vocabulary to get set with:

```
atlas.webapi.graph.vocabulary = "com.foo.CustomVocabulary"
```