### PR TITLE
default /healthcheck based on ServiceManager

### DIFF
--- a/atlas-akka/src/main/resources/reference.conf
+++ b/atlas-akka/src/main/resources/reference.conf
@@ -6,6 +6,7 @@ atlas.akka {
 
   # List of classes to load as API endpoints
   api-endpoints = ${?atlas.akka.api-endpoints} [
+    "com.netflix.atlas.akka.HealthcheckApi",
     "com.netflix.atlas.akka.ConfigApi",
     "com.netflix.atlas.akka.StaticPages"
   ]

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/HealthcheckApi.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/HealthcheckApi.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.akka
+
+import akka.actor.ActorRefFactory
+import com.netflix.iep.service.ServiceManager
+import com.typesafe.scalalogging.StrictLogging
+import spray.http._
+import spray.routing._
+
+
+/**
+  * Healthcheck endpoint based on health status of the ServiceManager. For backwards
+  * compatiblity, the status is marked as healthy if the ServiceManager is null. That
+  * behavior will likely change in the future, but for now just logs a warning.
+  */
+class HealthcheckApi(val actorRefFactory: ActorRefFactory, serviceManager: ServiceManager)
+    extends WebApi with StrictLogging {
+
+  if (serviceManager == null) {
+    logger.warn("ServiceManager is null, healthcheck will always return true")
+  }
+
+  def routes: RequestContext => Unit = {
+    path("healthcheck") {
+      if (serviceManager == null || serviceManager.isHealthy)
+        complete(StatusCodes.OK)
+      else
+        complete(StatusCodes.InternalServerError)
+    }
+  }
+}

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/WebServer.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/WebServer.scala
@@ -25,6 +25,8 @@ import akka.io.Inet
 import akka.util.Timeout
 import com.netflix.atlas.config.ConfigManager
 import com.netflix.iep.service.AbstractService
+import com.netflix.iep.service.ClassFactory
+import com.netflix.iep.service.DefaultClassFactory
 import com.netflix.spectator.api.Registry
 import com.typesafe.scalalogging.StrictLogging
 import spray.can.Http
@@ -35,8 +37,12 @@ import scala.util.Failure
 import scala.util.Success
 
 
-class WebServer(registry: Registry, name: String, port: Int)
+class WebServer(classFactory: ClassFactory, registry: Registry, name: String, port: Int)
     extends AbstractService with StrictLogging {
+
+  @deprecated(message = "Use default constructor instead.", since = "2016-03-16")
+  def this(registry: Registry, name: String, port: Int) =
+    this(new DefaultClassFactory(), registry, name, port)
 
   import scala.concurrent.duration._
 
@@ -58,9 +64,11 @@ class WebServer(registry: Registry, name: String, port: Int)
     system = ActorSystem(name)
     configure()
 
+    val handler = system.actorOf(
+      Props(classFactory.newInstance(classOf[RequestHandlerActor])), "request-handler")
+
     val bindPromise = Promise[Http.Bound]()
     val stats = system.actorOf(Props(new ServerStatsActor(registry, bindPromise)))
-    val handler = system.actorOf(Props[RequestHandlerActor], "request-handler")
     val options = List(Inet.SO.ReuseAddress(true))
     val bind = Http.Bind(handler,
       interface = "0.0.0.0",

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/HealthcheckApiSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/HealthcheckApiSuite.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.akka
+
+import com.netflix.iep.service.AbstractService
+import com.netflix.iep.service.Service
+import com.netflix.iep.service.ServiceManager
+import org.scalatest.FunSuite
+import spray.http.StatusCodes
+import spray.testkit.ScalatestRouteTest
+
+
+class HealthcheckApiSuite extends FunSuite with ScalatestRouteTest {
+
+  import scala.concurrent.duration._
+
+  implicit val routeTestTimeout = RouteTestTimeout(5.second)
+
+  val services = new java.util.HashSet[Service]
+  services.add(new AbstractService() {
+      override def startImpl(): Unit = ()
+      override def stopImpl(): Unit = ()
+    })
+
+  val serviceManager = new ServiceManager(services)
+  val endpoint = new HealthcheckApi(system, serviceManager)
+
+  test("/healthcheck pre-start") {
+    Get("/healthcheck") ~> endpoint.routes ~> check {
+      assert(response.status === StatusCodes.InternalServerError)
+    }
+  }
+
+  test("/healthcheck post-start") {
+    import scala.collection.JavaConversions._
+    services.foreach(_.asInstanceOf[AbstractService].start())
+    Get("/healthcheck") ~> endpoint.routes ~> check {
+      assert(response.status === StatusCodes.OK)
+    }
+  }
+}
+

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerActorSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerActorSuite.scala
@@ -23,6 +23,7 @@ import akka.testkit.ImplicitSender
 import akka.testkit.TestActorRef
 import akka.testkit.TestKit
 import com.netflix.atlas.json.Json
+import com.netflix.iep.service.DefaultClassFactory
 import com.netflix.spectator.api.DefaultRegistry
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
@@ -44,7 +45,7 @@ class RequestHandlerActorSuite extends TestKit(ActorSystem())
       |]
     """.stripMargin)
 
-  private val ref = TestActorRef(new RequestHandlerActor(new DefaultRegistry(), config))
+  private val ref = TestActorRef(new RequestHandlerActor(config, new DefaultClassFactory()))
 
   override def afterAll(): Unit = {
     system.terminate()
@@ -57,8 +58,8 @@ class RequestHandlerActorSuite extends TestKit(ActorSystem())
     }
   }
 
-  test("/healthcheck") {
-    ref ! HttpRequest(GET, Uri("/healthcheck"))
+  test("/ok") {
+    ref ! HttpRequest(GET, Uri("/ok"))
     expectMsgPF() {
       case HttpResponse(OK, _, _, _) =>
     }

--- a/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/WebServerProvider.scala
+++ b/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/WebServerProvider.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.standalone
+
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.inject.Singleton
+
+import akka.actor.Props
+import com.netflix.atlas.akka.WebServer
+import com.netflix.atlas.core.db.MemoryDatabase
+import com.netflix.atlas.webapi.ApiSettings
+import com.netflix.atlas.webapi.LocalDatabaseActor
+import com.netflix.atlas.webapi.LocalPublishActor
+import com.netflix.iep.service.ClassFactory
+import com.netflix.spectator.api.Registry
+
+@Singleton
+class WebServerProvider @Inject() (classFactory: ClassFactory, registry: Registry)
+    extends Provider[WebServer] {
+
+  override def get(): WebServer = {
+    new WebServer(classFactory, registry, "atlas", ApiSettings.port) {
+      override protected def configure(): Unit = {
+        super.configure()
+        val db = ApiSettings.newDbInstance
+        actorSystem.actorOf(Props(new LocalDatabaseActor(db)), "db")
+        db match {
+          case mem: MemoryDatabase =>
+            logger.info("enabling local publish to memory database")
+            actorSystem.actorOf(Props(new LocalPublishActor(registry, mem)), "publish")
+          case _ =>
+        }
+      }
+    }
+  }
+}

--- a/atlas-standalone/src/test/scala/com/netflix/atlas/standalone/MainSuite.scala
+++ b/atlas-standalone/src/test/scala/com/netflix/atlas/standalone/MainSuite.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.standalone
+
+import org.scalatest.FunSuite
+
+
+class MainSuite extends FunSuite {
+
+  test("start/shutdown") {
+    Main.start()
+    Main.shutdown()
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -105,6 +105,7 @@ object MainBuild extends Build {
   lazy val `atlas-standalone` = project
     .dependsOn(`atlas-webapi`)
     .settings(buildSettings: _*)
+    .settings(libraryDependencies ++= commonDeps)
     .settings(libraryDependencies ++= Seq(
       Dependencies.iepGovernator,
       Dependencies.guiceCore,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,12 +4,12 @@ object Dependencies {
   object Versions {
     val akka       = "2.4.2"
     val aws        = "1.10.60"
-    val iep        = "0.3.19"
+    val iep        = "0.3.21"
     val guice      = "4.0"
     val jackson    = "2.7.2"
     val log4j      = "2.5"
     val scala      = "2.11.8"
-    val slf4j      = "1.7.18"
+    val slf4j      = "1.7.19"
     val spectator  = "0.36.0"
     val spray      = "1.3.3"
   }


### PR DESCRIPTION
Previously the `/healthcheck` endpoint provided here always
returned 200 and was mostly used for debugging. This is now
`/ok`. The `/healthcheck` endpoint now indicates the service
health based on the ServiceManager so it should be usable
as a load balancer healthcheck endpoint.

With this change we shouldn't need a separate internal
healthcheck endpoint registered for use with the load
balancers and monitoring.