### PR TITLE
make QueryIndex.create more generic

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/QueryIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/QueryIndex.scala
@@ -121,10 +121,9 @@ object QueryIndex {
   }
 
   /**
-   * Create an index based on a list of queries. The value for the entry will be the raw input
-   * query.
+   * Create an index based on a list of entries.
    */
-  def create(entries: List[Entry[Query]]): QueryIndex[Query] = {
+  def create[T](entries: List[Entry[T]]): QueryIndex[T] = {
     val annotated = entries.flatMap { entry =>
       val qs = split(entry.query)
       qs.map(q => annotate(Entry(q, entry.value)))


### PR DESCRIPTION
Allow the entry type to vary so it is easier to create the index
for any entry rather than just those with a value type of Query.