### PR TITLE
remove unused query param

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/GraphDef.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/GraphDef.scala
@@ -78,7 +78,6 @@ case class GraphDef(
     title: Option[String] = None,
     legendType: LegendType = LegendType.LABELS_WITH_STATS,
     onlyGraph: Boolean = false,
-    fontSize: Option[Int] = None,
     numberFormat: String = "%f",
     loadTime: Long = -1,
     stats: CollectorStats = CollectorStats.unknown,

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
@@ -165,7 +165,6 @@ object GraphApi {
         zoom = flags.zoom,
         legendType = legendType,
         onlyGraph = flags.showOnlyGraph,
-        fontSize = flags.fontSize,
         numberFormat = numberFormat,
         plots = plots
       )
@@ -236,7 +235,6 @@ object GraphApi {
 
   case class ImageFlags(
       title: Option[String],
-      fontSize: Option[Int],
       width: Int,
       height: Int,
       zoom: Double,
@@ -275,7 +273,6 @@ object GraphApi {
 
     val flags = ImageFlags(
       title = params.get("title").filter(_ != ""),
-      fontSize = params.get("font_size").map(_.toInt),
       width = params.get("w").fold(ApiSettings.width)(_.toInt),
       height = params.get("h").fold(ApiSettings.height)(_.toInt),
       zoom = params.get("zoom").fold(1.0)(_.toDouble),


### PR DESCRIPTION
The `font_size` param is a legacy setting that hasn't
worked in years. It isn't really appropriate now as
several different font sizes are used and dynamic sizing
would need to be thoughout to ensure it still works well
with the layouts.