### PR TITLE
use addNaN for integral

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
@@ -223,9 +223,9 @@ object StatefulExpr {
         val bounded = t.data.bounded(context.start, context.end)
         val length = bounded.data.length
         var i = 1
-        bounded.data(0) += state.getOrElse(t.id, 0.0)
+        bounded.data(0) = Math.addNaN(bounded.data(0), state.getOrElse(t.id, Double.NaN))
         while (i < length) {
-          bounded.data(i) += bounded.data(i - 1)
+          bounded.data(i) = Math.addNaN(bounded.data(i), bounded.data(i - 1))
           i += 1
         }
         state(t.id) = bounded.data(i - 1)
@@ -253,7 +253,7 @@ object StatefulExpr {
         val length = bounded.data.length
         var i = 1
         var prev = bounded.data(0)
-        bounded.data(0) -= state.getOrElse(t.id, 0.0)
+        bounded.data(0) -= state.getOrElse(t.id, Double.NaN)
         while (i < length) {
           val tmp = prev
           prev = bounded.data(i)

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/DerivativeSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/DerivativeSuite.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import org.scalatest.FunSuite
+
+class DerivativeSuite extends FunSuite {
+
+  private val start = 0L
+  private val step = 60000L
+
+  def ts(values: Double*): TimeSeries = {
+    val seq = new ArrayTimeSeq(DsType.Gauge, start, step, values.toArray)
+    TimeSeries(Map("name" -> "test"), seq)
+  }
+
+  def eval(input: TimeSeries, n: Int): TimeSeries = {
+    val context = EvalContext(start, start + step * n, step)
+    val expr = StatefulExpr.Derivative(DataExpr.Sum(Query.True))
+    expr.eval(context, List(input)).data.head
+  }
+
+  test("basic") {
+    val input = ts(7.0, 8.0, 9.0)
+    assert(eval(input, 3).data === ts(Double.NaN, 1.0, 1.0).data)
+  }
+
+  test("basic with same value and decreasing") {
+    val input = ts(7.0, 42.0, 42.0, 43.0, 2.0, 5.0)
+    assert(eval(input, 6).data === ts(Double.NaN, 35.0, 0.0, 1.0, -41.0, 3.0).data)
+  }
+
+  test("basic with NaN values") {
+    val input = ts(7.0, 42.0, Double.NaN, 43.0, 2.0, 5.0)
+    assert(eval(input, 6).data === ts(Double.NaN, 35.0, Double.NaN, Double.NaN, -41.0, 3.0).data)
+  }
+}
+

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/IntegralSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/IntegralSuite.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import org.scalatest.FunSuite
+
+class IntegralSuite extends FunSuite {
+
+  private val start = 0L
+  private val step = 60000L
+
+  def ts(values: Double*): TimeSeries = {
+    val seq = new ArrayTimeSeq(DsType.Gauge, start, step, values.toArray)
+    TimeSeries(Map("name" -> "test"), seq)
+  }
+
+  def eval(input: TimeSeries, n: Int): TimeSeries = {
+    val context = EvalContext(start, start + step * n, step)
+    val expr = StatefulExpr.Integral(DataExpr.Sum(Query.True))
+    expr.eval(context, List(input)).data.head
+  }
+
+  test("basic") {
+    val input = ts(1.0, 1.0, 1.0)
+    assert(eval(input, 3).data === ts(1.0, 2.0, 3.0).data)
+  }
+
+  test("basic with same value and decreasing") {
+    val input = ts(Double.NaN, 35.0, 0.0, 1.0, -41.0, 3.0)
+    assert(eval(input, 6).data === ts(Double.NaN, 35.0, 35.0, 36.0, -5.0, -2.0).data)
+  }
+
+  test("basic with NaN values") {
+    val input = ts(Double.NaN, 35.0, Double.NaN, Double.NaN, -41.0, 3.0)
+    assert(eval(input, 6).data === ts(Double.NaN, 35.0, 35.0, 35.0, -6.0, -3.0).data)
+  }
+}
+

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
@@ -87,7 +87,7 @@ class TimeSeriesExprSuite extends FunSuite {
     "1,:per-step"                 -> const(ts(Map("name" -> "1.0"), "per-step(1.0)", 60)),
     "1,:integral"                 -> const(integral(Map("name" -> "1.0"), "integral(1.0)", 1.0)),
     "minuteOfDay,:time,1,:add"    -> const(integral(Map("name" -> "minuteOfDay"), "(minuteOfDay + 1.0)", 1.0)),
-    "1,:integral,:derivative"     -> const(ts(Map("name" -> "1.0"), "derivative(integral(1.0))", 1.0)),
+    "1,:integral,:derivative"     -> const(integralDerivative),
     "8,:integral"                 -> const(integral(Map("name" -> "8.0"), "integral(8.0)", 8.0)),
     ":true,:integral"             -> const(integral(Map(constTag), "integral(type=constant)", 55.0)),
     //"1,PT5M,:trend"               -> const(ts(Map("name" -> "1.0"), "trend(1.0, PT5M)", 1.0)),
@@ -276,6 +276,11 @@ class TimeSeriesExprSuite extends FunSuite {
     // Assumes starting at time 0, for amount calculation
     val seq = new FunctionTimeSeq(DsType.Gauge, 60000, t => amount + amount * (t / 60000))
     TimeSeries(tags, label, seq)
+  }
+
+  def integralDerivative: TimeSeries = {
+    val seq = new FunctionTimeSeq(DsType.Gauge, 60000, t => if (t == 0L) Double.NaN else 1.0)
+    TimeSeries(Map("name" -> "1.0"), "derivative(integral(1.0))", seq)
   }
 
   def const(t: TimeSeries): Params = Params(constants, List(t))


### PR DESCRIPTION
For lines that started reporting in the middle of a
chart the integral would report NaN all the way through.
The NaN values will now get treated as 0 if an actual
value is encountered.