### PR TITLE
docs: simplify sidebar for reference page

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
@@ -265,8 +265,8 @@ object StatefulVocabulary extends Vocabulary {
 
     override def summary: String =
       """
-        |Opposite of [:integral](#integral). Computes the rate of change per step of the input
-        |time series.
+        |Opposite of [:integral](stateful-integral). Computes the rate of change per step of the
+        |input time series.
       """.stripMargin.trim
 
     override def signature: String =

--- a/atlas-wiki/src/main/resources/examples/Anonymization.md
+++ b/atlas-wiki/src/main/resources/examples/Anonymization.md
@@ -1,3 +1,4 @@
+> [[Home]] ▸ Examples
 
 Occasionally it is useful to show a graph, but the exact values need to be suppressed. This can
 be useful for communicating with external support or including in a presentation. To avoid showing

--- a/atlas-wiki/src/main/resources/examples/Axis-Bounds.md
+++ b/atlas-wiki/src/main/resources/examples/Axis-Bounds.md
@@ -1,3 +1,4 @@
+> [[Home]] ▸ Examples
 
 The upper and lower bounds for an axis can be set to an explicit floating point value or:
 

--- a/atlas-wiki/src/main/resources/examples/Axis-Scale.md
+++ b/atlas-wiki/src/main/resources/examples/Axis-Scale.md
@@ -1,3 +1,4 @@
+> [[Home]] ▸ Examples
 
 There are currently two scales that can be used for an axis:
 

--- a/atlas-wiki/src/main/resources/examples/Basics.md
+++ b/atlas-wiki/src/main/resources/examples/Basics.md
@@ -1,3 +1,5 @@
+> [[Home]] ▸ Examples
+
 This section gives some examples to get started quickly creating simple graphs.
 
 * [Single Line](#single-line)

--- a/atlas-wiki/src/main/resources/examples/Color-Palettes.md
+++ b/atlas-wiki/src/main/resources/examples/Color-Palettes.md
@@ -1,3 +1,5 @@
+> [[Home]] ▸ Examples
+
 The follow color palettes are supported:
 
 * [armytage](#armytage)

--- a/atlas-wiki/src/main/resources/examples/Examples.md
+++ b/atlas-wiki/src/main/resources/examples/Examples.md
@@ -1,3 +1,4 @@
+> [[Home]] ▸ Examples
 
 Browse the sidebar to get a good overview of graph options. It is recommended to at least go
 through the [basics](Basics) section. There is also a quick visual index below:

--- a/atlas-wiki/src/main/resources/examples/Graph-Layout.md
+++ b/atlas-wiki/src/main/resources/examples/Graph-Layout.md
@@ -1,3 +1,5 @@
+> [[Home]] ▸ Examples
+
 The diagram below shows the parts of an Atlas graph and will be used when describing
 the behavior for various options.
 

--- a/atlas-wiki/src/main/resources/examples/Legends.md
+++ b/atlas-wiki/src/main/resources/examples/Legends.md
@@ -1,3 +1,5 @@
+> [[Home]] ▸ Examples
+
 Options for adjusting legend:
 
 * [Automatic](#automatic)

--- a/atlas-wiki/src/main/resources/examples/Line-Attributes.md
+++ b/atlas-wiki/src/main/resources/examples/Line-Attributes.md
@@ -1,3 +1,5 @@
+> [[Home]] ▸ Examples
+
 In addition to the [line style](Line-Styles) and [legend](Legends) the following attributes
 can be adjusted:
 

--- a/atlas-wiki/src/main/resources/examples/Line-Colors.md
+++ b/atlas-wiki/src/main/resources/examples/Line-Colors.md
@@ -1,3 +1,0 @@
-
-/api/v1/graph?s=e-1w&e=2012-01-01T00:00&q=name,sps,:eq,nf.cluster,nccp-silverlight,:eq,:and,:sum,000000,:color,silverlight,:legend,name,sps,:eq,nf.cluster,nccp-xbox,:eq,:and,:sum,ccccff,:color,xbox,:legend
-

--- a/atlas-wiki/src/main/resources/examples/Line-Styles.md
+++ b/atlas-wiki/src/main/resources/examples/Line-Styles.md
@@ -1,3 +1,5 @@
+> [[Home]] ▸ Examples
+
 There are four [line styles](style-ls) available:
 
 * [Line](#line)

--- a/atlas-wiki/src/main/resources/examples/Multi-Y.md
+++ b/atlas-wiki/src/main/resources/examples/Multi-Y.md
@@ -1,3 +1,5 @@
+> [[Home]] ▸ Examples
+
 Examples for using multiple Y-axes:
 
 * [Explicit](#explicit)

--- a/atlas-wiki/src/main/resources/examples/Output-Formats.md
+++ b/atlas-wiki/src/main/resources/examples/Output-Formats.md
@@ -1,3 +1,5 @@
+> [[Home]] ▸ Examples
+
 The following output formats are supported by default for [graphing](Graph):
 
 * [png](#png)

--- a/atlas-wiki/src/main/resources/examples/Stack.md
+++ b/atlas-wiki/src/main/resources/examples/Stack.md
@@ -1,3 +1,0 @@
-
-/api/v1/graph?e=2012-01-01T00:00&q=name,sps,:eq,nf.cluster,nccp-.*,:re,:and,:sum,(,nf.cluster,),:by,$nf.cluster,:legend&stack=1
-

--- a/atlas-wiki/src/main/resources/examples/Time-Shift.md
+++ b/atlas-wiki/src/main/resources/examples/Time-Shift.md
@@ -1,3 +1,4 @@
+> [[Home]] ▸ Examples
 
 A common use-case is to compare a given line with a shifted line to compare week-over-week or day-over-day. 
 

--- a/atlas-wiki/src/main/resources/examples/Time-Zone.md
+++ b/atlas-wiki/src/main/resources/examples/Time-Zone.md
@@ -1,3 +1,4 @@
+> [[Home]] ▸ Examples
 
 Examples for specifying the time zone:
 

--- a/atlas-wiki/src/main/resources/examples/Vision.md
+++ b/atlas-wiki/src/main/resources/examples/Vision.md
@@ -1,3 +1,5 @@
+> [[Home]] ▸ Examples
+
 The vision parameter can be used to simulate different types of
 [color blindness](http://www.colourblindawareness.org/colour-blindness/types-of-colour-blindness/).
 Permitted values are:

--- a/atlas-wiki/src/main/resources/examples/_Sidebar.md
+++ b/atlas-wiki/src/main/resources/examples/_Sidebar.md
@@ -1,5 +1,3 @@
-###[Home](Home) > [[Examples]]
-
 * [[Basics]]
 * [[Legends]]
 * [[Graph Layout]]

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Main.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Main.scala
@@ -184,7 +184,6 @@ object Main extends StrictLogging {
     val graph = new GraphHelper(webApi, new File(dir, "gen-images"), "stacklang/gen-images")
 
     val sidebar = new StringBuilder
-    sidebar.append("###[Home](Home) > Stack Language Reference\n\n")
     vocabs.foreach { vocab =>
       sidebar.append(s"\n**${vocab.name}**\n")
       vocab.words.sortWith(_.name < _.name).foreach { w =>

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Main.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Main.scala
@@ -252,7 +252,7 @@ object Main extends StrictLogging {
       generateStackLangRef(output)
       generateScriptedPages(output, List(
         new DES,
-        new StackLanguageReference,
+        new StackLanguageReference(vocabs, vocabDocs),
         new TimeZones
       ))
     } finally {

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Main.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Main.scala
@@ -185,12 +185,7 @@ object Main extends StrictLogging {
 
     val sidebar = new StringBuilder
     vocabs.foreach { vocab =>
-      sidebar.append(s"\n**${vocab.name}**\n")
-      vocab.words.sortWith(_.name < _.name).foreach { w =>
-        val page = overrides.getOrElse(w, BasicStackWordPage(vocab, w))
-        val fname = page.name
-        sidebar.append(s"* [${w.name}]($fname)\n")
-      }
+      sidebar.append(s"* [${vocab.name}](Reference-${vocab.name})\n")
     }
     writeFile(sidebar.toString(), new File(dir, "_Sidebar.md"))
 

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/StackLanguageReference.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/StackLanguageReference.scala
@@ -16,10 +16,14 @@
 package com.netflix.atlas.wiki.pages
 
 import com.netflix.atlas.core.model.StyleVocabulary
+import com.netflix.atlas.core.stacklang.Vocabulary
 import com.netflix.atlas.wiki.GraphHelper
 import com.netflix.atlas.wiki.Page
 
-class StackLanguageReference extends Page {
+class StackLanguageReference(
+    vocabs: List[Vocabulary],
+    vocabDocs: Map[String, String]) extends Page {
+
   override def name: String = "Stack-Language-Reference"
   override def path: Option[String] = Some("stacklang")
 
@@ -27,10 +31,30 @@ class StackLanguageReference extends Page {
     s"""
        |> [[Home]] ▸ Stack Language Reference
        |
-       |Reference for operations available in the stack language. Use the sidebar to navigate.
+       |Reference for operations available in the stack language. Operations can be browsed by
+       |[category](#categories) or [alphabetically by name](#alphabetical-listing).
+       |
+       |## Categories
+       |
+       |$referenceCategories
+       |
+       |## Alphabetical Listing
+       |
+       |Alphabetical listing of all operations. This can be useful if you know the name, but
+       |are unsure of the category.
        |
        |$referenceTOC
      """.stripMargin
+
+  private def referenceCategories: String = {
+    val builder = new StringBuilder
+    vocabs.foreach { vocab =>
+      builder.append(s"### [${vocab.name}](Reference-${vocab.name})\n\n")
+      builder.append(vocabDocs(vocab.name))
+      builder.append("\n\n")
+    }
+    builder.toString()
+  }
 
   private def referenceTOC: String = {
     import com.netflix.atlas.wiki._

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/StackLanguageReference.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/StackLanguageReference.scala
@@ -25,6 +25,8 @@ class StackLanguageReference extends Page {
 
   override def content(graph: GraphHelper): String =
     s"""
+       |> [[Home]] ▸ Stack Language Reference
+       |
        |Reference for operations available in the stack language. Use the sidebar to navigate.
        |
        |$referenceTOC


### PR DESCRIPTION
Breaks out the sidebar for each vocabulary to
make the sidebar shorter and only show the expanded
list for that category.