### PR TITLE
limit endpoints for wiki script

### DIFF
--- a/atlas-wiki/src/main/resources/application.conf
+++ b/atlas-wiki/src/main/resources/application.conf
@@ -1,0 +1,8 @@
+atlas {
+  akka {
+    api-endpoints = [
+      "com.netflix.atlas.webapi.TagsApi",
+      "com.netflix.atlas.webapi.GraphApi"
+    ]
+  }
+}


### PR DESCRIPTION
Limit the endpoints used on the wiki script to
just the tags and graph endpoints that are needed.