### PR TITLE
fix incremental des evaluation

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
@@ -108,13 +108,13 @@ object StatefulExpr {
       desF.bp = s.bp
 
       val data = ts.data
-      var pos = s.pos
+      var pos = 0
       while (pos < data.length) {
         val yn = data(pos)
         data(pos) = desF.next(yn)
         pos += 1
       }
-      State(pos, desF.currentSample, desF.sp, desF.bp)
+      State(0, desF.currentSample, desF.sp, desF.bp)
     }
 
     private def newState: State = State(0, 0, 0.0, 0.0)

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/DesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/DesSuite.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import org.scalatest.FunSuite
+import org.scalatest.Matchers._
+
+class DesSuite extends FunSuite {
+
+  val step = 60000L
+  val dataTags = Map("name" -> "cpu", "node" -> "i-1")
+  val stream = List(
+    List(Datapoint(dataTags,  0L * step, 1.0)),
+    List(Datapoint(dataTags,  1L * step, 1.5)),
+    List(Datapoint(dataTags,  2L * step, 1.6)),
+    List(Datapoint(dataTags,  3L * step, 1.7)),
+    List(Datapoint(dataTags,  4L * step, 1.4)),
+    List(Datapoint(dataTags,  5L * step, 1.3)),
+    List(Datapoint(dataTags,  6L * step, 1.2)),
+    List(Datapoint(dataTags,  7L * step, 1.0)),
+    List(Datapoint(dataTags,  8L * step, 0.0)),
+    List(Datapoint(dataTags,  9L * step, 0.0)),
+    List(Datapoint(dataTags, 10L * step, 1.0)),
+    List(Datapoint(dataTags, 11L * step, 1.1)),
+    List(Datapoint(dataTags, 12L * step, 1.2)),
+    List(Datapoint(dataTags, 13L * step, 1.2))
+  )
+
+  val inputTS = TimeSeries(dataTags, new ArrayTimeSeq(DsType.Gauge, 0L, step,
+    Array[Double](1.0, 1.5, 1.6, 1.7, 1.4, 1.3, 1.2, 1.0, 0.0, 0.0, 1.0, 1.1, 1.2, 1.2)))
+
+  val des = StatefulExpr.Des(DataExpr.Sum(Query.Equal("name" , "cpu")), 2, 0.1, 0.02)
+  val sdes = StatefulExpr.SlidingDes(DataExpr.Sum(Query.Equal("name" , "cpu")), 2, 0.1, 0.02)
+
+  def eval(expr: TimeSeriesExpr, data: List[List[Datapoint]]): List[List[TimeSeries]] = {
+    var state = Map.empty[StatefulExpr, Any]
+    data.map { ts =>
+      val t = ts.head.timestamp
+      val context = EvalContext(t, t + step, step, state)
+      val rs = expr.eval(context, ts)
+      state = rs.state
+      rs.data
+    }
+  }
+
+  test("des: incremental exec matches global") {
+    val s = 0L
+    val e = 14L * step
+    val context = EvalContext(s, e, step, Map.empty)
+    val expected = des.eval(context, List(inputTS)).data.head.data.bounded(s, e).data
+
+    val result = eval(des, stream)
+    result.zip(expected).zipWithIndex.foreach { case ((ts, v), i) =>
+      assert(ts.size === 1)
+      ts.foreach { t =>
+        val r = t.data(i * step)
+        if (i <= 1)
+          assert(r.isNaN)
+        else
+          assert(v === r +- 0.00001)
+      }
+    }
+  }
+
+  ignore("sdes: incremental exec matches global") {
+    val s = 0L
+    val e = 14L * step
+    val context = EvalContext(s, e, step, Map.empty)
+    val expected = sdes.eval(context, List(inputTS)).data.head.data.bounded(s, e).data
+
+    val result = eval(sdes, stream)
+    result.zip(expected).zipWithIndex.foreach { case ((ts, v), i) =>
+      assert(ts.size === 1)
+      ts.foreach { t =>
+        val r = t.data(i * step)
+        if (i <= 1)
+          assert(r.isNaN)
+        else
+          assert(v === r +- 0.00001)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Incremental DES evaluation should match a global
evaluation with all data available in advance. The
pos was being updated such that values after the
first datapoint were getting ignored.

There is still a problem with `:sdes`, but for now
this change just adds a test to illustrate it.
We'll look at fixing `:sdes` later.