### PR TITLE
extract the queries from a stack expression.

### DIFF
--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
@@ -154,6 +154,37 @@ class ExprApiSuite extends FunSuite with ScalatestRouteTest {
     assert(data.nonEmpty)
     assert(data.contains("add"))
   }
+
+  testGet("/api/v1/expr/queries?q=1,2") {
+    assert(response.status === StatusCodes.OK)
+    val data = Json.decode[List[String]](responseAs[String])
+    assert(data.isEmpty)
+  }
+
+  testGet("/api/v1/expr/queries?q=name,sps,:eq") {
+    assert(response.status === StatusCodes.OK)
+    val data = Json.decode[List[String]](responseAs[String])
+    assert(data === List("name,sps,:eq"))
+  }
+
+  testGet("/api/v1/expr/queries?q=name,sps,:eq,(,nf.cluster,),:by") {
+    assert(response.status === StatusCodes.OK)
+    val data = Json.decode[List[String]](responseAs[String])
+    assert(data === List("name,sps,:eq"))
+  }
+
+  testGet("/api/v1/expr/queries?q=name,sps,:eq,(,nf.cluster,),:by,:dup,:dup,4,:add") {
+    assert(response.status === StatusCodes.OK)
+    val data = Json.decode[List[String]](responseAs[String])
+    assert(data === List("name,sps,:eq"))
+  }
+
+  testGet("/api/v1/expr/queries?q=name,sps,:eq,(,nf.cluster,),:by,:true,:sum,name,:has,:add") {
+    assert(response.status === StatusCodes.OK)
+    val data = Json.decode[List[String]](responseAs[String])
+    println(data)
+    assert(data === List(":true", "name,:has", "name,sps,:eq"))
+  }
 }
 
 object ExprApiSuite {


### PR DESCRIPTION
Adds an expr endpoint for extracting the queries [1] from a stack expression. This can be useful for UIs that need to further explore the tag space associated with a graph expression. Output is a list of all distinct queries used.

Example, suppose I have a graph of requests and errors:

```
nf.app,www,:eq,name,http.req.complete,:eq,:and,(,statusCode,),:by
```

And I want to expand it to get one graph per zone or node for the application. Send a request:

```
GET /api/v1/expr/queries?q=nf.app,www,:eq,name,http.req.complete,:eq,:and,(,statusCode,),:by
```

The response is:

```json
[
  "nf.app,www,:eq,name,http.req.complete,:eq,:and"
]
```

This data can then be used with the [tags API](https://github.com/Netflix/atlas/wiki/Tags) to get all of the matching zones, nodes, etc.

[1] https://github.com/Netflix/atlas/wiki/Reference-query