### PR TITLE
encode graph url as part of image metadata

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/PngGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/PngGraphEngine.scala
@@ -26,7 +26,11 @@ trait PngGraphEngine extends GraphEngine {
   val contentType: String = "image/png"
 
   def write(config: GraphDef, output: OutputStream): Unit = {
-    val image = PngImage(createImage(config), Map.empty)
+    val metadata = config.source.fold(Map.empty[String, String]) { s =>
+      val desc = s"start=${config.startTime.toString}, end=${config.endTime.toString}"
+      Map("Source" -> s, "Description" -> desc)
+    }
+    val image = PngImage(createImage(config), metadata)
     image.write(output)
   }
 

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/GraphDef.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/GraphDef.scala
@@ -64,6 +64,9 @@ import com.netflix.atlas.core.model.TimeSeries
  *     Stats on how much data was processed to render the chart.
  * @param warnings
  *     Warnings to display to the user.
+ * @param source
+ *     Used to provide metadata for how the graph definition was created. For example the uri
+ *     input by the user.
  */
 case class GraphDef(
     plots: List[PlotDef],
@@ -81,7 +84,8 @@ case class GraphDef(
     numberFormat: String = "%f",
     loadTime: Long = -1,
     stats: CollectorStats = CollectorStats.unknown,
-    warnings: List[String] = Nil) {
+    warnings: List[String] = Nil,
+    source: Option[String] = None) {
 
   /** Total number of lines for all plots. */
   val numLines = plots.foldLeft(0) { (acc, p) => acc + p.data.size }

--- a/atlas-webapi/src/main/resources/reference.conf
+++ b/atlas-webapi/src/main/resources/reference.conf
@@ -67,6 +67,11 @@ atlas {
       // Vocabulary to use for the graph API. The value can be "default" or a class representing
       // the vocabulary to use.
       vocabulary = "default"
+
+      // If set to true, the graph uri will be encoded as a Source iTXt field in the generated
+      // png image. This can be useful for debugging and possibly other tooling, but increases
+      // the image sizes and may not be desirable if the image may be shared externally.
+      png-metadata-enabled = false
     }
 
     publish {

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
@@ -57,6 +57,8 @@ class ApiSettings(root: => Config) {
 
   def palette: String = config.getString("graph.palette")
 
+  def metadataEnabled: Boolean = config.getBoolean("graph.png-metadata-enabled")
+
   def maxDatapoints: Int = config.getInt("graph.max-datapoints")
 
   def engines: List[GraphEngine] = {

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
@@ -74,7 +74,7 @@ object GraphApi {
       id: String,
       isBrowser: Boolean,
       isAllowedFromBrowser: Boolean,
-      includeMeta: Boolean) {
+      uri: String) {
 
     def shouldOutputImage: Boolean = (format == "png")
 
@@ -165,7 +165,8 @@ object GraphApi {
         legendType = legendType,
         onlyGraph = flags.showOnlyGraph,
         numberFormat = numberFormat,
-        plots = plots
+        plots = plots,
+        source = if (ApiSettings.metadataEnabled) Some(uri) else None
       )
 
       gdef = gdef.withVisionType(flags.vision)
@@ -302,6 +303,7 @@ object GraphApi {
       id = id,
       isBrowser = false,
       isAllowedFromBrowser = true,
-      includeMeta = params.get("meta").contains("1"))
+      uri = req.uri.toString
+    )
   }
 }


### PR DESCRIPTION
Adds an option to have the image url encoded as part of the text
metadata on the image. This can be useful for debugging and in
some cases tooling that needs to figure out how the image was
derived.