### PR TITLE
ensure server shutsdown on bind failure

### DIFF
--- a/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/Main.scala
+++ b/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/Main.scala
@@ -88,8 +88,14 @@ object Main extends StrictLogging {
     val modules = new java.util.ArrayList[Module]()
     modules.add(overrides)
 
-    val gov = new Governator
-    gov.start(modules)
-    gov.addShutdownHook()
+    try {
+      val gov = new Governator
+      gov.start(modules)
+      gov.addShutdownHook()
+    } catch {
+      case t: Throwable =>
+        logger.error("server failed to start, shutting down", t)
+        System.exit(1)
+    }
   }
 }


### PR DESCRIPTION
When there was a bind failure the process would stay
up in a bad state. This change blocks on the service
start to ensure better integration with eureka status
and exits if there is a failure with the guice
initialization. The bouncing process can then easily
be tracked with the process restart counter in the
daemontools run script.

Tested bind failure with address already in use:

```
$ /usr/bin/nc -6 -v -l ::0 7101
```