### PR TITLE
missing offset on default label

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
@@ -79,6 +79,18 @@ class MemoryDatabaseSuite extends FunSuite {
     assert(exec("name,(,a,b,),:in") === List(ts("sum(name in (a,b))", 1, 4.0, 4.0, 4.0)))
   }
 
+  test(":re query") {
+    assert(exec("name,[ab]$,:re") === List(ts("sum(name~/^[ab]$/)", 1, 4.0, 4.0, 4.0)))
+  }
+
+  test(":has query") {
+    assert(exec("name,:has") === List(ts("sum(has(name))", 1, 4.0, 4.0, 4.0)))
+  }
+
+  test(":offset expr") {
+    assert(exec(":true,:sum,1m,:offset") === List(ts("sum(true) (offset=1m)", 1, Double.NaN, 4.0, 4.0)))
+  }
+
   test(":sum expr") {
     assert(exec(":true,:sum") === List(ts("sum(true)", 1, 4.0, 4.0, 4.0)))
   }


### PR DESCRIPTION
Fixes a regression introduced in the previous
commit. The offset if non-zero should be included
in the default label.

Conflicts:
	atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
	atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala