### PR TITLE
hex decoding for legend values (bug 1271)

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
@@ -30,7 +30,12 @@ case class StyleExpr(expr: TimeSeriesExpr, settings: Map[String, String]) extend
 
   def legend(t: TimeSeries): String = {
     val fmt = settings.getOrElse("legend", t.label)
-    Strings.substitute(fmt, t.tags)
+    val label = Strings.substitute(fmt, t.tags)
+    settings.get("decode").fold(label) {
+      case "hex"  => Strings.hexDecode(label, '_')
+      case "none" => label
+      case mode   => throw new IllegalArgumentException(s"unknown encoding '$mode'")
+    }
   }
 
   def sortBy: Option[String] = settings.get("sort")

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleVocabulary.scala
@@ -34,7 +34,7 @@ object StyleVocabulary extends Vocabulary {
   val dependsOn: List[Vocabulary] = List(FilterVocabulary)
 
   val words: List[Word] = List(
-    Alpha, Color, LineStyle, LineWidth, Legend, Axis, Offset, Filter, Sort, Order,
+    Alpha, Color, LineStyle, LineWidth, Legend, Decode, Axis, Offset, Filter, Sort, Order,
     Macro("area", List("area", ":ls"), List("42")),
     Macro("line", List("line", ":ls"), List("42")),
     Macro("stack", List("stack", ":ls"), List("42")),
@@ -158,6 +158,36 @@ object StyleVocabulary extends Vocabulary {
       """.stripMargin.trim
 
     override def examples: List[String] = List(s"name,sps,:eq,:sum,(,name,),:by,$$name")
+  }
+
+  case object Decode extends StyleWord {
+    override def name: String = "decode"
+
+    override def summary: String =
+      """
+        |> :warning: It is recommended to avoid using special symbols or trying to
+        |> encode structural information into tag values. This feature should be used
+        |> sparingly and with great care to ensure it will not result in a combinatorial
+        |> explosion.
+        |
+        |Perform decoding of the legend strings. Generally data going into Atlas
+        |is restricted to simple ascii characters that are easy to use as part of
+        |a URI. Most commonly the clients will convert unsupported characters to
+        |an `_`. In some case it is desirable to be able to reverse that for the
+        |purposes of presentation.
+        |
+        |* `none`: this is the default. It will not modify the legend string.
+        |* `hex`: perform a hex decoding of the legend string. This is similar to
+        |  [url encoding](https://en.wikipedia.org/wiki/Percent-encoding) except
+        |  that the `_` character is used instead of `%` to indicate the start of
+        |  an encoded symbol. The decoding is lenient, if the characters following
+        |  the `_` are not valid hexadecimal digits then it will just copy those
+        |  characters without modification.
+        |
+        |Since: 1.5
+      """.stripMargin.trim
+
+    override def examples: List[String] = List(s"1,one_21_25_26_3F,:legend,hex")
   }
 
   case object Axis extends StyleWord {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
@@ -20,6 +20,7 @@ import java.time.Duration
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
 
@@ -174,10 +175,18 @@ class StringsSuite extends FunSuite {
     assert(urlDecode(str) === expected)
   }
 
+  test("hexDecode, escape with _") {
+    val str = "a b %25 _ %_% _21%zb"
+    val expected = "a b %25 _ %_% !%zb"
+    assert(hexDecode(str, '_') === expected)
+  }
+
   test("urlEncode") {
     val str = "a&?= +[]()<>^$%\"':;-_|!@#*.~`\\/{}"
     val expected = "a%26%3F%3D%20%2B%5B%5D()%3C%3E%5E$%25%22':%3B-_%7C!@%23*.~`%5C/%7B%7D"
     assert(urlEncode(str) === expected)
+    assert(urlDecode(expected) === str)
+    assert(urlDecode(expected.toLowerCase(Locale.US)) === str)
   }
 
   test("urlEncode: CLDMTA-1582") {


### PR DESCRIPTION
Provides a style operator, `:decode`, that can be
used to perform hex decoding of the legend text.

Background: internally we restrict input to simple
alpha-numeric characters, `.`, `-`, and `_`. if
characters are used the data will get dropped as
invalid. If using the servo-atlas module, then it
will convert invalid characters to `_`. Most
commonly that was done for spaces.

The restriction is to ensure that it is easy and
safe to craft the query expressions and include
them as part of the URI in a variety of contexts.
Precise linkability is extremely important and
should not be compromised.

Some users do their own url encoding and the `%`
then gets converted to an `_`. This allows them
to undo the restriction and get the original
characters back. With this change that decoding
can now be specified as part of the expression.

There are quite a few misgivings about this
feature. In my view this feature encourages bad
behavior such as trying to encode structural
information into tag values or trying to abuse
it as a more general purpose data store. The
compromise for now is supporting the decode
with a clear warning in the docs and we'll see
how it goes.