### PR TITLE
Export state

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineDes.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineDes.scala
@@ -28,16 +28,9 @@ package com.netflix.atlas.core.algorithm
 class OnlineDes(training: Int, alpha: Double, beta: Double) {
   import OnlineDes._
 
-  var currentSample = 0
-  var sp = Double.NaN
-  var bp = Double.NaN
-
-  def this(state: OnlineDes.State) = {
-    this(state.training, state.alpha, state.beta)
-    currentSample = state.currentSample
-    sp = state.sp
-    bp = state.bp
-  }
+  private var currentSample = 0
+  private var sp = Double.NaN
+  private var bp = Double.NaN
 
   def next(v: Double): Double = {
     val retval = if (currentSample >= training) sp else Double.NaN
@@ -61,12 +54,19 @@ class OnlineDes(training: Int, alpha: Double, beta: Double) {
     bp = Double.NaN
   }
 
-  def state : State = State(training, alpha, beta, currentSample, sp, bp)
+  def state: State = State(training, alpha, beta, currentSample, sp, bp)
 }
 
 object OnlineDes {
   case class State(training: Int, alpha: Double, beta: Double, currentSample: Int, sp: Double, bp: Double)
 
-  def apply(state: State) = new OnlineDes(state)
-  def apply(training: Int, alpha: Double, beta: Double) = new OnlineDes(training, alpha, beta)
+  def apply(state: State) : OnlineDes = {
+    var des = new OnlineDes(state.training, state.alpha, state.beta)
+    des.currentSample = state.currentSample
+    des.sp = state.sp
+    des.bp = state.bp
+    des
+  }
+
+  def apply(training: Int, alpha: Double, beta: Double): OnlineDes = new OnlineDes(training, alpha, beta)
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineDes.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineDes.scala
@@ -26,10 +26,18 @@ package com.netflix.atlas.core.algorithm
  *     Trend smoothing factor.
  */
 class OnlineDes(training: Int, alpha: Double, beta: Double) {
+  import com.netflix.atlas.core.algorithm.OnlineDes._
 
   var currentSample = 0
   var sp = Double.NaN
   var bp = Double.NaN
+
+  def this(state: OnlineDes.State) = {
+    this(state.training, state.alpha, state.beta)
+    currentSample = state.currentSample
+    sp = state.sp
+    bp = state.bp
+  }
 
   def next(v: Double): Double = {
     val retval = if (currentSample >= training) sp else Double.NaN
@@ -52,4 +60,13 @@ class OnlineDes(training: Int, alpha: Double, beta: Double) {
     sp = Double.NaN
     bp = Double.NaN
   }
+
+  def state : State = State(training, alpha, beta, currentSample, sp, bp)
+}
+
+object OnlineDes {
+  case class State(training: Int, alpha: Double, beta: Double, currentSample: Int, sp: Double, bp: Double)
+
+  def apply(state: State) = new OnlineDes(state)
+  def apply(training: Int, alpha: Double, beta: Double) = new OnlineDes(training, alpha, beta)
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineDes.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineDes.scala
@@ -26,7 +26,7 @@ package com.netflix.atlas.core.algorithm
  *     Trend smoothing factor.
  */
 class OnlineDes(training: Int, alpha: Double, beta: Double) {
-  import com.netflix.atlas.core.algorithm.OnlineDes._
+  import OnlineDes._
 
   var currentSample = 0
   var sp = Double.NaN

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineSlidingDes.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineSlidingDes.scala
@@ -26,12 +26,21 @@ package com.netflix.atlas.core.algorithm
  * @param beta
  *     Trend smoothing factor.
  */
-class OnlineSlidingDes(training: Int, alpha: Double, beta: Double) {
+class OnlineSlidingDes(training: Int, alpha: Double, beta: Double, des1: OnlineDes, des2: OnlineDes) {
+  import com.netflix.atlas.core.algorithm.OnlineSlidingDes._
 
-  val des1 = new OnlineDes(training, alpha, beta)
-  val des2 = new OnlineDes(training, alpha, beta)
   var useOne = true
   var currentSample = 0
+
+  def this(state : OnlineSlidingDes.State) = {
+    this(state.training, state.alpha, state.beta, OnlineDes(state.des1State), OnlineDes(state.des2State))
+    this.useOne = state.useOne
+    this.currentSample = state.currentSample
+  }
+
+  def this(training: Int, alpha: Double, beta: Double) = {
+    this(training, alpha, beta, OnlineDes(training, alpha, beta), OnlineDes(training, alpha, beta))
+  }
 
   def next(v: Double): Double = {
     currentSample += 1
@@ -51,4 +60,14 @@ class OnlineSlidingDes(training: Int, alpha: Double, beta: Double) {
     des1.reset()
     des2.reset()
   }
+
+  def state: State = State(training, alpha, beta, useOne, currentSample, des1.state, des2.state)
+}
+
+object OnlineSlidingDes {
+  case class State(training: Int, alpha: Double, beta: Double, useOne: Boolean, currentSample: Int,
+                   des1State: OnlineDes.State, des2State: OnlineDes.State)
+
+  def apply (training: Int, alpha: Double, beta: Double) = new OnlineSlidingDes(training, alpha, beta)
+  def apply (state: State) = new OnlineSlidingDes(state)
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineSlidingDes.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineSlidingDes.scala
@@ -29,18 +29,8 @@ package com.netflix.atlas.core.algorithm
 class OnlineSlidingDes(training: Int, alpha: Double, beta: Double, des1: OnlineDes, des2: OnlineDes) {
   import OnlineSlidingDes._
 
-  var useOne = true
-  var currentSample = 0
-
-  def this(state : OnlineSlidingDes.State) = {
-    this(state.training, state.alpha, state.beta, OnlineDes(state.des1State), OnlineDes(state.des2State))
-    this.useOne = state.useOne
-    this.currentSample = state.currentSample
-  }
-
-  def this(training: Int, alpha: Double, beta: Double) = {
-    this(training, alpha, beta, OnlineDes(training, alpha, beta), OnlineDes(training, alpha, beta))
-  }
+  private var useOne = true
+  private var currentSample = 0
 
   def next(v: Double): Double = {
     currentSample += 1
@@ -68,6 +58,18 @@ object OnlineSlidingDes {
   case class State(training: Int, alpha: Double, beta: Double, useOne: Boolean, currentSample: Int,
                    des1State: OnlineDes.State, des2State: OnlineDes.State)
 
-  def apply (training: Int, alpha: Double, beta: Double) = new OnlineSlidingDes(training, alpha, beta)
-  def apply (state: State) = new OnlineSlidingDes(state)
+  def apply(state: OnlineSlidingDes.State): OnlineSlidingDes = {
+    val des1 = OnlineDes(state.des1State)
+    val des2 = OnlineDes(state.des2State)
+    var sdes = new OnlineSlidingDes(state.training, state.alpha, state.beta, des1, des2)
+    sdes.useOne = state.useOne
+    sdes.currentSample = state.currentSample
+    sdes
+  }
+
+  def apply (training: Int, alpha: Double, beta: Double): OnlineSlidingDes = {
+    val des1 = OnlineDes(training, alpha, beta)
+    val des2 = OnlineDes(training, alpha, beta)
+    new OnlineSlidingDes(training, alpha, beta, des1, des2)
+  }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineSlidingDes.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineSlidingDes.scala
@@ -27,7 +27,7 @@ package com.netflix.atlas.core.algorithm
  *     Trend smoothing factor.
  */
 class OnlineSlidingDes(training: Int, alpha: Double, beta: Double, des1: OnlineDes, des2: OnlineDes) {
-  import com.netflix.atlas.core.algorithm.OnlineSlidingDes._
+  import OnlineSlidingDes._
 
   var useOne = true
   var currentSample = 0

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
@@ -119,7 +119,7 @@ object StatefulExpr {
         data(pos) = desF.next(yn)
         pos += 1
       }
-      State(0, desF.state)
+      State(desF.state)
     }
 
     def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
@@ -130,7 +130,7 @@ object StatefulExpr {
         val s = state.getOrElse(t.id, {
           val desF = OnlineDes(trainingSize, alpha, beta)
           desF.reset()
-          State(0, desF.state)
+          State(desF.state)
         })
         state(t.id) = eval(bounded, s)
         TimeSeries(t.tags, s"des(${t.label})", bounded)
@@ -140,7 +140,7 @@ object StatefulExpr {
   }
 
   object Des {
-    case class State(pos: Int, desState: OnlineDes.State)
+    case class State(desState: OnlineDes.State)
 
     type StateMap = scala.collection.mutable.AnyRefMap[BigInteger, State]
   }


### PR DESCRIPTION
For future work, we will want to render the internal state to JSON or similar.  This change set adds a side object for OnlineDes and OnlineSlidingDes which is a simple case class, easily rendered to JSON.  This state class is used in the :des and :sdes operators to store and restore internal state, which allows this to be rendered to JSON as well.

Additionally, the state passed into StatefulExpression eval() methods is not modified in any expression.