### PR TITLE
fix out of bounds exception for java8 classes

### DIFF
--- a/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
@@ -402,6 +402,14 @@ class JsonSuite extends FunSuite {
     val b = Json.smileEncode[List[Int]](v)
     assert(Json.smileDecode[List[Int]](b) === v)
   }
+
+  // See ObjWithLambda comments for details
+  test("object with lambda") {
+    val obj = new ObjWithLambda
+    obj.setFoo("abc")
+    val json = Json.encode(obj)
+    assert(json === """{"foo":"abc"}""")
+  }
 }
 
 case object JsonSuiteObject

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/ObjWithLambda.java
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/ObjWithLambda.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.json;
+
+import java.util.function.Function;
+
+/**
+ * Simple test object to verify lambda issue with paranamer is fixed:
+ *
+ * https://github.com/FasterXML/jackson-module-paranamer/issues/13
+ * https://github.com/paul-hammant/paranamer/issues/17
+ *
+ * <pre>
+ * java.lang.ArrayIndexOutOfBoundsException: 55596
+ *   at com.fasterxml.jackson.module.paranamer.shaded.BytecodeReadingParanamer$ClassReader.readUnsignedShort(BytecodeReadingParanamer.java:722)
+ *   at com.fasterxml.jackson.module.paranamer.shaded.BytecodeReadingParanamer$ClassReader.accept(BytecodeReadingParanamer.java:571)
+ *   at com.fasterxml.jackson.module.paranamer.shaded.BytecodeReadingParanamer$ClassReader.access$200(BytecodeReadingParanamer.java:338)
+ *   at com.fasterxml.jackson.module.paranamer.shaded.BytecodeReadingParanamer.lookupParameterNames(BytecodeReadingParanamer.java:103)
+ *   at com.fasterxml.jackson.module.paranamer.shaded.CachingParanamer.lookupParameterNames(CachingParanamer.java:79)
+ * </pre>
+ */
+public class ObjWithLambda {
+
+  private String foo;
+
+  public void setFoo(String value) {
+    final Function<String, String> check = v -> {
+      if (v == null) throw new NullPointerException("value cannot be null");
+      return v;
+    };
+    foo = check.apply(value);
+  }
+
+  public String getFoo() {
+    return foo;
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
     val aws        = "1.10.56"
     val iep        = "0.3.19"
     val guice      = "4.0"
-    val jackson    = "2.6.4"
+    val jackson    = "2.7.2"
     val log4j      = "2.5"
     val scala      = "2.11.7"
     val slf4j      = "1.7.18"


### PR DESCRIPTION
When using the Json helper for classes that contain a
lambda there was an ArrayIndexOutOfBoundsException
coming from paranamer shadowed into jackson. See test
case for more details on the error.

This bumps to jackson 2.7.2 which uses a newer shaded
version of paranamer.