### PR TITLE
docs: create search index for wiki

### DIFF
--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Page.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Page.scala
@@ -103,7 +103,7 @@ trait StackWordPage extends Page {
     val params = if (name.startsWith("cf-")) "step=5m" else ""
 
     val buf = new StringBuilder
-    buf.append(s"### `$example,:$name`")
+    buf.append(s"### `$example,:$name`\n\n")
     buf.append("<table><thead><th>Pos</th><th>Input</th><th>Output</th></thead><tbody>")
     zipStacks(in, out).zipWithIndex.foreach { case ((i, o), p) =>
       buf.append(s"<tr>\n<td>$p</td>\n")


### PR DESCRIPTION
Generate search index json file for the wiki
that can be consumed easily with lunr. Format
is similar to index created by mkdocs, e.g.:

https://netflix.github.io/spectator/en/latest/mkdocs/search_index.json