### PR TITLE
initial merge of additional expr utilities

### DIFF
--- a/atlas-webapi/src/main/resources/reference.conf
+++ b/atlas-webapi/src/main/resources/reference.conf
@@ -135,6 +135,74 @@ atlas {
       // normalized locally on the client 2 times the step is likely more appropriate.
       max-age = ${atlas.core.model.step}
     }
+
+    expr {
+      complete {
+        // Words that are excluded from the list returned by the auto-completion suggestions.
+        // These typically are either ones that always match, such as :depth or :true, or are
+        // considered deprecated and should not be recommended to users.
+        excluded-words = [
+          // Stack manipulation
+          "-rot",
+          "2over",
+          "call",
+          "clear",
+          "depth",
+          "drop",
+          "dup",
+          "each",
+          "fcall",
+          "format",
+          "get",
+          "list",
+          "map",
+          "ndrop",
+          "nip",
+          "nlist",
+          "over",
+          "pick",
+          "roll",
+          "rot",
+          "set",
+          "sset",
+          "swap",
+          "tuck",
+
+          // Queries
+          "true",
+          "false",
+          "reic",
+          "not",
+
+          // Data aggregations
+          "all",
+          "cf-avg",
+          "cf-sum",
+          "cf-min",
+          "cf-max",
+          "head",
+
+          // Math
+          "des",
+          "des-simple",
+          "des-fast",
+          "des-slow",
+          "des-slower",
+          "des-epic-signal",
+          "des-epic-viz",
+          "random"
+
+          // Filter
+          "stat-max",
+          "stat-min",
+          "stat-avg",
+          "stat-total",
+          "stat-min-mf",
+          "stat-max-mf",
+          "stat-avg-mf"
+        ]
+      }
+    }
   }
 
   akka {

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
@@ -79,4 +79,9 @@ class ApiSettings(root: => Config) {
   def maxDatapointAge: Long = config.getDuration("publish.max-age", TimeUnit.MILLISECONDS)
 
   def validationRules: List[Rule] = Rule.load(config.getConfigList("publish.rules"))
+
+  def excludedWords: Set[String] = {
+    import scala.collection.JavaConversions._
+    config.getStringList("expr.complete.excluded-words").toSet
+  }
 }

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
@@ -15,9 +15,13 @@
  */
 package com.netflix.atlas.webapi
 
+import com.netflix.atlas.akka.DiagnosticMessage
 import com.netflix.atlas.json.Json
 import org.scalatest.FunSuite
 import spray.http.StatusCodes
+import spray.routing.RequestContext
+import spray.routing.Route
+import spray.routing.directives.ExecutionDirectives
 import spray.testkit.ScalatestRouteTest
 
 
@@ -31,8 +35,16 @@ class ExprApiSuite extends FunSuite with ScalatestRouteTest {
 
   def testGet(uri: String)(f: => Unit): Unit = {
     test(uri) {
-      Get(uri) ~> endpoint.routes ~> check(f)
+      Get(uri) ~> routes ~> check(f)
     }
+  }
+
+  private def routes: RequestContext => Unit = {
+    ExecutionDirectives.handleExceptions(exceptionHandler) { endpoint.routes }
+  }
+
+  private def exceptionHandler: PartialFunction[Throwable, Route] = {
+    case t: Throwable => { ctx => DiagnosticMessage.handleException(ctx.responder)(t) }
   }
 
   testGet("/api/v1/expr") {
@@ -45,42 +57,107 @@ class ExprApiSuite extends FunSuite with ScalatestRouteTest {
     assert(data.size === 4)
   }
 
-  testGet("/api/v1/expr?q=name,sps,:eq,:sum,$name,:legend&vocab=style") {
+  testGet("/api/v1/expr/debug") {
+    assert(response.status === StatusCodes.BadRequest)
+  }
+
+  testGet("/api/v1/expr/debug?q=name,sps,:eq") {
+    assert(response.status === StatusCodes.OK)
+    val data = Json.decode[List[ExprApiSuite.Output]](responseAs[String])
+    assert(data.size === 4)
+  }
+
+  testGet("/api/v1/expr/debug?q=name,sps,:eq,:sum,$name,:legend&vocab=style") {
     assert(response.status === StatusCodes.OK)
     val data = Json.decode[List[ExprApiSuite.Output]](responseAs[String])
     assert(data.size === 7)
   }
 
-  testGet("/api/v1/expr?q=name,sps,:eq,:sum,$name,:legend,foo,:sset,foo,:get") {
+  testGet("/api/v1/expr/debug?q=name,sps,:eq,:sum,$name,:legend,foo,:sset,foo,:get") {
     assert(response.status === StatusCodes.OK)
     val data = Json.decode[List[ExprApiSuite.Output]](responseAs[String])
     assert(data.size === 11)
     assert(data.last.context.variables("foo") == "name,sps,:eq,:sum,$name,:legend")
   }
 
-  testGet("/api/v1/expr?q=name,sps,:eq,:sum,$name,:legend&vocab=query") {
+  testGet("/api/v1/expr/debug?q=name,sps,:eq,:sum,$name,:legend&vocab=query") {
     assert(response.status === StatusCodes.BadRequest)
   }
 
-  testGet("/api/v1/expr?q=name,sps,:eq,cluster,:has&vocab=query") {
+  testGet("/api/v1/expr/debug?q=name,sps,:eq,cluster,:has&vocab=query") {
     assert(response.status === StatusCodes.BadRequest)
   }
 
-  testGet("/api/v1/expr?q=name,sps,:eq,:clear&vocab=query") {
+  testGet("/api/v1/expr/debug?q=name,sps,:eq,:clear&vocab=query") {
     assert(response.status === StatusCodes.BadRequest)
   }
 
-  testGet("/api/v1/expr?q=name,sps,:eq,:sum,$name,:legend,foo") {
+  testGet("/api/v1/expr/debug?q=name,sps,:eq,:sum,$name,:legend,foo") {
     assert(response.status === StatusCodes.BadRequest)
   }
 
-  testGet("/api/v1/expr?q=name,sps,:eq,:sum,$name,:legend,foo,:clear") {
+  testGet("/api/v1/expr/debug?q=name,sps,:eq,:sum,$name,:legend,foo,:clear") {
     assert(response.status === StatusCodes.BadRequest)
   }
 
+  testGet("/api/v1/expr/normalize") {
+    assert(response.status === StatusCodes.BadRequest)
+  }
+
+  testGet("/api/v1/expr/normalize?q=name,sps,:eq") {
+    assert(response.status === StatusCodes.OK)
+    val data = Json.decode[List[String]](responseAs[String])
+    assert(data === List("name,sps,:eq"))
+  }
+
+  testGet("/api/v1/expr/normalize?q=name,sps,:eq,:dup,2,:mul,:swap") {
+    assert(response.status === StatusCodes.OK)
+    val data = Json.decode[List[String]](responseAs[String])
+    assert(data === List("name,sps,:eq,:sum,2.0,:const,:mul", "name,sps,:eq"))
+  }
+
+  testGet("/api/v1/expr/normalize?q=(,name,:swap,:eq,nf.cluster,foo,:eq,:and,:sum,),foo,:sset,cpu,foo,:fcall,disk,foo,:fcall") {
+    assert(response.status === StatusCodes.OK)
+    val data = Json.decode[List[String]](responseAs[String])
+    val expected = List(
+      "name,cpu,:eq,nf.cluster,foo,:eq,:and,:sum",
+      "name,disk,:eq,nf.cluster,foo,:eq,:and,:sum")
+    assert(data === expected)
+  }
+
+  testGet("/api/v1/expr/complete") {
+    assert(response.status === StatusCodes.BadRequest)
+  }
+
+  testGet("/api/v1/expr/complete?q=name,sps,:eq") {
+    assert(response.status === StatusCodes.OK)
+    val data = Json.decode[List[ExprApiSuite.Candidate]](responseAs[String]).map(_.name)
+    assert(data.nonEmpty)
+    assert(!data.contains("add"))
+  }
+
+  testGet("/api/v1/expr/complete?q=name,sps,:eq,(,nf.cluster,)") {
+    assert(response.status === StatusCodes.OK)
+    val data = Json.decode[List[ExprApiSuite.Candidate]](responseAs[String]).map(_.name)
+    assert(data === List("by", "by", "offset"))
+  }
+
+  // TODO: Right now these fail. As a future improvement suggestions should be possible within
+  // a list context by ignoring everything outside of the list.
+  testGet("/api/v1/expr/complete?q=name,sps,:eq,(,nf.cluster,name") {
+    assert(response.status === StatusCodes.BadRequest)
+  }
+
+  testGet("/api/v1/expr/complete?q=1,2") {
+    assert(response.status === StatusCodes.OK)
+    val data = Json.decode[List[ExprApiSuite.Candidate]](responseAs[String]).map(_.name)
+    assert(data.nonEmpty)
+    assert(data.contains("add"))
+  }
 }
 
 object ExprApiSuite {
   case class Output(program: List[String], context: Context)
   case class Context(stack: List[String], variables: Map[String, String])
+  case class Candidate(name: String, signature: String, description: String)
 }


### PR DESCRIPTION
This adds some additional API endpoints for manipulating the
expressions. Some of these need some further work, but are
minimally usable now and merging should make it easier to
get additional feedback form ui team.

* `/api/v1/expr` is still works and is an alias for the
  `/api/v1/expr/debug` endpoint.
* `/api/v1/expr/debug` executes an expression step by step and
  is frequently used for helping to debug problems with an
  expression.
* `/api/v1/expr/normalize` simplifies an expression and expands
  all stack manipulation operations.
* `api/v1/expr/complete` provides a list of possible commands
  given a current expression.