### PR TITLE
api to debug/validate expressions

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
@@ -123,6 +123,10 @@ case class Interpreter(vocabulary: List[Word]) {
     debug(program, Context(this, Nil, Map.empty))
   }
 
+  final def debug(program: String): List[Step] = {
+    debug(program.trim.split("\\s*,\\s*").filter(_.nonEmpty).toList)
+  }
+
   /**
    * Return a list of all words in the vocabulary for this interpreter that match the provided
    * stack.

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.webapi
+
+import akka.actor.ActorRefFactory
+import com.netflix.atlas.akka.WebApi
+import com.netflix.atlas.core.model.Expr
+import com.netflix.atlas.core.stacklang.Interpreter
+import com.netflix.atlas.json.Json
+import spray.http.HttpEntity
+import spray.http.HttpResponse
+import spray.http.MediaTypes
+import spray.http.StatusCodes
+import spray.routing.RequestContext
+
+/**
+ * Generates a list of steps for executing an expression. This endpoint is typically used for
+ * validating or debugging an expression.
+ */
+class ExprApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi {
+
+  private val vocabulary = ApiSettings.graphVocabulary
+
+  private val vocabularies = {
+    vocabulary.dependencies.map(v => v.name -> v).toMap + (vocabulary.name -> vocabulary)
+  }
+
+  def routes: RequestContext => Unit = {
+    path("api" / "v1" / "expr") {
+      get { ctx =>
+        try processRequest(ctx) catch handleException(ctx)
+      }
+    }
+  }
+
+  private def newInterpreter(name: String): Interpreter = {
+    val vocab = vocabularies(name)
+    new Interpreter(vocab.allWords)
+  }
+
+  /**
+   * Currently the values just get converted to a string as the automatic json mapping doesn't
+   * provide enough context. Also, the formatter when laying out the expressions for the debug
+   * view works well enough for displaying the expr strings to the user. The output can be
+   * enhanced in a later version.
+   */
+  private def valueString(value: Any): String = value match {
+    case v: Expr => v.exprString
+    case v       => v.toString
+  }
+
+  private def processRequest(ctx: RequestContext): Unit = {
+    val query = ctx.request.uri.query.get("q").getOrElse {
+      throw new IllegalArgumentException("missing required parameter 'q'")
+    }
+
+    val vocabName = ctx.request.uri.query.getOrElse("vocab", vocabulary.name)
+
+    val interpreter = newInterpreter(vocabName)
+    val steps = interpreter.debug(query).map { step =>
+      val stack = step.context.stack.map(valueString)
+      val vars = step.context.variables.map(t => t._1 -> valueString(t._2))
+      val ctxt = Map("stack" -> stack, "variables" -> vars)
+      Map("program" -> step.program, "context" -> ctxt)
+    }
+
+    val data = Json.encode(steps)
+    val entity = HttpEntity(MediaTypes.`application/json`, data)
+    ctx.responder ! HttpResponse(StatusCodes.OK, entity = entity)
+  }
+}

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.webapi
+
+import com.netflix.atlas.json.Json
+import org.scalatest.FunSuite
+import spray.http.StatusCodes
+import spray.testkit.ScalatestRouteTest
+
+
+class ExprApiSuite extends FunSuite with ScalatestRouteTest {
+
+  import scala.concurrent.duration._
+
+  implicit val routeTestTimeout = RouteTestTimeout(5.second)
+
+  val endpoint = new ExprApi
+
+  def testGet(uri: String)(f: => Unit): Unit = {
+    test(uri) {
+      Get(uri) ~> endpoint.routes ~> check(f)
+    }
+  }
+
+  testGet("/api/v1/expr") {
+    assert(response.status === StatusCodes.BadRequest)
+  }
+
+  testGet("/api/v1/expr?q=name,sps,:eq") {
+    assert(response.status === StatusCodes.OK)
+    val data = Json.decode[List[ExprApiSuite.Output]](responseAs[String])
+    assert(data.size === 4)
+  }
+
+  testGet("/api/v1/expr?q=name,sps,:eq,:sum,$name,:legend&vocab=style") {
+    assert(response.status === StatusCodes.OK)
+    val data = Json.decode[List[ExprApiSuite.Output]](responseAs[String])
+    assert(data.size === 7)
+  }
+
+  testGet("/api/v1/expr?q=name,sps,:eq,:sum,$name,:legend,foo,:sset") {
+    assert(response.status === StatusCodes.OK)
+    val data = Json.decode[List[ExprApiSuite.Output]](responseAs[String])
+    assert(data.size === 9)
+    assert(data.last.context.variables("foo") == "name,sps,:eq,:sum,$name,:legend")
+  }
+
+  testGet("/api/v1/expr?q=name,sps,:eq,:sum,$name,:legend&vocab=query") {
+    assert(response.status === StatusCodes.BadRequest)
+  }
+
+}
+
+object ExprApiSuite {
+  case class Output(program: List[String], context: Context)
+  case class Context(stack: List[String], variables: Map[String, String])
+}


### PR DESCRIPTION
Moving in from internal extensions. For now the
values just get mapped to strings to avoid the
legacy codec classes.