### PR TITLE
fix warning about possible interpolation error

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleVocabulary.scala
@@ -112,7 +112,7 @@ object StyleVocabulary extends Vocabulary {
         |Set the legend text.
       """.stripMargin.trim
 
-    override def examples: List[String] = List("name,sps,:eq,:sum,(,name,),:by,$name")
+    override def examples: List[String] = List(s"name,sps,:eq,:sum,(,name,),:by,$$name")
   }
 
   case object Axis extends StyleWord {


### PR DESCRIPTION
```
[warn] ./atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleVocabulary.scala:115: possible missing interpolator: detected interpolated identifier `$name`
[warn]     override def examples: List[String] = List("name,sps,:eq,:sum,(,name,),:by,$name")
[warn]                                                ^
[warn] one warning found
```