### PR TITLE
disable forking tests

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/TimeSeriesBufferSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/TimeSeriesBufferSuite.scala
@@ -16,9 +16,11 @@
 package com.netflix.atlas.core.db
 
 import com.netflix.atlas.core.model.ArrayBlock
+import com.netflix.atlas.core.model.ArrayTimeSeq
 import com.netflix.atlas.core.model.Block
 import com.netflix.atlas.core.model.ConsolidationFunction
 import com.netflix.atlas.core.model.ConstantBlock
+import com.netflix.atlas.core.model.DsType
 import com.netflix.atlas.core.util.Math
 import nl.jqno.equalsverifier.EqualsVerifier
 import nl.jqno.equalsverifier.Warning
@@ -505,10 +507,20 @@ class TimeSeriesBufferSuite extends FunSuite {
   }
 
   test("equals") {
+    // https://groups.google.com/forum/#!topic/equalsverifier/R5MWUGVx-C8
+
+    val t1 = Map("a" -> "1")
+    val t2 = Map("a" -> "2")
+
+    val step = 60000L
+    val s1 = new ArrayTimeSeq(DsType.Gauge,  5 * step, step, Array(1.0))
+    val s2 = new ArrayTimeSeq(DsType.Gauge,  5 * step, step, Array(1.0, 2.0))
     EqualsVerifier
-      .forClass(classOf[TimeSeriesBuffer])
-      .suppress(Warning.NULL_FIELDS)
-      .suppress(Warning.NONFINAL_FIELDS)
-      .verify()
+        .forClass(classOf[TimeSeriesBuffer])
+        .withPrefabValues(classOf[Map[_, _]], t1, t2)
+        .withPrefabValues(classOf[ArrayTimeSeq], s1, s2)
+        .suppress(Warning.NULL_FIELDS)
+        .suppress(Warning.NONFINAL_FIELDS)
+        .verify()
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -15,7 +15,6 @@ object MainBuild extends Build {
            scalacOptions ++= BuildSettings.compilerFlags,
               crossPaths := false,
            sourcesInBase := false,
-            fork in Test := true,   // Needed to avoid ClassNotFoundException with equalsverifier
               exportJars := true,   // Needed for one-jar, with multi-project
        externalResolvers := BuildSettings.resolvers,
      checkLicenseHeaders := License.checkLicenseHeaders(streams.value.log, sourceDirectory.value),


### PR DESCRIPTION
Tests are no longer forked by default. That was done
as a workaround for an issue with equalsverifier, but
more recently there is another workaround using prefab
values:

https://groups.google.com/forum/#!topic/equalsverifier/R5MWUGVx-C8

The hope is that this will avoid some transient failures
with travis builds. See #322 for more details.