### PR TITLE
add experimental output format with all metadata

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/CsvGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/CsvGraphEngine.scala
@@ -25,7 +25,7 @@ import com.netflix.atlas.chart.model.GraphDef
 
 class CsvGraphEngine(val name: String, val contentType: String, sep: String) extends GraphEngine {
 
-  def write(config: GraphDef, output: OutputStream) {
+  def write(config: GraphDef, output: OutputStream): Unit = {
     val writer = new OutputStreamWriter(output, "UTF-8")
     val seriesList = config.plots.flatMap(_.lines)
     val count = seriesList.size

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonCodec.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonCodec.scala
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.chart
+
+import java.awt.Color
+import java.io.OutputStream
+import java.time.Instant
+import java.time.ZoneId
+
+import com.fasterxml.jackson.core.JsonFactory
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.atlas.chart.model._
+import com.netflix.atlas.core.model.ArrayTimeSeq
+import com.netflix.atlas.core.model.CollectorStats
+import com.netflix.atlas.core.model.DsType
+import com.netflix.atlas.core.model.TimeSeries
+import com.netflix.atlas.core.util.Streams
+import com.netflix.atlas.core.util.Strings
+
+/**
+  * Helper for converting a graph definition to and from json. The format is still being tested
+  * and is not yet considered final. To allow data to be incrementally written in the future, this
+  * format uses an array with entries following the pattern:
+  *
+  * ```
+  * [graph-metadata, plot-metadata, ... lines ..., plot-metadata, ... lines ..., ...]
+  * ```
+  *
+  * Metadata is output first so something could setup initial rendering. Then we output the
+  * `plot-metadata` that corresponds to all lines on a given axis. That is followed by the set
+  * of lines. This pattern is repeated until all plots have been output.
+  */
+private[this] object JsonCodec {
+
+  import com.netflix.atlas.json.JsonParserHelper._
+  private val factory = new JsonFactory()
+  private val mapper = new ObjectMapper(factory)
+
+  def encode(config: GraphDef): String = {
+    Streams.string { w =>
+      val gen = factory.createGenerator(w)
+      writeGraphDef(gen, config)
+      gen.close()
+    }
+  }
+
+  def encode(output: OutputStream, config: GraphDef): Unit = {
+    val gen = factory.createGenerator(output)
+    writeGraphDef(gen, config)
+    gen.close()
+  }
+
+  def decode(json: String): GraphDef = {
+    val parser = factory.createParser(json)
+    readGraphDef(parser)
+  }
+
+  private def writeGraphDef(gen: JsonGenerator, config: GraphDef): Unit = {
+    gen.writeStartArray()
+    writeGraphDefMetadata(gen, config)
+    config.plots.foreach { plot =>
+      writePlotDefMetadata(gen, plot)
+      plot.data.foreach { data =>
+        writeDataDef(gen, data, config.startTime.toEpochMilli, config.endTime.toEpochMilli)
+      }
+    }
+    gen.writeEndArray()
+  }
+
+  private def writeGraphDefMetadata(gen: JsonGenerator, config: GraphDef): Unit = {
+    gen.writeStartObject()
+    gen.writeStringField("type", "graph-metadata")
+    gen.writeNumberField("startTime", config.startTime.toEpochMilli)
+    gen.writeNumberField("endTime", config.endTime.toEpochMilli)
+    gen.writeArrayFieldStart("timezones")
+    config.timezones.foreach { tz => gen.writeString(tz.getId) }
+    gen.writeEndArray()
+    gen.writeNumberField("step", config.step)
+
+    gen.writeNumberField("width", config.width)
+    gen.writeNumberField("height", config.height)
+    gen.writeStringField("layout", config.layout.name())
+    gen.writeNumberField("zoom", config.zoom)
+
+    config.title.foreach { t => gen.writeStringField("title", t) }
+    gen.writeStringField("legendType", config.legendType.name())
+    gen.writeBooleanField("onlyGraph", config.onlyGraph)
+
+    if (config.loadTime > 0) {
+      gen.writeNumberField("loadTime", config.loadTime)
+    }
+
+    if (config.stats != CollectorStats.unknown) {
+      gen.writeObjectFieldStart("stats")
+      gen.writeNumberField("inputLines", config.stats.inputLines)
+      gen.writeNumberField("inputDatapoints", config.stats.inputDatapoints)
+      gen.writeNumberField("outputLines", config.stats.outputLines)
+      gen.writeNumberField("outputDatapoints", config.stats.outputDatapoints)
+      gen.writeEndObject()
+    }
+
+    gen.writeArrayFieldStart("warnings")
+    config.warnings.foreach { w => gen.writeString(w) }
+    gen.writeEndArray()
+    gen.writeEndObject()
+  }
+
+  private def writePlotDefMetadata(gen: JsonGenerator, plot: PlotDef): Unit = {
+    gen.writeStartObject()
+    gen.writeStringField("type", "plot-metadata")
+    plot.ylabel.foreach { v => gen.writeStringField("ylabel", v) }
+    plot.axisColor.foreach { v =>
+      gen.writeFieldName("axisColor")
+      writeColor(gen, v)
+    }
+    gen.writeStringField("scale", plot.scale.name())
+    gen.writeStringField("upper", plot.upper.toString)
+    gen.writeStringField("lower", plot.lower.toString)
+    gen.writeBooleanField("showTickLabels", plot.showTickLabels)
+    gen.writeEndObject()
+  }
+
+  private def writeDataDef(gen: JsonGenerator, data: DataDef, start: Long, end: Long): Unit = {
+    data match {
+      case v: LineDef  => writeLineDef(gen, v, start, end)
+      case v: HSpanDef => writeHSpanDef(gen, v)
+      case v: VSpanDef => writeVSpanDef(gen, v)
+    }
+  }
+
+  private def writeLineDef(gen: JsonGenerator, line: LineDef, start: Long, end: Long): Unit = {
+    gen.writeStartObject()
+    gen.writeStringField("type", "timeseries")
+    gen.writeStringField("label", line.data.label)
+    gen.writeFieldName("color")
+    writeColor(gen, line.color)
+    gen.writeStringField("lineStyle", line.lineStyle.name())
+    gen.writeNumberField("lineWidth", line.lineWidth)
+    gen.writeObjectFieldStart("tags")
+    line.data.tags.foreach { case (k, v) => gen.writeStringField(k, v) }
+    gen.writeEndObject()
+    gen.writeObjectFieldStart("data")
+    gen.writeStringField("type", "array")
+    gen.writeArrayFieldStart("values")
+    line.data.data.foreach(start, end) { (_, v) => gen.writeNumber(v) }
+    gen.writeEndArray()
+    gen.writeEndObject()
+    gen.writeEndObject()
+  }
+
+  private def writeHSpanDef(gen: JsonGenerator, span: HSpanDef): Unit = {
+    gen.writeStartObject()
+    gen.writeStringField("type", "hspan")
+    span.label.foreach { v => gen.writeStringField("label", v) }
+    gen.writeFieldName("color")
+    writeColor(gen, span.color)
+    gen.writeNumberField("v1", span.v1)
+    gen.writeNumberField("v2", span.v2)
+    gen.writeEndObject()
+  }
+
+  private def writeVSpanDef(gen: JsonGenerator, span: VSpanDef): Unit = {
+    gen.writeStartObject()
+    gen.writeStringField("type", "vspan")
+    span.label.foreach { v => gen.writeStringField("label", v) }
+    gen.writeFieldName("color")
+    writeColor(gen, span.color)
+    gen.writeNumberField("t1", span.t1.toEpochMilli)
+    gen.writeNumberField("t2", span.t2.toEpochMilli)
+    gen.writeEndObject()
+  }
+
+  private def writeColor(gen: JsonGenerator, color: Color): Unit = {
+    gen.writeString(f"${color.getRGB}%08X")
+  }
+
+  private def readGraphDef(parser: JsonParser): GraphDef = {
+    var gdef: GraphDef = null
+    var pdef: PlotDef = null
+    val plots = List.newBuilder[PlotDef]
+    var data = List.newBuilder[DataDef]
+    foreachItem(parser) {
+      val node = mapper.readTree[JsonNode](parser)
+      node.get("type").asText() match {
+        case "graph-metadata" =>
+          if (gdef != null)
+            throw new IllegalStateException("multiple graph-metadata blocks")
+          gdef = toGraphDef(node)
+        case "plot-metadata" =>
+          if (pdef != null) plots += pdef.copy(data = data.result())
+          pdef = toPlotDef(node)
+          data = List.newBuilder[DataDef]
+        case "timeseries" =>
+          if (pdef == null)
+            throw new IllegalStateException("plot-metadata is not defined")
+          data += toLineDef(gdef, node)
+        case "hspan" =>
+          if (pdef == null)
+            throw new IllegalStateException("plot-metadata is not defined")
+          data += toHSpanDef(node)
+        case "vspan" =>
+          if (pdef == null)
+            throw new IllegalStateException("plot-metadata is not defined")
+          data += toVSpanDef(node)
+      }
+    }
+    if (pdef != null) plots += pdef.copy(data = data.result())
+    gdef.copy(plots = plots.result())
+  }
+
+  private def toGraphDef(node: JsonNode): GraphDef = {
+    import scala.collection.JavaConversions._
+    GraphDef(Nil,
+      startTime  = Instant.ofEpochMilli(node.get("startTime").asLong()),
+      endTime    = Instant.ofEpochMilli(node.get("endTime").asLong()),
+      timezones  = node.get("timezones").elements.map(n => ZoneId.of(n.asText())).toList,
+      step       = node.get("step").asLong(),
+      width      = node.get("width").asInt(),
+      height     = node.get("height").asInt(),
+      layout     = Layout.valueOf(node.get("layout").asText()),
+      zoom       = node.get("zoom").asDouble(),
+      title      = Option(node.get("title")).map(_.asText()),
+      legendType = LegendType.valueOf(node.get("legendType").asText()),
+      onlyGraph  = node.get("onlyGraph").asBoolean(),
+      loadTime   = Option(node.get("loadTime")).fold(-1L)(_.asLong()),
+      warnings   = node.get("warnings").elements.map(_.asText()).toList
+    )
+  }
+
+  private def toCollectorStats(node: JsonNode): CollectorStats = {
+    CollectorStats(
+      inputLines       = node.get("inputLines").asLong(),
+      inputDatapoints  = node.get("inputDatapoints").asLong(),
+      outputLines      = node.get("outputLines").asLong(),
+      outputDatapoints = node.get("outputDatapoints").asLong()
+    )
+  }
+
+ private def toPlotDef(node: JsonNode): PlotDef = {
+    PlotDef(Nil,
+      ylabel         = Option(node.get("ylabel")).map(_.asText()),
+      axisColor      = Option(node.get("axisColor")).map(toColor),
+      scale          = Scale.valueOf(node.get("scale").asText()),
+      upper          = PlotBound(node.get("upper").asText()),
+      lower          = PlotBound(node.get("lower").asText()),
+      showTickLabels = node.get("showTickLabels").asBoolean()
+    )
+  }
+
+  /**
+    * Need to make sure alpha is handled properly, it will get ignored in some cases with the
+    * color class.
+    *
+    * ```
+    * scala> val c = new Color(Integer.parseUnsignedInt("32FF0000", 16))
+    * c: java.awt.Color = java.awt.Color[r=255,g=0,b=0]
+    *
+    * scala> c.getAlpha
+    * res0: Int = 255
+    * ```
+    */
+  private def toColor(node: JsonNode): Color = Strings.parseColor(node.asText())
+
+  private def toLineDef(gdef: GraphDef, node: JsonNode): LineDef = {
+    LineDef(
+      data      = toTimeSeries(gdef, node),
+      color     = toColor(node.get("color")),
+      lineStyle = LineStyle.valueOf(node.get("lineStyle").asText()),
+      lineWidth = node.get("lineWidth").asDouble().toFloat
+    )
+  }
+
+  private def toHSpanDef(node: JsonNode): HSpanDef = {
+    HSpanDef(
+      v1     = node.get("v1").asDouble(),
+      v2     = node.get("v2").asDouble(),
+      color  = toColor(node.get("color")),
+      label  = Option(node.get("label")).map(_.asText())
+    )
+  }
+
+  private def toVSpanDef(node: JsonNode): VSpanDef = {
+    VSpanDef(
+      t1     = Instant.ofEpochMilli(node.get("t1").asLong()),
+      t2     = Instant.ofEpochMilli(node.get("t2").asLong()),
+      color  = toColor(node.get("color")),
+      label  = Option(node.get("label")).map(_.asText())
+    )
+  }
+
+  private def toTimeSeries(gdef: GraphDef, node: JsonNode): TimeSeries = {
+    import scala.collection.JavaConversions._
+    val tags = node.get("tags").fields.map(e => e.getKey -> e.getValue.asText()).toMap
+    val values = node.get("data").get("values").elements.map(_.asDouble()).toArray
+    val seq = new ArrayTimeSeq(DsType.Gauge, gdef.startTime.toEpochMilli, gdef.step, values)
+    TimeSeries(tags, node.get("label").asText(), seq)
+  }
+}

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonGraphEngine.scala
@@ -29,7 +29,7 @@ class JsonGraphEngine(quoteNonNumeric: Boolean) extends GraphEngine {
   def name: String = "json"
   def contentType: String = "application/json"
 
-  def write(config: GraphDef, output: OutputStream) {
+  def write(config: GraphDef, output: OutputStream): Unit = {
     val writer = new OutputStreamWriter(output, "UTF-8")
     val seriesList = config.plots.flatMap(_.lines)
     val count = seriesList.size

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/PngGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/PngGraphEngine.scala
@@ -25,7 +25,7 @@ import com.netflix.atlas.core.util.PngImage
 trait PngGraphEngine extends GraphEngine {
   val contentType: String = "image/png"
 
-  def write(config: GraphDef, output: OutputStream) {
+  def write(config: GraphDef, output: OutputStream): Unit = {
     val image = PngImage(createImage(config), Map.empty)
     image.write(output)
   }

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/StatsJsonGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/StatsJsonGraphEngine.scala
@@ -33,7 +33,7 @@ class StatsJsonGraphEngine extends GraphEngine {
   def name: String = "stats.json"
   def contentType: String = "application/json"
 
-  private def writeRawField(gen: JsonGenerator, name: String, value: String) {
+  private def writeRawField(gen: JsonGenerator, name: String, value: String): Unit = {
     gen.writeFieldName(name)
     gen.writeRawValue(value)
   }

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/V2JsonGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/V2JsonGraphEngine.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.chart
+
+import java.io.OutputStream
+
+import com.netflix.atlas.chart.model.GraphDef
+
+/**
+  * Experimental variant of json encoding. The format is not yet final and may change. Goals:
+  *
+  * - Include all metadata so the output can be used to precisely recreate the image. This is
+  *   useful for debugging and allows dynamic rendering to be more precise.
+  *
+  * - Must be parseable with a standard json parser. The default json format encodes NaN and
+  *   Infinity without quotes so it cannot be used without parser extensions. The std.json format
+  *   fixes that, but in all new formats they should be standard for the json encoding.
+  *
+  * - Allow the data to be incrementally returned. With many of the existing formats the entire
+  *   payload must be ready before we can output data. As data volumes get bigger it is
+  *   necessary to be able to emit data as it becomes available.
+  *
+  * - Consistent where possible to the SSE payloads from the fetch API.
+  */
+class V2JsonGraphEngine extends GraphEngine {
+  override def name: String = "v2.json"
+  override def contentType: String = "application/json"
+
+  override def write(config: GraphDef, output: OutputStream): Unit = {
+    JsonCodec.encode(output, config)
+  }
+}

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/GraphDef.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/GraphDef.scala
@@ -23,6 +23,7 @@ import com.netflix.atlas.chart.GraphConstants
 import com.netflix.atlas.chart.graphics.Constants
 import com.netflix.atlas.core.model.CollectorStats
 import com.netflix.atlas.core.model.SummaryStats
+import com.netflix.atlas.core.model.TimeSeries
 
 /**
  * Definition of a time series graph.
@@ -47,6 +48,8 @@ import com.netflix.atlas.core.model.SummaryStats
  *     final image size will get calculated using this height as a starting point.
  * @param layout
  *     Layout mode to use for rendering the image. Default is CANVAS.
+ * @param zoom
+ *     Zoom factor to apply as a transform to the image.
  * @param title
  *     Title of the graph.
  * @param legendType
@@ -114,7 +117,7 @@ case class GraphDef(
 
     val size = plot.data.size
     if (size > GraphConstants.MaxYAxis) {
-      val msg = s"Too many Y-axes, ${size} > ${GraphConstants.MaxYAxis}, axis per line disabled."
+      val msg = s"Too many Y-axes, $size > ${GraphConstants.MaxYAxis}, axis per line disabled."
       copy(warnings = msg :: warnings)
     } else {
       val newPlots = plot.data.map { d => plot.copy(data = List(d), axisColor = None) }
@@ -153,6 +156,16 @@ case class GraphDef(
     adjustLines { line =>
       val stats = SummaryStats(line.data.data, startTime.toEpochMilli, endTime.toEpochMilli)
       line.copy(legendStats = stats)
+    }
+  }
+
+  /** Return a new graph defintion with the lines bounded. */
+  def bounded: GraphDef = {
+    val s = startTime.toEpochMilli
+    val e = endTime.toEpochMilli
+    adjustLines { line =>
+      val seq = line.data.data.bounded(s, e)
+      line.copy(data = TimeSeries(line.data.tags, line.data.label, seq))
     }
   }
 }

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/PlotBound.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/PlotBound.scala
@@ -49,6 +49,8 @@ object PlotBound {
     def upper(hasArea: Boolean, max: Double): Double = {
       if (hasArea && max < 0.0) 0.0 else max
     }
+
+    override def toString: String = "auto-style"
   }
 
   /**
@@ -57,6 +59,7 @@ object PlotBound {
   case object AutoData extends PlotBound {
     def lower(hasArea: Boolean, min: Double): Double = min
     def upper(hasArea: Boolean, max: Double): Double = max
+    override def toString: String = "auto-data"
   }
 
   /**
@@ -65,6 +68,7 @@ object PlotBound {
   case class Explicit(v: Double) extends PlotBound {
     def lower(hasArea: Boolean, min: Double): Double = v
     def upper(hasArea: Boolean, max: Double): Double = v
+    override def toString: String = v.toString
   }
 
 }

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/JsonGraphEngineSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/JsonGraphEngineSuite.scala
@@ -46,7 +46,7 @@ class JsonGraphEngineSuite extends FunSuite {
     expected.stripMargin.split("\n").mkString("")
   }
 
-  def process(engine: GraphEngine, expected: String) {
+  def process(engine: GraphEngine, expected: String): Unit = {
     val data = PlotDef(label(constantSeriesDef(42), constantSeriesDef(Double.NaN)))
 
     val graphDef = GraphDef(

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/PngGraphEngineSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/PngGraphEngineSuite.scala
@@ -121,7 +121,7 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
      new Color(c.getRed, c.getGreen, c.getBlue, 75)
   }
 
-  override def afterAll() {
+  override def afterAll(): Unit = {
     graphAssertions.generateReport(getClass)
   }
 
@@ -136,6 +136,15 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
 
   def load(resource: String): GraphDef = {
     Streams.scope(Streams.resource(resource)) { in => Json.decode[GraphData](in).toGraphDef }
+  }
+
+  def check(name: String, graphDef: GraphDef): Unit = {
+    val json = JsonCodec.encode(graphDef)
+    assert(graphDef.bounded === JsonCodec.decode(json))
+
+    val image = PngImage(graphEngine.createImage(graphDef), Map.empty)
+    graphAssertions.assertEquals(image, name, bless)
+
   }
 
   /*
@@ -155,8 +164,7 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
     //atlas generated sample is 780 wide less 64 origin less 16 r side padding == 700
     //expect to see width of spikes vary as x values repeat due to rounding
     //RrdGraph calculates x values based on number of pixels/second
-    val image = PngImage(graphEngine.createImage(graphDef), Map.empty)
-    graphAssertions.assertEquals(image, name, bless)
+    check(name, graphDef)
   }
 
   test("one_data_point_wide_spike") {
@@ -199,8 +207,7 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
       plots = List(plotDef)
     )
 
-    val image = PngImage(graphEngine.createImage(graphDef), Map.empty)
-    graphAssertions.assertEquals(image, name, bless)
+    check(name, graphDef)
   }
 
   private def lines(name: String, vs: Seq[Double], f: GraphDef => GraphDef): Unit = {
@@ -214,9 +221,8 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
         plots = List(plotDef)
       )
 
-      val image = PngImage(graphEngine.createImage(f(graphDef)), Map.empty)
       val fname = s"${prefix}_$name.png"
-      graphAssertions.assertEquals(image, fname, bless)
+      check(fname, f(graphDef))
     }
   }
 
@@ -287,9 +293,8 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
         plots = List(plotDef)
       )
 
-      val image = PngImage(graphEngine.createImage(f(graphDef)), Map.empty)
       val fname = s"${prefix}_$testName.png"
-      graphAssertions.assertEquals(image, fname, bless)
+      check(fname, f(graphDef))
     }
   }
 
@@ -315,9 +320,8 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
       plots = List(plotDef)
     )
 
-    val image = PngImage(graphEngine.createImage(graphDef), Map.empty)
     val fname = s"${prefix}_single_line_hspans.png"
-    graphAssertions.assertEquals(image, fname, bless)
+    check(fname, graphDef)
   }
 
   test("single_line_vspans") {
@@ -334,9 +338,8 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
       plots = List(plotDef)
     )
 
-    val image = PngImage(graphEngine.createImage(graphDef), Map.empty)
     val fname = s"${prefix}_single_line_vspans.png"
-    graphAssertions.assertEquals(image, fname, bless)
+    check(fname, graphDef)
   }
 
   private def doubleLine(name: String, f: GraphDef => GraphDef): Unit = {
@@ -367,9 +370,8 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
       plots = List(plotDef1)
     )
 
-    val image = PngImage(graphEngine.createImage(graphDef), Map.empty)
     val fname = s"${prefix}_double_yaxis.png"
-    graphAssertions.assertEquals(image, fname, bless)
+    check(fname, graphDef)
   }
 
   test("vspans_from_line") {
@@ -383,9 +385,8 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
       endTime = ZonedDateTime.of(2012, 1, 1, 8, 0, 0, 0, ZoneOffset.UTC).toInstant,
       plots = List(plotDef))
 
-    val image = PngImage(graphEngine.createImage(graphDef), Map.empty)
     val name = prefix + "_vspans_from_line.png"
-    graphAssertions.assertEquals(image, name, bless)
+    check(name, graphDef)
   }
 
   test("multiy_no_lines") {
@@ -394,9 +395,8 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
       endTime = ZonedDateTime.of(2012, 1, 2, 0, 0, 0, 0, ZoneOffset.UTC).toInstant,
       plots = List(PlotDef(Nil), PlotDef(Nil))
     )
-    val image = PngImage(graphEngine.createImage(graphDef), Map.empty)
     val name = prefix + "_multiy_no_lines.png"
-    graphAssertions.assertEquals(image, name, bless)
+    check(name, graphDef)
   }
 
   test("multiy_two") {
@@ -405,9 +405,8 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
       endTime = ZonedDateTime.of(2012, 1, 2, 0, 0, 0, 0, ZoneOffset.UTC).toInstant,
       plots = List(PlotDef(label(simpleSeriesDef(100))), PlotDef(label(simpleSeriesDef(100000))))
     )
-    val image = PngImage(graphEngine.createImage(graphDef), Map.empty)
     val name = prefix + "_multiy_two.png"
-    graphAssertions.assertEquals(image, name, bless)
+    check(name, graphDef)
   }
 
   test("multiy_issue-119") {
@@ -419,9 +418,8 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
         PlotDef(label(0, p, simpleSeriesDef(123456.0, 123457.0))),
         PlotDef(label(1, p, simpleSeriesDef(1e15, 1e15 - 9e2))))
     )
-    val image = PngImage(graphEngine.createImage(graphDef), Map.empty)
     val name = prefix + "_multiy_issue-119.png"
-    graphAssertions.assertEquals(image, name, bless)
+    check(name, graphDef)
   }
 
   test("multiy_two_colors") {
@@ -433,9 +431,8 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
         PlotDef(label(0, p, simpleSeriesDef(100))),
         PlotDef(label(1, p, simpleSeriesDef(100000))))
     )
-    val image = PngImage(graphEngine.createImage(graphDef), Map.empty)
     val name = prefix + "_multiy_two_colors.png"
-    graphAssertions.assertEquals(image, name, bless)
+    check(name, graphDef)
   }
 
   def multiy(name: String, f: PlotDef => PlotDef): Unit = {
@@ -449,9 +446,8 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
         endTime = ZonedDateTime.of(2012, 1, 2, 0, 0, 0, 0, ZoneOffset.UTC).toInstant,
         plots = plots.toList
       )
-      val image = PngImage(graphEngine.createImage(graphDef), Map.empty)
       val fname = s"${prefix}_multiy_n_$name.png"
-      graphAssertions.assertEquals(image, fname, bless)
+      check(fname, graphDef)
     }
   }
 
@@ -473,9 +469,8 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
       endTime = ZonedDateTime.of(2012, 1, 2, 0, 0, 0, 0, ZoneOffset.UTC).toInstant,
       plots = List(plotDef))
 
-    val image = PngImage(graphEngine.createImage(graphDef), Map.empty)
     val name = prefix + "_issue-119_missing_y_labels.png"
-    graphAssertions.assertEquals(image, name, bless)
+    check(name, graphDef)
   }
 
   test("issue-119_small_range_large_base") {
@@ -486,9 +481,8 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
       endTime = ZonedDateTime.of(2012, 1, 2, 0, 0, 0, 0, ZoneOffset.UTC).toInstant,
       plots = List(plotDef))
 
-    val image = PngImage(graphEngine.createImage(graphDef), Map.empty)
     val name = prefix + "_issue-119_small_range_large_base.png"
-    graphAssertions.assertEquals(image, name, bless)
+    check(name, graphDef)
   }
 
   test("issue-119_small_range_large_negative") {
@@ -499,9 +493,8 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
       endTime = ZonedDateTime.of(2012, 1, 2, 0, 0, 0, 0, ZoneOffset.UTC).toInstant,
       plots = List(plotDef))
 
-    val image = PngImage(graphEngine.createImage(graphDef), Map.empty)
     val name = prefix + "_issue-119_small_range_large_negative.png"
-    graphAssertions.assertEquals(image, name, bless)
+    check(name, graphDef)
   }
 
   test("zero_line_with_end_gap") {
@@ -523,9 +516,8 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
       endTime = start2.plus(1, ChronoUnit.MINUTES),
       plots = List(plotDef))
 
-    val image = PngImage(graphEngine.createImage(graphDef), Map.empty)
     val name = prefix + "_zero_line_with_end_gap.png"
-    graphAssertions.assertEquals(image, name, bless)
+    check(name, graphDef)
   }
 
   lines("too_many_lines", (0 until 1024).map(_.toDouble).toSeq, v => v)
@@ -550,9 +542,8 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
           "Something really bad happened.")
     )
 
-    val image = PngImage(graphEngine.createImage(graphDef), Map.empty)
     val name = prefix + "_notices.png"
-    graphAssertions.assertEquals(image, name, bless)
+    check(name, graphDef)
   }
 
   VisionType.values.foreach { vt =>

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
@@ -136,15 +136,15 @@ object Json {
     jsonMapper.writeValueAsString(obj)
   }
 
-  def encode[T: Manifest](writer: Writer, obj: T) {
+  def encode[T: Manifest](writer: Writer, obj: T): Unit = {
     jsonMapper.writeValue(writer, obj)
   }
 
-  def encode[T: Manifest](stream: OutputStream, obj: T) {
+  def encode[T: Manifest](stream: OutputStream, obj: T): Unit = {
     jsonMapper.writeValue(stream, obj)
   }
 
-  def encode[T: Manifest](gen: JsonGenerator, obj: T) {
+  def encode[T: Manifest](gen: JsonGenerator, obj: T): Unit = {
     jsonMapper.writeValue(gen, obj)
   }
 
@@ -187,7 +187,7 @@ object Json {
     smileMapper.writeValueAsBytes(obj)
   }
 
-  def smileEncode[T: Manifest](stream: OutputStream, obj: T) {
+  def smileEncode[T: Manifest](stream: OutputStream, obj: T): Unit = {
     smileMapper.writeValue(stream, obj)
   }
 

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/JsonParserHelper.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/JsonParserHelper.scala
@@ -41,7 +41,7 @@ object JsonParserHelper {
     throw new IllegalArgumentException(fullMsg)
   }
 
-  def requireNextToken(parser: JsonParser, expected: JsonToken) {
+  def requireNextToken(parser: JsonParser, expected: JsonToken): Unit = {
     val t = parser.nextToken()
     if (t != expected) fail(parser, s"expected $expected but received $t")
   }
@@ -59,6 +59,16 @@ object JsonParserHelper {
     vs.result()
   }
 
+  def nextBoolean(parser: JsonParser): Boolean = {
+    import com.fasterxml.jackson.core.JsonToken._
+    parser.nextToken() match {
+      case VALUE_FALSE   => parser.getValueAsBoolean
+      case VALUE_TRUE    => parser.getValueAsBoolean
+      case VALUE_STRING  => java.lang.Boolean.valueOf(parser.getText)
+      case t             => fail(parser, s"expected VALUE_FALSE or VALUE_TRUE but received $t")
+    }
+  }
+
   def nextInt(parser: JsonParser): Int = {
     requireNextToken(parser, JsonToken.VALUE_NUMBER_INT)
     parser.getValueAsInt
@@ -68,6 +78,8 @@ object JsonParserHelper {
     requireNextToken(parser, JsonToken.VALUE_NUMBER_INT)
     parser.getValueAsLong
   }
+
+  def nextFloat(parser: JsonParser): Double = nextDouble(parser).toFloat
 
   def nextDouble(parser: JsonParser): Double = {
     import com.fasterxml.jackson.core.JsonToken._
@@ -79,18 +91,18 @@ object JsonParserHelper {
     }
   }
 
-  def foreachItem[T](parser: JsonParser)(f: => T) {
+  def foreachItem[T](parser: JsonParser)(f: => T): Unit = {
     requireNextToken(parser, JsonToken.START_ARRAY)
     while (parser.nextToken() != JsonToken.END_ARRAY) { f }
   }
 
-  def foreachField[T](parser: JsonParser)(f: PartialFunction[String, T]) {
+  def foreachField[T](parser: JsonParser)(f: PartialFunction[String, T]): Unit = {
     while (skipTo(parser, JsonToken.FIELD_NAME, JsonToken.END_OBJECT)) {
       f(parser.getText)
     }
   }
 
-  def firstField[T](parser: JsonParser)(f: PartialFunction[String, T]) {
+  def firstField[T](parser: JsonParser)(f: PartialFunction[String, T]): Unit = {
     if (skipTo(parser, JsonToken.FIELD_NAME, JsonToken.END_OBJECT)) {
       f(parser.getText)
     }

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/JsonSupport.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/JsonSupport.scala
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.core.JsonGenerator
 
 
 trait JsonSupport {
-  def encode(gen: JsonGenerator) {
+  def encode(gen: JsonGenerator): Unit = {
     Json.encode(gen, this)
   }
 

--- a/atlas-webapi/src/main/resources/reference.conf
+++ b/atlas-webapi/src/main/resources/reference.conf
@@ -60,6 +60,7 @@ atlas {
         "com.netflix.atlas.chart.JsonGraphEngine",
         "com.netflix.atlas.chart.StatsJsonGraphEngine",
         "com.netflix.atlas.chart.StdJsonGraphEngine",
+        "com.netflix.atlas.chart.V2JsonGraphEngine",
         "com.netflix.atlas.chart.DefaultGraphEngine"
       ]
 


### PR DESCRIPTION
**The format is not final yet and may still change in
incompatible ways.**

Adds an experimental JSON output format that includes all
metadata so we can precisely detect presentation settings
if using external rendering. This is becoming more common
with various javascript libraries and there is a desire
to accurately capture user-intent for palettes, stack vs
area, etc.

It was a bit difficult to shoehorn this into existing
formats and there are a number of short comings so we'll
keep this to the side for now to get more experience with
the new format.