### PR TITLE
fix bug with status when the route is created

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/HealthcheckApi.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/HealthcheckApi.scala
@@ -36,10 +36,10 @@ class HealthcheckApi(
     serviceManagerProvider.get()
     path("healthcheck") {
       respondWithMediaType(MediaTypes.`application/json`) {
-        if (serviceManager.isHealthy)
-          complete(HttpResponse(StatusCodes.OK, entity = summary))
-        else
-          complete(HttpResponse(StatusCodes.InternalServerError, entity = summary))
+        get { ctx =>
+          val status = if (serviceManager.isHealthy) StatusCodes.OK else StatusCodes.InternalServerError
+          ctx.responder ! HttpResponse(status, entity = summary)
+        }
       }
     }
   }


### PR DESCRIPTION
The status was being chosen when the route was created
instead of when the healthcheck endpoint was being
called.