### PR TITLE
filter before grouping with eval helper

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
@@ -255,7 +255,10 @@ object DataExpr {
 
     override def eval(context: EvalContext, data: List[TimeSeries]): ResultSet = {
       val ks = Query.exactKeys(query) ++ keys
-      val groups = data.groupBy(t => keyString(t.tags)).toList
+      val groups = data
+        .filter(t => query.matches(t.tags))
+        .groupBy(t => keyString(t.tags))
+        .toList
       val sorted = groups.sortWith(_._1 < _._1)
       val newData = sorted.flatMap {
         case (null, _) => Nil

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
@@ -120,6 +120,7 @@ class TimeSeriesExprSuite extends FunSuite {
     ":true,(,name,),:by,1,:head"  -> const(byName.take(1)),
     ":true,(,name,),:by,4,:head"  -> const(byName.sortWith(_.label < _.label).take(4)),
     ":true,(,name,),:by,50,:head" -> const(byName),
+    ":false,(,name,),:by"         -> const(Nil),
     "NaN,NaN,:add"                -> const(ts(Map("name" -> "NaN"), "(NaN + NaN)", Double.NaN)),
     "NaN,1.0,:add"                -> const(ts(Map("name" -> "NaN"), "(NaN + 1.0)", 1.0)),
     "1.0,NaN,:add"                -> const(ts(Map("name" -> "1.0"), "(1.0 + NaN)", 1.0)),


### PR DESCRIPTION
Avoids getting entries with NaN values for data
that doesn't match the query. In most cases this
wouldn't be an issue since the data was pre-filtered
based on the query before evaluation. This change
makes it more convenient when doing an eval with
an arbitrary data set.