### PR TITLE
fix links for expressions in wiki

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataVocabulary.scala
@@ -53,7 +53,7 @@ object DataVocabulary extends Vocabulary {
     override def examples: List[String] = List("name,sps,:eq")
   }
 
-  object All extends DataWord {
+  case object All extends DataWord {
     override def name: String = "all"
 
     def newInstance(q: Query): DataExpr = DataExpr.All(q)
@@ -67,7 +67,7 @@ object DataVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object Sum extends DataWord {
+  case object Sum extends DataWord {
     override def name: String = "sum"
 
     def newInstance(q: Query): DataExpr = DataExpr.Sum(q)
@@ -79,7 +79,7 @@ object DataVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object Count extends DataWord {
+  case object Count extends DataWord {
     override def name: String = "count"
 
     def newInstance(q: Query): DataExpr = DataExpr.Count(q)
@@ -91,7 +91,7 @@ object DataVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object Min extends DataWord {
+  case object Min extends DataWord {
     override def name: String = "min"
 
     def newInstance(q: Query): DataExpr = DataExpr.Min(q)
@@ -102,7 +102,7 @@ object DataVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object Max extends DataWord {
+  case object Max extends DataWord {
     override def name: String = "max"
 
     def newInstance(q: Query): DataExpr = DataExpr.Max(q)
@@ -113,7 +113,7 @@ object DataVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object GroupBy extends SimpleWord {
+  case object GroupBy extends SimpleWord {
     override def name: String = "by"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -142,7 +142,7 @@ object DataVocabulary extends Vocabulary {
       "name,sps,:eq,nf.cluster,nccp-silverlight,:eq,:and,(,nf.asg,nf.zone,)")
   }
 
-  object Head extends SimpleWord {
+  case object Head extends SimpleWord {
     override def name: String = "head"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -172,7 +172,7 @@ object DataVocabulary extends Vocabulary {
       "ERROR:42,1")
   }
 
-  object Offset extends SimpleWord {
+  case object Offset extends SimpleWord {
     override def name: String = "offset"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -216,7 +216,7 @@ object DataVocabulary extends Vocabulary {
       "name,sps,:eq,:count")
   }
 
-  object CfSum extends CfWord {
+  case object CfSum extends CfWord {
     override def cf: ConsolidationFunction = ConsolidationFunction.Sum
     override def name: String = "cf-sum"
 
@@ -226,7 +226,7 @@ object DataVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object CfAvg extends CfWord {
+  case object CfAvg extends CfWord {
     override def cf: ConsolidationFunction = ConsolidationFunction.Avg
     override def name: String = "cf-avg"
 
@@ -236,7 +236,7 @@ object DataVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object CfMin extends CfWord {
+  case object CfMin extends CfWord {
     override def cf: ConsolidationFunction = ConsolidationFunction.Min
     override def name: String = "cf-min"
 
@@ -246,7 +246,7 @@ object DataVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object CfMax extends CfWord {
+  case object CfMax extends CfWord {
     override def cf: ConsolidationFunction = ConsolidationFunction.Max
     override def name: String = "cf-max"
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterVocabulary.scala
@@ -37,7 +37,7 @@ object FilterVocabulary extends Vocabulary {
     Macro("stat-avg-mf", List("avg", ":stat"), List("42"))
   )
 
-  object Stat extends SimpleWord {
+  case object Stat extends SimpleWord {
     override def name: String = "stat"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -101,7 +101,7 @@ object FilterVocabulary extends Vocabulary {
     def value: FilterExpr
   }
 
-  object StatMax extends StatWord {
+  case object StatMax extends StatWord {
     override def name: String = "stat-max"
 
     def value: FilterExpr = FilterExpr.StatMax
@@ -112,7 +112,7 @@ object FilterVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object StatMin extends StatWord {
+  case object StatMin extends StatWord {
     override def name: String = "stat-min"
 
     def value: FilterExpr = FilterExpr.StatMin
@@ -123,7 +123,7 @@ object FilterVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object StatAvg extends StatWord {
+  case object StatAvg extends StatWord {
     override def name: String = "stat-avg"
 
     def value: FilterExpr = FilterExpr.StatAvg
@@ -134,7 +134,7 @@ object FilterVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object StatTotal extends StatWord {
+  case object StatTotal extends StatWord {
     override def name: String = "stat-total"
 
     def value: FilterExpr = FilterExpr.StatTotal
@@ -145,7 +145,7 @@ object FilterVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object Filter extends SimpleWord {
+  case object Filter extends SimpleWord {
     override def name: String = "filter"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -100,7 +100,7 @@ object MathVocabulary extends Vocabulary {
       List("name,playback.startLatency,:eq"))
   )
 
-  object GroupBy extends SimpleWord {
+  case object GroupBy extends SimpleWord {
     override def name: String = "by"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -126,7 +126,7 @@ object MathVocabulary extends Vocabulary {
     override def examples: List[String] = List("name,sps,:eq,:avg,(,nf.cluster,)")
   }
 
-  object Const extends SimpleWord {
+  case object Const extends SimpleWord {
     override def name: String = "const"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -147,7 +147,7 @@ object MathVocabulary extends Vocabulary {
     override def examples: List[String] = List("42")
   }
 
-  object Random extends SimpleWord {
+  case object Random extends SimpleWord {
     override def name: String = "random"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = { case _ => true }
@@ -166,7 +166,7 @@ object MathVocabulary extends Vocabulary {
     override def examples: List[String] = List("")
   }
 
-  object Time extends SimpleWord {
+  case object Time extends SimpleWord {
     override def name: String = "time"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -191,7 +191,7 @@ object MathVocabulary extends Vocabulary {
     override def examples: List[String] = List("hourOfDay", "HOUR_OF_DAY")
   }
 
-  object CommonQuery extends SimpleWord {
+  case object CommonQuery extends SimpleWord {
     override def name: String = "cq"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -233,7 +233,7 @@ object MathVocabulary extends Vocabulary {
     override def examples: List[String] = List("0", "64", "-64")
   }
 
-  object Abs extends UnaryWord {
+  case object Abs extends UnaryWord {
     override def name: String = "abs"
 
     def newInstance(t: TimeSeriesExpr): TimeSeriesExpr = MathExpr.Abs(t)
@@ -245,7 +245,7 @@ object MathVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object Negate extends UnaryWord {
+  case object Negate extends UnaryWord {
     override def name: String = "neg"
 
     def newInstance(t: TimeSeriesExpr): TimeSeriesExpr = MathExpr.Negate(t)
@@ -257,7 +257,7 @@ object MathVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object Sqrt extends UnaryWord {
+  case object Sqrt extends UnaryWord {
     override def name: String = "sqrt"
 
     def newInstance(t: TimeSeriesExpr): TimeSeriesExpr = MathExpr.Sqrt(t)
@@ -269,7 +269,7 @@ object MathVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object PerStep extends UnaryWord {
+  case object PerStep extends UnaryWord {
     override def name: String = "per-step"
 
     def newInstance(t: TimeSeriesExpr): TimeSeriesExpr = MathExpr.PerStep(t)
@@ -300,7 +300,7 @@ object MathVocabulary extends Vocabulary {
       "name,sps,:eq,:sum,name,requestsPerSecond,:eq,:max,(,name,),:by")
   }
 
-  object Add extends BinaryWord {
+  case object Add extends BinaryWord {
     override def name: String = "add"
 
     def newInstance(t1: TimeSeriesExpr, t2: TimeSeriesExpr): TimeSeriesExpr = {
@@ -314,7 +314,7 @@ object MathVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object Subtract extends BinaryWord {
+  case object Subtract extends BinaryWord {
     override def name: String = "sub"
 
     def newInstance(t1: TimeSeriesExpr, t2: TimeSeriesExpr): TimeSeriesExpr = {
@@ -328,7 +328,7 @@ object MathVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object Multiply extends BinaryWord {
+  case object Multiply extends BinaryWord {
     override def name: String = "mul"
 
     def newInstance(t1: TimeSeriesExpr, t2: TimeSeriesExpr): TimeSeriesExpr = {
@@ -342,7 +342,7 @@ object MathVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object Divide extends BinaryWord {
+  case object Divide extends BinaryWord {
     override def name: String = "div"
 
     def newInstance(t1: TimeSeriesExpr, t2: TimeSeriesExpr): TimeSeriesExpr = {
@@ -360,7 +360,7 @@ object MathVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object GreaterThan extends BinaryWord {
+  case object GreaterThan extends BinaryWord {
     override def name: String = "gt"
 
     def newInstance(t1: TimeSeriesExpr, t2: TimeSeriesExpr): TimeSeriesExpr = {
@@ -374,7 +374,7 @@ object MathVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object GreaterThanEqual extends BinaryWord {
+  case object GreaterThanEqual extends BinaryWord {
     override def name: String = "ge"
 
     def newInstance(t1: TimeSeriesExpr, t2: TimeSeriesExpr): TimeSeriesExpr = {
@@ -388,7 +388,7 @@ object MathVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object LessThan extends BinaryWord {
+  case object LessThan extends BinaryWord {
     override def name: String = "lt"
 
     def newInstance(t1: TimeSeriesExpr, t2: TimeSeriesExpr): TimeSeriesExpr = {
@@ -402,7 +402,7 @@ object MathVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object LessThanEqual extends BinaryWord {
+  case object LessThanEqual extends BinaryWord {
     override def name: String = "le"
 
     def newInstance(t1: TimeSeriesExpr, t2: TimeSeriesExpr): TimeSeriesExpr = {
@@ -416,7 +416,7 @@ object MathVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object FAdd extends BinaryWord {
+  case object FAdd extends BinaryWord {
     override def name: String = "fadd"
 
     def newInstance(t1: TimeSeriesExpr, t2: TimeSeriesExpr): TimeSeriesExpr = {
@@ -430,7 +430,7 @@ object MathVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object FSubtract extends BinaryWord {
+  case object FSubtract extends BinaryWord {
     override def name: String = "fsub"
 
     def newInstance(t1: TimeSeriesExpr, t2: TimeSeriesExpr): TimeSeriesExpr = {
@@ -444,7 +444,7 @@ object MathVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object FMultiply extends BinaryWord {
+  case object FMultiply extends BinaryWord {
     override def name: String = "fmul"
 
     def newInstance(t1: TimeSeriesExpr, t2: TimeSeriesExpr): TimeSeriesExpr = {
@@ -458,7 +458,7 @@ object MathVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object FDivide extends BinaryWord {
+  case object FDivide extends BinaryWord {
     override def name: String = "fdiv"
 
     def newInstance(t1: TimeSeriesExpr, t2: TimeSeriesExpr): TimeSeriesExpr = {
@@ -473,7 +473,7 @@ object MathVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object And extends BinaryWord {
+  case object And extends BinaryWord {
     override def name: String = "and"
 
     def newInstance(t1: TimeSeriesExpr, t2: TimeSeriesExpr): TimeSeriesExpr = {
@@ -487,7 +487,7 @@ object MathVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object Or extends BinaryWord {
+  case object Or extends BinaryWord {
     override def name: String = "or"
 
     def newInstance(t1: TimeSeriesExpr, t2: TimeSeriesExpr): TimeSeriesExpr = {
@@ -523,7 +523,7 @@ object MathVocabulary extends Vocabulary {
       "name,sps,:eq,:max,(,nf.cluster,),:by")
   }
 
-  object Sum extends AggrWord {
+  case object Sum extends AggrWord {
     override def name: String = "sum"
 
     def newInstance(t: TimeSeriesExpr): TimeSeriesExpr = MathExpr.Sum(t)
@@ -534,7 +534,7 @@ object MathVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object Count extends AggrWord {
+  case object Count extends AggrWord {
     override def name: String = "count"
 
     def newInstance(t: TimeSeriesExpr): TimeSeriesExpr = MathExpr.Count(t)
@@ -545,7 +545,7 @@ object MathVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object Min extends AggrWord {
+  case object Min extends AggrWord {
     override def name: String = "min"
 
     def newInstance(t: TimeSeriesExpr): TimeSeriesExpr = MathExpr.Min(t)
@@ -556,7 +556,7 @@ object MathVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object Max extends AggrWord {
+  case object Max extends AggrWord {
     override def name: String = "max"
 
     def newInstance(t: TimeSeriesExpr): TimeSeriesExpr = MathExpr.Max(t)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/QueryVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/QueryVocabulary.scala
@@ -46,7 +46,7 @@ object QueryVocabulary extends Vocabulary {
     Not
   )
 
-  object True extends SimpleWord {
+  case object True extends SimpleWord {
     override def name: String = "true"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = { case _ => true }
@@ -65,7 +65,7 @@ object QueryVocabulary extends Vocabulary {
     override def examples: List[String] = List("")
   }
 
-  object False extends SimpleWord {
+  case object False extends SimpleWord {
     override def name: String = "false"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = { case _ => true }
@@ -84,7 +84,7 @@ object QueryVocabulary extends Vocabulary {
     override def examples: List[String] = List("")
   }
 
-  object HasKey extends SimpleWord {
+  case object HasKey extends SimpleWord {
     override def name: String = "has"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -124,7 +124,7 @@ object QueryVocabulary extends Vocabulary {
       "ERROR:name")
   }
 
-  object Equal extends KeyValueWord {
+  case object Equal extends KeyValueWord {
     override def name: String = "eq"
 
     def newInstance(k: String, v: String): Query = Query.Equal(k, v)
@@ -135,7 +135,7 @@ object QueryVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object LessThan extends KeyValueWord {
+  case object LessThan extends KeyValueWord {
     override def name: String = "lt"
 
     def newInstance(k: String, v: String): Query = Query.LessThan(k, v)
@@ -146,7 +146,7 @@ object QueryVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object LessThanEqual extends KeyValueWord {
+  case object LessThanEqual extends KeyValueWord {
     override def name: String = "le"
 
     def newInstance(k: String, v: String): Query = Query.LessThanEqual(k, v)
@@ -157,7 +157,7 @@ object QueryVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object GreaterThan extends KeyValueWord {
+  case object GreaterThan extends KeyValueWord {
     override def name: String = "gt"
 
     def newInstance(k: String, v: String): Query = Query.GreaterThan(k, v)
@@ -168,7 +168,7 @@ object QueryVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object GreaterThanEqual extends KeyValueWord {
+  case object GreaterThanEqual extends KeyValueWord {
     override def name: String = "ge"
 
     def newInstance(k: String, v: String): Query = Query.GreaterThanEqual(k, v)
@@ -179,7 +179,7 @@ object QueryVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  object Regex extends KeyValueWord {
+  case object Regex extends KeyValueWord {
     override def name: String = "re"
 
     def newInstance(k: String, v: String): Query = Query.Regex(k, v)
@@ -198,7 +198,7 @@ object QueryVocabulary extends Vocabulary {
       "ERROR:name")
   }
 
-  object RegexIgnoreCase extends KeyValueWord {
+  case object RegexIgnoreCase extends KeyValueWord {
     override def name: String = "reic"
 
     def newInstance(k: String, v: String): Query = Query.RegexIgnoreCase(k, v)
@@ -217,7 +217,7 @@ object QueryVocabulary extends Vocabulary {
       "ERROR:name")
   }
 
-  object In extends SimpleWord {
+  case object In extends SimpleWord {
     override def name: String = "in"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -244,7 +244,7 @@ object QueryVocabulary extends Vocabulary {
       "ERROR:name,sps")
   }
 
-  object And extends SimpleWord {
+  case object And extends SimpleWord {
     override def name: String = "and"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -270,7 +270,7 @@ object QueryVocabulary extends Vocabulary {
       List(":false,:false", ":false,:true", ":true,:false", ":true,:true")
   }
 
-  object Or extends SimpleWord {
+  case object Or extends SimpleWord {
     override def name: String = "or"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -296,7 +296,7 @@ object QueryVocabulary extends Vocabulary {
       List(":false,:false", ":false,:true", ":true,:false", ":true,:true")
   }
 
-  object Not extends SimpleWord {
+  case object Not extends SimpleWord {
     override def name: String = "not"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
@@ -40,7 +40,7 @@ object StatefulVocabulary extends Vocabulary {
     Macro("des-epic-signal", desEpicSignal, List("name,sps,:eq,:sum,10,0.1,0.5,0.2,0.2,4"))
   )
 
-  object RollingCount extends SimpleWord {
+  case object RollingCount extends SimpleWord {
     override def name: String = "rolling-count"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -61,7 +61,7 @@ object StatefulVocabulary extends Vocabulary {
     override def examples: List[String] = List(":random,0.4,:gt,5")
   }
 
-  object Des extends SimpleWord {
+  case object Des extends SimpleWord {
     override def name: String = "des"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -84,7 +84,7 @@ object StatefulVocabulary extends Vocabulary {
     override def examples: List[String] = List("name,requestsPerSecond,:eq,:sum,5,0.1,0.5")
   }
 
-  object Trend extends SimpleWord {
+  case object Trend extends SimpleWord {
     override def name: String = "trend"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -107,7 +107,7 @@ object StatefulVocabulary extends Vocabulary {
     override def examples: List[String] = List(":random,PT5M", ":random,20m")
   }
 
-  object Integral extends SimpleWord {
+  case object Integral extends SimpleWord {
     override def name: String = "integral"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -131,7 +131,7 @@ object StatefulVocabulary extends Vocabulary {
       "name,requestsPerSecond,:eq,:sum,:per-step")
   }
 
-  object Derivative extends SimpleWord {
+  case object Derivative extends SimpleWord {
     override def name: String = "derivative"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
@@ -123,6 +123,22 @@ case class Interpreter(vocabulary: List[Word]) {
     debug(program, Context(this, Nil, Map.empty))
   }
 
+  /**
+   * Return a list of all words in the vocabulary for this interpreter that match the provided
+   * stack.
+   */
+  final def candidates(stack: List[Any]): List[Word] = {
+    vocabulary.filter(_.matches(stack))
+  }
+
+  /**
+   * Return a list of overloaded variants that match. The first word in the list is what would
+   * get used when executing.
+   */
+  final def candidates(name: String, stack: List[Any]): List[Word] = {
+    words(name).filter(_.matches(stack))
+  }
+
   override def toString: String = s"Interpreter(${vocabulary.size} words)"
 }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/StandardVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/StandardVocabulary.scala
@@ -71,7 +71,7 @@ object StandardVocabulary extends Vocabulary {
   }
 
   /** Pop a list off the stack and execute it as a program. */
-  object Call extends Word {
+  case object Call extends Word {
     override def name: String = "call"
 
     override def matches(stack: List[Any]): Boolean = stack match {
@@ -98,7 +98,7 @@ object StandardVocabulary extends Vocabulary {
   }
 
   /** Remove all items from the stack. */
-  object Clear extends SimpleWord {
+  case object Clear extends SimpleWord {
     override def name: String = "clear"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = { case _ => true }
@@ -116,7 +116,7 @@ object StandardVocabulary extends Vocabulary {
   }
 
   /** Compute the depth of the stack. */
-  object Depth extends SimpleWord {
+  case object Depth extends SimpleWord {
     override def name: String = "depth"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = { case _ => true }
@@ -139,7 +139,7 @@ object StandardVocabulary extends Vocabulary {
   }
 
   /** Remove the item on the top of the stack. */
-  object Drop extends SimpleWord {
+  case object Drop extends SimpleWord {
     override def name: String = "drop"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = { case vs => vs.nonEmpty }
@@ -159,7 +159,7 @@ object StandardVocabulary extends Vocabulary {
   }
 
   /** Duplicate the item on the top of the stack. */
-  object Dup extends SimpleWord {
+  case object Dup extends SimpleWord {
     override def name: String = "dup"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = { case vs => vs.nonEmpty }
@@ -179,7 +179,7 @@ object StandardVocabulary extends Vocabulary {
   }
 
   /** For each item in a list push it on the stack and apply a function. */
-  object Each extends Word {
+  case object Each extends Word {
     override def name: String = "each"
 
     override def matches(stack: List[Any]): Boolean = stack match {
@@ -208,7 +208,7 @@ object StandardVocabulary extends Vocabulary {
   }
 
   /** Format a string. */
-  object Format extends SimpleWord {
+  case object Format extends SimpleWord {
     override def name: String = "format"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -231,7 +231,7 @@ object StandardVocabulary extends Vocabulary {
   }
 
   /** Get the value of a variable and push it on the stack. */
-  object Get extends Word {
+  case object Get extends Word {
     override def name: String = "get"
 
     override def matches(stack: List[Any]): Boolean = stack match {
@@ -257,7 +257,7 @@ object StandardVocabulary extends Vocabulary {
   }
 
   /** Pick an item in the stack and put a copy on the top. */
-  object Pick extends SimpleWord {
+  case object Pick extends SimpleWord {
     override def name: String = "pick"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -279,7 +279,7 @@ object StandardVocabulary extends Vocabulary {
   }
 
   /** Create a new list by applying a function to all elements of a list. */
-  object Map extends Word {
+  case object Map extends Word {
     override def name: String = "map"
 
     override def matches(stack: List[Any]): Boolean = stack match {
@@ -311,7 +311,7 @@ object StandardVocabulary extends Vocabulary {
   }
 
   /** Drop the top N items from the stack. */
-  object NDrop extends SimpleWord {
+  case object NDrop extends SimpleWord {
     override def name: String = "ndrop"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -333,7 +333,7 @@ object StandardVocabulary extends Vocabulary {
   }
 
   /** Create a list with the top N items from the stack. */
-  object NList extends SimpleWord {
+  case object NList extends SimpleWord {
     override def name: String = "nlist"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -355,7 +355,7 @@ object StandardVocabulary extends Vocabulary {
   }
 
   /** Copy the item in the second position on the stack to the top. */
-  object Over extends SimpleWord {
+  case object Over extends SimpleWord {
     override def name: String = "over"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -377,7 +377,7 @@ object StandardVocabulary extends Vocabulary {
   }
 
   /** Rotate an item in the stack and put it on the top. */
-  object Roll extends SimpleWord {
+  case object Roll extends SimpleWord {
     override def name: String = "roll"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -400,7 +400,7 @@ object StandardVocabulary extends Vocabulary {
   }
 
   /** Rotate the stack so that the item at the bottom is now at the top. */
-  object Rot extends SimpleWord {
+  case object Rot extends SimpleWord {
     override def name: String = "rot"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = { case vs => vs.nonEmpty }
@@ -420,7 +420,7 @@ object StandardVocabulary extends Vocabulary {
   }
 
   /** Rotate the stack so that the item at the top is now at the bottom. */
-  object ReverseRot extends SimpleWord {
+  case object ReverseRot extends SimpleWord {
     override def name: String = "-rot"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = { case vs => vs.nonEmpty }
@@ -440,7 +440,7 @@ object StandardVocabulary extends Vocabulary {
   }
 
   /** Set the value of a variable. */
-  object Set extends Word {
+  case object Set extends Word {
     override def name: String = "set"
 
     override def matches(stack: List[Any]): Boolean = stack match {
@@ -467,7 +467,7 @@ object StandardVocabulary extends Vocabulary {
   }
 
   /** Swap the top two items on the stack. */
-  object Swap extends SimpleWord {
+  case object Swap extends SimpleWord {
     override def name: String = "swap"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
@@ -489,7 +489,7 @@ object StandardVocabulary extends Vocabulary {
   }
 
   /** Pop all items off the stack and push them as a list. */
-  object ToList extends Word {
+  case object ToList extends Word {
     override def name: String = "list"
 
     override def matches(stack: List[Any]): Boolean = true

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Vocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Vocabulary.scala
@@ -27,6 +27,9 @@ trait Vocabulary {
 
   def words: List[Word]
 
+  /** Return a flattened list of all dependency vocabularies. */
+  def dependencies: List[Vocabulary] = dependsOn.flatMap(d => d :: d.dependencies)
+
   /**
    * Return a flattened list of all words from this vocabulary plus words from all dependencies.
    */

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/VocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/VocabularySuite.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import org.scalatest.FunSuite
+
+class VocabularySuite extends FunSuite {
+
+  for (vocab <- StyleVocabulary :: StyleVocabulary.dependencies; w <- vocab.words) {
+    test(s"${vocab.name}: ${w.name} == self") {
+      assert(w === w)
+    }
+  }
+}
+

--- a/atlas-wiki/src/main/resources/stacklang/Stack-Language-Reference.md
+++ b/atlas-wiki/src/main/resources/stacklang/Stack-Language-Reference.md
@@ -1,2 +1,16 @@
 
 Reference for operations available in the stack language. Use the sidebar to navigate.
+
+```wiki.script
+import com.netflix.atlas.wiki._
+val w2v = (vocab :: vocab.dependencies).flatMap(v => v.words.map(_ -> v.name)).toMap
+val words = vocab.allWords.groupBy(_.name)
+val sections = words.toList.sortWith(_._1 < _._1).map { case (name, ws) =>
+  val items = ws.map { w =>
+    val vocabName = w2v(w)
+    s"* [${w.signature}]($vocabName-${Utils.fileName(name)})"
+  }
+  s"#### $name\n\n${items.mkString("\n")}\n"
+}
+sections.mkString("\n")
+```

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Main.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Main.scala
@@ -33,6 +33,7 @@ import com.netflix.atlas.core.model.StyleVocabulary
 import com.netflix.atlas.core.model.TimeSeriesExpr
 import com.netflix.atlas.core.stacklang.Interpreter
 import com.netflix.atlas.core.stacklang.StandardVocabulary
+import com.netflix.atlas.core.stacklang.Vocabulary
 import com.netflix.atlas.core.stacklang.Word
 import com.netflix.atlas.core.util.Streams._
 import com.netflix.atlas.webapi.ApiSettings
@@ -89,8 +90,10 @@ object Main extends StrictLogging {
 
   private def eval(lines: List[String], dir: File): List[String] = {
     engine.createBindings().put("graphObj", new GraphHelper(webApi, dir, "gen-images"))
+    engine.createBindings().put("vocabObj", StyleVocabulary)
     val script = s"""
       val graph = graphObj.asInstanceOf[${classOf[GraphHelper].getName}]
+      val vocab = vocabObj.asInstanceOf[${classOf[Vocabulary].getName}]
       ${lines.mkString("", "\n", "\n")}
       """
     val result = engine.eval(script)
@@ -245,9 +248,7 @@ object Main extends StrictLogging {
     vocabs.foreach { vocab =>
       sidebar.append(s"\n**${vocab.name}**\n")
       vocab.words.foreach { w =>
-        // Using unicode hyphen is a hack to get around:
-        // https://github.com/github/markup/issues/345
-        val fname = s"${vocab.name}-${w.name.replace('-', '\u2010')}"
+        val fname = s"${vocab.name}-${Utils.fileName(w.name)}"
         sidebar.append(s"* [${w.name}]($fname)\n")
         val f = new File(dir, s"$fname.md")
         writeFile(renderWord(w, graph), f)

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Utils.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Utils.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.wiki
+
+object Utils {
+  // Using unicode hyphen is a hack to get around:
+  // https://github.com/github/markup/issues/345
+  def fileName(name: String) = name.replace('-', '\u2010')
+}


### PR DESCRIPTION
Updates the word links for graph expressions to point
to the actual page. See [examples](https://github.com/Netflix/atlas/wiki/Single-Line).
The make it easier to generate a link with just the name
the [reference page](https://github.com/Netflix/atlas/wiki/Stack-Language-Reference)
was updated with an alphabetical list showing the variants.

Not addressed in this PR, but updating the jmh plugin to
0.1.15 breaks the publish-wiki task in the makefile. The
first problem is the working directory changes to be the
atlas-wiki project dir. Fixing that leads to strange exception
when trying to run:

```
info] [init] error: error while loading Object, Missing dependency 'object scala in compiler mirror', required by /Library/Java/JavaVirtualMachines/jdk1.8.0_25.jdk/Contents/Home/jre/lib/rt.jar(java/lang/Object.class)
[info]
[info] Failed to initialize compiler: object scala in compiler mirror not found.
[info] ** Note that as of 2.8 scala does not assume use of the java classpath.
[info] ** For the old behavior pass -usejavacp to scala, or if using a Settings
[info] ** object programmatically, settings.usejavacp.value = true.
[error] Exception in thread "main" scala.reflect.internal.MissingRequirementError: object scala in compiler mirror not found.
[error] 	at scala.reflect.internal.MissingRequirementError$.signal(MissingRequirementError.scala:17)
[error] 	at scala.reflect.internal.MissingRequirementError$.notFound(MissingRequirementError.scala:18)
[error] 	at scala.reflect.internal.Mirrors$RootsBase.getModuleOrClass(Mirrors.scala:53)
[error] 	at scala.reflect.internal.Mirrors$RootsBase.getModuleOrClass(Mirrors.scala:66)
[error] 	at scala.reflect.internal.Mirrors$RootsBase.getPackage(Mirrors.scala:173)
[error] 	at scala.reflect.internal.Definitions$DefinitionsClass.ScalaPackage$lzycompute(Definitions.scala:161)
[error] 	at scala.reflect.internal.Definitions$DefinitionsClass.ScalaPackage(Definitions.scala:161)
[error] 	at scala.reflect.internal.Definitions$DefinitionsClass.ScalaPackageClass$lzycompute(Definitions.scala:162)
[error] 	at scala.reflect.internal.Definitions$DefinitionsClass.ScalaPackageClass(Definitions.scala:162)
[error] 	at scala.reflect.internal.Definitions$DefinitionsClass.init(Definitions.scala:1392)
[error] 	at scala.tools.nsc.Global$Run.<init>(Global.scala:1216)
[error] 	at scala.tools.nsc.interpreter.IMain.compileSourcesKeepingRun(IMain.scala:422)
[error] 	at scala.tools.nsc.interpreter.IMain$ReadEvalPrint.compileAndSaveRun(IMain.scala:841)
[error] 	at scala.tools.nsc.interpreter.IMain$ReadEvalPrint.compile(IMain.scala:800)
[error] 	at scala.tools.nsc.interpreter.IMain.bind(IMain.scala:664)
[error] 	at scala.tools.nsc.interpreter.IMain.bind(IMain.scala:701)
[error] 	at scala.tools.nsc.interpreter.IMain$$anon$2.put(IMain.scala:1035)
[error] 	at com.netflix.atlas.wiki.Main$.eval(Main.scala:91)
[error] 	at com.netflix.atlas.wiki.Main$.process(Main.scala:106)
[error] 	at com.netflix.atlas.wiki.Main$.com$netflix$atlas$wiki$Main$$processTemplate(Main.scala:121)
[error] 	at com.netflix.atlas.wiki.Main$$anonfun$com$netflix$atlas$wiki$Main$$copy$2.apply(Main.scala:159)
[error] 	at com.netflix.atlas.wiki.Main$$anonfun$com$netflix$atlas$wiki$Main$$copy$2.apply(Main.scala:157)
[error] 	at scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
[error] 	at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
[error] 	at com.netflix.atlas.wiki.Main$.com$netflix$atlas$wiki$Main$$copy(Main.scala:157)
[error] 	at com.netflix.atlas.wiki.Main$.main(Main.scala:272)
[error] 	at com.netflix.atlas.wiki.Main.main(Main.scala)
java.lang.RuntimeException: Nonzero exit code returned from runner: 1
	at scala.sys.package$.error(package.scala:27)
```