### PR TITLE
fix warning

### DIFF
--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalPublishActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalPublishActor.scala
@@ -68,8 +68,10 @@ class LocalPublishActor(db: MemoryDatabase) extends Actor with ActorLogging {
   }
 
   private def updateStats(failures: List[ValidationResult]): Unit = {
-    failures.foreach { case ValidationResult.Fail(error, _) =>
-      Spectator.registry.counter(numInvalid.withTag("error", error))
+    failures.foreach {
+      case ValidationResult.Pass           => // Ignored
+      case ValidationResult.Fail(error, _) =>
+        Spectator.registry.counter(numInvalid.withTag("error", error))
     }
   }
 


### PR DESCRIPTION
```
[warn] atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalPublishActor.scala:71: match may not be exhaustive.
[warn] It would fail on the following input: Pass
[warn]     failures.foreach { case ValidationResult.Fail(error, _) =>
[warn]                      ^
[warn] one warning found
```