### PR TITLE
adjust load factor for primitive maps

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongIntHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongIntHashMap.scala
@@ -31,7 +31,11 @@ class LongIntHashMap(noData: Long, capacity: Int = 10) {
   private[this] var keys = newArray(capacity)
   private[this] var values = new Array[Int](keys.length)
   private[this] var used = 0
-  private[this] var cutoff = math.max(3, (keys.length * 0.7).toInt)
+  private[this] var cutoff = computeCutoff(keys.length)
+
+  // Set at 50% capacity to get reasonable tradeoff between performance and
+  // memory use. See IntIntMap benchmark.
+  private def computeCutoff(n: Int): Int = math.max(3, n / 2)
 
   private def newArray(n: Int): Array[Long] = {
     val tmp = new Array[Long](PrimeFinder.nextPrime(n))
@@ -54,7 +58,7 @@ class LongIntHashMap(noData: Long, capacity: Int = 10) {
     }
     keys = tmpKS
     values = tmpVS
-    cutoff = math.max(3, (tmpKS.length * 0.7).toInt)
+    cutoff = computeCutoff(tmpKS.length)
   }
 
   private def hash(k: Long): Int = java.lang.Long.hashCode(k)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/RefIntHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/RefIntHashMap.scala
@@ -28,7 +28,11 @@ class RefIntHashMap[T](capacity: Int = 10) {
   private[this] var keys = newArray(capacity)
   private[this] var values = new Array[Int](keys.length)
   private[this] var used = 0
-  private[this] var cutoff = math.max(3, (keys.length * 0.7).toInt)
+  private[this] var cutoff = computeCutoff(keys.length)
+
+  // Set at 50% capacity to get reasonable tradeoff between performance and
+  // memory use. See IntIntMap benchmark.
+  private def computeCutoff(n: Int): Int = math.max(3, n / 2)
 
   private def newArray(n: Int): Array[T] = {
     // Note, we do a cast here and avoid using RefIntHashMap[T: ClassTag] because
@@ -86,7 +90,7 @@ class RefIntHashMap[T](capacity: Int = 10) {
     }
     keys = tmpKS
     values = tmpVS
-    cutoff = math.max(3, (tmpKS.length * 0.7).toInt)
+    cutoff = computeCutoff(tmpKS.length)
   }
 
   private def put(ks: Array[T], vs: Array[Int], k: T, v: Int): Boolean = {

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/IntIntMap.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/IntIntMap.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Threads
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.util.Random
+
+/**
+  * Sanity check for integer hash set.
+  *
+  * ```
+  * > run -wi 10 -i 10 -f1 -t1 .*IntIntMap.*
+  * ...
+  * load factor of 0.7
+  *
+  * [info] Benchmark                        Mode  Cnt      Score     Error  Units
+  * [info] IntIntMap.testIntIntHashMap800  thrpt   10  10374.640 ± 782.568  ops/s
+  * [info] IntIntMap.testIntIntHashMap8k   thrpt   10    589.537 ±   8.124  ops/s
+  * [info] IntIntMap.testJavaHashMap800    thrpt   10   4051.768 ± 499.362  ops/s
+  * [info] IntIntMap.testJavaHashMap8k     thrpt   10   2846.103 ±  14.858  ops/s
+  *
+  * load factor of 0.5
+  *
+  * [info] Benchmark                        Mode  Cnt      Score     Error  Units
+  * [info] IntIntMap.testIntIntHashMap800  thrpt   10  11713.871 ± 271.158  ops/s
+  * [info] IntIntMap.testIntIntHashMap8k   thrpt   10   3963.805 ±  59.359  ops/s
+  * [info] IntIntMap.testJavaHashMap800    thrpt   10   4371.380 ±  93.346  ops/s
+  * [info] IntIntMap.testJavaHashMap8k     thrpt   10   2709.591 ±  71.376  ops/s
+  * ```
+  */
+@State(Scope.Thread)
+class IntIntMap {
+
+  private val values800 = (0 until 10000).map(_ => math.abs(Random.nextInt(800))).toArray
+  private val values8k = (0 until 10000).map(_ => math.abs(Random.nextInt(8000))).toArray
+
+  @Threads(1)
+  @Benchmark
+  def testIntIntHashMap800(bh: Blackhole): Unit = {
+    val map = new IntIntHashMap(-1, 10)
+    var i = 0
+    while (i < values800.length) {
+      map.increment(values800(i))
+      i += 1
+    }
+    bh.consume(map)
+  }
+
+  @Threads(1)
+  @Benchmark
+  def testJavaHashMap800(bh: Blackhole): Unit = {
+    val map = new java.util.HashMap[Int, Int](10)
+    var i = 0
+    while (i < values800.length) {
+      map.compute(values800(i), (k, v) => v + 1)
+      i += 1
+    }
+    bh.consume(map)
+  }
+
+  @Threads(1)
+  @Benchmark
+  def testIntIntHashMap8k(bh: Blackhole): Unit = {
+    val map = new IntIntHashMap(-1, 10)
+    var i = 0
+    while (i < values8k.length) {
+      map.increment(values8k(i))
+      i += 1
+    }
+    bh.consume(map)
+  }
+
+  @Threads(1)
+  @Benchmark
+  def testJavaHashMap8k(bh: Blackhole): Unit = {
+    val map = new java.util.HashMap[Int, Int](10)
+    var i = 0
+    while (i < values8k.length) {
+      map.compute(values8k(i), (k, v) => v + 1)
+      i += 1
+    }
+    bh.consume(map)
+  }
+}


### PR DESCRIPTION
Changes the primitive maps to resize at 50% full
rather than 70%. The 70% factor was originally
chosen to keep the memory use lower and for the
primary use-cases we didn't see much performance
degradation at the time. Rolling it out to more
systems though we have started seeing cases where
it performs quite badly and 50% does an order of
magnitude better.

JMH test with a simple example included.

```
0.7

[info] Benchmark                        Mode  Cnt      Score     Error  Units
[info] IntIntMap.testIntIntHashMap800  thrpt   10  10374.640 ± 782.568  ops/s
[info] IntIntMap.testIntIntHashMap8k   thrpt   10    589.537 ±   8.124  ops/s
[info] IntIntMap.testJavaHashMap800    thrpt   10   4051.768 ± 499.362  ops/s
[info] IntIntMap.testJavaHashMap8k     thrpt   10   2846.103 ±  14.858  ops/s

0.5

[info] Benchmark                        Mode  Cnt      Score     Error  Units
[info] IntIntMap.testIntIntHashMap800  thrpt   10  11713.871 ± 271.158  ops/s
[info] IntIntMap.testIntIntHashMap8k   thrpt   10   3963.805 ±  59.359  ops/s
[info] IntIntMap.testJavaHashMap800    thrpt   10   4371.380 ±  93.346  ops/s
[info] IntIntMap.testJavaHashMap8k     thrpt   10   2709.591 ±  71.376  ops/s
```