### PR TITLE
configure prefixes for single page apps

### DIFF
--- a/atlas-akka/src/main/resources/reference.conf
+++ b/atlas-akka/src/main/resources/reference.conf
@@ -10,6 +10,25 @@ atlas.akka {
     "com.netflix.atlas.akka.StaticPages"
   ]
 
+  # Settings for the StaticPages API
+  static {
+    # Default page to redirect to when hitting /
+    default-page = "/ui"
+
+    # For single-page javascript apps, a list of prefixes and the page they map to. Any path with
+    # that prefix will return the same page.
+    single-page-prefixes = [
+      {
+        # Path prefix to use. Should be single-level, just the name, with no '/'.
+        prefix = "ui"
+
+        # Resource to fetch when the prefix is requested. This is the resource in the classpath
+        # not path on the server.
+        resource = "www/index.html"
+      }
+    ]
+  }
+
   # How long to wait before giving up on bind
   bind-timeout = 5 seconds
 }

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/StaticPagesSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/StaticPagesSuite.scala
@@ -33,12 +33,14 @@ class StaticPagesSuite extends FunSuite with ScalatestRouteTest {
   test("/static") {
     Get("/static") ~> endpoint.routes ~> check {
       assert(response.status === StatusCodes.OK)
+      assert(responseAs[String].contains("Index Page"))
     }
   }
 
   test("/static/") {
     Get("/static/") ~> endpoint.routes ~> check {
       assert(response.status === StatusCodes.OK)
+      assert(responseAs[String].contains("Index Page"))
     }
   }
 
@@ -46,7 +48,21 @@ class StaticPagesSuite extends FunSuite with ScalatestRouteTest {
     Get("/") ~> endpoint.routes ~> check {
       assert(response.status === StatusCodes.MovedPermanently)
       val loc = response.headers.find(_.is("location")).map(_.value)
-      assert(loc === Some("/static/index.html"))
+      assert(loc === Some("/ui"))
+    }
+  }
+
+  test("/ui") {
+    Get("/ui") ~> endpoint.routes ~> check {
+      assert(response.status === StatusCodes.OK)
+      assert(responseAs[String].contains("Index Page"))
+    }
+  }
+
+  test("/ui/foo/bar") {
+    Get("/ui/foo/bar") ~> endpoint.routes ~> check {
+      assert(response.status === StatusCodes.OK)
+      assert(responseAs[String].contains("Index Page"))
     }
   }
 }


### PR DESCRIPTION
Adds two configuration options for the StaticPages webapi:

1. `atlas.akka.static.default-page`: configures the default
   page to redirect to when the user accesses `/` on the
   server.
2. `atlas.akka.static.single-page-prefixes`: configures zero
   or more prefixes that map to a single resource. This is for
   single page apps where the javascript should interpret the
   rest of the path.