### PR TITLE
add nf.job and nf.task keys

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TagKey.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TagKey.scala
@@ -75,6 +75,12 @@ object TagKey {
   /** Image id for the instance reporting the metric. */
   final val image = netflixPrefix + "ami"
 
+  /** Name for a job running in a framework like hadoop. */
+  final val job = netflixPrefix + "job"
+
+  /** Id for a task that runs as part of a job.  */
+  final val task = netflixPrefix + "task"
+
   /** ISO country code. */
   final val country = netflixPrefix + "country"
 
@@ -91,6 +97,7 @@ object TagKey {
     application, cluster, autoScalingGroup, node,
     region, availabilityZone,
     vmType, image,
+    job, task,
     country, countryRollup)
 
   /** A list of standard tags. */

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/NonStandardKeyRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/NonStandardKeyRuleSuite.scala
@@ -33,4 +33,12 @@ class NonStandardKeyRuleSuite extends FunSuite {
     assert(res.isFailure)
   }
 
+  test("job") {
+    assert(rule.validate("nf.job", "def") === ValidationResult.Pass)
+  }
+
+  test("task") {
+    assert(rule.validate("nf.task", "def") === ValidationResult.Pass)
+  }
+
 }


### PR DESCRIPTION
There is increasing interest in have a more common tagging
scheme for hadoop, spark, mantis, etc. All of these have
a notion of a job which gets broken down into a set of tasks.