### PR TITLE
work-around for null context classloader

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/graphics/Constants.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/graphics/Constants.scala
@@ -21,12 +21,13 @@ import java.awt.Font
 import java.awt.Stroke
 import java.awt.image.BufferedImage
 
+import com.netflix.atlas.config.ConfigManager
 import com.netflix.atlas.core.util.Strings
 import com.typesafe.config.ConfigFactory
 
 object Constants {
 
-  private val config = ConfigFactory.load().getConfig("atlas.chart")
+  private val config = ConfigManager.current.getConfig("atlas.chart")
 
   private def color(name: String): Color = Strings.parseColor(config.getString(s"colors.$name"))
 


### PR DESCRIPTION
In some cases we are seeing:

```
Thread.currentThread().getContextClassLoader() == null
```

With this change we'll log a warning and try the
classloader for a given class.

/cc @fangji 