### PR TITLE
add :percentiles and :median

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/ModelExtractors.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/ModelExtractors.scala
@@ -39,6 +39,13 @@ object ModelExtractors {
     }
   }
 
+  case object DoubleListType {
+    def unapply(value: Any): Option[List[Double]] = value match {
+      case StringListType(vs) => Try(vs.map(_.toDouble)).toOption
+      case _                  => None
+    }
+  }
+
   case object AggrType {
     def unapply(value: Any): Option[AggregateFunction] = value match {
       case v: Query             => Some(DataExpr.Sum(v))

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TagKey.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TagKey.scala
@@ -87,6 +87,9 @@ object TagKey {
   /** ISO country code rollup used by NCCP. */
   final val countryRollup = netflixPrefix + "country.rollup"
 
+  /** Used to store the bucket id for percentile approximation. */
+  final val percentile = "percentile"
+
   /** List of atlas tag keys. */
   val atlas: List[String] = List(
     allTags, uniqueTags,

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/PercentilesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/PercentilesSuite.scala
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import java.util.concurrent.TimeUnit
+import java.util.stream.Collectors
+
+import com.netflix.atlas.core.stacklang.Interpreter
+import com.netflix.spectator.api.Counter
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.histogram.PercentileBuckets
+import com.netflix.spectator.api.histogram.PercentileDistributionSummary
+import com.netflix.spectator.api.histogram.PercentileTimer
+import org.scalatest.FunSuite
+import org.scalatest.Matchers._
+
+import scala.language.postfixOps
+
+class PercentilesSuite extends FunSuite {
+
+  private val interpreter = Interpreter(MathVocabulary.allWords)
+
+  private val start = 0L
+  private val step = 60000L
+
+  def ts(bucket: String, values: Double*): TimeSeries = {
+    val seq = new ArrayTimeSeq(DsType.Gauge, start, step, values.toArray)
+    val mode = if (Integer.parseInt(bucket.substring(1), 16) % 2 == 0) "even" else "odd"
+    TimeSeries(Map("name" -> "test", "mode" -> mode, "percentile" -> bucket), seq)
+  }
+
+  def eval(str: String, input: List[TimeSeries]): List[TimeSeries] = {
+    val expr = interpreter.execute(str).stack match {
+      case (v: TimeSeriesExpr) :: _ => v
+      case _                        => throw new IllegalArgumentException("invalid expr")
+    }
+    val context = EvalContext(start, start + step * 2, step)
+    expr.eval(context, input).data
+  }
+
+  private val input100 = {
+    (0 until 100).map { i =>
+      val bucket = f"D${PercentileBuckets.indexOf(i)}%04X"
+      val v = 1.0 / 60.0
+      ts(bucket, v, v)
+    } toList
+  }
+
+  private val inputTimer100 = {
+    (0 until 100).map { i =>
+      val bucket = f"T${PercentileBuckets.indexOf(i)}%04X"
+      val v = 1.0 / 60.0
+      ts(bucket, v, v)
+    } toList
+  }
+
+  private val inputNaN = {
+    (0 until 100).map { i =>
+      val bucket = f"D${PercentileBuckets.indexOf(i)}%04X"
+      val v = Double.NaN
+      ts(bucket, v, v)
+    } toList
+  }
+
+  private val inputSpectatorTimer = {
+    import scala.collection.JavaConversions._
+    val r = new DefaultRegistry()
+    val t = PercentileTimer.get(r, r.createId("test"))
+    (0 until 100).foreach { i =>
+      t.record(i, TimeUnit.MILLISECONDS)
+    }
+
+    val counters = r.counters.collect(Collectors.toList[Counter]).toList
+    counters.map { c =>
+      val v = c.count / 60.0
+      val seq = new ArrayTimeSeq(DsType.Gauge, start, step, Array(v, v))
+      val tags = c.id.tags.map(t => t.key -> t.value).toMap + ("name" -> c.id.name)
+      TimeSeries(tags, seq)
+    }
+  }
+
+  private val inputSpectatorDistSummary = {
+    import scala.collection.JavaConversions._
+    val r = new DefaultRegistry()
+    val t = PercentileDistributionSummary.get(r, r.createId("test"))
+    (0 until 100).foreach { i => t.record(i) }
+
+    val counters = r.counters.collect(Collectors.toList[Counter]).toList
+    counters.map { c =>
+      val v = c.count / 60.0
+      val seq = new ArrayTimeSeq(DsType.Gauge, start, step, Array(v, v))
+      val tags = c.id.tags.map(t => t.key -> t.value).toMap + ("name" -> c.id.name)
+      TimeSeries(tags, seq)
+    }
+  }
+
+  test("distribution summary :sum") {
+    val data = eval("name,test,:eq,(,9,25,50,90,100,),:percentiles", input100)
+
+    assert(data.size === 5)
+    List(9.0, 25.0, 50.0, 90.0).zip(data).foreach { case (p, t) =>
+      val estimate = t.data(0L)
+      assert(t.tags === Map("name" -> "test", "percentile" -> f"$p%5.1f"))
+      assert(t.label === f"percentile(name=test, $p%5.1f)")
+      assert(p === (estimate +- 2.0))
+    }
+    assert(data.last.label === f"percentile(name=test, 100.0)")
+  }
+
+  test("timer :sum") {
+    val data = eval("name,test,:eq,(,25,50,90,),:percentiles", inputTimer100)
+
+    assert(data.size === 3)
+    List(25.0, 50.0, 90.0).zip(data).foreach { case (p, t) =>
+      val estimate = t.data(0L)
+      assert(t.tags === Map("name" -> "test", "percentile" -> f"$p%5.1f"))
+      assert(t.label === f"percentile(name=test, $p%5.1f)")
+      assert(p / 1e9 === (estimate +- 2.0e-9))
+    }
+  }
+
+  test("spectator distribution summary :sum") {
+    val data = eval("name,test,:eq,(,9,25,50,90,100,),:percentiles", inputSpectatorDistSummary)
+
+    assert(data.size === 5)
+    List(9.0, 25.0, 50.0, 90.0).zip(data).foreach { case (p, t) =>
+      val estimate = t.data(0L)
+      assert(t.tags === Map("name" -> "test", "percentile" -> f"$p%5.1f"))
+      assert(t.label === f"percentile(name=test, $p%5.1f)")
+      assert(p === (estimate +- 2.0))
+    }
+    assert(data.last.label === f"percentile(name=test, 100.0)")
+  }
+
+  test("spectator timer :sum") {
+    val data = eval("name,test,:eq,(,25,50,90,),:percentiles", inputSpectatorTimer)
+
+    assert(data.size === 3)
+    List(25.0, 50.0, 90.0).zip(data).foreach { case (p, t) =>
+      val estimate = t.data(0L)
+      assert(t.tags === Map("name" -> "test", "percentile" -> f"$p%5.1f"))
+      assert(t.label === f"percentile(name=test, $p%5.1f)")
+
+      // Values were 0 ot 100 recorded in milliseconds, should be reported in seconds
+      assert(p / 1e3 === (estimate +- 2.0e-3))
+    }
+  }
+
+  test("distribution summary :max") {
+    val data = eval("name,test,:eq,:max,(,25,50,90,),:percentiles", input100)
+
+    assert(data.size === 3)
+    List(25.0, 50.0, 90.0).zip(data).foreach { case (p, t) =>
+      val estimate = t.data(0L)
+      assert(t.tags === Map("name" -> "test", "percentile" -> f"$p%5.1f"))
+      assert(t.label === f"percentile(name=test, $p%5.1f)")
+      assert(p === (estimate +- 2.0))
+    }
+  }
+
+  test("distribution summary :median") {
+    val data = eval("name,test,:eq,:median", input100)
+
+    assert(data.size === 1)
+    List(50.0).zip(data).foreach { case (p, t) =>
+      val estimate = t.data(0L)
+      assert(t.tags === Map("name" -> "test", "percentile" -> f"$p%5.1f"))
+      assert(t.label === f"percentile(name=test, $p%5.1f)")
+      assert(p === (estimate +- 2.0))
+    }
+  }
+
+  test("group by empty") {
+    val data = eval("name,test,:eq,(,foo,),:by,(,25,50,90,),:percentiles", input100)
+    assert(data.size === 0)
+  }
+
+  test("group by with single result") {
+    val data = eval("name,test,:eq,(,name,),:by,(,25,50,90,),:percentiles", input100)
+
+    assert(data.size === 3)
+    List(25.0, 50.0, 90.0).zip(data).foreach { case (p, t) =>
+      val estimate = t.data(0L)
+      assert(t.tags === Map("name" -> "test", "percentile" -> f"$p%5.1f"))
+      assert(t.label === f"percentile((name=test), $p%5.1f)")
+      assert(p === (estimate +- 2.0))
+    }
+  }
+
+  test("group by with multiple results") {
+    val data = eval("name,test,:eq,(,mode,),:by,(,25,50,90,),:percentiles", input100)
+
+    assert(data.size === 6)
+    List(25.0, 50.0, 90.0).zip(data.filter(_.tags("mode") == "even")).foreach { case (p, t) =>
+      val estimate = t.data(0L)
+      assert(t.tags === Map("name" -> "test", "mode" -> "even", "percentile" -> f"$p%5.1f"))
+      assert(t.label === f"percentile((mode=even), $p%5.1f)")
+      assert(p === (estimate +- 10.0))
+    }
+    List(25.0, 50.0, 90.0).zip(data.filter(_.tags("mode") == "odd")).foreach { case (p, t) =>
+      val estimate = t.data(0L)
+      assert(t.tags === Map("name" -> "test", "mode" -> "odd", "percentile" -> f"$p%5.1f"))
+      assert(t.label === f"percentile((mode=odd), $p%5.1f)")
+      assert(p === (estimate +- 10.0))
+    }
+  }
+
+  test("group by multi-level") {
+    val data = eval("name,test,:eq,(,mode,),:by,(,25,50,90,),:percentiles,:max,(,percentile,),:by", input100)
+
+    assert(data.size === 3)
+    List(25.0, 50.0, 90.0).zip(data).foreach { case (p, t) =>
+      val estimate = t.data(0L)
+      assert(t.tags === Map("name" -> "test", "percentile" -> f"$p%5.1f"))
+      assert(t.label === f"(percentile=$p%5.1f)")
+      assert(p === (estimate +- 10.0))
+    }
+  }
+
+  test("distribution summary empty") {
+    val data = eval(":false,(,25,50,90,),:percentiles", input100)
+    assert(data.size === 0)
+  }
+
+  test("distribution summary NaN") {
+    val data = eval(":true,(,25,50,90,),:percentiles", inputNaN)
+
+    assert(data.size === 3)
+    List(25.0, 50.0, 90.0).zip(data).foreach { case (p, t) =>
+      val estimate = t.data(0L)
+      assert(t.tags === Map("percentile" -> f"$p%5.1f"))
+      assert(t.label === f"percentile(true, $p%5.1f)")
+      assert(estimate.isNaN)
+    }
+  }
+
+  test("bad input: too small") {
+    intercept[IllegalArgumentException] {
+      eval("name,test,:eq,(,-1,),:percentiles", input100)
+    }
+  }
+
+  test("bad input: too big") {
+    intercept[IllegalArgumentException] {
+      eval("name,test,:eq,(,100.1,),:percentiles", input100)
+    }
+  }
+
+  test("bad input: string in list") {
+    intercept[IllegalStateException] {
+      eval("name,test,:eq,(,50,foo,),:percentiles", input100)
+    }
+  }
+
+  test("bad input: unsupported :head") {
+    intercept[IllegalStateException] {
+      eval("name,test,:eq,(,mode,),:by,4,:head,(,50,),:percentiles", input100)
+    }
+  }
+
+  test("bad input: unsupported :all") {
+    intercept[IllegalStateException] {
+      eval("name,test,:eq,:all,(,50,),:percentiles", input100)
+    }
+  }
+}
+

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     val log4j      = "2.5"
     val scala      = "2.11.7"
     val slf4j      = "1.7.13"
-    val spectator  = "0.33.0"
+    val spectator  = "0.34.1"
     val spray      = "1.3.3"
   }
 


### PR DESCRIPTION
Adds a `:percentiles` helper to compute estimated percentiles
for spectator PercentileTimer and PercentileDistributionSummary.
These use a precomputed set of buckets that partition the range
of non-negative long values to allow for arbitrary slicing and
dicing based on the dimensions and still get a reasonable
approximation of percentiles.

This approach is less accurate than alternatives like t-Digest,
but more efficent and practical for our use-cases.

It is used just after the data function which should be a sum
or group by:

```
name,requestLatency,:eq,(,50,90,),:percentiles
name,requestLatency,:eq,(,nf.cluster,),:by,(,50,90,),:percentiles
```

The output will be one line per input per requested percentile.
There is also a helper, `:median` that is just short hand for
`(,50,),:percentiles`.