### PR TITLE
add command line tool for image diff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ WIKI_PRG        := atlas-wiki/runMain com.netflix.atlas.wiki.Main
 WIKI_INPUT_DIR  := $(shell pwd)/atlas-wiki/src/main/resources
 WIKI_OUTPUT_DIR := $(shell pwd)/target/atlas.wiki
 
-LAUNCHER_JAR_URL := https://repo1.maven.org/maven2/com/netflix/iep/iep-launcher/0.1.14/iep-launcher-0.1.14.jar
+LAUNCHER_JAR_URL := http://jcenter.bintray.com/com/netflix/iep/iep-launcher/0.3.8/iep-launcher-0.3.8.jar
 
 .PHONY: build snapshot release clean coverage license update-wiki publish-wiki
 

--- a/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/ImageDiff.scala
+++ b/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/ImageDiff.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.standalone
+
+import java.awt.image.RenderedImage
+
+import com.netflix.atlas.core.util.PngImage
+import com.netflix.atlas.core.util.Streams._
+
+/**
+  * Command line tool for finding differences between two png images. The exit code will be 0
+  * if there is no difference and 1 if there is a difference. An output image will be created
+  * showing which pixels are different, black pixesls are the same for both, red pixels are
+  * different.
+  */
+object ImageDiff {
+
+  private def load(fname: String): RenderedImage = {
+    PngImage(scope(fileIn(fname))(byteArray)).data
+  }
+
+  private def store(fname: String, image: PngImage): Unit = {
+    scope(fileOut(fname))(image.write)
+  }
+
+  def main(args: Array[String]): Unit = {
+    if (args.length != 3) {
+      System.err.println(s"Usage: ImageDiff <image1> <image2> <diff-image>")
+      sys.exit(2)
+    }
+
+    val image1 = load(args(0))
+    val image2 = load(args(1))
+
+    val diff = PngImage.diff(image1, image2)
+    store(args(2), diff)
+    sys.exit(if (diff.metadata("identical") == "true") 0 else 1)
+  }
+}


### PR DESCRIPTION
Makes the image diff utility used for tests available
as a command line tool. Mainly for scripting some
comparisons.