### PR TITLE
fix path when test are run with being forked

### DIFF
--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/PngGraphEngineSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/PngGraphEngineSuite.scala
@@ -35,6 +35,7 @@ import com.netflix.atlas.core.util.PngImage
 import com.netflix.atlas.core.util.Streams
 import com.netflix.atlas.json.Json
 import com.netflix.atlas.test.GraphAssertions
+import com.netflix.atlas.test.SrcPath
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FunSuite
 
@@ -44,7 +45,7 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
   private val dataDir   = s"graphengine/data"
 
   // SBT working directory gets updated with fork to be the dir for the project
-  private val baseDir = "."
+  private val baseDir = SrcPath.forProject("atlas-chart")
   private val goldenDir = s"$baseDir/src/test/resources/graphengine/${getClass.getSimpleName}"
   private val targetDir = s"$baseDir/target/${getClass.getSimpleName}"
   private val graphAssertions = new GraphAssertions(goldenDir, targetDir)

--- a/atlas-test/src/main/scala/com/netflix/atlas/test/SrcPath.scala
+++ b/atlas-test/src/main/scala/com/netflix/atlas/test/SrcPath.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.test
+
+import java.io.File
+
+/**
+  * Utility for finding source path for the current sub project. This should be used sparingly.
+  * If read-only is needed, then use getResource instead. The primary use-case is for tests
+  * around images where there is an option to bless changes and update the golden files in the
+  * source resources directory.
+  */
+object SrcPath {
+  def forProject(name: String): String = {
+    val cwd = new File(".").getCanonicalFile
+    val subProject = new File(cwd, name)
+    if (subProject.exists()) {
+      // If not forking for tests or running in the ide, the working directory is typically
+      // the root for the overall project.
+      s"$subProject"
+    } else if (cwd.getName == name) {
+      // If the tests are forked, then the working directory is expected to be the directory
+      // for the sub-project.
+      "."
+    } else {
+      // Otherwise, some other case we haven't seen, force the user to figure it out
+      throw new IllegalStateException(s"cannot determine source dir for $name, working dir: $cwd")
+    }
+  }
+}

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiSuite.scala
@@ -21,6 +21,7 @@ import com.netflix.atlas.core.util.Hash
 import com.netflix.atlas.core.util.PngImage
 import com.netflix.atlas.core.util.Streams
 import com.netflix.atlas.test.GraphAssertions
+import com.netflix.atlas.test.SrcPath
 import org.scalatest.FunSuite
 import spray.http.HttpEntity
 import spray.http.MediaTypes._
@@ -46,7 +47,7 @@ class GraphApiSuite extends FunSuite with ScalatestRouteTest {
   val all = template ::: others
 
   // SBT working directory gets updated with fork to be the dir for the project
-  private val baseDir = "."
+  private val baseDir = SrcPath.forProject("atlas-webapi")
   private val goldenDir = s"$baseDir/src/test/resources/${getClass.getSimpleName}"
   private val targetDir = s"$baseDir/target/${getClass.getSimpleName}"
   private val graphAssertions = new GraphAssertions(goldenDir, targetDir)


### PR DESCRIPTION
The working directory changes to the sub-project when the
tests are forked. For the image tests this is used to
determine the source path so that if the flag is enabled
the diffs can be blessed to update the golden files.