### PR TITLE
make decode(JsonParser) public

### DIFF
--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
@@ -42,7 +42,7 @@ object Json {
     def decode(input: InputStream): T = decode(factory.createParser(input))
     def decode(input: Reader): T = decode(factory.createParser(input))
 
-    private def decode(parser: JsonParser): T = {
+    def decode(parser: JsonParser): T = {
       try {
         val value = reader.readValue[T](parser)
         require(parser.nextToken() == null, "invalid json, additional content after value")


### PR DESCRIPTION
Allow the cached decoder to be used for cases where we
already have the parser instance.