### PR TITLE
require query step is >= db step

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
@@ -131,81 +131,54 @@ class MemoryDatabase(config: Config) extends Database {
   }
 
   private def executeImpl(context: EvalContext, expr: DataExpr): List[TimeSeries] = {
-    val query = TagQuery(Some(expr.query))
+    val cfStep = context.step
+    require(cfStep >= step, "step for query must be >= step for the database")
+    require(cfStep % step == 0, "consolidated step must be multiple of db step")
 
+    val query = TagQuery(Some(expr.query))
     val aggr = blockAggr(expr)
     val collector = AggregateCollector(expr)
 
-    val cfStep = context.step
-    if (cfStep >= step) {
-      require(cfStep % step == 0, "consolidated step must be multiple of db step")
+    val end = context.end
+    val multiple = (cfStep / step).asInstanceOf[Int]
+    val s = context.start / cfStep
+    val e = end / cfStep
+    val bs = s * multiple
+    val be = e * multiple
 
-      val end = context.end
-      val multiple = (cfStep / step).asInstanceOf[Int]
-      val s = context.start / cfStep
-      val e = end / cfStep
-      val bs = s * multiple
-      val be = e * multiple
+    val stepLength = be - bs + 1
+    val cfStepLength = stepLength / multiple
+    val bufStart = bs * step
+    val bufEnd = bufStart + cfStepLength * cfStep - cfStep
 
-      val stepLength = be - bs + 1
-      val cfStepLength = stepLength / multiple
-      val bufStart = bs * step
-      val bufEnd = bufStart + cfStepLength * cfStep - cfStep
+    def newBuffer(tags: Map[String, String]): TimeSeriesBuffer = {
+      TimeSeriesBuffer(tags, cfStep, bufStart, bufEnd)
+    }
 
-      def newBuffer(tags: Map[String, String]): TimeSeriesBuffer = {
-        TimeSeriesBuffer(tags, cfStep, bufStart, bufEnd)
-      }
-
-      index.findItems(query).foreach { item =>
-        item.blocks.blockList.foreach { b =>
-          queryBlocks.increment()
-          // Check if the block has data for the desired time range
-          val blockEnd = b.start + (b.size + 1) * step
-          if (b.start <= be * step && blockEnd >= bs * step) {
-            aggrBlocks.increment()
-            collector.add(item.tags, List(b), aggr, expr.cf, multiple, newBuffer)
-          }
+    index.findItems(query).foreach { item =>
+      item.blocks.blockList.foreach { b =>
+        queryBlocks.increment()
+        // Check if the block has data for the desired time range
+        val blockEnd = b.start + (b.size + 1) * step
+        if (b.start <= be * step && blockEnd >= bs * step) {
+          aggrBlocks.increment()
+          collector.add(item.tags, List(b), aggr, expr.cf, multiple, newBuffer)
         }
       }
+    }
 
-      val stats = collector.stats
-      queryMetrics.increment(stats.inputLines)
-      queryLines.increment(stats.outputLines)
-      queryInputDatapoints.increment(stats.inputDatapoints)
-      queryOutputDatapoints.increment(stats.outputDatapoints)
+    val stats = collector.stats
+    queryMetrics.increment(stats.inputLines)
+    queryLines.increment(stats.outputLines)
+    queryInputDatapoints.increment(stats.inputDatapoints)
+    queryOutputDatapoints.increment(stats.outputDatapoints)
 
-      expr.eval(context, collector.result).data
-    } else {
-      require(step % cfStep == 0, "db step must be multiple of consolidated step")
-
-      val end = context.end
-      val multiple = (step / cfStep).asInstanceOf[Int]
-      val s = context.start / step
-      val e = end / step
-
-      def newBuffer(tags: Map[String, String]): TimeSeriesBuffer = {
-        TimeSeriesBuffer(tags, step, s * step, e * step)
-      }
-
-      index.findItems(query).foreach { item =>
-        item.blocks.blockList.foreach { b =>
-          queryBlocks.increment()
-          // Check if the block has data for the desired time range
-          val blockEnd = b.start + (b.size + 1) * step
-          if (b.start <= s * step && blockEnd >= e * step) {
-            aggrBlocks.increment()
-            collector.add(item.tags, List(b), aggr, expr.cf, multiple, newBuffer)
-          }
-        }
-      }
-
-      val stats = collector.stats
-      queryMetrics.increment(stats.inputLines)
-      queryLines.increment(stats.outputLines)
-      queryInputDatapoints.increment(stats.inputDatapoints)
-      queryOutputDatapoints.increment(stats.outputDatapoints)
-
-      expr.eval(context, collector.result).data
+    val vs = collector.result
+      .map { t => DataExpr.withDefaultLabel(expr, t) }
+      .sortWith { _.label < _.label }
+    expr match {
+      case DataExpr.Head(_, n) => vs.take(n)
+      case _                   => vs
     }
   }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
@@ -56,6 +56,16 @@ sealed trait DataExpr extends TimeSeriesExpr {
 }
 
 object DataExpr {
+
+  def withDefaultLabel(expr: DataExpr, ts: TimeSeries): TimeSeries = {
+    expr match {
+      case af: AggregateFunction => ts.withLabel(af.labelString)
+      case by: GroupBy           => ts.withLabel(s"(${by.keyString(ts.tags).trim})")
+      case Head(df, _)           => withDefaultLabel(df, ts)
+      case _                     => ts.withLabel(TimeSeries.toLabel(ts.tags))
+    }
+  }
+
   case class All(query: Query, offset: Duration = Duration.ZERO) extends DataExpr {
     def cf: ConsolidationFunction = ConsolidationFunction.Sum
     override def withOffset(d: Duration): All = copy(offset = d)
@@ -68,6 +78,7 @@ object DataExpr {
   }
 
   sealed trait AggregateFunction extends DataExpr with BinaryOp {
+    def labelString: String
 
     def withConsolidation(f: ConsolidationFunction): AggregateFunction
 
@@ -98,6 +109,8 @@ object DataExpr {
 
     override def withOffset(d: Duration): Sum = copy(offset = d)
 
+    def labelString: String = s"sum(${query.labelString})"
+
     override def exprString: String = {
       if (cf == ConsolidationFunction.Avg) s"$query,:sum" else s"$query,:sum,$cf"
     }
@@ -126,6 +139,8 @@ object DataExpr {
 
     override def withOffset(d: Duration): Count = copy(offset = d)
 
+    def labelString: String = s"count(${query.labelString})"
+
     override def exprString: String = {
       if (cf == ConsolidationFunction.Avg) s"$query,:count" else s"$query,:count,$cf"
     }
@@ -141,7 +156,11 @@ object DataExpr {
     }
 
     override def withOffset(d: Duration): Min = copy(offset = d)
+
+    def labelString: String = s"min(${query.labelString})"
+
     override def exprString: String = s"$query,:min"
+
     def apply(v1: Double, v2: Double): Double = Math.minNaN(v1, v2)
   }
 
@@ -153,7 +172,11 @@ object DataExpr {
     }
 
     override def withOffset(d: Duration): Max = copy(offset = d)
+
+    def labelString: String = s"max(${query.labelString})"
+
     override def exprString: String = s"$query,:max"
+
     def apply(v1: Double, v2: Double): Double = Math.maxNaN(v1, v2)
   }
 
@@ -174,6 +197,8 @@ object DataExpr {
     override def withOffset(d: Duration): Consolidation = {
       Consolidation(af.withOffset(d).asInstanceOf[AggregateFunction], cf)
     }
+
+    def labelString: String = af.labelString
 
     override def exprString: String = s"$af,$cf"
     def apply(v1: Double, v2: Double): Double = af(v1, v2)

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.db
+
+import com.netflix.atlas.core.model._
+import com.netflix.atlas.core.stacklang.Interpreter
+import com.typesafe.config.ConfigFactory
+import org.scalatest.FunSuite
+
+class MemoryDatabaseSuite extends FunSuite {
+
+  private val interpreter = new Interpreter(DataVocabulary.allWords)
+
+  private val step = DefaultSettings.stepSize
+
+  private val db = new MemoryDatabase(ConfigFactory.parseString(
+    """
+      |block-size = 60
+      |num-blocks = 2
+      |rebuild-frequency = 10s
+      |test-mode = true
+    """.stripMargin))
+
+  addData("a", 1.0, 2.0, 3.0)
+  addData("b", 3.0, 2.0, 1.0)
+
+  private val context = EvalContext(0, 3 * step, step)
+
+  private def addData(name: String, values: Double*): Unit = {
+    val tags = Map("name" -> name)
+    val data = values.toList.zipWithIndex.map { case (v, i) =>
+      Datapoint(tags, i * step, v)
+    }
+    db.update(data)
+    db.index.rebuildIndex()
+  }
+
+  private def expr(str: String): DataExpr = {
+    interpreter.execute(str).stack match {
+      case ModelExtractors.DataExprType(v) :: Nil => v
+      case _ => throw new IllegalArgumentException(s"invalid data expr: $str")
+    }
+  }
+
+  private def exec(str: String, s: Long = step): List[TimeSeries] = {
+    val ctxt = context.copy(step = s)
+    db.execute(ctxt, expr(str)).sortWith(_.label < _.label).map { t =>
+      t.mapTimeSeq(s => s.bounded(context.start, context.end))
+    }
+  }
+
+  private def ts(label: String, mul: Int, values: Double*): TimeSeries = {
+    TimeSeries(Map.empty, label, new ArrayTimeSeq(DsType.Gauge, 0L, mul * step, values.toArray))
+  }
+
+  private def ts(name: String, label: String, mul: Int, values: Double*): TimeSeries = {
+    val seq = new ArrayTimeSeq(DsType.Gauge, 0L, mul * step, values.toArray)
+    TimeSeries(Map("name" -> name), label, seq)
+  }
+
+  test(":eq query") {
+    assert(exec("name,a,:eq") === List(ts("a", "sum(name=a)", 1, 1.0, 2.0, 3.0)))
+  }
+
+  test(":in query") {
+    assert(exec("name,(,a,b,),:in") === List(ts("sum(name in (a,b))", 1, 4.0, 4.0, 4.0)))
+  }
+
+  test(":sum expr") {
+    assert(exec(":true,:sum") === List(ts("sum(true)", 1, 4.0, 4.0, 4.0)))
+  }
+
+  test(":count expr") {
+    assert(exec(":true,:count") === List(ts("count(true)", 1, 2.0, 2.0, 2.0)))
+  }
+
+  test(":min expr") {
+    assert(exec(":true,:min") === List(ts("min(true)", 1, 1.0, 2.0, 1.0)))
+  }
+
+  test(":max expr") {
+    assert(exec(":true,:max") === List(ts("max(true)", 1, 3.0, 2.0, 3.0)))
+  }
+
+  test(":by expr") {
+    val expected = List(
+      ts("a", "(name=a)", 1, 1.0, 2.0, 3.0),
+      ts("b", "(name=b)", 1, 3.0, 2.0, 1.0)
+    )
+    assert(exec(":true,(,name,),:by") === expected)
+  }
+
+  test(":all expr") {
+    val expected = List(
+      ts("a", "name=a", 1, 1.0, 2.0, 3.0),
+      ts("b", "name=b", 1, 3.0, 2.0, 1.0)
+    )
+    assert(exec(":true,:all") === expected)
+  }
+
+  test(":by,1,:head expr") {
+    val expected = List(
+      ts("a", "(name=a)", 1, 1.0, 2.0, 3.0)
+    )
+    assert(exec(":true,(,name,),:by,1,:head") === expected)
+  }
+
+  test(":by,2,:head expr") {
+    val expected = List(
+      ts("a", "(name=a)", 1, 1.0, 2.0, 3.0),
+      ts("b", "(name=b)", 1, 3.0, 2.0, 1.0)
+    )
+    assert(exec(":true,(,name,),:by,2,:head") === expected)
+  }
+
+  test(":by,3,:head expr") {
+    val expected = List(
+      ts("a", "(name=a)", 1, 1.0, 2.0, 3.0),
+      ts("b", "(name=b)", 1, 3.0, 2.0, 1.0)
+    )
+    assert(exec(":true,(,name,),:by,3,:head") === expected)
+  }
+
+  test(":sum expr, c=3") {
+    assert(exec(":true,:sum", 3 * step) === List(ts("sum(true)", 3, 4.0)))
+  }
+
+  test(":sum expr, c=3, cf=sum") {
+    assert(exec(":true,:sum,:cf-sum", 3 * step) === List(ts("sum(true)", 3, 12.0)))
+  }
+
+  test(":sum expr, c=3, cf=max") {
+    assert(exec(":true,:sum,:cf-max", 3 * step) === List(ts("sum(true)", 3, 6.0)))
+  }
+
+  test(":count expr, c=3") {
+    assert(exec(":true,:count", 3 * step) === List(ts("count(true)", 3, 2.0)))
+  }
+
+  test(":count expr, c=3, cf=sum") {
+    assert(exec(":true,:count,:cf-sum", 3 * step) === List(ts("count(true)", 3, 6.0)))
+  }
+
+  test(":count expr, c=3, cf=max") {
+    assert(exec(":true,:count,:cf-max", 3 * step) === List(ts("count(true)", 3, 2.0)))
+  }
+
+  test(":min expr, c=3") {
+    assert(exec(":true,:min", 3 * step) === List(ts("min(true)", 3, 1.0)))
+  }
+
+  test(":max expr, c=3") {
+    assert(exec(":true,:max", 3 * step) === List(ts("max(true)", 3, 3.0)))
+  }
+
+  test(":by expr, c=3") {
+    val expected = List(
+      ts("a", "(name=a)", 3, 2.0),
+      ts("b", "(name=b)", 3, 2.0)
+    )
+    assert(exec(":true,(,name,),:by", 3 * step) === expected)
+  }
+
+  test(":all expr, c=3") {
+    val expected = List(
+      ts("a", "name=a", 3, 6.0),
+      ts("b", "name=b", 3, 6.0)
+    )
+    assert(exec(":true,:all", 3 * step) === expected)
+  }
+}

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphRequestActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphRequestActor.scala
@@ -81,8 +81,6 @@ class GraphRequestActor extends Actor with ActorLogging {
   }
 
   private def sendImage(data: Map[DataExpr, List[TimeSeries]]): Unit = {
-    val ts = data.values.flatten
-
     val seriesList = request.exprs.flatMap { s =>
       val ts = s.expr.eval(request.evalContext, data).data
       val exprStr = s.expr.toString


### PR DESCRIPTION
In the past this wasn't always true, but we will now
handle this in the query aggregation layer.

This change also adds some additional test-cases to
boost confidence for refactoring/merging a few more
internal components.

The tag generated labels don't wind up being empty
very often in practice, but it does happen. For
aggregates this change also defaults to just using
an expression summary on the labels. Bigger win will
be if we can finally stop aggregating tag maps. Looks
like that still breaks a few uses, but may be able
to clean up in one of the upcoming deprecation cycles.