### PR TITLE
use internationalized text fields for png metadata

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/PngImageSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/PngImageSuite.scala
@@ -97,4 +97,18 @@ class PngImageSuite extends FunSuite {
     assert(diff2.metadata("identical") === "true")
     assert(diff2.metadata("diff-pixel-count") === "0")
   }
+
+  test("image metadata") {
+    val metadata = Map(
+      "english"    -> "source url",
+      "japanese"   -> "ソースURL",
+      "compressed" -> (0 until 10000).mkString(",")
+    )
+    val img = PngImage.error("test", 100, 100).copy(metadata = metadata)
+
+    val bytes = img.toByteArray
+    val decoded = PngImage(bytes)
+
+    assert(metadata === decoded.metadata)
+  }
 }


### PR DESCRIPTION
For some use-cases we may have unicode characters in the text
fields. This change switches the metadata fields to get encoded
as iTXt fields instead of tEXt. For more information see:

http://www.libpng.org/pub/png/spec/1.2/PNG-Chunks.html#C.iTXt