### PR TITLE
docs: indicate version for new operations

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataVocabulary.scala
@@ -180,6 +180,8 @@ object DataVocabulary extends Vocabulary {
       """
         |Restrict the output to the first `N` lines from the input expression. The lines will be
         |chosen based on a lexical ordering of the group by keys.
+        |
+        |Since: 1.5.0
       """.stripMargin.trim
 
     override def signature: String = "DataExpr Int -- DataExpr"

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
@@ -104,6 +104,8 @@ object StatefulVocabulary extends Vocabulary {
       """
         |Experimental alternative to DES. Should only be used for testing and may change or be
         |removed in the future with no notice.
+        |
+        |Since: 1.5.0
       """.stripMargin.trim
 
     override def signature: String =

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/StandardVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/StandardVocabulary.scala
@@ -131,6 +131,8 @@ object StandardVocabulary extends Vocabulary {
     override def summary: String =
       """
         |Push the depth of the stack.
+        |
+        |Since: 1.5.0
       """.stripMargin.trim
 
     override def signature: String = " -- N"
@@ -271,6 +273,8 @@ object StandardVocabulary extends Vocabulary {
     override def summary: String =
       """
         |Pick an item in the stack and put a copy on the top.
+        |
+        |Since: 1.5.0
       """.stripMargin.trim
 
     override def signature: String = "aN ... a0 N -- aN ... a0 aN"
@@ -325,6 +329,8 @@ object StandardVocabulary extends Vocabulary {
     override def summary: String =
       """
         |Remove the top N items on the stack.
+        |
+        |Since: 1.5.0
       """.stripMargin.trim
 
     override def signature: String = "aN ... a0 N -- aN"
@@ -347,6 +353,8 @@ object StandardVocabulary extends Vocabulary {
     override def summary: String =
       """
         |Create a list with the top N items on the stack.
+        |
+        |Since: 1.5.0
       """.stripMargin.trim
 
     override def signature: String = "aN ... a0 N -- aN List(aN-1 ... a0)"
@@ -392,6 +400,8 @@ object StandardVocabulary extends Vocabulary {
     override def summary: String =
       """
         |Rotate an item in the stack and put it on the top.
+        |
+        |Since: 1.5.0
       """.stripMargin.trim
 
     override def signature: String = "aN ... a0 N -- aN-1 ... a0 aN"


### PR DESCRIPTION
For some of the new operations indicate the version they
were added in to reduce confusion.