### PR TITLE
docs: fix links to spectator wiki

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
@@ -259,8 +259,8 @@ object StatefulVocabulary extends Vocabulary {
         || 1     | 5         |
         || 0     | 5         |
         |
-        |For a [counter](https://github.com/Netflix/spectator/wiki/Counter-Usage), each data point
-        |represents the average rate per second over the step interval. To compute the total
+        |For a [counter](http://netflix.github.io/spectator/en/latest/intro/counter/), each data
+        |point represents the average rate per second over the step interval. To compute the total
         |amount incremented, the value first needs to be converted to a rate per step interval.
         |This conversion can be performed using the [:per-step](math-per‐step) operation.
       """.stripMargin.trim

--- a/atlas-wiki/src/main/resources/Concepts.md
+++ b/atlas-wiki/src/main/resources/Concepts.md
@@ -41,8 +41,8 @@ Usage of tags will typically fall into two categories:
    category.
 
 When creating metrics it is important to carefully think about how the data should be tagged. See
-the [naming conventions](https://github.com/Netflix/spectator/wiki/Conventions) docs for more
-information.
+the [naming conventions](http://netflix.github.io/spectator/en/latest/intro/conventions/) docs for
+more information.
 
 ## Metric
 
@@ -59,10 +59,10 @@ the same metric.
 A data point is a triple consisting of tags, timestamp, and a value. It is important to understand
 at a high level how data points correlate with the measurement. Consider requests hitting a
 server, this would typically be measured using a
-[counter](https://github.com/Netflix/spectator/wiki/Counter-Usage). Each time a request is received
-the counter is incremented. There is not one data point per increment, a data point represents
-the behavior over a span of time called the [step size](#step-size). The client library will
-sample the counter once for each interval and report a single value.
+[counter](http://netflix.github.io/spectator/en/latest/intro/counter/). Each time a request is
+received the counter is incremented. There is not one data point per increment, a data point
+represents the behavior over a span of time called the [step size](#step-size). The client library
+will sample the counter once for each interval and report a single value.
 
 Suppose that each circle in the diagram below represents a request:
 
@@ -99,7 +99,7 @@ consistent.
 
 How a normalized value is computed depends on the data source type. Atlas supports three types
 indicated by the value of the `atlas.dstype` tag. In general, you should not need to worry about
-that, client libraries like [spectator](https://github.com/Netflix/spectator/wiki) will
+that, client libraries like [spectator](http://netflix.github.io/spectator/en/latest/) will
 automatically handle tagging based on the data source type.
 
 It is recommended to at least skim through the normalization for [gauges](#gauge) and
@@ -235,7 +235,7 @@ avoid gaps in the graph if a subset of time series used in an aggregate have gap
 
 ## Naming Conventions
 
-See [naming conventions](https://github.com/Netflix/spectator/wiki/Conventions).
+See [naming conventions](http://netflix.github.io/spectator/en/latest/intro/conventions/).
 
 
 

--- a/atlas-wiki/src/main/resources/Getting-Started.md
+++ b/atlas-wiki/src/main/resources/Getting-Started.md
@@ -6,7 +6,7 @@ machine. For other common tasks see:
 * Querying Data:
     * [Examples](Examples)
     * [Tutorial](Stack-Language)
-* [Instrumenting Code](https://github.com/Netflix/spectator/wiki)
+* [Instrumenting Code](http://netflix.github.io/spectator/en/latest/)
 
 ## Run a Demo Instance
 

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/DistStddev.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/DistStddev.scala
@@ -27,7 +27,7 @@ case object DistStddev extends StackWordPage {
   override def signature: String = s"`Query -- TimeSeriesExpr`"
 
   override def summary: String = """
-      |Compute standard deviation for [timers](https://github.com/Netflix/spectator/wiki/Timer-Usage)
-      |and [distribution summaries](https://github.com/Netflix/spectator/wiki/Distribution-Summary-Usage).
+      |Compute standard deviation for [timers](http://netflix.github.io/spectator/en/latest/intro/timer/)
+      |and [distribution summaries](http://netflix.github.io/spectator/en/latest/intro/dist-summary/).
     """.stripMargin.trim
 }


### PR DESCRIPTION
Spectator docs moved off of github wiki. Fix links
that were broken with that change.