### PR TITLE
docs: add links to presentations

### DIFF
--- a/atlas-wiki/src/main/resources/Presentations.md
+++ b/atlas-wiki/src/main/resources/Presentations.md
@@ -1,0 +1,65 @@
+
+## Atlas Overview
+
+High level overview of Atlas backend.
+
+|               |               |
+|---------------|---------------|
+| **Presenter** | [@brharrington](https://github.com/brharrington) |
+| **Date**      | 2014-12-16    |
+| **Links**     | [PDF](http://netflix.github.io/atlas/atlas_overview.pdf) |
+
+## Atlas Telemetry: A Platform Begets an Ecosystem
+
+Summary of Atlas and surrounding tooling used at Netflix.
+
+|               |               |
+|---------------|---------------|
+| **Presenter** | [@copperlight](https://github.com/copperlight)  |
+| **Date**      | 2015-11-17    |
+| **Links**     | [Video](https://www.youtube.com/watch?v=cd-5ADtsTK4) |
+
+## Canary Analyze All The Things
+
+Overview of canary analysis at Netflix. Canary analysis is one type of tooling that relies
+heavily on Atlas data internally.
+
+|               |               |
+|---------------|---------------|
+| **Presenter** | [@royrapoport](https://github.com/royrapoport)  |
+| **Date**      | 2014-08-28    |
+| **Links**     | [Video and Slides](http://www.infoq.com/presentations/canary-analysis-deployment-pattern) |
+
+## Cloud Operations at Netflix
+
+Summary of how Netflix thinks about operations. Not specific to Atlas, but Atlas is one of the
+tools involved.
+
+|               |               |
+|---------------|---------------|
+| **Presenter** | [@royrapoport](https://github.com/royrapoport)  |
+| **Date**      | 2013-11-20    |
+| **Links**     | [Video](https://www.youtube.com/watch?v=7779Wrun5fo) |
+
+## Netflix: Amazon S3 and Amazon Elastic MapReduce to Monitor at Gigascale
+
+AWS re:Invent presentation on the usage of S3 and EMR for Atlas.
+
+|               |               |
+|---------------|---------------|
+| **Presenter** | [@royrapoport](https://github.com/royrapoport)  |
+| **Date**      | 2013-10-26    |
+| **Links**     | [Video](https://www.youtube.com/watch?v=tHrT6kQR7vw) |
+
+## Operational Insight
+
+Overview of operational insight at Netflix.
+
+|               |               |
+|---------------|---------------|
+| **Presenter** | [@royrapoport](https://github.com/royrapoport)  |
+| **Date**      | 2015-06-17    |
+| **Links**     | [Video](https://vimeo.com/131377936) |
+
+
+

--- a/atlas-wiki/src/main/resources/_Sidebar.md
+++ b/atlas-wiki/src/main/resources/_Sidebar.md
@@ -1,6 +1,7 @@
 ###[Home](Home)
 * [[Overview]]
 * [[Getting Started]]
+* [[Presentations]]
 * [Examples](Single-Line)
 * [[Concepts]]
 * API


### PR DESCRIPTION
Adds a page to the wiki with links to various presentations
on Atlas or related tooling used at Netflix.