### PR TITLE
fix aggregation failure for empty by

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -323,8 +323,11 @@ object MathExpr {
 
     def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
       val rs = expr.eval(context, data)
-      val t = TimeSeries.aggregate(rs.data.iterator, context.start, context.end, this)
-      ResultSet(this, List(TimeSeries(t.tags, s"$name(${t.label})", t.data)), rs.state)
+      val ts = if (rs.data.isEmpty) Nil else {
+        val t = TimeSeries.aggregate(rs.data.iterator, context.start, context.end, this)
+        List(TimeSeries(t.tags, s"$name(${t.label})", t.data))
+      }
+      ResultSet(this, ts, rs.state)
     }
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
@@ -121,6 +121,7 @@ class TimeSeriesExprSuite extends FunSuite {
     ":true,(,name,),:by,4,:head"  -> const(byName.sortWith(_.label < _.label).take(4)),
     ":true,(,name,),:by,50,:head" -> const(byName),
     ":false,(,name,),:by"         -> const(Nil),
+    "n,:has,(,n,),:by,4,:div,:sum" -> const(Nil),
     "NaN,NaN,:add"                -> const(ts(Map("name" -> "NaN"), "(NaN + NaN)", Double.NaN)),
     "NaN,1.0,:add"                -> const(ts(Map("name" -> "NaN"), "(NaN + 1.0)", 1.0)),
     "1.0,NaN,:add"                -> const(ts(Map("name" -> "1.0"), "(1.0 + NaN)", 1.0)),


### PR DESCRIPTION
When using the math aggregate on an empty group by result
it an exception was being thrown:

```
requirement failed: must have 1 or more time series to perform
aggregation
```

Example: `:false,(,name,),:by,4,:div,:sum`

It will now return an empty result in the same way that
`:false,(,name,),:by` does.