### PR TITLE
remove dependency on trove4j

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/LazyTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/LazyTagIndex.scala
@@ -23,12 +23,12 @@ import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.Tag
 import com.netflix.atlas.core.model.TagKey
 import com.netflix.atlas.core.model.TaggedItem
+import com.netflix.atlas.core.util.IntHashSet
 import com.netflix.atlas.core.util.Interner
 import gnu.trove.map.hash.TIntIntHashMap
 import gnu.trove.map.hash.TObjectIntHashMap
 import gnu.trove.procedure.TIntIntProcedure
 import gnu.trove.procedure.TObjectIntProcedure
-import gnu.trove.set.hash.TIntHashSet
 import org.slf4j.LoggerFactory
 
 
@@ -50,7 +50,7 @@ class LazyTagIndex[T <: TaggedItem](items: Array[T], interner: Interner[String])
   type LazyValueMap = util.IdentityHashMap[String, LazySet]
   type LazyKeyMap = util.IdentityHashMap[String, LazyValueMap]
 
-  type ValueMap = util.IdentityHashMap[String, TIntHashSet]
+  type ValueMap = util.IdentityHashMap[String, IntHashSet]
   type KeyMap = util.IdentityHashMap[String, ValueMap]
 
   // Comparator for ordering tagged items using the id
@@ -98,7 +98,7 @@ class LazyTagIndex[T <: TaggedItem](items: Array[T], interner: Interner[String])
         val internedV = interner.intern(v)
         var matchSet = vidx.get(internedV)
         if (matchSet == null) {
-          matchSet = new TIntHashSet
+          matchSet = new IntHashSet(-1, 20)
           vidx.put(internedV, matchSet)
         }
         matchSet.add(pos)
@@ -106,7 +106,7 @@ class LazyTagIndex[T <: TaggedItem](items: Array[T], interner: Interner[String])
         // Add to key index
         matchSet = kidx.get(internedK)
         if (matchSet == null) {
-          matchSet = new TIntHashSet
+          matchSet = new IntHashSet(-1, 20)
           kidx.put(internedK, matchSet)
         }
         matchSet.add(pos)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Block.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Block.scala
@@ -18,9 +18,6 @@ package com.netflix.atlas.core.model
 import java.util
 
 import com.netflix.atlas.core.util.DoubleIntHashMap
-import gnu.trove.map.hash.TDoubleIntHashMap
-
-//import com.netflix.atlas.core.block.DefaultBlockCodec
 import com.netflix.atlas.core.util.ArrayHelper
 import com.netflix.atlas.core.util.Math
 
@@ -143,21 +140,6 @@ object Block {
     }
     compress(result)
   }
-
-  /** Returns a byte array representing the block data. The start time will not be stored. */
-  /*def toByteArray(block: Block): Array[Byte] = {
-    val buffer = ByteBuffer.allocate(block.byteCount)
-    val codec = new DefaultBlockCodec(block.start)
-    codec.encode(buffer, block)
-    buffer.array
-  }*/
-
-  /** Returns a block decoded from the buffer created using `toByteArray`. */
-  /*def fromByteArray(start: Long, bytes: Array[Byte]): Block = {
-    val buffer = ByteBuffer.wrap(bytes)
-    val codec = new DefaultBlockCodec(start)
-    codec.decode(buffer)
-  }*/
 }
 
 /**

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Block.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Block.scala
@@ -17,11 +17,12 @@ package com.netflix.atlas.core.model
 
 import java.util
 
+import com.netflix.atlas.core.util.DoubleIntHashMap
+import gnu.trove.map.hash.TDoubleIntHashMap
+
 //import com.netflix.atlas.core.block.DefaultBlockCodec
 import com.netflix.atlas.core.util.ArrayHelper
 import com.netflix.atlas.core.util.Math
-import gnu.trove.map.hash.TDoubleIntHashMap
-import gnu.trove.procedure.TDoubleIntProcedure
 
 
 /**
@@ -50,7 +51,8 @@ object Block {
     } else {
       // Keeps track of values we have already seen and maps them to an index. NaN doesn't equal
       // anything so it cannot be found in the map. We special case it to always have index -1.
-      val idxMap = new TDoubleIntHashMap(10, 0.5f, Double.NaN, SparseBlock.NOT_FOUND)
+      //val idxMap = new TDoubleIntHashMap(10, 0.5f, Double.NaN, SparseBlock.NOT_FOUND)
+      val idxMap = new DoubleIntHashMap
       var nextIdx = 0
 
       // Index into the value array
@@ -63,7 +65,7 @@ object Block {
       while (i < block.size) {
         val v = block.buffer(i)
         val predefIdx = SparseBlock.predefinedIndex(v)
-        var idx = if (predefIdx == SparseBlock.UNDEFINED) idxMap.get(v) else predefIdx
+        var idx = if (predefIdx == SparseBlock.UNDEFINED) idxMap.get(v, SparseBlock.NOT_FOUND) else predefIdx
         if (idx == SparseBlock.NOT_FOUND) {
           if (nextIdx == MAX_SIZE) return block
           idx = nextIdx
@@ -78,7 +80,7 @@ object Block {
 
       // Populate values array
       val values = new Array[Double](idxMap.size)
-      idxMap.forEachEntry(new FillArrayProcedure(values))
+      idxMap.foreach { (k, v) => values(v) = k }
 
       // Choose the appropriate block type
       if (isConstant)
@@ -156,14 +158,6 @@ object Block {
     val codec = new DefaultBlockCodec(start)
     codec.decode(buffer)
   }*/
-
-  /** Fills an array based on a map of double to int. */
-  private class FillArrayProcedure(values: Array[Double]) extends TDoubleIntProcedure {
-    def execute(v: Double, idx: Int): Boolean = {
-      if (idx >= 0) values(idx) = v
-      true
-    }
-  }
 }
 
 /**

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/DoubleIntHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/DoubleIntHashMap.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+/**
+  * Mutable double to integer map based on an underlying LongIntHashMap.
+  * Primary use-case is computing a count for the number of times a particular
+  * value was encountered.
+  *
+  * @param noData
+  *     Value to use to represent no data in the array. This value should not
+  *     be used in the input. Default is NaN.
+  * @param capacity
+  *     Initial capacity guideline. The actual size of the underlying buffer
+  *     will be the next prime >= `capacity`. Default is 10.
+  */
+class DoubleIntHashMap(noData: Double = Double.NaN, capacity: Int = 10) {
+
+  private[this] val data = new LongIntHashMap(d2l(noData), capacity)
+
+  private def d2l(k: Double): Long = java.lang.Double.doubleToLongBits(k)
+  private def l2d(k: Long): Double = java.lang.Double.longBitsToDouble(k)
+
+  /**
+    * Put a double to integer pair into the map. The key, `k`, should not be
+    * equivalent to the `noData` value used for this map. If an entry with the
+    * same key already exists, then the value will be overwritten.
+    */
+  def put(k: Double, v: Int): Unit = data.put(d2l(k), v)
+
+  /**
+    * Get the value associated with key, `k`. If no value is present, then the
+    * `dflt` value will be returned.
+    */
+  def get(k: Double, dflt: Int): Int = data.get(d2l(k), dflt)
+
+  /**
+    * Add one to the count associated with `k`. If the key is not already in the
+    * map a new entry will be created with a count of 1.
+    */
+  def increment(k: Long): Unit = increment(k, 1)
+
+  /**
+    * Add `amount` to the count associated with `k`. If the key is not already in the
+    * map a new entry will be created with a count of `amount`.
+    */
+  def increment(k: Long, amount: Int): Unit = data.increment(d2l(k), amount)
+
+  /** Execute `f` for each item in the set. */
+  def foreach(f: (Double, Int) => Unit): Unit = {
+    data.foreach { (k, v) => f(l2d(k), v) }
+  }
+
+  /** Return the number of items in the set. This is a constant time operation. */
+  def size: Int = data.size
+
+  /** Converts this set to a Map[Double, Int]. Used mostly for debugging and tests. */
+  def toMap: Map[Double, Int] = {
+    val builder = Map.newBuilder[Double, Int]
+    foreach { (k, v) => builder += k -> v }
+    builder.result()
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/DoubleIntHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/DoubleIntHashMap.scala
@@ -51,13 +51,13 @@ class DoubleIntHashMap(noData: Double = Double.NaN, capacity: Int = 10) {
     * Add one to the count associated with `k`. If the key is not already in the
     * map a new entry will be created with a count of 1.
     */
-  def increment(k: Long): Unit = increment(k, 1)
+  def increment(k: Double): Unit = increment(k, 1)
 
   /**
     * Add `amount` to the count associated with `k`. If the key is not already in the
     * map a new entry will be created with a count of `amount`.
     */
-  def increment(k: Long, amount: Int): Unit = data.increment(d2l(k), amount)
+  def increment(k: Double, amount: Int): Unit = data.increment(d2l(k), amount)
 
   /** Execute `f` for each item in the set. */
   def foreach(f: (Double, Int) => Unit): Unit = {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntHashSet.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntHashSet.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+/**
+  * Mutable integer set based on open-addressing. Primary use-case is deduping
+  * integers so it only supports `add` and `foreach`.
+  *
+  * @param noData
+  *     Value to use to represent no data in the array. This value should not
+  *     be used in the input.
+  * @param capacity
+  *     Initial capacity guideline. The actual size of the underlying buffer
+  *     will be the next prime >= `capacity`. Default is 10.
+  */
+class IntHashSet(noData: Int, capacity: Int = 10) {
+
+  private[this] var data = newArray(capacity)
+  private[this] var used = 0
+  private[this] var cutoff = math.max(3, (data.length * 0.7).toInt)
+
+  private def newArray(n: Int): Array[Int] = {
+    val tmp = new Array[Int](PrimeFinder.nextPrime(n))
+    var i = 0
+    while (i < tmp.length) {
+      tmp(i) = noData
+      i += 1
+    }
+    tmp
+  }
+
+  private def resize(): Unit = {
+    val tmp = newArray(data.length * 2)
+    var i = 0
+    while (i < data.length) {
+      val v = data(i)
+      if (v != noData) add(tmp, v)
+      i += 1
+    }
+    data = tmp
+    cutoff = math.max(3, (tmp.length * 0.7).toInt)
+  }
+
+  private def add(buffer: Array[Int], v: Int): Unit = {
+    var pos = math.abs(v) % buffer.length
+    while (true) {
+      val prev = buffer(pos)
+      if (prev == noData || prev == v) {
+        buffer(pos) = v
+        return
+      }
+      pos = (pos + 1) % buffer.length
+    }
+  }
+
+  /**
+    * Add an integer into the set. The value, `v`, should not be equivalent to the
+    * `noData` value used for this set.
+    */
+  def add(v: Int): Unit = {
+    if (used >= cutoff) resize()
+    add(data, v)
+    used += 1
+  }
+
+  /** Execute `f` for each item in the set. */
+  def foreach(f: Int => Unit): Unit = {
+    var i = 0
+    while (i < data.length) {
+      val v = data(i)
+      if (v != noData) f(v)
+      i += 1
+    }
+  }
+
+  /** Return the number of items in the set. This is a constant time operation. */
+  def size: Int = used
+
+  /** Converts this set to an Array[Int]. */
+  def toArray: Array[Int] = {
+    val tmp = new Array[Int](used)
+    var i = 0
+    foreach { v =>
+      tmp(i) = v
+      i += 1
+    }
+    tmp
+  }
+
+  /** Converts this set to a List[Int]. Used mostly for debugging and tests. */
+  def toList: List[Int] = {
+    val builder = List.newBuilder[Int]
+    foreach { v => builder += v }
+    builder.result()
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntHashSet.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntHashSet.scala
@@ -56,15 +56,13 @@ class IntHashSet(noData: Int, capacity: Int = 10) {
 
   private def add(buffer: Array[Int], v: Int): Boolean = {
     var pos = math.abs(v) % buffer.length
-    while (true) {
-      val prev = buffer(pos)
-      if (prev == noData || prev == v) {
-        buffer(pos) = v
-        return prev == noData
-      }
+    var posV = buffer(pos)
+    while (posV != noData && posV != v) {
       pos = (pos + 1) % buffer.length
+      posV = buffer(pos)
     }
-    false
+    buffer(pos) = v
+    posV == noData
   }
 
   /**

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntHashSet.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntHashSet.scala
@@ -54,16 +54,17 @@ class IntHashSet(noData: Int, capacity: Int = 10) {
     cutoff = math.max(3, (tmp.length * 0.7).toInt)
   }
 
-  private def add(buffer: Array[Int], v: Int): Unit = {
+  private def add(buffer: Array[Int], v: Int): Boolean = {
     var pos = math.abs(v) % buffer.length
     while (true) {
       val prev = buffer(pos)
       if (prev == noData || prev == v) {
         buffer(pos) = v
-        return
+        return prev == noData
       }
       pos = (pos + 1) % buffer.length
     }
+    false
   }
 
   /**
@@ -72,8 +73,7 @@ class IntHashSet(noData: Int, capacity: Int = 10) {
     */
   def add(v: Int): Unit = {
     if (used >= cutoff) resize()
-    add(data, v)
-    used += 1
+    if (add(data, v)) used += 1
   }
 
   /** Execute `f` for each item in the set. */

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntIntHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntIntHashMap.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+/**
+  * Mutable integer map based on open-addressing. Primary use-case is computing
+  * a count for the number of times a paritcular value was encountered.
+  *
+  * @param noData
+  *     Value to use to represent no data in the array. This value should not
+  *     be used in the input.
+  * @param capacity
+  *     Initial capacity guideline. The actual size of the underlying buffer
+  *     will be the next prime >= `capacity`. Default is 10.
+  */
+class IntIntHashMap(noData: Int, capacity: Int = 10) {
+
+  private[this] var keys = newArray(capacity)
+  private[this] var values = new Array[Int](keys.length)
+  private[this] var used = 0
+  private[this] var cutoff = math.max(3, (keys.length * 0.7).toInt)
+
+  private def newArray(n: Int): Array[Int] = {
+    val tmp = new Array[Int](PrimeFinder.nextPrime(n))
+    var i = 0
+    while (i < tmp.length) {
+      tmp(i) = noData
+      i += 1
+    }
+    tmp
+  }
+
+  private def resize(): Unit = {
+    val tmpKS = newArray(keys.length * 2)
+    val tmpVS = new Array[Int](tmpKS.length)
+    var i = 0
+    while (i < keys.length) {
+      val k = keys(i)
+      if (k != noData) put(tmpKS, tmpVS, k, values(i))
+      i += 1
+    }
+    keys = tmpKS
+    values = tmpVS
+    cutoff = math.max(3, (tmpKS.length * 0.7).toInt)
+  }
+
+  private def put(ks: Array[Int], vs: Array[Int], k: Int, v: Int): Boolean = {
+    var pos = math.abs(k) % ks.length
+    while (true) {
+      val prev = ks(pos)
+      if (prev == noData || prev == k) {
+        ks(pos) = k
+        vs(pos) = v
+        return prev == noData
+      }
+      pos = (pos + 1) % ks.length
+    }
+    false
+  }
+
+  /**
+    * Put an integer key/value pair into the map. The key, `k`, should not be
+    * equivalent to the `noData` value used for this map. If an entry with the
+    * same key already exists, then the value will be overwritten.
+    */
+  def put(k: Int, v: Int): Unit = {
+    if (used >= cutoff) resize()
+    if (put(keys, values, k, v)) used += 1
+  }
+
+  /**
+    * Add one to the count associated with `k`. If the key is not already in the
+    * map a new entry will be created with a count of 1.
+    */
+  def increment(k: Int): Unit = increment(k, 1)
+
+  /**
+    * Add `amount` to the count associated with `k`. If the key is not already in the
+    * map a new entry will be created with a count of `amount`.
+    */
+  def increment(k: Int, amount: Int): Unit = {
+    if (used >= cutoff) resize()
+    var pos = math.abs(k) % keys.length
+    while (true) {
+      val prev = keys(pos)
+      if (prev == noData || prev == k) {
+        keys(pos) = k
+        values(pos) += amount
+        if (prev == noData) used += 1
+        return
+      }
+      pos = (pos + 1) % keys.length
+    }
+  }
+
+  /** Execute `f` for each item in the set. */
+  def foreach(f: (Int, Int) => Unit): Unit = {
+    var i = 0
+    while (i < keys.length) {
+      val k = keys(i)
+      if (k != noData) f(k, values(i))
+      i += 1
+    }
+  }
+
+  /** Return the number of items in the set. This is a constant time operation. */
+  def size: Int = used
+
+  /** Converts this set to a Map[Int, Int]. Used mostly for debugging and tests. */
+  def toMap: Map[Int, Int] = {
+    val builder = Map.newBuilder[Int, Int]
+    foreach { (k, v) => builder += k -> v }
+    builder.result()
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntIntHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntIntHashMap.scala
@@ -59,16 +59,14 @@ class IntIntHashMap(noData: Int, capacity: Int = 10) {
 
   private def put(ks: Array[Int], vs: Array[Int], k: Int, v: Int): Boolean = {
     var pos = math.abs(k) % ks.length
-    while (true) {
-      val prev = ks(pos)
-      if (prev == noData || prev == k) {
-        ks(pos) = k
-        vs(pos) = v
-        return prev == noData
-      }
+    var posV = ks(pos)
+    while (posV != noData && posV != k) {
       pos = (pos + 1) % ks.length
+      posV = ks(pos)
     }
-    false
+    ks(pos) = k
+    vs(pos) = v
+    posV == noData
   }
 
   /**

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongIntHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongIntHashMap.scala
@@ -61,16 +61,14 @@ class LongIntHashMap(noData: Long, capacity: Int = 10) {
 
   private def put(ks: Array[Long], vs: Array[Int], k: Long, v: Int): Boolean = {
     var pos = math.abs(hash(k)) % ks.length
-    while (true) {
-      val prev = ks(pos)
-      if (prev == noData || prev == k) {
-        ks(pos) = k
-        vs(pos) = v
-        return prev == noData
-      }
+    var posV = ks(pos)
+    while (posV != noData && posV != k) {
       pos = (pos + 1) % ks.length
+      posV = ks(pos)
     }
-    false
+    ks(pos) = k
+    vs(pos) = v
+    posV == noData
   }
 
   /**

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/RefIntHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/RefIntHashMap.scala
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+/**
+  * Mutable reference to integer map based on open-addressing. Primary use-case is
+  * computing a count for the number of times a particular value was encountered.
+  *
+  * @param capacity
+  *     Initial capacity guideline. The actual size of the underlying buffer
+  *     will be the next prime >= `capacity`. Default is 10.
+  */
+class RefIntHashMap[T](capacity: Int = 10) {
+
+  private[this] var keys = newArray(capacity)
+  private[this] var values = new Array[Int](keys.length)
+  private[this] var used = 0
+  private[this] var cutoff = math.max(3, (keys.length * 0.7).toInt)
+
+  private def newArray(n: Int): Array[T] = {
+    // Note, we do a cast here and avoid using RefIntHashMap[T: ClassTag] because
+    // the ClassTag seems to add a lot of memory overhead. From jol when using
+    // ClassTag:
+    //
+    // com.netflix.atlas.core.util.RefIntHashMap@78e94dcfd footprint:
+    // COUNT       AVG       SUM   DESCRIPTION
+    //    55        50      2760   [C
+    //     1        64        64   [I
+    //     4        20        80   [Ljava.lang.Class;
+    //     1        64        64   [Ljava.lang.Long;
+    //     3        40       120   [Ljava.lang.Object;
+    //     9        35       320   [Ljava.lang.reflect.Field;
+    //     2        16        32   [Ljava.lang.reflect.Method;
+    //     1        24        24   [Ljava.lang.reflect.TypeVariable;
+    //     1        16        16   [Lsun.reflect.generics.tree.ClassTypeSignature;
+    //     2        24        48   [Lsun.reflect.generics.tree.FieldTypeSignature;
+    //     1        24        24   [Lsun.reflect.generics.tree.FormalTypeParameter;
+    //     3        16        48   [Lsun.reflect.generics.tree.TypeArgument;
+    //     1        32        32   com.netflix.atlas.core.util.RefIntHashMap
+    //    22       525     11560   java.lang.Class
+    //     7        56       392   java.lang.Class$ReflectionData
+    //     5        24       120   java.lang.Long
+    //    55        24      1320   java.lang.String
+    //     1        16        16   java.lang.ref.ReferenceQueue$Lock
+    //     1        32        32   java.lang.ref.ReferenceQueue$Null
+    //     7        40       280   java.lang.ref.SoftReference
+    //    52        72      3744   java.lang.reflect.Field
+    //     3        24        72   java.util.ArrayList
+    //     1        16        16   scala.reflect.ClassTag$$anon$1
+    //     2        32        64   sun.reflect.UnsafeObjectFieldAccessorImpl
+    //     9        32       288   sun.reflect.UnsafeQualifiedObjectFieldAccessorImpl
+    //     1        40        40   sun.reflect.UnsafeQualifiedStaticObjectFieldAccessorImpl
+    //     1        24        24   sun.reflect.generics.factory.CoreReflectionFactory
+    //     2        32        64   sun.reflect.generics.reflectiveObjects.TypeVariableImpl
+    //     1        32        32   sun.reflect.generics.repository.ClassRepository
+    //     1        24        24   sun.reflect.generics.scope.ClassScope
+    //     1        24        24   sun.reflect.generics.tree.ClassSignature
+    //     3        16        48   sun.reflect.generics.tree.ClassTypeSignature
+    //     2        24        48   sun.reflect.generics.tree.FormalTypeParameter
+    //     3        24        72   sun.reflect.generics.tree.SimpleClassTypeSignature
+    //   264               21912   (total)
+    new Array[AnyRef](PrimeFinder.nextPrime(n)).asInstanceOf[Array[T]]
+  }
+
+  private def resize(): Unit = {
+    val tmpKS = newArray(keys.length * 2)
+    val tmpVS = new Array[Int](tmpKS.length)
+    var i = 0
+    while (i < keys.length) {
+      val k = keys(i)
+      if (k != null) put(tmpKS, tmpVS, k, values(i))
+      i += 1
+    }
+    keys = tmpKS
+    values = tmpVS
+    cutoff = math.max(3, (tmpKS.length * 0.7).toInt)
+  }
+
+  private def put(ks: Array[T], vs: Array[Int], k: T, v: Int): Boolean = {
+    var pos = math.abs(k.hashCode()) % ks.length
+    var posV = ks(pos)
+    while (posV != null && posV != k) {
+      pos = (pos + 1) % ks.length
+      posV = ks(pos)
+    }
+    ks(pos) = k
+    vs(pos) = v
+    posV == null
+  }
+
+  /**
+    * Put a ref to integer pair into the map. The key, `k`, should not be
+    * equivalent to the `noData` value used for this map. If an entry with the
+    * same key already exists, then the value will be overwritten.
+    */
+  def put(k: T, v: Int): Unit = {
+    if (used >= cutoff) resize()
+    if (put(keys, values, k, v)) used += 1
+  }
+
+  /**
+    * Get the value associated with key, `k`. If no value is present, then the
+    * `dflt` value will be returned.
+    */
+  def get(k: T, dflt: Int): Int = {
+    var pos = math.abs(k.hashCode()) % keys.length
+    while (true) {
+      val prev = keys(pos)
+      if (prev == null)
+        return dflt
+      else if (prev == k)
+        return values(pos)
+      else
+        pos = (pos + 1) % keys.length
+    }
+    dflt
+  }
+
+  /**
+    * Add one to the count associated with `k`. If the key is not already in the
+    * map a new entry will be created with a count of 1.
+    */
+  def increment(k: T): Unit = increment(k, 1)
+
+  /**
+    * Add `amount` to the count associated with `k`. If the key is not already in the
+    * map a new entry will be created with a count of `amount`.
+    */
+  def increment(k: T, amount: Int): Unit = {
+    if (used >= cutoff) resize()
+    var pos = math.abs(k.hashCode()) % keys.length
+    while (true) {
+      val prev = keys(pos)
+      if (prev == null || prev == k) {
+        keys(pos) = k
+        values(pos) += amount
+        if (prev == null) used += 1
+        return
+      }
+      pos = (pos + 1) % keys.length
+    }
+  }
+
+  /** Execute `f` for each item in the set. */
+  def foreach(f: (T, Int) => Unit): Unit = {
+    var i = 0
+    while (i < keys.length) {
+      val k = keys(i)
+      if (k != null) f(k, values(i))
+      i += 1
+    }
+  }
+
+  /** Return the number of items in the set. This is a constant time operation. */
+  def size: Int = used
+
+  /** Apply a mapping function `f` and converts the result to an array. */
+  def mapToArray[R](buffer: Array[R])(f: (T, Int) => R): Array[R] = {
+    require(buffer.length == used, s"buffer.length (${buffer.length}) != size ($used)")
+    var i = 0
+    var j = 0
+    while (i < keys.length) {
+      val k = keys(i)
+      if (k != null) {
+        buffer(j) = f(k, values(i))
+        j += 1
+      }
+      i += 1
+    }
+    buffer
+  }
+
+  /** Converts this set to a Map[T, Int]. Used mostly for debugging and tests. */
+  def toMap: Map[T, Int] = {
+    val builder = Map.newBuilder[T, Int]
+    foreach { (k, v) => builder += k -> v }
+    builder.result()
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/DoubleIntHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/DoubleIntHashMapSuite.scala
@@ -22,73 +22,66 @@ import org.scalatest.FunSuite
 import scala.util.Random
 
 
-class IntIntHashMapSuite extends FunSuite {
+class DoubleIntHashMapSuite extends FunSuite {
 
   test("put") {
-    val m = new IntIntHashMap(-1)
+    val m = new DoubleIntHashMap
     assert(0 === m.size)
-    m.put(11, 42)
+    m.put(11.0, 42)
     assert(1 === m.size)
-    assert(Map(11 -> 42) === m.toMap)
+    assert(Map(11.0 -> 42) === m.toMap)
   }
 
   test("get") {
-    val m = new IntIntHashMap(-1)
-    assert(m.get(42, -1) === -1)
-    m.put(11, 27)
-    assert(m.get(42, -1) === -1)
-    assert(m.get(11, -1) === 27)
-  }
-
-  test("get - collisions") {
-    // Underlying capacity will be 11, next prime after 10, so 0 and multiples of 11
-    // will collide
-    val m = new IntIntHashMap(-1, 10)
-    m.put(0, 0)
-    m.put(11, 1)
-    m.put(22, 2)
-    assert(m.size === 3)
-    assert(m.get(0, -1) === 0)
-    assert(m.get(11, -1) === 1)
-    assert(m.get(22, -1) === 2)
+    val m = new DoubleIntHashMap
+    assert(m.get(42.0, -1) === -1)
+    m.put(11.0, 27)
+    assert(m.get(42.0, -1) === -1)
+    assert(m.get(11.0, -1) === 27)
   }
 
   test("dedup") {
-    val m = new IntIntHashMap(-1)
-    m.put(42, 1)
-    assert(Map(42 -> 1) === m.toMap)
+    val m = new DoubleIntHashMap
+    m.put(42.0, 1)
+    assert(Map(42.0 -> 1) === m.toMap)
     assert(1 === m.size)
-    m.put(42, 2)
-    assert(Map(42 -> 2) === m.toMap)
+    m.put(42.0, 2)
+    assert(Map(42.0 -> 2) === m.toMap)
     assert(1 === m.size)
   }
 
   test("increment") {
-    val m = new IntIntHashMap(-1)
+    val m = new DoubleIntHashMap
     assert(0 === m.size)
 
-    m.increment(42)
+    m.increment(42.0)
     assert(1 === m.size)
-    assert(Map(42 -> 1) === m.toMap)
+    assert(Map(42.0 -> 1) === m.toMap)
 
-    m.increment(42)
+    m.increment(42.0)
     assert(1 === m.size)
-    assert(Map(42 -> 2) === m.toMap)
+    assert(Map(42.0 -> 2) === m.toMap)
 
-    m.increment(42, 7)
+    m.increment(42.0, 7)
     assert(1 === m.size)
-    assert(Map(42 -> 9) === m.toMap)
+    assert(Map(42.0 -> 9) === m.toMap)
   }
 
   test("resize") {
-    val m = new IntIntHashMap(-1, 10)
+    val m = new DoubleIntHashMap
     (0 until 10000).foreach(i => m.put(i, i))
     assert((0 until 10000).map(i => i -> i).toMap === m.toMap)
   }
 
+  test("resize - increment") {
+    val m = new DoubleIntHashMap
+    (0 until 10000).foreach(i => m.increment(i, i))
+    assert((0 until 10000).map(i => i -> i).toMap === m.toMap)
+  }
+
   test("random") {
-    val jmap = new scala.collection.mutable.HashMap[Int, Int]
-    val imap = new IntIntHashMap(-1, 10)
+    val jmap = new scala.collection.mutable.HashMap[Double, Int]
+    val imap = new DoubleIntHashMap
     (0 until 10000).foreach { i =>
       val v = Random.nextInt()
       imap.put(v, i)
@@ -100,13 +93,13 @@ class IntIntHashMapSuite extends FunSuite {
 
   test("memory per map") {
     // Sanity check to verify if some change introduces more overhead per set
-    val bytes = ClassLayout.parseClass(classOf[IntIntHashMap]).instanceSize()
-    assert(bytes === 32)
+    val bytes = ClassLayout.parseClass(classOf[DoubleIntHashMap]).instanceSize()
+    assert(bytes === 16)
   }
 
   test("memory - 5 items") {
-    val imap = new IntIntHashMap(-1, 10)
-    val jmap = new java.util.HashMap[Int, Int](10)
+    val imap = new DoubleIntHashMap
+    val jmap = new java.util.HashMap[Double, Int](10)
     (0 until 5).foreach { i =>
       imap.put(i, i)
       jmap.put(i, i)
@@ -119,15 +112,15 @@ class IntIntHashMapSuite extends FunSuite {
     //println(jgraph.toFootprint)
 
     // Only objects should be the key/value arrays and the map itself
-    assert(igraph.totalCount() === 3)
+    assert(igraph.totalCount() === 4)
 
-    // Sanity check size is < 200 bytes
-    assert(igraph.totalSize() <= 200)
+    // Sanity check size is < 250 bytes
+    assert(igraph.totalSize() <= 250)
   }
 
   test("memory - 10k items") {
-    val imap = new IntIntHashMap(-1, 10)
-    val jmap = new java.util.HashMap[Int, Int](10)
+    val imap = new DoubleIntHashMap
+    val jmap = new java.util.HashMap[Double, Int](10)
     (0 until 10000).foreach { i =>
       imap.put(i, i)
       jmap.put(i, i)
@@ -140,10 +133,10 @@ class IntIntHashMapSuite extends FunSuite {
     //println(jgraph.toFootprint)
 
     // Only objects should be the key/value arrays and the map itself
-    assert(igraph.totalCount() === 3)
+    assert(igraph.totalCount() === 4)
 
-    // Sanity check size is < 220kb
-    assert(igraph.totalSize() <= 220000)
+    // Sanity check size is < 320kb
+    assert(igraph.totalSize() <= 320000)
   }
 
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntHashSetSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntHashSetSuite.scala
@@ -104,17 +104,4 @@ class IntHashSetSuite extends FunSuite {
     // Sanity check size is < 110kb
     assert(igraph.totalSize() <= 110000)
   }
-
-  private val values10k = (0 until 10000).map(_ => math.abs(Random.nextInt())).toArray
-  test("foo") {
-    val set = new IntHashSet(-1, 10)
-    val jset = new java.util.HashSet[Int](10)
-    var i = 0
-    while (i < values10k.length) {
-      set.add(values10k(i))
-      jset.add(values10k(i))
-      i += 1
-    }
-  }
-
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntHashSetSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntHashSetSuite.scala
@@ -28,6 +28,7 @@ class IntHashSetSuite extends FunSuite {
     val s = new IntHashSet(-1, 10)
     s.add(11)
     assert(List(11) === s.toList)
+    assert(1 === s.size)
   }
 
   test("dedup") {
@@ -44,6 +45,7 @@ class IntHashSetSuite extends FunSuite {
     val s = new IntHashSet(-1, 10)
     (0 until 10000).foreach(s.add)
     assert((0 until 10000).toSet === s.toList.toSet)
+    assert(s.size === 10000)
   }
 
   test("random") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntHashSetSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntHashSetSuite.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import gnu.trove.set.hash.TIntHashSet
+import org.openjdk.jol.info.ClassLayout
+import org.openjdk.jol.info.GraphLayout
+import org.scalatest.FunSuite
+
+import scala.util.Random
+
+
+class IntHashSetSuite extends FunSuite {
+
+  test("add") {
+    val s = new IntHashSet(-1, 10)
+    s.add(11)
+    assert(List(11) === s.toList)
+  }
+
+  test("dedup") {
+    val s = new IntHashSet(-1, 10)
+    s.add(42)
+    assert(List(42) === s.toList)
+    s.add(42)
+    assert(List(42) === s.toList)
+  }
+
+  test("resize") {
+    val s = new IntHashSet(-1, 10)
+    (0 until 10000).foreach(s.add)
+    assert((0 until 10000).toSet === s.toList.toSet)
+  }
+
+  test("random") {
+    val jset = new scala.collection.mutable.HashSet[Int]
+    val iset = new IntHashSet(-1, 10)
+    (0 until 10000).foreach { i =>
+      val v = Random.nextInt()
+      iset.add(v)
+      jset.add(v)
+    }
+    assert(jset.toSet === iset.toList.toSet)
+  }
+
+  test("memory per set") {
+    // Sanity check to verify if some change introduces more overhead per set
+    val bytes = ClassLayout.parseClass(classOf[IntHashSet]).instanceSize()
+    assert(bytes === 32)
+  }
+
+  test("memory - 5 items") {
+    val iset = new IntHashSet(-1, 10)
+    val jset = new java.util.HashSet[Int](10)
+    (0 until 5).foreach { i =>
+      iset.add(i)
+      jset.add(i)
+    }
+
+    val igraph = GraphLayout.parseInstance(iset)
+    val jgraph = GraphLayout.parseInstance(jset)
+
+    //println(igraph.toFootprint)
+    //println(jgraph.toFootprint)
+
+    // Only objects should be the array and the set itself
+    assert(igraph.totalCount() === 2)
+
+    // Sanity check size is < 100 bytes
+    assert(igraph.totalSize() <= 100)
+  }
+
+  test("memory - 10k items") {
+    val iset = new IntHashSet(-1, 10)
+    val jset = new java.util.HashSet[Int](10)
+    (0 until 10000).foreach { i =>
+      iset.add(i)
+      jset.add(i)
+    }
+
+    val igraph = GraphLayout.parseInstance(iset)
+    val jgraph = GraphLayout.parseInstance(jset)
+
+    //println(igraph.toFootprint)
+    //println(jgraph.toFootprint)
+
+    // Only objects should be the array and the set itself
+    assert(igraph.totalCount() === 2)
+
+    // Sanity check size is < 110kb
+    assert(igraph.totalSize() <= 110000)
+  }
+
+  private val values10k = (0 until 10000).map(_ => math.abs(Random.nextInt())).toArray
+  test("foo") {
+    val set = new IntHashSet(-1, 10)
+    val jset = new java.util.HashSet[Int](10)
+    var i = 0
+    while (i < values10k.length) {
+      set.add(values10k(i))
+      jset.add(values10k(i))
+      i += 1
+    }
+  }
+
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntHashSetSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntHashSetSuite.scala
@@ -15,7 +15,6 @@
  */
 package com.netflix.atlas.core.util
 
-import gnu.trove.set.hash.TIntHashSet
 import org.openjdk.jol.info.ClassLayout
 import org.openjdk.jol.info.GraphLayout
 import org.scalatest.FunSuite
@@ -35,8 +34,10 @@ class IntHashSetSuite extends FunSuite {
     val s = new IntHashSet(-1, 10)
     s.add(42)
     assert(List(42) === s.toList)
+    assert(1 === s.size)
     s.add(42)
     assert(List(42) === s.toList)
+    assert(1 === s.size)
   }
 
   test("resize") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntIntHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntIntHashMapSuite.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import org.openjdk.jol.info.ClassLayout
+import org.openjdk.jol.info.GraphLayout
+import org.scalatest.FunSuite
+
+import scala.util.Random
+
+
+class IntIntHashMapSuite extends FunSuite {
+
+  test("add") {
+    val m = new IntIntHashMap(-1)
+    assert(0 === m.size)
+    m.put(11, 42)
+    assert(1 === m.size)
+    assert(Map(11 -> 42) === m.toMap)
+  }
+
+  test("dedup") {
+    val m = new IntIntHashMap(-1)
+    m.put(42, 1)
+    assert(Map(42 -> 1) === m.toMap)
+    assert(1 === m.size)
+    m.put(42, 2)
+    assert(Map(42 -> 2) === m.toMap)
+    assert(1 === m.size)
+  }
+
+  test("increment") {
+    val m = new IntIntHashMap(-1)
+    assert(0 === m.size)
+
+    m.increment(42)
+    assert(1 === m.size)
+    assert(Map(42 -> 1) === m.toMap)
+
+    m.increment(42)
+    assert(1 === m.size)
+    assert(Map(42 -> 2) === m.toMap)
+
+    m.increment(42, 7)
+    assert(1 === m.size)
+    assert(Map(42 -> 9) === m.toMap)
+  }
+
+  test("resize") {
+    val m = new IntIntHashMap(-1, 10)
+    (0 until 10000).foreach(i => m.put(i, i))
+    assert((0 until 10000).map(i => i -> i).toMap === m.toMap)
+  }
+
+  test("random") {
+    val jmap = new scala.collection.mutable.HashMap[Int, Int]
+    val imap = new IntIntHashMap(-1, 10)
+    (0 until 10000).foreach { i =>
+      val v = Random.nextInt()
+      imap.put(v, i)
+      jmap.put(v, i)
+    }
+    assert(jmap.toMap === imap.toMap)
+    assert(jmap.size === imap.size)
+  }
+
+  test("memory per map") {
+    // Sanity check to verify if some change introduces more overhead per set
+    val bytes = ClassLayout.parseClass(classOf[IntIntHashMap]).instanceSize()
+    assert(bytes === 32)
+  }
+
+  test("memory - 5 items") {
+    val imap = new IntIntHashMap(-1, 10)
+    val jmap = new java.util.HashMap[Int, Int](10)
+    (0 until 5).foreach { i =>
+      imap.put(i, i)
+      jmap.put(i, i)
+    }
+
+    val igraph = GraphLayout.parseInstance(imap)
+    val jgraph = GraphLayout.parseInstance(jmap)
+
+    //println(igraph.toFootprint)
+    //println(jgraph.toFootprint)
+
+    // Only objects should be the key/value arrays and the map itself
+    assert(igraph.totalCount() === 3)
+
+    // Sanity check size is < 200 bytes
+    assert(igraph.totalSize() <= 200)
+  }
+
+  test("memory - 10k items") {
+    val imap = new IntIntHashMap(-1, 10)
+    val jmap = new java.util.HashMap[Int, Int](10)
+    (0 until 10000).foreach { i =>
+      imap.put(i, i)
+      jmap.put(i, i)
+    }
+
+    val igraph = GraphLayout.parseInstance(imap)
+    val jgraph = GraphLayout.parseInstance(jmap)
+
+    //println(igraph.toFootprint)
+    //println(jgraph.toFootprint)
+
+    // Only objects should be the key/value arrays and the map itself
+    assert(igraph.totalCount() === 3)
+
+    // Sanity check size is < 220kb
+    assert(igraph.totalSize() <= 220000)
+  }
+
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/LongIntHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/LongIntHashMapSuite.scala
@@ -24,12 +24,33 @@ import scala.util.Random
 
 class LongIntHashMapSuite extends FunSuite {
 
-  test("add") {
+  test("put") {
     val m = new LongIntHashMap(-1)
     assert(0 === m.size)
     m.put(11, 42)
     assert(1 === m.size)
     assert(Map(11 -> 42) === m.toMap)
+  }
+
+  test("get") {
+    val m = new LongIntHashMap(-1)
+    assert(m.get(42, -1) === -1)
+    m.put(11, 27)
+    assert(m.get(42, -1) === -1)
+    assert(m.get(11, -1) === 27)
+  }
+
+  test("get - collisions") {
+    // Underlying capacity will be 11, next prime after 10, so 0 and multiples of 11
+    // will collide
+    val m = new LongIntHashMap(-1, 10)
+    m.put(0, 0)
+    m.put(11, 1)
+    m.put(22, 2)
+    assert(m.size === 3)
+    assert(m.get(0, -1) === 0)
+    assert(m.get(11, -1) === 1)
+    assert(m.get(22, -1) === 2)
   }
 
   test("dedup") {
@@ -59,9 +80,26 @@ class LongIntHashMapSuite extends FunSuite {
     assert(Map(42 -> 9) === m.toMap)
   }
 
+  test("increment - collisions") {
+    // Underlying capacity will be 11, next prime after 10, so 0 and multiples of 11
+    // will collide
+    val m = new LongIntHashMap(-1, 10)
+    m.increment(0)
+    m.increment(11)
+    m.increment(22)
+    assert(m.size === 3)
+    m.foreach { (_, v) => assert(v === 1) }
+  }
+
   test("resize") {
     val m = new LongIntHashMap(-1, 10)
     (0 until 10000).foreach(i => m.put(i, i))
+    assert((0 until 10000).map(i => i -> i).toMap === m.toMap)
+  }
+
+  test("resize - increment") {
+    val m = new LongIntHashMap(-1, 10)
+    (0 until 10000).foreach(i => m.increment(i, i))
     assert((0 until 10000).map(i => i -> i).toMap === m.toMap)
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/LongIntHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/LongIntHashMapSuite.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import org.openjdk.jol.info.ClassLayout
+import org.openjdk.jol.info.GraphLayout
+import org.scalatest.FunSuite
+
+import scala.util.Random
+
+
+class LongIntHashMapSuite extends FunSuite {
+
+  test("add") {
+    val m = new LongIntHashMap(-1)
+    assert(0 === m.size)
+    m.put(11, 42)
+    assert(1 === m.size)
+    assert(Map(11 -> 42) === m.toMap)
+  }
+
+  test("dedup") {
+    val m = new LongIntHashMap(-1)
+    m.put(42, 1)
+    assert(Map(42 -> 1) === m.toMap)
+    assert(1 === m.size)
+    m.put(42, 2)
+    assert(Map(42 -> 2) === m.toMap)
+    assert(1 === m.size)
+  }
+
+  test("increment") {
+    val m = new LongIntHashMap(-1)
+    assert(0 === m.size)
+
+    m.increment(42)
+    assert(1 === m.size)
+    assert(Map(42 -> 1) === m.toMap)
+
+    m.increment(42)
+    assert(1 === m.size)
+    assert(Map(42 -> 2) === m.toMap)
+
+    m.increment(42, 7)
+    assert(1 === m.size)
+    assert(Map(42 -> 9) === m.toMap)
+  }
+
+  test("resize") {
+    val m = new LongIntHashMap(-1, 10)
+    (0 until 10000).foreach(i => m.put(i, i))
+    assert((0 until 10000).map(i => i -> i).toMap === m.toMap)
+  }
+
+  test("random") {
+    val jmap = new scala.collection.mutable.HashMap[Long, Int]
+    val imap = new LongIntHashMap(-1, 10)
+    (0 until 10000).foreach { i =>
+      val v = Random.nextInt()
+      imap.put(v, i)
+      jmap.put(v, i)
+    }
+    assert(jmap.toMap === imap.toMap)
+    assert(jmap.size === imap.size)
+  }
+
+  test("memory per map") {
+    // Sanity check to verify if some change introduces more overhead per set
+    val bytes = ClassLayout.parseClass(classOf[LongIntHashMap]).instanceSize()
+    assert(bytes === 40)
+  }
+
+  test("memory - 5 items") {
+    val imap = new LongIntHashMap(-1, 10)
+    val jmap = new java.util.HashMap[Long, Int](10)
+    (0 until 5).foreach { i =>
+      imap.put(i, i)
+      jmap.put(i, i)
+    }
+
+    val igraph = GraphLayout.parseInstance(imap)
+    val jgraph = GraphLayout.parseInstance(jmap)
+
+    //println(igraph.toFootprint)
+    //println(jgraph.toFootprint)
+
+    // Only objects should be the key/value arrays and the map itself
+    assert(igraph.totalCount() === 3)
+
+    // Sanity check size is < 250 bytes
+    assert(igraph.totalSize() <= 250)
+  }
+
+  test("memory - 10k items") {
+    val imap = new LongIntHashMap(-1, 10)
+    val jmap = new java.util.HashMap[Long, Int](10)
+    (0 until 10000).foreach { i =>
+      imap.put(i, i)
+      jmap.put(i, i)
+    }
+
+    val igraph = GraphLayout.parseInstance(imap)
+    val jgraph = GraphLayout.parseInstance(jmap)
+
+    //println(igraph.toFootprint)
+    //println(jgraph.toFootprint)
+
+    // Only objects should be the key/value arrays and the map itself
+    assert(igraph.totalCount() === 3)
+
+    // Sanity check size is < 320kb
+    assert(igraph.totalSize() <= 320000)
+  }
+
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/RefIntHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/RefIntHashMapSuite.scala
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import org.openjdk.jol.info.ClassLayout
+import org.openjdk.jol.info.GraphLayout
+import org.scalatest.FunSuite
+
+import scala.util.Random
+
+
+class RefIntHashMapSuite extends FunSuite {
+
+  import java.lang.{Long => JLong}
+
+  test("put") {
+    val m = new RefIntHashMap[JLong]
+    assert(0 === m.size)
+    m.put(11L, 42)
+    assert(1 === m.size)
+    assert(Map(11L -> 42) === m.toMap)
+  }
+
+  test("get") {
+    val m = new RefIntHashMap[JLong]
+    assert(m.get(42L, -1) === -1)
+    m.put(11L, 27)
+    assert(m.get(42L, -1) === -1)
+    assert(m.get(11L, -1) === 27)
+  }
+
+  test("get - collisions") {
+    // Underlying capacity will be 11, next prime after 10, so 0 and multiples of 11
+    // will collide
+    val m = new RefIntHashMap[JLong]
+    m.put(0L, 0)
+    m.put(11L, 1)
+    m.put(22L, 2)
+    assert(m.size === 3)
+    assert(m.get(0L, -1) === 0)
+    assert(m.get(11L, -1) === 1)
+    assert(m.get(22L, -1) === 2)
+  }
+
+  test("dedup") {
+    val m = new RefIntHashMap[JLong]
+    m.put(42L, 1)
+    assert(Map(42L -> 1) === m.toMap)
+    assert(1 === m.size)
+    m.put(42L, 2)
+    assert(Map(42L -> 2) === m.toMap)
+    assert(1 === m.size)
+  }
+
+  test("increment") {
+    val m = new RefIntHashMap[JLong]
+    assert(0 === m.size)
+
+    m.increment(42L)
+    assert(1 === m.size)
+    assert(Map(42L -> 1) === m.toMap)
+
+    m.increment(42L)
+    assert(1 === m.size)
+    assert(Map(42L -> 2) === m.toMap)
+
+    m.increment(42L, 7)
+    assert(1 === m.size)
+    assert(Map(42L -> 9) === m.toMap)
+  }
+
+  test("increment - collisions") {
+    // Underlying capacity will be 11, next prime after 10, so 0 and multiples of 11
+    // will collide
+    val m = new RefIntHashMap[JLong]
+    m.increment(0L)
+    m.increment(11L)
+    m.increment(22L)
+    assert(m.size === 3)
+    m.foreach { (_, v) => assert(v === 1) }
+  }
+
+  test("mapToArray") {
+    val m = new RefIntHashMap[JLong]
+    m.increment(0L)
+    m.increment(11L)
+    m.increment(22L)
+    val data = m.mapToArray(new Array[Long](m.size)) { (k, v) => k + v }
+    assert(data.toList === List(1, 12, 23))
+  }
+
+  test("mapToArray -- invalid length") {
+    val m = new RefIntHashMap[JLong]
+    m.increment(0L)
+    m.increment(11L)
+    m.increment(22L)
+    intercept[IllegalArgumentException] {
+      m.mapToArray(new Array[Long](0)) { (k, v) => k + v }
+    }
+  }
+
+  test("resize") {
+    val m = new RefIntHashMap[JLong]
+    (0 until 10000).foreach(i => m.put(i.toLong, i))
+    assert((0 until 10000).map(i => i -> i).toMap === m.toMap)
+  }
+
+  test("resize - increment") {
+    val m = new RefIntHashMap[JLong]
+    (0 until 10000).foreach(i => m.increment(i.toLong, i))
+    assert((0 until 10000).map(i => i -> i).toMap === m.toMap)
+  }
+
+  test("random") {
+    val jmap = new scala.collection.mutable.HashMap[Long, Int]
+    val imap = new RefIntHashMap[JLong]
+    (0 until 10000).foreach { i =>
+      val v = Random.nextInt()
+      imap.put(v.toLong, i)
+      jmap.put(v, i)
+    }
+    assert(jmap.toMap === imap.toMap)
+    assert(jmap.size === imap.size)
+  }
+
+  test("memory per map") {
+    // Sanity check to verify if some change introduces more overhead per set
+    val bytes = ClassLayout.parseClass(classOf[RefIntHashMap[JLong]]).instanceSize()
+    assert(bytes === 32)
+  }
+
+  test("memory - 5 items") {
+    val imap = new RefIntHashMap[JLong]
+    val jmap = new java.util.HashMap[Long, Int](10)
+    (0 until 5).foreach { i =>
+      imap.put(i.toLong, i)
+      jmap.put(i, i)
+    }
+
+    val igraph = GraphLayout.parseInstance(imap)
+    val jgraph = GraphLayout.parseInstance(jmap)
+
+    //println(igraph.toFootprint)
+    //println(jgraph.toFootprint)
+
+    // Only objects should be the key/value arrays and the map itself + 5 key objects
+    assert(igraph.totalCount() === 8)
+
+    // Sanity check size is < 300 bytes
+    assert(igraph.totalSize() <= 300)
+  }
+
+  test("memory - 10k items") {
+    val imap = new RefIntHashMap[JLong]
+    val jmap = new java.util.HashMap[Long, Int](10)
+    (0 until 10000).foreach { i =>
+      imap.put(i.toLong, i)
+      jmap.put(i, i)
+    }
+
+    val igraph = GraphLayout.parseInstance(imap)
+    val jgraph = GraphLayout.parseInstance(jmap)
+
+    //println(igraph.toFootprint)
+    //println(jgraph.toFootprint)
+
+    // Only objects should be the key/value arrays and the map itself + 10000 key objects
+    assert(igraph.totalCount() === 3 + 10000)
+
+    // Sanity check size is < 500kb
+    assert(igraph.totalSize() <= 500000)
+  }
+
+}

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/IntSet.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/IntSet.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Threads
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.util.Random
+
+/**
+  * Sanity check for integer hash set.
+  *
+  * ```
+  * > run -wi 10 -i 10 -f1 -t1 .*IntSet.*
+  * ...
+  * [info] Benchmark                    Mode  Cnt       Score       Error  Units
+  * [info] IntSet.testIntHashSet       thrpt   10  478541.525 ± 29615.965  ops/s
+  * [info] IntSet.testIntHashSet10k    thrpt   10    1531.614 ±    73.903  ops/s
+  * [info] IntSet.testJavaHashSet      thrpt   10  376161.309 ±  5242.341  ops/s
+  * [info] IntSet.testJavaHashSet10k   thrpt   10    2169.164 ±   126.964  ops/s
+  * [info] IntSet.testTroveHashSet     thrpt   10  416539.087 ± 29554.649  ops/s
+  * [info] IntSet.testTroveHashSet10k  thrpt   10    1813.617 ±    30.182  ops/s
+  * ```
+  */
+@State(Scope.Thread)
+class IntSet {
+
+  private val values100 = (0 until 100).map(_ => math.abs(Random.nextInt())).toArray
+  private val values10k = (0 until 10000).map(_ => math.abs(Random.nextInt())).toArray
+
+  @Threads(1)
+  @Benchmark
+  def testIntHashSet(bh: Blackhole): Unit = {
+    val set = new IntHashSet(-1, 10)
+    var i = 0
+    while (i < values100.length) {
+      set.add(values100(i))
+      i += 1
+    }
+    bh.consume(set)
+  }
+
+  @Threads(1)
+  @Benchmark
+  def testJavaHashSet(bh: Blackhole): Unit = {
+    val set = new java.util.HashSet[Int](10)
+    var i = 0
+    while (i < values100.length) {
+      set.add(values100(i))
+      i += 1
+    }
+    bh.consume(set)
+  }
+
+  @Threads(1)
+  @Benchmark
+  def testIntHashSet10k(bh: Blackhole): Unit = {
+    val set = new IntHashSet(-1, 10)
+    var i = 0
+    while (i < values10k.length) {
+      set.add(values10k(i))
+      i += 1
+    }
+    bh.consume(set)
+  }
+
+  @Threads(1)
+  @Benchmark
+  def testJavaHashSet10k(bh: Blackhole): Unit = {
+    val set = new java.util.HashSet[Int](10)
+    var i = 0
+    while (i < values10k.length) {
+      set.add(values10k(i))
+      i += 1
+    }
+    bh.consume(set)
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -80,7 +80,8 @@ object MainBuild extends Build {
     .settings(libraryDependencies ++= Seq(
       Dependencies.caffeine,
       Dependencies.trove,
-      Dependencies.equalsVerifier % "test"
+      Dependencies.equalsVerifier % "test",
+      Dependencies.jol % "test"
     ))
 
   lazy val `atlas-jmh` = project

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -79,7 +79,6 @@ object MainBuild extends Build {
     .settings(libraryDependencies ++= commonDeps)
     .settings(libraryDependencies ++= Seq(
       Dependencies.caffeine,
-      Dependencies.trove,
       Dependencies.equalsVerifier % "test",
       Dependencies.jol % "test"
     ))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -59,6 +59,5 @@ object Dependencies {
   val sprayClient     = "io.spray" % "spray-client_2.11" % spray
   val sprayRouting    = "io.spray" % "spray-routing_2.11" % spray
   val sprayTestkit    = "io.spray" % "spray-testkit_2.11" % spray
-  val trove           = "net.sf.trove4j" % "trove4j" % "3.0.3"
   val typesafeConfig  = "com.typesafe" % "config" % "1.3.0"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,6 +36,7 @@ object Dependencies {
   val jacksonScala2   = "com.fasterxml.jackson.module" % "jackson-module-scala_2.11" % jackson
   val jacksonSmile2   = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-smile" % jackson
   val jodaConvert     = "org.joda" % "joda-convert" % "1.8.1"
+  val jol             = "org.openjdk.jol" % "jol-core" % "0.5"
   val log4jApi        = "org.apache.logging.log4j" % "log4j-api" % log4j
   val log4jCore       = "org.apache.logging.log4j" % "log4j-core" % log4j
   val log4jJcl        = "org.apache.logging.log4j" % "log4j-jcl" % log4j


### PR DESCRIPTION
There are two main reasons:

1. Desire not to have LGPL licensed lib as transitive.
2. Minimize dependencies for core lib.