### PR TITLE
update cq to ignore values that are not understood

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -195,7 +195,7 @@ object MathVocabulary extends Vocabulary {
     override def name: String = "cq"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
-      case (_: Query) :: (_: Expr) :: _ => true
+      case (_: Query) :: _ :: _ => true
     }
 
     protected def executor: PartialFunction[List[Any], List[Any]] = {
@@ -204,17 +204,23 @@ object MathVocabulary extends Vocabulary {
           case q1: Query => Query.And(q1, q2)
         }
         newExpr :: stack
+      case (_: Query) :: stack =>
+        // Ignore items on the stack that are not expressions. So we pop the query and leave
+        // the rest of the stack unchanged.
+        stack
     }
 
     override def summary: String =
       """
-        |Recursively AND a common query to all queries in an expression.
+        |Recursively AND a common query to all queries in an expression. If the first parameter
+        |is not an expression, then it will be not be modified.
       """.stripMargin.trim
 
     override def signature: String = "Expr Query -- Expr"
 
     override def examples: List[String] = List(
-      "name,ssCpuUser,:eq,name,DiscoveryStatus_UP,:eq,:mul,nf.app,alerttest,:eq")
+      "name,ssCpuUser,:eq,name,DiscoveryStatus_UP,:eq,:mul,nf.app,alerttest,:eq",
+      "42,nf.app,alerttest,:eq")
   }
 
   sealed trait UnaryWord extends SimpleWord {


### PR DESCRIPTION
When using a constant on the stack it will get automatically
converted to a TimeSeriesExpr when the graph is rendered. So
if I have something like:

```
name,sps,:eq,:sum,$name,:legend,42
```

It will work for graph rendering. However, if using `:cq` to
append a query restriction with `:each`, e.g.:

```
name,sps,:eq,:sum,$name,:legend,42,:list,(,app,foo,:eq,:cq,),:each
```

It will fail because 42 is not an Expr. Having `:cq` coerce
to an expression is not desirable because it would change
the type and could break existing queries that apply
additional operations.

With this change `:cq` will ignore values it doesn't understand
and leave them on the stack unmodified.