### PR TITLE
update maven groupId

### DIFF
--- a/project/Bintray.scala
+++ b/project/Bintray.scala
@@ -20,7 +20,7 @@ object Bintray {
 
   lazy val settings: Seq[Def.Setting[_]] = bintraySettings ++ Seq(
     bintrayRepository := "maven",
-    bintrayPackage := "atlas",
+    bintrayPackage := "atlas_v1",
     bintrayOrganization := Some("netflixoss"),
     bintrayReleaseOnPublish := false,
     licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.txt")),

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -2,7 +2,7 @@ import sbt._
 import sbt.Keys._
 
 object BuildSettings {
-  val organization = "com.netflix.atlas"
+  val organization = "com.netflix.atlas_v1"
 
   val compilerFlags = Seq(
     "-deprecation",


### PR DESCRIPTION
Due to some historical baggage, it is a pain to get the
artifacts into jcenter with the current com.netflix.atlas
groupId. This changes the id to add a version as I couldn't
come up with something better. This may also be useful in
the future to allow side by side import of a v2 version.