### PR TITLE
index for efficiently matching many queries

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/QueryIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/QueryIndex.scala
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.index
+
+import com.netflix.atlas.core.model.Query
+
+/**
+ * Index for quickly matching a set of tags against many query expressions. The intended use-case
+ * is for stream processing. If a stream of tagged data points are flowing through the system
+ * and we have thousands of queries, then we need efficient ways to:
+ *
+ * 1. Check if a datapoint is a match to any of the queries. This can be used to quickly filter
+ *    out data that isn't going to be needed.
+ * 2. Figure out which queries or expressions match a given datapoint.
+ *
+ * @param indexes
+ *     Map of :eq query to a sub-index. This is used to recursively search the set after finding
+ *     the first match.
+ * @param entries
+ *     Entries that remain after checking all the simple :eq queries. This list will be searched
+ *     using a linear scan to get final matching with regex or other more complicated query
+ *     clauses.
+ */
+case class QueryIndex[T](
+    indexes: Map[Query.Equal, QueryIndex[T]],
+    entries: List[QueryIndex.Entry[T]]) {
+
+  /** Returns true if the tags match any of the queries in the index. */
+  def matches(tags: Map[String, String]): Boolean = {
+    val qs = tags.map(t => Query.Equal(t._1, t._2)).toList
+    matches(tags, qs)
+  }
+
+  private def matches(tags: Map[String, String], queries: List[Query.Equal]): Boolean = {
+    queries match {
+      case q :: qs =>
+        val children = indexes.get(q) match {
+          case Some(qt) => qt.matches(tags, qs)
+          case None     => matches(tags, qs)
+        }
+        children || entries.exists(_.query.matches(tags))
+      case Nil =>
+        entries.exists(_.query.matches(tags))
+    }
+  }
+
+  /** Finds the set of items that match the provided tags. */
+  def matchingEntries(tags: Map[String, String]): List[T] = {
+    val qs = tags.map(t => Query.Equal(t._1, t._2)).toList
+    matchingEntries(tags, qs).distinct
+  }
+
+  private def matchingEntries(tags: Map[String, String], queries: List[Query.Equal]): List[T] = {
+    queries match {
+      case q :: qs =>
+        val children = indexes.get(q) match {
+          case Some(qt) => qt.matchingEntries(tags, qs)
+          case None     => matchingEntries(tags, qs)
+        }
+        children ::: entries.filter(_.query.matches(tags)).map(_.value)
+      case Nil =>
+        entries.filter(_.query.matches(tags)).map(_.value)
+    }
+  }
+
+  /**
+   * Creates a string representation of the index tree. Warning: this can be large if many queries
+   * are indexed.
+   */
+  override def toString: String = {
+    val buf = new StringBuilder
+    append(buf, 0)
+    buf.toString()
+  }
+
+  private def append(buf: StringBuilder, indent: Int): Unit = {
+    val pad1 = "    " * indent
+    val pad2 = "    " * (indent + 1)
+    buf.append(pad1).append("children\n")
+    indexes.foreach { case (k, child) =>
+      buf.append(pad2).append(k).append('\n')
+      child.append(buf, indent + 2)
+    }
+    buf.append(pad1).append("queries\n")
+    entries.foreach { e => buf.append(pad2).append(e.query).append('\n') }
+  }
+}
+
+/**
+  * Helper for building an index.
+  */
+object QueryIndex {
+
+  case class Entry[T](query: Query, value: T)
+
+  private case class AnnotatedEntry[T](entry: Entry[T], filters: Set[Query.Equal]) {
+    def toList: List[(Query.Equal, AnnotatedEntry[T])] = {
+      filters.toList.map(q => q -> AnnotatedEntry(entry, filters - q))
+    }
+  }
+
+  /**
+   * Create an index based on a list of queries. The value for the entry will be the raw input
+   * query.
+   */
+  def apply(queries: List[Query]): QueryIndex[Query] = {
+    create(queries.map(q => Entry(q, q)))
+  }
+
+  /**
+   * Create an index based on a list of queries. The value for the entry will be the raw input
+   * query.
+   */
+  def create(entries: List[Entry[Query]]): QueryIndex[Query] = {
+    val annotated = entries.flatMap { entry =>
+      val qs = split(entry.query)
+      qs.map(q => annotate(Entry(q, entry.value)))
+    }
+    createImpl(annotated)
+  }
+
+  /**
+   * Recursively build the index.
+   */
+  private def createImpl[T](entries: List[AnnotatedEntry[T]]): QueryIndex[T] = {
+    val (children, leaf) = entries.partition(_.filters.nonEmpty)
+    val trees = children.flatMap(_.toList).groupBy(_._1).map { case (q, ts) =>
+      q -> QueryIndex.createImpl(ts.map(_._2))
+    }
+    QueryIndex(trees, leaf.map(_.entry))
+  }
+
+  /**
+   * Split :in queries into a list of queries using :eq.
+   */
+  private def split(query: Query): List[Query] = {
+    query match {
+      case Query.And(q1, q2) => for (a <- split(q1); b <- split(q2)) yield { Query.And(a, b) }
+      case Query.In(k, vs)   => vs.map { v => Query.Equal(k, v) }
+      case _                 => List(query)
+    }
+  }
+
+  /**
+   * Convert a query into a list of query clauses that are ANDd together.
+   */
+  private def conjunctionList(query: Query): List[Query] = {
+    query match {
+      case Query.And(q1, q2)     => conjunctionList(q1) ::: conjunctionList(q2)
+      case q                     => List(q)
+    }
+  }
+
+  /**
+   * Annotate an entry with a set of :eq queries that should filter in the input before checking
+   * against the final remaining query. Ideally if the query is only using :eq and :and the final
+   * remainder will be :true.
+   */
+  private def annotate[T](entry: Entry[T]): AnnotatedEntry[T] = {
+    val distinct = conjunctionList(entry.query).distinct
+    val filters   = distinct.collect { case q: Query.Equal => q }
+    val remainder = distinct.collect { case q if !q.isInstanceOf[Query.Equal] => q }
+    val remainderQ = if (remainder.isEmpty) Query.True else remainder.reduce { (a, b) => Query.And(a, b) }
+    AnnotatedEntry(Entry(remainderQ, entry.value), filters.toSet)
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/QueryIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/QueryIndexSuite.scala
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.index
+
+import com.netflix.atlas.core.model.Query
+import org.scalatest.FunSuite
+
+class QueryIndexSuite extends FunSuite {
+
+  private val id1 = Map("a" -> "1")
+  private val id2 = Map("a" -> "1", "b" -> "2")
+  private val id3 = Map("a" -> "1", "b" -> "2")
+
+  test("empty") {
+    val index = QueryIndex(Nil)
+    assert(!index.matches(Map.empty))
+    assert(!index.matches(Map("a" -> "1")))
+  }
+
+  test("matchingEntries empty") {
+    val index = QueryIndex(Nil)
+    assert(index.matchingEntries(Map.empty).isEmpty)
+    assert(index.matchingEntries(Map("a" -> "1")).isEmpty)
+  }
+
+  test("single query: simple") {
+    val q = Query.And(Query.Equal("a", "1"), Query.Equal("b", "2"))
+    val index = QueryIndex(List(q))
+
+    // Not all tags are present
+    assert(!index.matches(Map.empty))
+    assert(!index.matches(Map("a" -> "1")))
+
+    // matches
+    assert(index.matches(Map("a" -> "1", "b" -> "2")))
+    assert(index.matches(Map("a" -> "1", "b" -> "2", "c" -> "3")))
+
+    // a doesn't match
+    assert(!index.matches(Map("a" -> "2", "b" -> "2", "c" -> "3")))
+
+    // b doesn't match
+    assert(!index.matches(Map("a" -> "1", "b" -> "3", "c" -> "3")))
+  }
+
+  test("matchingEntries single query: simple") {
+    val q = Query.And(Query.Equal("a", "1"), Query.Equal("b", "2"))
+    val index = QueryIndex(List(q))
+
+    // Not all tags are present
+    assert(index.matchingEntries(Map.empty).isEmpty)
+    assert(index.matchingEntries(Map("a" -> "1")).isEmpty)
+
+    // matches
+    assert(index.matchingEntries(Map("a" -> "1", "b" -> "2")) === List(q))
+    assert(index.matchingEntries(Map("a" -> "1", "b" -> "2", "c" -> "3")) === List(q))
+
+    // a doesn't match
+    assert(index.matchingEntries(Map("a" -> "2", "b" -> "2", "c" -> "3")).isEmpty)
+
+    // b doesn't match
+    assert(index.matchingEntries(Map("a" -> "1", "b" -> "3", "c" -> "3")).isEmpty)
+  }
+
+  test("single query: complex") {
+    val q = Query.And(Query.And(Query.Equal("a", "1"), Query.Equal("b", "2")), Query.HasKey("c"))
+    val index = QueryIndex(List(q))
+
+    // Not all tags are present
+    assert(!index.matches(Map.empty))
+    assert(!index.matches(Map("a" -> "1")))
+    assert(!index.matches(Map("a" -> "1", "b" -> "2")))
+
+    // matches
+    assert(index.matches(Map("a" -> "1", "b" -> "2", "c" -> "3")))
+
+    // a doesn't match
+    assert(!index.matches(Map("a" -> "2", "b" -> "2", "c" -> "3")))
+
+    // b doesn't match
+    assert(!index.matches(Map("a" -> "1", "b" -> "3", "c" -> "3")))
+  }
+
+  test("matchingEntries single query: complex") {
+    val q = Query.And(Query.And(Query.Equal("a", "1"), Query.Equal("b", "2")), Query.HasKey("c"))
+    val index = QueryIndex(List(q))
+
+    // Not all tags are present
+    assert(index.matchingEntries(Map.empty).isEmpty)
+    assert(index.matchingEntries(Map("a" -> "1")).isEmpty)
+    assert(index.matchingEntries(Map("a" -> "1", "b" -> "2")).isEmpty)
+
+    // matchingEntries
+    assert(index.matchingEntries(Map("a" -> "1", "b" -> "2", "c" -> "3")) === List(q))
+
+    // a doesn't match
+    assert(index.matchingEntries(Map("a" -> "2", "b" -> "2", "c" -> "3")).isEmpty)
+
+    // b doesn't match
+    assert(index.matchingEntries(Map("a" -> "1", "b" -> "3", "c" -> "3")).isEmpty)
+  }
+
+  test("many queries") {
+    // CpuUsage for all instances
+    val cpuUsage = Query.Equal("name", "cpuUsage")
+
+    // DiskUsage query per node
+    val diskUsage = Query.Equal("name", "diskUsage")
+    val diskUsagePerNode = (0 until 100).toList.map { i =>
+      val node = f"i-$i%05d"
+      Query.And(Query.Equal("nf.node", node), diskUsage)
+    }
+
+    val index = QueryIndex(cpuUsage :: diskUsagePerNode)
+
+    // Not all tags are present
+    assert(!index.matches(Map.empty))
+    assert(!index.matches(Map("a" -> "1")))
+
+    // matches
+    assert(index.matches(Map("name" -> "cpuUsage", "nf.node" -> "unknown")))
+    assert(index.matches(Map("name" -> "cpuUsage", "nf.node" -> "i-00099")))
+    assert(index.matches(Map("name" -> "diskUsage", "nf.node" -> "i-00099")))
+
+    // shouldn't match
+    assert(!index.matches(Map("name" -> "diskUsage", "nf.node" -> "unknown")))
+    assert(!index.matches(Map("name" -> "memoryUsage", "nf.node" -> "i-00099")))
+  }
+
+  test("matchingEntries many queries") {
+    // CpuUsage for all instances
+    val cpuUsage = Query.Equal("name", "cpuUsage")
+
+    // DiskUsage query per node
+    val diskUsage = Query.Equal("name", "diskUsage")
+    val diskUsagePerNode = (0 until 100).toList.map { i =>
+      val node = f"i-$i%05d"
+      Query.And(Query.Equal("nf.node", node), diskUsage)
+    }
+
+    val index = QueryIndex(cpuUsage :: diskUsage :: diskUsagePerNode)
+
+    // Not all tags are present
+    assert(index.matchingEntries(Map.empty).isEmpty)
+    assert(index.matchingEntries(Map("a" -> "1")).isEmpty)
+
+    // matchingEntries
+    assert(index.matchingEntries(Map("name" -> "cpuUsage", "nf.node" -> "unknown")) === List(cpuUsage))
+    assert(index.matchingEntries(Map("name" -> "cpuUsage", "nf.node" -> "i-00099")) === List(cpuUsage))
+    assert(index.matchingEntries(Map("name" -> "diskUsage", "nf.node" -> "i-00099")) === List(diskUsagePerNode.last, diskUsage))
+    assert(index.matchingEntries(Map("name" -> "diskUsage", "nf.node" -> "unknown")) === List(diskUsage))
+
+    // shouldn't match
+    assert(index.matchingEntries(Map("name" -> "memoryUsage", "nf.node" -> "i-00099")).isEmpty)
+  }
+}

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/index/QueryIndexMatching.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/index/QueryIndexMatching.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.index
+
+import com.netflix.atlas.core.model.Query
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Threads
+import org.openjdk.jmh.infra.Blackhole
+
+/**
+ * Check to see how query index performs with simple queries based on index size. With similar test
+ * with real data using 17k alert expressions that decomposed into over 33k query expressions, the
+ * index was around 1000x faster for processing a metrics payload of 5000 datapoints. The loop took
+ * around 6 seconds and the index took around 6ms. The real dataset is slower mostly due to more
+ * regex being used in real queries and not being used in this synthetic data.
+ *
+ * ```
+ * > run -wi 10 -i 10 -f1 -t1 .*QueryIndexMatching.*
+ * ```
+ *
+ * Initial results:
+ *
+ * ```
+ * Benchmark                         Mode  Cnt        Score        Error  Units
+ * QueryIndexMatching.index_100     thrpt   10  1427970.545 ±  42632.895  ops/s
+ * QueryIndexMatching.index_1000    thrpt   10  1337580.661 ± 113418.137  ops/s
+ * QueryIndexMatching.index_10000   thrpt   10  1341069.994 ± 104992.441  ops/s
+ * QueryIndexMatching.index_100000  thrpt   10  1290159.738 ±  76488.013  ops/s
+ * QueryIndexMatching.loop_100      thrpt   10   714393.977 ±  26067.308  ops/s
+ * QueryIndexMatching.loop_1000     thrpt   10    68317.877 ±   6006.013  ops/s
+ * QueryIndexMatching.loop_10000    thrpt   10     3831.356 ±    454.029  ops/s
+ * QueryIndexMatching.loop_100000   thrpt   10      375.074 ±     30.352  ops/s
+ * ```
+ */
+@State(Scope.Thread)
+class QueryIndexMatching {
+
+  // CpuUsage for all instances
+  private val cpuUsage = Query.Equal("name", "cpuUsage")
+
+  // DiskUsage query per node
+  private val diskUsage = Query.Equal("name", "diskUsage")
+
+  private def diskUsagePerNode(n: Int): List[Query] = {
+    (0 until n).toList.map { i =>
+      val node = f"i-$i%05d"
+      Query.And(Query.Equal("nf.node", node), diskUsage)
+    }
+  }
+
+  private val queries_100 = cpuUsage :: diskUsagePerNode(100)
+  private val index_100 = QueryIndex(queries_100)
+
+  private val queries_1000 = cpuUsage :: diskUsagePerNode(1000)
+  private val index_1000 = QueryIndex(queries_1000)
+
+  private val queries_10000 = cpuUsage :: diskUsagePerNode(10000)
+  private val index_10000 = QueryIndex(queries_10000)
+
+  private val queries_100000 = cpuUsage :: diskUsagePerNode(100000)
+  private val index_100000 = QueryIndex(queries_100000)
+
+  // Sample tag map that doesn't match the above queries. Not matching is often the most expensive
+  // because it will not be able to short circuit
+  private val id = Map(
+    "nf.app"     -> "atlas_backend",
+    "nf.cluster" -> "atlas_backend-dev",
+    "nf.asg"     -> "atlas_backend-dev-v001",
+    "nf.stack"   -> "dev",
+    "nf.region"  -> "us-east-1",
+    "nf.zone"    -> "us-east-1e",
+    "nf.node"    -> "i-123456789",
+    "nf.ami"     -> "ami-987654321",
+    "nf.vmtype"  -> "r3.2xlarge",
+    "name"       -> "jvm.gc.pause",
+    "cause"      -> "Allocation_Failure",
+    "action"     -> "end_of_major_GC",
+    "statistic"  -> "totalTime"
+  )
+
+  @Threads(1)
+  @Benchmark
+  def loop_100(bh: Blackhole): Unit = {
+    bh.consume(queries_100.exists(_.matches(id)))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def loop_1000(bh: Blackhole): Unit = {
+    bh.consume(queries_1000.exists(_.matches(id)))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def loop_10000(bh: Blackhole): Unit = {
+    bh.consume(queries_10000.exists(_.matches(id)))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def loop_100000(bh: Blackhole): Unit = {
+    bh.consume(queries_100000.exists(_.matches(id)))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def index_100(bh: Blackhole): Unit = {
+    bh.consume(index_100.matches(id))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def index_1000(bh: Blackhole): Unit = {
+    bh.consume(index_1000.matches(id))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def index_10000(bh: Blackhole): Unit = {
+    bh.consume(index_10000.matches(id))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def index_100000(bh: Blackhole): Unit = {
+    bh.consume(index_100000.matches(id))
+  }
+
+}


### PR DESCRIPTION
The current indexes allow us to quickly check a query
against many tag sets. For some use-cases, in particular,
stream processing, we need to check a tag set against
many queries.

The specific use-case is inline alert processing. Currently
in the main environment there are around 17k alert expressions
used for alerts. Decomposing those into individual queries
we get around 33k queries. With a quick test of comparing
a real payload of 5000 datapoints to find matches within the
alert query set takes around 6.2s using a naive loop. This
query index takes around 6ms.

We'll likely need to do some further optimization to reduce
the number of allocations when doing the match, but current
testing shows it to be good enough to include in a snapshot
for more experimentation.