### PR TITLE
fix invalid period exception for duration match

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/ModelExtractors.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/ModelExtractors.scala
@@ -26,7 +26,7 @@ object ModelExtractors {
 
   case object DurationType {
     def unapply(value: Any): Option[Duration] = value match {
-      case v: String         => Some(Strings.parseDuration(v))
+      case v: String         => Try(Strings.parseDuration(v)).toOption
       case v: Duration       => Some(v)
       case _                 => None
     }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.atlas.core.stacklang.Interpreter
+import org.scalatest.FunSuite
+
+class ModelExtractorsSuite extends FunSuite {
+
+  private val words = StyleVocabulary.allWords
+  private val interpreter = Interpreter(words)
+
+  private val candidates = words.filter(!_.matches(Nil))
+
+  def completionTest(expr: String, expected: Int): Unit = {
+    test(expr) {
+      val result = interpreter.execute(expr)
+      candidates.filter(_.matches(result.stack)).foreach(System.err.println)
+      assert(candidates.count(_.matches(result.stack)) === expected)
+    }
+  }
+
+  completionTest("name",                                   8)
+  completionTest("name,sps",                              18)
+  completionTest("name,sps,:eq",                          20)
+  completionTest("name,sps,:eq,app,foo,:eq",              40)
+  completionTest("name,sps,:eq,app,foo,:eq,:and,(,asg,)", 10)
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
@@ -28,7 +28,6 @@ class ModelExtractorsSuite extends FunSuite {
   def completionTest(expr: String, expected: Int): Unit = {
     test(expr) {
       val result = interpreter.execute(expr)
-      candidates.filter(_.matches(result.stack)).foreach(System.err.println)
       assert(candidates.count(_.matches(result.stack)) === expected)
     }
   }


### PR DESCRIPTION
If the string was an invalid duration the `DurationType` matcher
was throwing:

```
java.lang.IllegalArgumentException: invalid period sps
	at com.netflix.atlas.core.util.Strings$.parseDuration(Strings.scala:397)
	at com.netflix.atlas.core.model.ModelExtractors$DurationType$.unapply(ModelExtractors.scala:29)
```