### PR TITLE
docs: add note on getting started page

### DIFF
--- a/atlas-wiki/src/main/resources/Getting-Started.md
+++ b/atlas-wiki/src/main/resources/Getting-Started.md
@@ -5,7 +5,7 @@ machine. For other common tasks see:
 * [Using Atlas at Netflix](http://go/insightdocs)
 * Querying Data:
     * [Examples](Examples)
-    * [Tutorial](Stack-Language-Tutorial)
+    * [Tutorial](Stack-Language)
 * [Instrumenting Code](https://github.com/Netflix/spectator/wiki)
 
 ## Run a Demo Instance

--- a/atlas-wiki/src/main/resources/Getting-Started.md
+++ b/atlas-wiki/src/main/resources/Getting-Started.md
@@ -1,8 +1,19 @@
+
+The instructions on this page are for quickly getting a sample backend server running on a local
+machine. For other common tasks see:
+
+* [Using Atlas at Netflix](http://go/insightdocs)
+* Querying Data:
+    * [Examples](Examples)
+    * [Tutorial](Stack-Language-Tutorial)
+* [Instrumenting Code](https://github.com/Netflix/spectator/wiki)
+
 ## Run a Demo Instance
 
 **Prerequisites**
 
-* These instructions assume a unix based machine with [curl](http://curl.haxx.se/). Other systems may work, but have not been tried.
+* These instructions assume a unix based machine with [curl](http://curl.haxx.se/). Other systems
+  may work, but have not been tried.
 * Java 8 or higher is required.
 
 To quickly run a version with some synthetic sample data:
@@ -34,7 +45,8 @@ $ curl -s 'http://localhost:7101/api/v1/tags/name?q=nf.app,nccp,:eq'
 
 ## Generate Graphs
 
-These graph API URLs show off a couple of the capabilities of the Atlas backend.  See the [Examples](https://github.com/Netflix/atlas/wiki/Examples) page for more detailed use cases.
+These graph API URLs show off a couple of the capabilities of the Atlas backend.  See the
+[Examples](https://github.com/Netflix/atlas/wiki/Examples) page for more detailed use cases.
 
 ```
 # graph all metrics with a name tag value of ssCpuUser, using an :avg aggregation


### PR DESCRIPTION
Some internal users found the getting started page confusing
as they don't need to run Atlas, just use it. We need to do
some further cleanup of how the docs flow, but for now this
adds a quick note at the top with some links to other common
references.