### PR TITLE
add more docs around time parameters

### DIFF
--- a/atlas-wiki/src/main/resources/Graph.md
+++ b/atlas-wiki/src/main/resources/Graph.md
@@ -66,44 +66,7 @@ presentable in a graph.
 </table>
 
 ### End time (e)
-Specifies the end time of the graph. Permitted values:
-
-<table>
-  <tbody>
-    <tr>
-      <th>
-        <p>Value</p>
-      </th>
-      <th>
-        <p>Description</p>
-      </th>
-    </tr>
-    <tr>
-      <td>
-        <p>now</p>
-      </td>
-      <td>
-        <p>Current time, this is the default.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <p>unix timestamp</p>
-      </td>
-      <td>
-        <p>A number representing the number of seconds since the epoch, e.g. <code>date +%s</code>.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <p>ISO8601 timestamp</p>
-      </td>
-      <td>
-        <p>A string following the ISO8601 date time format, e.g. <code>date +%Y-%m-%dT%H:%M</code>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+Specifies the end time of the graph. See docs on [time parameters](Time-Parameters).
 
 ### Format (format)
 
@@ -220,44 +183,7 @@ Acceptable values are 0 (false, the default) and 1 (true).  For example,
 
 ### Start time (s)
 
-Specifies the start time of the graph. Permitted values:
-
-<table>
-  <tbody>
-    <tr>
-      <th>
-        <p>Value</p>
-      </th>
-      <th>
-        <p>Description</p>
-      </th>
-    </tr>
-    <tr>
-      <td>
-        <p>relative time</p>
-      </td>
-      <td>
-        <p>Time relative to the specified end time. The default is <code>e-3h</code>.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <p>unix timestamp</p>
-      </td>
-      <td>
-        <p>A number representing the number of seconds since the epoch, e.g. <code>date +%s</code>.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <p>ISO8601 timestamp</p>
-      </td>
-      <td>
-        <p>A string following the ISO8601 date time format, e.g. <code>date +%Y-%m-%dT%H:%M</code>.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+Specifies the start time of the graph. See docs on [time parameters](Time-Parameters).
 
 ### Step size (step)
 

--- a/atlas-wiki/src/main/resources/Time-Parameters.md
+++ b/atlas-wiki/src/main/resources/Time-Parameters.md
@@ -1,0 +1,143 @@
+APIs that accept time ranges support three parameters:
+
+1. Start time (`s`)
+2. End time (`e`)
+3. Time zone (`tz`)
+
+## Time Zone
+
+Time zone can be any valid [time zone id](Time-Zones) string.
+
+## Absolute Times
+
+Absolute times can be specified by [name](#named-times) or as a [timestamp](#timestamps). 
+
+### Named Times
+
+Named times are references that will get resolved to a timestamp when a query is
+executed. For example, with graphs it is common to set the end time to `now`.
+
+| Name | Description |
+|------|-------------|
+| `s` | User specified start time. Can only be used as part of the end parameter. |
+| `e` | User specified end time. Can only be used as part of the start parameter. |
+| `now` | Current time. |
+| `epoch` | January 1, 1970 UTC. |
+
+### Timestamps
+
+Explicit timestamps can use the following [formats](http://pubs.opengroup.org/onlinepubs/009695399/functions/strftime.html):
+
+| Format | Description |
+|--------|-------------|
+| %Y-%m-%d  | Date using the timezone for the query. The time will be 00:00. |
+| %Y-%m-%dT%H:%M | Date time using the timezone for the query. The seconds will be 00. |
+| %Y-%m-%dT%H:%M:%S | Date time using the timezone for the query. |
+| %s | Seconds since January 1, 1970 UTC. |
+| %s (ms) | Milliseconds since January 1, 1970 UTC. |
+
+For times since the epoch both seconds and milliseconds are supported because
+both are in common use and it helps to avoid confusion when copy and pasting
+from another source. Values less than or equal 2,147,483,648 (2<sup>31</sup>)
+will be treated as a timestamp in seconds. Values above that will be
+treated as a timestamp in milliseconds. So times from the epoch to
+1970-01-25T20:31:23 cannot be represented in the millisecond form. In practice,
+this limitation has not been a problem.
+
+The first three formats above can also be used with an [explicit time zone](#zone-offsets).
+
+### Zone Offsets
+
+An explicit time zone can be specified as `Z` to indicate UTC or by using an offset
+in hours and minutes. For example:
+
+```
+2012-01-12T01:37Z
+2012-01-12T01:37-00:00
+2012-01-12T01:37-07:00
+2012-01-12T01:37-07:42
+```
+
+A common format recommended for logs at Netflix is an ISO timestamp in UTC:
+
+```
+2012-01-12T01:37:27Z
+```
+
+These can be copy and pasted to quickly check a graph for a timestamp from a log
+file. For practical purposes in Atlas a `-00:00` offset timezone can be thought of
+as UTC, but depending on the source may have some
+[additional meaning](https://tools.ietf.org/html/rfc3339#section-4.3).
+
+## Relative Times
+
+Relative times consist of a [named time](#namedtimes) used for an anchor and
+an offset duration.
+
+```
+<named=time> '-' <duration>
+<named-time> '+' <duration>
+```
+
+For example:
+
+| Pattern | Description |
+|---------|-------------|
+| now-1w  | One week ago. |
+| e-1w    | One week before the end time. |
+| s+6h    | Six hours after the start time. |
+| s+P2DT6H5M | Two days, 6 hours, and 5 minutes after the start time. |
+
+### Duration vs Period
+
+This section is using the definition of duration and period from the
+[java time libraries](https://docs.oracle.com/javase/tutorial/datetime/iso/period.html). In short:
+
+* Durations are a fixed number of seconds.
+* Periods represent a length of time in a given calendar. For example, the length of
+  a day will vary if there is a daylight savings transition.
+
+The offset used for relative times in Atlas are durations because:
+
+*  It is
+  primarily focused on shorter time spans (~ 2 weeks) where drift is less of
+  an issue. In this range the variation is most commonly seen for the daylight
+  savings time transitions. 
+* For time shifts day over day and week over week are the most common for
+  operational purposes. During daylight savings time transitions a fixed duration
+  seems to cause the least confusion, especially when the transition time is within
+  the window being displayed. The primary use-case where periods were found to be
+  more beneficial and less confusing is for week over week when looking at a
+  small window that does not include the transition. In those cases if the signal
+  reflects human behavior, such as playing movies, then the week over week pattern
+  will typically line up better if using a period. 
+
+### Simple Duration
+
+A simple offset uses a positive integer followed by one of these units:
+
+* `s`, `second`, or `seconds`
+* `m`, `min`, `minute`, or `minutes`
+* `h`, `hour`, or `hours`
+* `d`, `day`, or `days`
+* `w`, `week`, or `weeks`
+* `month` or `months`
+* `y`, `year`, or `years`
+
+All durations are a fixed number of seconds. A day is 24 hours, week is 7 days,
+month is 30 days, and a year is 365 days.
+
+### ISO Duration
+
+The duration can also be specified as an
+[ISO duration string](https://tools.ietf.org/html/rfc3339#appendix-A), but day (`D`)
+is the largest part that can be used within the duration. Others such as week (`W`),
+month (`M`), and year (`Y`) are not supported. Examples:
+
+| Pattern | Description |
+|---------|-------------|
+| P1D  | One day of exactly 24 hours. |
+| P1DT37M    | One day and 37 minutes. |
+| PT5H6M    | Five hours and six minutes. |
+
+For more details see docs on [parsing durations](https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-).

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Main.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Main.scala
@@ -39,6 +39,7 @@ import com.netflix.atlas.core.util.Streams._
 import com.netflix.atlas.webapi.ApiSettings
 import com.netflix.atlas.webapi.LocalDatabaseActor
 import com.netflix.atlas.wiki.pages.DES
+import com.netflix.atlas.wiki.pages.TimeZones
 import com.netflix.atlas.wiki.pages.`Stack-Language-Reference`
 import com.typesafe.scalalogging.StrictLogging
 
@@ -230,7 +231,8 @@ object Main extends StrictLogging {
       generateStackLangRef(output)
       generateScriptedPages(output, List(
         new DES,
-        new `Stack-Language-Reference`
+        new `Stack-Language-Reference`,
+        new TimeZones
       ))
     } finally {
       system.shutdown()

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/TimeZones.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/TimeZones.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.wiki.pages
+
+import java.time.ZoneId
+import java.time.format.TextStyle
+import java.util.Locale
+
+import com.netflix.atlas.wiki.GraphHelper
+import com.netflix.atlas.wiki.SimplePage
+
+class TimeZones extends SimplePage {
+  override def name: String = "Time-Zones"
+
+  override def content(graph: GraphHelper): String =
+    s"""
+       |All supported time zone ids.
+       |
+       |## Common
+       |
+       |At Netflix the most common ids in use are:
+       |
+       || Zone Id    | Short Display Name |
+       ||------------|--------------------|
+       || UTC        | UTC                |
+       || US/Pacific | PT                 |
+       |
+       |## By Zone Id
+       |
+       |$supportedIds
+       |
+       |## By Display Name
+       |
+       |Short display names are used in some views, such as multi-timezone plots. This table
+       |provides a reference of the diplay name to the id.
+       |
+       |$displayNameToZoneId
+    """.stripMargin
+
+  private def supportedIds: String = {
+    import scala.collection.JavaConversions._
+    val zones = ZoneId.getAvailableZoneIds.toList.sortWith(_ < _).map { id =>
+      s"| $id | ${ZoneId.of(id).getDisplayName(TextStyle.SHORT, Locale.US)} |"
+    }
+    """
+      || Zone Id | Short Display Name |
+      ||---------|--------------------|
+    """.stripMargin + zones.mkString("\n")
+  }
+
+  private def displayNameToZoneId: String = {
+    import scala.collection.JavaConversions._
+    val zones = ZoneId.getAvailableZoneIds.toList
+    val byName = zones.groupBy(id => ZoneId.of(id).getDisplayName(TextStyle.SHORT, Locale.US))
+    val sorted = byName.toList.sortWith(_._1 < _._1).map { case (name, ids) =>
+      s"| $name | ${ids.mkString(", ")} |"
+    }
+    """
+      || Short Display Name | Zone Ids |
+      ||---------|--------------------|
+    """.stripMargin + sorted.mkString("\n")
+  }
+}


### PR DESCRIPTION
Provides a more detailed overview of the options allowed
on time parameters. Also adds a simple reference page on
the time zones mainly to provide a clear reference showing
how the the short display name used for the label on multi
timezone graphs correspond to ids. There doesn't seem to
be a widely agreed on format for the short names. Still
need to find the source the jdk uses.