### PR TITLE
set the aws host resolve tests to ignore

### DIFF
--- a/atlas-aws/src/test/scala/com/netflix/atlas/aws/DefaultAwsClientFactorySuite.scala
+++ b/atlas-aws/src/test/scala/com/netflix/atlas/aws/DefaultAwsClientFactorySuite.scala
@@ -31,10 +31,12 @@ class DefaultAwsClientFactorySuite extends FunSuite {
   val endpoints = config.getConfig("atlas.aws.endpoint").entrySet.toList
   endpoints.sortWith(_.getKey < _.getKey).foreach { endpoint =>
     val service = endpoint.getKey
-      test(s"resolve: $service") {
-        val host = endpoint.getValue.unwrapped.asInstanceOf[String]
-        InetAddress.getByName(host)
-      }
+    // Can be slow (~30s) to run and we don't update the list that often. Can be enabled when
+    // the list is updated.
+    ignore(s"resolve: $service") {
+      val host = endpoint.getValue.unwrapped.asInstanceOf[String]
+      InetAddress.getByName(host)
+    }
   }
 
   // Try a few key services


### PR DESCRIPTION
These can take a while to run (~30s) and we don't update
the list all that often. They can be reenabled when the list
is changed or if it becomes a problem.