### PR TITLE
add output format for compatible json

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonGraphEngine.scala
@@ -18,9 +18,11 @@ package com.netflix.atlas.chart
 import java.io.OutputStream
 import java.io.OutputStreamWriter
 
-class JsonGraphEngine extends GraphEngine {
+class JsonGraphEngine(quoteNonNumeric: Boolean) extends GraphEngine {
 
   import com.netflix.atlas.chart.GraphEngine._
+
+  def this() = this(false)
 
   def name: String = "json"
   def contentType: String = "application/json"
@@ -62,7 +64,10 @@ class JsonGraphEngine extends GraphEngine {
       gen.writeStartArray()
       seriesList.foreach { series =>
         val v = series.data.data(timestamp)
-        gen.writeRawValue(numberFmt.format(v))
+        if (!quoteNonNumeric || java.lang.Double.isFinite(v))
+          gen.writeRawValue(numberFmt.format(v))
+        else
+          gen.writeString(v.toString)
       }
       gen.writeEndArray()
       timestamp += step

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/StdJsonGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/StdJsonGraphEngine.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.chart
+
+/**
+ * Json output format that quotes non-numeric values like NaN and Infinity. Historically we
+ * have always emitted them unquoted, but that is not standard JSON and so it creates issues with
+ * some parsers. To avoid breaking backwards compatibility the existing "json" type will not
+ * change, but this class adds a "std.json" type. The non-compatible json will not be used on
+ * any v2 endpoints.
+ */
+class StdJsonGraphEngine extends JsonGraphEngine(true) {
+  override def name: String = "std.json"
+}

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/JsonGraphEngineSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/JsonGraphEngineSuite.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.chart
+
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+
+import com.netflix.atlas.core.model.DsType
+import com.netflix.atlas.core.model.FunctionTimeSeq
+import com.netflix.atlas.core.model.TimeSeries
+import com.netflix.atlas.core.util.Streams
+import org.scalatest.FunSuite
+
+
+class JsonGraphEngineSuite extends FunSuite {
+
+  val step = 60000
+
+  def constant(v: Double): TimeSeries = {
+    TimeSeries(Map("name" -> v.toString), new FunctionTimeSeq(DsType.Gauge, step, _ => v))
+  }
+
+  def constantSeriesDef(value: Double) : SeriesDef = {
+    val seriesDef = new SeriesDef
+    seriesDef.data = constant(value)
+    seriesDef
+  }
+
+  def label(vs: SeriesDef*): List[SeriesDef] = {
+    vs.zipWithIndex.foreach { case (v, i) => v.label = i.toString }
+    vs.toList
+  }
+
+  def strip(expected: String): String = {
+    expected.stripMargin.split("\n").mkString("")
+  }
+
+  def process(engine: GraphEngine, expected: String) {
+    val plotDef = new PlotDef
+    plotDef.series = label(constantSeriesDef(42), constantSeriesDef(Double.NaN))
+
+    val graphDef = new GraphDef
+    graphDef.startTime = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant
+    graphDef.endTime = ZonedDateTime.of(2012, 1, 1, 0, 3, 0, 0, ZoneOffset.UTC).toInstant
+    graphDef.plots = List(plotDef)
+
+    val bytes = Streams.byteArray { out => engine.write(graphDef, out) }
+    val json = new String(bytes, "UTF-8")
+    assert(json === strip(expected))
+  }
+
+  test("json") {
+    val expected =
+      """{
+        |"start":1325376000000,
+        |"step":60000,
+        |"legend":["0","1"],
+        |"metrics":[{},{}],
+        |"values":[[42.000000,NaN],[42.000000,NaN],[42.000000,NaN],[42.000000,NaN]],
+        |"notices":[]
+        |}"""
+
+    process(new JsonGraphEngine, expected)
+  }
+
+  test("std.json") {
+    val expected =
+      """{
+        |"start":1325376000000,
+        |"step":60000,
+        |"legend":["0","1"],
+        |"metrics":[{},{}],
+        |"values":[[42.000000,"NaN"],[42.000000,"NaN"],[42.000000,"NaN"],[42.000000,"NaN"]],
+        |"notices":[]
+        |}"""
+
+    process(new StdJsonGraphEngine, expected)
+  }
+
+}

--- a/atlas-webapi/src/main/resources/reference.conf
+++ b/atlas-webapi/src/main/resources/reference.conf
@@ -59,6 +59,7 @@ atlas {
         "com.netflix.atlas.chart.TabSepGraphEngine",
         "com.netflix.atlas.chart.JsonGraphEngine",
         "com.netflix.atlas.chart.StatsJsonGraphEngine",
+        "com.netflix.atlas.chart.StdJsonGraphEngine",
         "com.netflix.atlas.chart.Rrd4jGraphEngine"
       ]
 


### PR DESCRIPTION
The default json output of `/api/v1/graph` will output values
`NaN`, `Infinity`, and `-Infinity` as literals which is not
standard json and can cause issues with some parsers. To avoid
breaking backwards compatibility a new output format option,
`std.json`, is provided so a user can choose to get compatible
json. The use of non-standard json features will be avoided in
future APIs.