### PR TITLE
fix #107, use ssh for publish-wiki

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ license:
 
 $(WIKI_OUTPUT_DIR):
 	mkdir -p target
-	git clone https://github.com/Netflix/atlas.wiki.git $(WIKI_OUTPUT_DIR)
+	git clone git@github.com:Netflix/atlas.wiki.git $(WIKI_OUTPUT_DIR)
 
 update-wiki: $(WIKI_OUTPUT_DIR)
 	cd $(WIKI_OUTPUT_DIR) && git rm -rf *


### PR DESCRIPTION
Use ssh for publish-wiki task to make it easier with
2FA enabled.