### PR TITLE
rewrite can cause duplicate case objects

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Expr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Expr.scala
@@ -29,7 +29,11 @@ trait Expr extends Product {
   def rewrite(f: PartialFunction[Expr, Expr]): Expr = {
     if (f.isDefinedAt(this)) f(this) else {
       this match {
-        case p: Product =>
+        // If the productArity is 0 we cannot change instance so return the existing class. A
+        // common case where the arity is 0 are case objects. If they go through the product
+        // case it causes duplicate instances of the objects to get created leading to strange
+        // failures in other places.
+        case p: Product if p.productArity > 0 =>
           val params = p.productIterator.map {
             case e: Expr => e.rewrite(f)
             case v       => v.asInstanceOf[AnyRef]

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ExprRewriteSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ExprRewriteSuite.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.atlas.core.model.DataExpr.AggregateFunction
+import org.scalatest.FunSuite
+
+class ExprRewriteSuite extends FunSuite {
+
+  test("basic") {
+    val avgHashCode = System.identityHashCode(ConsolidationFunction.Avg)
+    val expr = DataExpr.Sum(Query.True)
+    val result = expr.rewrite {
+      case q: Query => Query.False
+    }
+    assert(result === DataExpr.Sum(Query.False))
+    assert(System.identityHashCode(result.asInstanceOf[AggregateFunction].cf) === avgHashCode)
+    ConsolidationFunction.Avg
+  }
+
+  // The expr rewrite uses reflection and can result in duplicate case objects leading to
+  // confusing MatchErrors or other subtle failures later on.
+  test("rewrite should not cause duplicates case objects") {
+    val trueHashCode = System.identityHashCode(Query.True)
+    val expr = Query.And(Query.True, Query.False)
+    val result = expr.rewrite {
+      case Query.Not(q) => Query.False
+    }
+    assert(result === Query.And(Query.True, Query.False))
+    assert(System.identityHashCode(result.asInstanceOf[Query.And].q1) === trueHashCode)
+  }
+
+}
+


### PR DESCRIPTION
If the productArity is 0 we cannot change instance so
return the existing class. A common case where the arity
is 0 are case objects. If they go through the product
case it causes duplicate instances of the objects to get
created leading to strange failures in other places.