### PR TITLE
Use bash for publish test

### DIFF
--- a/scripts/publish-test.sh
+++ b/scripts/publish-test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Simple example for testing publish. Usage:


### PR DESCRIPTION
At least on Ubuntu 14, /bin/sh doesn't appear to provide `$RANDOM`