### PR TITLE
report 0 for 0/0 on graph

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -346,8 +346,11 @@ object MathVocabulary extends Vocabulary {
     override def summary: String =
       """
         |Compute a new time series where each interval has the value `(a / b)` where `a`
-        | and `b` are the corresponding intervals in the input time series. If `b` is 0, then
-        | NaN will be returned as the value for the interval.
+        | and `b` are the corresponding intervals in the input time series. If `a` and `b` are 0,
+        | then 0 will be returned for the interval. If only `b` is 0, then NaN will be returned as
+        | the value for the interval.
+        |
+        |Use the [fdiv](math-fdiv) operator to get strict floating point behavior.
       """.stripMargin.trim
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
@@ -130,6 +130,8 @@ class TimeSeriesExprSuite extends FunSuite {
     "NaN,1.0,:div"                -> const(ts(Map("name" -> "NaN"), "(NaN / 1.0)", Double.NaN)),
     "1.0,NaN,:div"                -> const(ts(Map("name" -> "1.0"), "(1.0 / NaN)", Double.NaN)),
     "2.0,1.0,:div"                -> const(ts(Map("name" -> "2.0"), "(2.0 / 1.0)", 2.0)),
+    "2.0,0.0,:div"                -> const(ts(Map("name" -> "2.0"), "(2.0 / 0.0)", Double.NaN)),
+    "0.0,0.0,:div"                -> const(ts(Map("name" -> "0.0"), "(0.0 / 0.0)", 0.0)),
     "NaN,NaN,:fadd"               -> const(ts(Map("name" -> "NaN"), "(NaN + NaN)", Double.NaN)),
     "NaN,1.0,:fadd"               -> const(ts(Map("name" -> "NaN"), "(NaN + 1.0)", Double.NaN)),
     "1.0,NaN,:fadd"               -> const(ts(Map("name" -> "1.0"), "(1.0 + NaN)", Double.NaN)),
@@ -146,6 +148,8 @@ class TimeSeriesExprSuite extends FunSuite {
     "NaN,1.0,:fdiv"               -> const(ts(Map("name" -> "NaN"), "(NaN / 1.0)", Double.NaN)),
     "1.0,NaN,:fdiv"               -> const(ts(Map("name" -> "1.0"), "(1.0 / NaN)", Double.NaN)),
     "2.0,1.0,:fdiv"               -> const(ts(Map("name" -> "2.0"), "(2.0 / 1.0)", 2.0)),
+    "2.0,0.0,:fdiv"               -> const(ts(Map("name" -> "2.0"), "(2.0 / 0.0)", Double.PositiveInfinity)),
+    "0.0,0.0,:fdiv"               -> const(ts(Map("name" -> "0.0"), "(0.0 / 0.0)", Double.NaN)),
     ":true,1w,:offset"            -> const(ts(constTag, "type=constant (offset=1w)", 55)),
     ":true,5,:add,1w,:offset"     -> const(ts(constTag, "(type=constant (offset=1w) + 5.0)", 60)),
     "42"                          -> const(ts(42))


### PR DESCRIPTION
A common case for timers is to divide a `totalTime` stat
by the `count` stat. For intervals where there is no activity
both will have a value of 0. The previous behavior was to
treat this as NaN but we have frequently seen users confuse
that for a failure to report data since it leads to a spotty
chart with a lot of gaps. Now if both the numerator and
denominator are 0, then the value will be 0 to make it more
clear that 0 was explicitly reported and there was no activity
rather than a failure to report.

For uses that need the typical floating point behavior the
`:fdiv` operator can be used instead. It has also been fixed
os that it doesn't special case div by zero to be NaN instead
of Infinity.