### PR TITLE
make naming of sdes operations consistent

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
@@ -146,7 +146,7 @@ object StatefulExpr {
     import com.netflix.atlas.core.model.StatefulExpr.Des._
 
     def dataExprs: List[DataExpr] = expr.dataExprs
-    override def toString: String = s"$expr,$trainingSize,$alpha,$beta,:sliding-des"
+    override def toString: String = s"$expr,$trainingSize,$alpha,$beta,:sdes"
 
     def isGrouped: Boolean = expr.isGrouped
 
@@ -189,7 +189,7 @@ object StatefulExpr {
         val bounded = t.data.bounded(context.start, context.end)
         val s = state.getOrElse(t.id, newState)
         state(t.id) = eval(bounded, s, alignedSkip.toInt)
-        TimeSeries(t.tags, s"sliding-des(${t.label})", bounded)
+        TimeSeries(t.tags, s"sdes(${t.label})", bounded)
       }
       ResultSet(this, newData, rs.state + (this -> state))
     }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
@@ -36,10 +36,10 @@ object StatefulVocabulary extends Vocabulary {
     Macro("des-fast",   List("10", "0.1",  "0.02", ":des"), List("42")),
     Macro("des-slower", List("10", "0.05", "0.03", ":des"), List("42")),
     Macro("des-slow",   List("10", "0.03", "0.04", ":des"), List("42")),
-    Macro("sdes-simple", List("10", "0.1",  "0.5",  ":sliding-des"), List("42")),
-    Macro("sdes-fast",   List("10", "0.1",  "0.02", ":sliding-des"), List("42")),
-    Macro("sdes-slower", List("10", "0.05", "0.03", ":sliding-des"), List("42")),
-    Macro("sdes-slow",   List("10", "0.03", "0.04", ":sliding-des"), List("42")),
+    Macro("sdes-simple", List("10", "0.1",  "0.5",  ":sdes"), List("42")),
+    Macro("sdes-fast",   List("10", "0.1",  "0.02", ":sdes"), List("42")),
+    Macro("sdes-slower", List("10", "0.05", "0.03", ":sdes"), List("42")),
+    Macro("sdes-slow",   List("10", "0.03", "0.04", ":sdes"), List("42")),
 
     Macro("des-epic-signal", desEpicSignal, List("name,sps,:eq,:sum,10,0.1,0.5,0.2,0.2,4"))
   )
@@ -89,7 +89,7 @@ object StatefulVocabulary extends Vocabulary {
   }
 
   case object SlidingDes extends SimpleWord {
-    override def name: String = "sliding-des"
+    override def name: String = "sdes"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
       case (_: String) :: (_: String) :: (_: String) :: TimeSeriesType(_) :: _ => true


### PR DESCRIPTION
The base operator was called `:sliding-des` and all
other variants were `:sdes-*`. With this change `:sdes`
is used consistently for sliding DES operations.

The shorter form was generally preferred because it
makes it much easier to switch between `:des` and `:sdes`
by just changing a single character. When experimenting
and comparing the results of both this is quite handy.