### PR TITLE
allow renderning hints to be setup in config

### DIFF
--- a/atlas-chart/src/main/resources/reference.conf
+++ b/atlas-chart/src/main/resources/reference.conf
@@ -1,0 +1,11 @@
+
+atlas {
+  chart {
+    // Allows arbitrary rendering hints to be set on the graphics object used for the chart.
+    // See the javadocs for more information on available options:
+    // http://docs.oracle.com/javase/7/docs/api/java/awt/RenderingHints.html
+    rendering-hints {
+      KEY_RENDERING = "VALUE_RENDER_SPEED"
+    }
+  }
+}


### PR DESCRIPTION
Adds a block in the chart config to allow for rendering hints
such as antialiasing to be specified.