### PR TITLE
allow alpha to modify explicit color

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleVocabularySuite.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.atlas.core.model.ModelExtractors.PresentationType
+import com.netflix.atlas.core.stacklang.Interpreter
+import org.scalatest.FunSuite
+
+class StyleVocabularySuite extends FunSuite {
+
+  val interpreter = new Interpreter(StyleVocabulary.allWords)
+
+  def eval(s: String): StyleExpr = {
+    interpreter.execute(s).stack match {
+      case PresentationType(v) :: Nil => v
+    }
+  }
+
+  test("no additional style") {
+    val expr = eval(":true")
+    val expected = StyleExpr(DataExpr.Sum(Query.True), Map.empty)
+    assert(expr === expected)
+  }
+
+  test("alpha") {
+    val expr = eval(":true,40,:alpha")
+    val expected = StyleExpr(DataExpr.Sum(Query.True), Map("alpha" -> "40"))
+    assert(expr === expected)
+  }
+
+  test("color") {
+    val expr = eval(":true,f00,:color")
+    val expected = StyleExpr(DataExpr.Sum(Query.True), Map("color" -> "f00"))
+    assert(expr === expected)
+  }
+
+  test("alpha > color") {
+    val expr = eval(":true,40,:alpha,f00,:color")
+    val expected = StyleExpr(DataExpr.Sum(Query.True), Map("color" -> "f00"))
+    assert(expr === expected)
+  }
+
+  test("alpha > color > alpha") {
+    val expr = eval(":true,40,:alpha,f00,:color,60,:alpha")
+    val expected = StyleExpr(DataExpr.Sum(Query.True), Map("color" -> "60ff0000"))
+    assert(expr === expected)
+  }
+}
+


### PR DESCRIPTION
Before `:alpha` would only modify the alpha setting for
colors selected from the palette. If an explicit color
was used the alpha setting from the color would always
get chosen. Now an alpha setting that comes after a color
in the expression will override the alpha setting for
that color.