### PR TITLE
fixes #266 server log is confusing for 404s

### DIFF
--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerActorSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerActorSuite.scala
@@ -30,6 +30,7 @@ import org.scalatest.FunSuiteLike
 import spray.http.HttpMethods._
 import spray.http.StatusCodes._
 import spray.http._
+import spray.routing.MethodRejection
 
 
 class RequestHandlerActorSuite extends TestKit(ActorSystem())
@@ -48,6 +49,13 @@ class RequestHandlerActorSuite extends TestKit(ActorSystem())
 
   override def afterAll(): Unit = {
     system.terminate()
+  }
+
+  test("/not-found") {
+    ref ! HttpRequest(GET, Uri("/not-found"))
+    expectMsgPF() {
+      case HttpResponse(NotFound, _, _, _) =>
+    }
   }
 
   test("/healthcheck") {
@@ -119,6 +127,13 @@ class RequestHandlerActorSuite extends TestKit(ActorSystem())
     expectMsgPF() {
       case HttpResponse(OK, entity, _, _) =>
         assert(entity.asString(HttpCharsets.`UTF-8`) === "foo")
+    }
+  }
+
+  test("/chunked with wrong method") {
+    ref ! HttpRequest(POST, Uri("/chunked"))
+    expectMsgPF() {
+      case HttpResponse(MethodNotAllowed, _, _, _) =>
     }
   }
 }

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerActorSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerActorSuite.scala
@@ -30,7 +30,6 @@ import org.scalatest.FunSuiteLike
 import spray.http.HttpMethods._
 import spray.http.StatusCodes._
 import spray.http._
-import spray.routing.MethodRejection
 
 
 class RequestHandlerActorSuite extends TestKit(ActorSystem())


### PR DESCRIPTION
Now shows the 404 NotFound rather than an exception about
route rejection in the logs.