### PR TITLE
lines should explicitly refer to axis

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/V2JsonGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/V2JsonGraphEngine.scala
@@ -33,6 +33,11 @@ import com.netflix.atlas.chart.model.GraphDef
   *   payload must be ready before we can output data. As data volumes get bigger it is
   *   necessary to be able to emit data as it becomes available.
   *
+  * - Allow for incremental evaluation of the data over time. The constant metadata for the
+  *   chart should be written out first. Data can arrive over time. For example, in a streaming
+  *   execution we might get data for all lines for a given minute, then the next minute, and
+  *   so on.
+  *
   * - Consistent where possible to the SSE payloads from the fetch API.
   */
 class V2JsonGraphEngine extends GraphEngine {


### PR DESCRIPTION
For the experimental v2.json format this changes the
output so that all plot metadata will be emitted first
and then the lines will explicitly refer to the axis.

Before the metadata for a plot would be emitted followed
by all lines on that plot. That would be repeated for
each plot. The problem with this is that format becomes
cumbersome for a streaming evaluation where we only have
data for a single time interval at a time. With this
change the same format can be used for the normal
evaluation or a streaming evaluation.