### PR TITLE
1.4.x update maven groupId

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/ConfigApi.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/ConfigApi.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/CustomDirectives.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/CustomDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/CustomMediaTypes.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/CustomMediaTypes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/DiagnosticMessage.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/DiagnosticMessage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/Paths.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/Paths.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/RequestHandlerActor.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/RequestHandlerActor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/ServerStats.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/ServerStats.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/StaticPages.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/StaticPages.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/UnboundedMeteredMailbox.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/UnboundedMeteredMailbox.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/WebApi.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/WebApi.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/WebServer.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/WebServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/ConfigApiSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/ConfigApiSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/CustomDirectivesSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/CustomDirectivesSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerActorSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerActorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/ServerStatsSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/ServerStatsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/StaticPagesSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/StaticPagesSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/TestApi.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/TestApi.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-aws/src/main/scala/com/netflix/atlas/aws/AwsClientFactory.scala
+++ b/atlas-aws/src/main/scala/com/netflix/atlas/aws/AwsClientFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-aws/src/main/scala/com/netflix/atlas/aws/DefaultAwsClientFactory.scala
+++ b/atlas-aws/src/main/scala/com/netflix/atlas/aws/DefaultAwsClientFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-aws/src/main/scala/com/netflix/atlas/aws/FileCredentialsProvider.scala
+++ b/atlas-aws/src/main/scala/com/netflix/atlas/aws/FileCredentialsProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-aws/src/test/scala/com/netflix/atlas/aws/AwsClientFactorySuite.scala
+++ b/atlas-aws/src/test/scala/com/netflix/atlas/aws/AwsClientFactorySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-aws/src/test/scala/com/netflix/atlas/aws/DefaultAwsClientFactorySuite.scala
+++ b/atlas-aws/src/test/scala/com/netflix/atlas/aws/DefaultAwsClientFactorySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/Colors.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/Colors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/CommaSepGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/CommaSepGraphEngine.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/CsvGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/CsvGraphEngine.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/GraphConstants.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/GraphConstants.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/GraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/GraphEngine.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonGraphEngine.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/LineStyle.java
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/LineStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/Notice.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/Notice.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/Palette.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/Palette.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/PngGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/PngGraphEngine.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/Rrd4jGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/Rrd4jGraphEngine.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/StatsJsonGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/StatsJsonGraphEngine.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/TabSepGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/TabSepGraphEngine.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/VisionType.java
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/VisionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/ColorsSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/ColorsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/PngGraphEngineSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/PngGraphEngineSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/Rrd4jGraphEngineSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/Rrd4jGraphEngineSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-config/src/main/scala/com/netflix/atlas/config/ConfigManager.scala
+++ b/atlas-config/src/main/scala/com/netflix/atlas/config/ConfigManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-config/src/test/scala/com/netflix/atlas/config/ConfigManagerSuite.scala
+++ b/atlas-config/src/test/scala/com/netflix/atlas/config/ConfigManagerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/AggregateCollector.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/AggregateCollector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/BlockStore.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/BlockStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/BlockStoreItem.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/BlockStoreItem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/DataSet.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/DataSet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/Database.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/Database.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/Limits.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/Limits.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/StaticDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/StaticDatabase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/TimeSeriesBuffer.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/TimeSeriesBuffer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/BatchUpdateTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/BatchUpdateTagIndex.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/CachingTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/CachingTagIndex.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/LazySet.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/LazySet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/LazyTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/LazyTagIndex.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/SimpleTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/SimpleTagIndex.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/TagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/TagIndex.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/TagQuery.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/TagQuery.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Block.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Block.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/CollectorStats.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/CollectorStats.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/ConsolidationFunction.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/ConsolidationFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataVocabulary.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Datapoint.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Datapoint.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DefaultSettings.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DefaultSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DsType.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DsType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/EvalContext.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/EvalContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Expr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Expr.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Extractors.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Extractors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterExpr.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterVocabulary.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/QueryVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/QueryVocabulary.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/ResultSet.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/ResultSet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleVocabulary.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/SummaryStats.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/SummaryStats.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Tag.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Tag.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TagKey.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TagKey.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TaggedItem.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TaggedItem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TimeSeq.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TimeSeq.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TimeSeries.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TimeSeries.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TimeSeriesExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TimeSeriesExpr.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/package.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/norm/LastValueFunction.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/norm/LastValueFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/norm/NormalizationCache.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/norm/NormalizationCache.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/norm/NormalizeValueFunction.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/norm/NormalizeValueFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/norm/RateValueFunction.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/norm/RateValueFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/norm/UpdateValueFunction.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/norm/UpdateValueFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/norm/ValueFunction.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/norm/ValueFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Context.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Context.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/StandardVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/StandardVocabulary.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Vocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Vocabulary.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Word.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Word.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/ArrayHelper.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/ArrayHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Hash.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Hash.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/InternMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/InternMap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Interner.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Interner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Math.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Math.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/PngImage.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/PngImage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/PrimeFinder.java
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/PrimeFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Step.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Step.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Streams.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Streams.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/StringMatcher.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/StringMatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/UnitPrefix.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/UnitPrefix.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/HasKeyRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/HasKeyRule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/KeyLengthRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/KeyLengthRule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/KeyPatternRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/KeyPatternRule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/MaxUserTagsRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/MaxUserTagsRule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/NonStandardKeyRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/NonStandardKeyRule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/Rule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/Rule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/TagRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/TagRule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ValidCharactersRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ValidCharactersRule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ValidationResult.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ValidationResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ValueLengthRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ValueLengthRule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ValuePatternRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ValuePatternRule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/AggregateCollectorSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/AggregateCollectorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryBlockStoreSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryBlockStoreSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/TimeSeriesBufferSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/TimeSeriesBufferSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/BatchUpdateTagIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/BatchUpdateTagIndexSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/DataSet.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/DataSet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/LazySetSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/LazySetSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/LazyTagIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/LazyTagIndexSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/SimpleTagIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/SimpleTagIndexSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/TagIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/TagIndexSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/AndWordSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/AndWordSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ArrayTimeSeqSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ArrayTimeSeqSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/BlockSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/BlockSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataExamplesSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/FilterExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/FilterExamplesSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/InWordSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/InWordSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/MapStepTimeSeqSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/MapStepTimeSeqSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathExamplesSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/NotWordSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/NotWordSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/OrWordSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/OrWordSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/QueryExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/QueryExamplesSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/StatefulExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/StatefulExamplesSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleExamplesSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleExprSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/norm/LastValueFunctionSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/norm/LastValueFunctionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/norm/NormalizeValueFunctionSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/norm/NormalizeValueFunctionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/norm/RateValueFunctionSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/norm/RateValueFunctionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/BaseExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/BaseExamplesSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/BaseWordSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/BaseWordSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/CallSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/CallSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/ClearSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/ClearSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/DropSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/DropSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/DupSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/DupSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/EachSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/EachSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/FormatSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/FormatSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/GetSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/GetSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/InterpreterSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/InterpreterSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/MapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/MapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/OverSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/OverSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/ReverseRotSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/ReverseRotSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/RotSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/RotSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/SetSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/SetSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/StandardExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/StandardExamplesSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/SwapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/SwapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/VocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/VocabularySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/Assert.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/Assert.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/HashSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/HashSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/InternMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/InternMapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/InternerSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/InternerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/MathSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/MathSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/PngImageSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/PngImageSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/SmallHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/SmallHashMapSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringMatcherSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringMatcherSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/HasKeyRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/HasKeyRuleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/KeyLengthRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/KeyLengthRuleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/KeyPatternRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/KeyPatternRuleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/MaxUserTagsRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/MaxUserTagsRuleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/NonStandardKeyRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/NonStandardKeyRuleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/RuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/RuleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ValidCharactersRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ValidCharactersRuleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ValueLengthRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ValueLengthRuleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ValuePatternRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ValuePatternRuleSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/MathMax.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/MathMax.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/StringMatching.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/StringMatching.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/JsonParserHelper.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/JsonParserHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/JsonSupport.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/JsonSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/Main.scala
+++ b/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/Main.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-test/src/main/scala/com/netflix/atlas/test/GraphAssertions.scala
+++ b/atlas-test/src/main/scala/com/netflix/atlas/test/GraphAssertions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphRequestActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphRequestActor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalDatabaseActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalDatabaseActor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalPublishActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalPublishActor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/RequestId.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/RequestId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsApi.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsRequestActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsRequestActor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ApiSettingsSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ApiSettingsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishApiJsonSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishApiJsonSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishApiSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/RequestIdSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/RequestIdSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/TagsApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/TagsApiSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/GraphHelper.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/GraphHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Main.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Main.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/project/Bintray.scala
+++ b/project/Bintray.scala
@@ -20,7 +20,7 @@ object Bintray {
 
   lazy val settings: Seq[Def.Setting[_]] = bintraySettings ++ Seq(
     bintrayRepository := "maven",
-    bintrayPackage := "atlas",
+    bintrayPackage := "atlas_v1",
     bintrayOrganization := Some("netflixoss"),
     bintrayReleaseOnPublish := false,
     licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.txt")),

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -2,7 +2,7 @@ import sbt._
 import sbt.Keys._
 
 object BuildSettings {
-  val organization = "com.netflix.atlas"
+  val organization = "com.netflix.atlas_v1"
 
   val compilerFlags = Seq(
     "-deprecation",


### PR DESCRIPTION
Backport of groupId change.

Due to some historical baggage, it is a pain to get the
artifacts into jcenter with the current com.netflix.atlas
groupId. This changes the id to add a version as I couldn't
come up with something better. This may also be useful in
the future to allow side by side import of a v2 version.