### PR TITLE
use no data line for aggregates

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
@@ -179,9 +179,14 @@ class MemoryDatabase(registry: Registry, config: Config) extends Database {
     val vs = collector.result
       .map { t => DataExpr.withDefaultLabel(expr, t) }
       .sortWith { _.label < _.label }
+    finalValues(context, expr, vs)
+  }
+
+  private def finalValues(context: EvalContext, expr: DataExpr, vs: List[TimeSeries]): List[TimeSeries] = {
     expr match {
-      case DataExpr.Head(_, n) => vs.take(n)
-      case _                   => vs
+      case DataExpr.Head(e, n)                         => finalValues(context, e, vs).take(n)
+      case _: DataExpr.AggregateFunction if vs.isEmpty => List(TimeSeries.noData(context.step))
+      case _                                           => vs
     }
   }
 

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiMemDbSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiMemDbSuite.scala
@@ -69,7 +69,7 @@ class GraphApiMemDbSuite extends FunSuite with ScalatestRouteTest {
 
   test("txt: IAE if not match for arguement to binary op") {
     Get("/api/v1/graph?q=name,foo,:eq,:sum,name,bar,:eq,:sum,:add&format=txt") ~> endpoint.routes ~> check {
-      assert(response.status === StatusCodes.BadRequest)
+      assert(response.status === StatusCodes.OK)
     }
   }
 


### PR DESCRIPTION
For simple aggregates where nothing matches the query.
This ensures that binary operations that combine results
will work as expected when one side of the expression
does not have data for a given window.