### PR TITLE
add default exception handler

### DIFF
--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/TestApi.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/TestApi.scala
@@ -34,9 +34,6 @@ class TestApi(val actorRefFactory: ActorRefFactory) extends WebApi {
         try {
           val v = Json.decode[String](parser)
           ctx.responder ! HttpResponse(status = OK, entity = v)
-        } catch {
-          case e: Exception =>
-            ctx.responder ! HttpResponse(status = BadRequest, entity = e.getMessage)
         } finally {
           parser.close()
         }


### PR DESCRIPTION
Adds a default exception handler for the routes added
with webapi. Helps to avoid confusing issues if an api
didn't add in a custom handler.