### PR TITLE
always add the axis color

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonCodec.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonCodec.scala
@@ -128,10 +128,8 @@ private[this] object JsonCodec {
     gen.writeStringField("type", "plot-metadata")
     gen.writeNumberField("id", id)
     plot.ylabel.foreach { v => gen.writeStringField("ylabel", v) }
-    plot.axisColor.foreach { v =>
-      gen.writeFieldName("axisColor")
-      writeColor(gen, v)
-    }
+    gen.writeFieldName("axisColor")
+    writeColor(gen, plot.getAxisColor)
     gen.writeStringField("scale", plot.scale.name())
     gen.writeStringField("upper", plot.upper.toString)
     gen.writeStringField("lower", plot.lower.toString)

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/GraphDef.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/GraphDef.scala
@@ -174,4 +174,7 @@ case class GraphDef(
       line.copy(data = TimeSeries(line.data.tags, line.data.label, seq))
     }
   }
+
+  /** Normalize the definition so it can be reliably compared. Mostly used for test cases. */
+  def normalize: GraphDef = copy(plots = plots.map(_.normalize)).bounded
 }

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/PlotDef.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/PlotDef.scala
@@ -145,5 +145,7 @@ case class PlotDef(
   def verticalSpans: List[VSpanDef] = data.collect { case v: VSpanDef => v }
 
   def lines: List[LineDef] = data.collect { case v: LineDef => v }
+
+  def normalize: PlotDef = copy(axisColor = Some(getAxisColor))
 }
 

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/PngGraphEngineSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/PngGraphEngineSuite.scala
@@ -142,7 +142,7 @@ abstract class PngGraphEngineSuite extends FunSuite with BeforeAndAfterAll {
 
   def check(name: String, graphDef: GraphDef): Unit = {
     val json = JsonCodec.encode(graphDef)
-    assert(graphDef.bounded === JsonCodec.decode(json))
+    assert(graphDef.normalize === JsonCodec.decode(json))
 
     val image = PngImage(graphEngine.createImage(graphDef), Map.empty)
     graphAssertions.assertEquals(image, name, bless)


### PR DESCRIPTION
For the v2.json format always be explicit about
the axis color. Before it was optional, but this
makes it easier for dynamic rendering without having
to worry about the rules the backend uses to
assign the color based on the lines.