### PR TITLE
inject config and actor system

### DIFF
--- a/atlas-akka/src/main/resources/reference.conf
+++ b/atlas-akka/src/main/resources/reference.conf
@@ -1,8 +1,18 @@
 
 atlas.akka {
-  # Regex that determines how the path tag value to use when mapping data about an actor into a
-  # meter. There a should be a single capture group which will be the path to report.
-  pathPattern = "^akka://(?:[^/]+)/(?:system|user)/(IO-TCP|IO-HTTP)/.*$"
+
+  # Regex that determines how the path tag value to use when mapping data about an
+  # actor into a meter. There a should be a single capture group which will be the
+  # path to report.
+  path-pattern = "^akka://(?:[^/]+)/(?:system|user)/([-a-zA-Z]+)/.*$"
+
+  # List of additional actor classes to load
+  actors = ${?atlas.akka.actors} [
+    {
+      name = "deadLetterStats"
+      class = "com.netflix.atlas.akka.DeadLetterStatsActor"
+    }
+  ]
 
   # List of classes to load as API endpoints
   api-endpoints = ${?atlas.akka.api-endpoints} [
@@ -30,6 +40,12 @@ atlas.akka {
     ]
   }
 
+  # Name of the actor system
+  name = "atlas"
+
+  # Port to use for the web server
+  port = 7101
+
   # How long to wait before giving up on bind
   bind-timeout = 5 seconds
 }
@@ -45,6 +61,7 @@ akka {
     }
     default-mailbox {
       mailbox-type = "com.netflix.atlas.akka.UnboundedMeteredMailbox"
+      path-pattern = ${atlas.akka.path-pattern}
     }
 
     default-dispatcher {

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/ActorService.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/ActorService.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.akka
+
+import javax.inject.Inject
+
+import akka.actor.Actor
+import akka.actor.ActorSystem
+import akka.actor.Props
+import com.netflix.iep.service.AbstractService
+import com.netflix.iep.service.ClassFactory
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+/**
+  * Exposes actor system as service for healthcheck and proper shutdown. Additional
+  * actors to start up can be specified using the `atlas.akka.actors` property.
+  */
+class ActorService @Inject() (system: ActorSystem, config: Config, classFactory: ClassFactory)
+  extends AbstractService with StrictLogging {
+
+  override def startImpl(): Unit = {
+    import scala.collection.JavaConverters._
+    config.getConfigList("atlas.akka.actors").asScala.foreach { cfg =>
+      val name = cfg.getString("name")
+      val cls = Class.forName(cfg.getString("class"))
+      system.actorOf(Props(classFactory.newInstance[Actor](cls)), name)
+      logger.info(s"created actor '$name' using class '${cls.getName}'")
+    }
+  }
+
+  override def stopImpl(): Unit = {
+    Await.ready(system.terminate(), Duration.Inf)
+  }
+}

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/ActorSystemProvider.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/ActorSystemProvider.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.akka
+
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.inject.Singleton
+
+import akka.actor.ActorSystem
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
+
+/** Provider for getting an instance of the actor system. */
+@Singleton
+class ActorSystemProvider @Inject() (config: Config, registry: Registry)
+  extends Provider[ActorSystem] {
+
+  private val name = config.getString("atlas.akka.name")
+  private val system = ActorSystem(name, config)
+
+  override def get(): ActorSystem = system
+}

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/ConfigApi.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/ConfigApi.scala
@@ -19,7 +19,6 @@ import java.io.StringWriter
 import java.util.Properties
 
 import akka.actor.ActorRefFactory
-import com.netflix.atlas.config.ConfigManager
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
@@ -35,7 +34,7 @@ import spray.routing._
  * supported and can be used to dump the data as json, hocon, or properties. The default format
  * is json.
  */
-class ConfigApi(val actorRefFactory: ActorRefFactory) extends WebApi {
+class ConfigApi(config: Config, implicit val actorRefFactory: ActorRefFactory) extends WebApi {
 
   import spray.http.StatusCodes._
 
@@ -59,7 +58,6 @@ class ConfigApi(val actorRefFactory: ActorRefFactory) extends WebApi {
   private def doGet(ctx: RequestContext, path: Option[String]): Unit = {
     val format = ctx.request.uri.query.get("format").getOrElse("json")
     if (formats.contains(format)) {
-      val config = ConfigManager.current
       path match {
         case Some(p) if !config.hasPath(p) =>
           sendError(ctx, NotFound, s"no matching path '$p'")

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/DeadLetterStatsActor.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/DeadLetterStatsActor.scala
@@ -16,41 +16,46 @@
 package com.netflix.atlas.akka
 
 import akka.actor.Actor
-import akka.actor.ActorPath
 import akka.actor.AllDeadLetters
 import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
 
 
 /**
- * Update counter for dead letters in the actor system. The counter name is `akka.deadLetters`
- * and has dimensions for:
- *
- *  - `class`: the type of dead letter. Value should be either DeadLetter or SuppressedDeadLetter.
- *  - `sender`: summary of path for sender. See Paths for more details.
- *  - `recipient`: summary of path for recipient. See Paths for more details.
- *
- * To use subscribe to the dead letters on the event stream:
- *
- * http://doc.akka.io/docs/akka/2.4.0/scala/event-bus.html#Dead_Letters
- *
- * @param registry
- *     Spectator registry to use for metrics.
- * @param pathMapper
- *     Maps an actor path to a tag value for the metric. This should be chosen to avoid
- *     parts of the path such as incrementing counters in the path of short lived actors.
- */
-class DeadLetterStatsActor(registry: Registry, pathMapper: ActorPath => String)
+  * Update counter for dead letters in the actor system. The counter name is `akka.deadLetters`
+  * and has dimensions for:
+  *
+  *  - `class`: the type of dead letter. Value should be either DeadLetter or SuppressedDeadLetter.
+  *  - `sender`: summary of path for sender. See Paths for more details.
+  *  - `recipient`: summary of path for recipient. See Paths for more details.
+  *
+  * To use subscribe to the dead letters on the event stream:
+  *
+  * http://doc.akka.io/docs/akka/2.4.0/scala/event-bus.html#Dead_Letters
+  *
+  * @param registry
+  *     Spectator registry to use for metrics.
+  * @param config
+  *     Config to use for creating the path mapper using the `atlas.akka.path-pattern`
+  *     This pattern maps an actor path to a tag value for the metric. This should be
+  *     chosen to avoid parts of the path such as incrementing counters in the path of
+  *     short lived actors.
+  */
+class DeadLetterStatsActor(registry: Registry, config: Config)
     extends Actor with StrictLogging {
 
+  context.system.eventStream.subscribe(self, classOf[AllDeadLetters])
+
+  private val pathMapper = Paths.createMapper(config.getConfig("atlas.akka"))
   private val deadLetterId = registry.createId("akka.deadLetters")
 
   def receive: Receive = {
     case letter: AllDeadLetters =>
-      val id = deadLetterId
-        .withTag("class",     letter.getClass.getSimpleName)
-        .withTag("sender",    pathMapper(letter.sender.path))
-        .withTag("recipient", pathMapper(letter.recipient.path))
+      val id = deadLetterId.withTags(
+        "class",     letter.getClass.getSimpleName,
+        "sender",    pathMapper(letter.sender.path),
+        "recipient", pathMapper(letter.recipient.path))
       registry.counter(id).increment()
   }
 }

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/Paths.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/Paths.scala
@@ -15,21 +15,31 @@
  */
 package com.netflix.atlas.akka
 
+import java.util.regex.Pattern
+
 import akka.actor.ActorPath
-import com.netflix.atlas.config.ConfigManager
+import com.typesafe.config.Config
 
-
+/** Helper for creating mapping functions to extract a tag value based on an actor path. */
 object Paths {
-  private val config = ConfigManager.current
-  private val Path = config.getString("atlas.akka.pathPattern").r
+
+  type Mapper = ActorPath => String
+
+  /** Create a mapping function from a config object using the `path-pattern` field. */
+  def createMapper(config: Config): Mapper = createMapper(config.getString("path-pattern"))
+
+  /** Create a mapper from a regex string. */
+  def createMapper(pattern: String): Mapper = createMapper(Pattern.compile(pattern))
 
   /**
-   * Summarizes a path for use in a metric tag.
-   */
-  def tagValue(path: ActorPath): String = {
-    path.toString match {
-      case Path(v) => v
-      case _       => "uncategorized"
+    * Creates a mapping function that extracts a tag value based on the
+    * pattern. The pattern should have a single capturing group that contains
+    * the string to use for the tag value.
+    */
+  def createMapper(pattern: Pattern): Mapper = {
+    path => {
+      val matcher = pattern.matcher(path.toString)
+      if (matcher.matches() && matcher.groupCount() == 1) matcher.group(1) else "uncategorized"
     }
   }
 }

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/StaticPages.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/StaticPages.scala
@@ -16,16 +16,15 @@
 package com.netflix.atlas.akka
 
 import akka.actor.ActorRefFactory
-import com.netflix.atlas.config.ConfigManager
+import com.typesafe.config.Config
 import spray.http._
 import spray.routing._
 
 /**
  * Adds a directive to serve static pages from the 'www' resource directory.
  */
-class StaticPages(implicit val actorRefFactory: ActorRefFactory) extends WebApi {
+class StaticPages(config: Config, implicit val actorRefFactory: ActorRefFactory) extends WebApi {
 
-  private val config = ConfigManager.current
   private val defaultPage = config.getString("atlas.akka.static.default-page")
 
   def routes: RequestContext => Unit = {

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/UnboundedMeteredMailbox.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/UnboundedMeteredMailbox.scala
@@ -18,6 +18,7 @@ package com.netflix.atlas.akka
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit
 
+import akka.actor.ActorPath
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.dispatch.Envelope
@@ -70,8 +71,18 @@ class UnboundedMeteredMailbox(settings: ActorSystem.Settings, config: Config) ex
 
   import com.netflix.atlas.akka.UnboundedMeteredMailbox._
 
+  private val Path = config.getString("path-pattern").r
+
+  /** Summarizes a path for use in a metric tag. */
+  def tagValue(path: ActorPath): String = {
+    path.toString match {
+      case Path(v) => v
+      case _       => "uncategorized"
+    }
+  }
+
   final override def create(owner: Option[ActorRef], system: Option[ActorSystem]): MessageQueue = {
-    val path = owner.fold("unknown")(r => Paths.tagValue(r.path))
+    val path = owner.fold("unknown")(r => tagValue(r.path))
     new MeteredMessageQueue(path)
   }
 }

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/ConfigApiSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/ConfigApiSuite.scala
@@ -18,7 +18,6 @@ package com.netflix.atlas.akka
 import java.io.StringReader
 import java.util.Properties
 
-import com.netflix.atlas.config.ConfigManager
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import org.scalatest.FunSuite
@@ -32,8 +31,8 @@ class ConfigApiSuite extends FunSuite with ScalatestRouteTest {
 
   implicit val routeTestTimeout = RouteTestTimeout(5.second)
 
-  val endpoint = new ConfigApi(system)
-  val sysConfig = ConfigManager.current
+  val sysConfig = ConfigFactory.load()
+  val endpoint = new ConfigApi(sysConfig, system)
 
   test("/config") {
     Get("/api/v2/config") ~> endpoint.routes ~> check {

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/DeadLetterStatsActorSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/DeadLetterStatsActorSuite.scala
@@ -16,7 +16,6 @@
 package com.netflix.atlas.akka
 
 import akka.actor.Actor
-import akka.actor.ActorPath
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.actor.DeadLetter
@@ -27,11 +26,9 @@ import akka.testkit.ImplicitSender
 import akka.testkit.TestActorRef
 import akka.testkit.TestKit
 import com.netflix.spectator.api.DefaultRegistry
+import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FunSuiteLike
-import spray.can.Http
-
-import scala.concurrent.Promise
 
 
 class DeadLetterStatsActorSuite extends TestKit(ActorSystem())
@@ -39,18 +36,13 @@ class DeadLetterStatsActorSuite extends TestKit(ActorSystem())
     with FunSuiteLike
     with BeforeAndAfterAll {
 
-  private val pathPattern = "^akka://(?:[^/]+)/(?:system|user)/([^/]+)(?:/.*)?$".r
-
-  private def pathMapper(path: ActorPath): String = {
-    path.toString match {
-      case pathPattern(p) => p
-      case _              => "uncategorized"
-    }
-  }
+  private val config = ConfigFactory.parseString(
+    """
+      |atlas.akka.path-pattern = "^akka://(?:[^/]+)/(?:system|user)/([^/]+)(?:/.*)?$"
+    """.stripMargin)
 
   private val registry = new DefaultRegistry()
-  private val bindPromise = Promise[Http.Bound]()
-  private val ref = TestActorRef(new DeadLetterStatsActor(registry, pathMapper))
+  private val ref = TestActorRef(new DeadLetterStatsActor(registry, config))
 
   private val sender = newRef("from")
   private val recipient = newRef("to")

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/StaticPagesSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/StaticPagesSuite.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.akka
 
+import com.typesafe.config.ConfigFactory
 import org.scalatest.FunSuite
 import spray.http.StatusCodes
 import spray.testkit.ScalatestRouteTest
@@ -22,7 +23,7 @@ import spray.testkit.ScalatestRouteTest
 
 class StaticPagesSuite extends FunSuite with ScalatestRouteTest {
 
-  val endpoint = new StaticPages
+  val endpoint = new StaticPages(ConfigFactory.load(), system)
 
   test("/static/test") {
     Get("/static/test") ~> endpoint.routes ~> check {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
@@ -36,8 +36,6 @@ import org.slf4j.LoggerFactory
 
 class MemoryDatabase(registry: Registry, config: Config) extends Database {
 
-  def this(config: Config) = this(Spectator.globalRegistry, config)
-
   /** How many metrics are being processed for transform queries. */
   private val queryMetrics = registry.counter("atlas.db.queryMetrics")
 
@@ -202,10 +200,7 @@ class MemoryDatabase(registry: Registry, config: Config) extends Database {
 }
 
 object MemoryDatabase {
-  def apply(k: String): MemoryDatabase = {
-    val cfg = ConfigManager.current
-    new MemoryDatabase(cfg.getConfig(k))
+  def apply(cfg: Config): MemoryDatabase = {
+    new MemoryDatabase(Spectator.globalRegistry(), cfg.getConfig("atlas.core.db"))
   }
-
-  def default: MemoryDatabase = apply("atlas.core.db")
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/SimpleStaticDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/SimpleStaticDatabase.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.db
+
+import com.netflix.atlas.core.index.LazyTagIndex
+import com.netflix.atlas.core.index.TagIndex
+import com.netflix.atlas.core.index.TagQuery
+import com.netflix.atlas.core.model.DataExpr
+import com.netflix.atlas.core.model.EvalContext
+import com.netflix.atlas.core.model.TimeSeries
+
+class SimpleStaticDatabase(data: List[TimeSeries]) extends Database {
+  val index: TagIndex[TimeSeries] = new LazyTagIndex(data.toArray)
+
+  def execute(context: EvalContext, expr: DataExpr): List[TimeSeries] = {
+    val q = TagQuery(Some(expr.query))
+    val offset = expr.offset.toMillis
+    if (offset == 0) expr.eval(context, index.findItems(q)).data else {
+      val offsetContext = context.withOffset(expr.offset.toMillis)
+      expr.eval(offsetContext, index.findItems(q)).data.map { t =>
+        t.offset(offset)
+      }
+    }
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
@@ -26,12 +26,14 @@ class MemoryDatabaseSuite extends FunSuite {
 
   private val step = DefaultSettings.stepSize
 
-  private val db = new MemoryDatabase(ConfigFactory.parseString(
+  private val db = MemoryDatabase(ConfigFactory.parseString(
     """
-      |block-size = 60
-      |num-blocks = 2
-      |rebuild-frequency = 10s
-      |test-mode = true
+      |atlas.core.db {
+      |  block-size = 60
+      |  num-blocks = 2
+      |  rebuild-frequency = 10s
+      |  test-mode = true
+      |}
     """.stripMargin))
 
   addData("a", 1.0, 2.0, 3.0)

--- a/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/Main.scala
+++ b/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/Main.scala
@@ -17,12 +17,18 @@ package com.netflix.atlas.standalone
 
 import java.io.File
 
+import akka.actor.ActorSystem
 import com.google.inject.AbstractModule
 import com.google.inject.Module
 import com.google.inject.multibindings.Multibinder
 import com.google.inject.multibindings.OptionalBinder
 import com.google.inject.util.Modules
+import com.netflix.atlas.akka.ActorService
+import com.netflix.atlas.akka.ActorSystemProvider
+import com.netflix.atlas.akka.WebServer
 import com.netflix.atlas.config.ConfigManager
+import com.netflix.atlas.core.db.Database
+import com.netflix.atlas.webapi.DatabaseProvider
 import com.netflix.iep.guice.GuiceHelper
 import com.netflix.iep.service.Service
 import com.netflix.iep.service.ServiceManager
@@ -74,8 +80,12 @@ object Main extends StrictLogging {
         OptionalBinder.newOptionalBinder(binder(), classOf[Registry])
           .setBinding().toInstance(Spectator.globalRegistry())
 
+        bind(classOf[ActorSystem]).toProvider(classOf[ActorSystemProvider])
+        bind(classOf[Database]).toProvider(classOf[DatabaseProvider])
+
         val serviceBinder = Multibinder.newSetBinder(binder, classOf[Service])
-        serviceBinder.addBinding().toProvider(classOf[WebServerProvider])
+        serviceBinder.addBinding().to(classOf[ActorService])
+        serviceBinder.addBinding().to(classOf[WebServer])
       }
     }
 

--- a/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/WebServerProvider.scala
+++ b/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/WebServerProvider.scala
@@ -27,13 +27,15 @@ import com.netflix.atlas.webapi.LocalDatabaseActor
 import com.netflix.atlas.webapi.LocalPublishActor
 import com.netflix.iep.service.ClassFactory
 import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
 
 @Singleton
-class WebServerProvider @Inject() (classFactory: ClassFactory, registry: Registry)
+class WebServerProvider @Inject() (config: Config, classFactory: ClassFactory, registry: Registry)
     extends Provider[WebServer] {
 
-  override def get(): WebServer = {
-    new WebServer(classFactory, registry, "atlas", ApiSettings.port) {
+  override def get(): WebServer = null
+  /*
+    new WebServer(config, classFactory, registry) {
       override protected def configure(): Unit = {
         super.configure()
         val db = ApiSettings.newDbInstance
@@ -46,5 +48,5 @@ class WebServerProvider @Inject() (classFactory: ClassFactory, registry: Registr
         }
       }
     }
-  }
+  }*/
 }

--- a/atlas-standalone/src/test/resources/application.conf
+++ b/atlas-standalone/src/test/resources/application.conf
@@ -1,4 +1,4 @@
 
 // Use a random port for the server when running tests
 // https://github.com/Netflix/atlas/issues/392
-atlas.webapi.main.port = 0
+atlas.akka.port = 0

--- a/atlas-webapi/src/main/resources/reference.conf
+++ b/atlas-webapi/src/main/resources/reference.conf
@@ -34,9 +34,6 @@ atlas {
   }
 
   webapi {
-    main {
-      port = 7101
-    }
 
     tags {
       max-limit = 1000
@@ -207,6 +204,13 @@ atlas {
   }
 
   akka {
+    actors = ${?atlas.akka.actors} [
+      {
+        name = "db"
+        class = "com.netflix.atlas.webapi.LocalDatabaseActor"
+      }
+    ]
+
     api-endpoints = ${?atlas.akka.api-endpoints} [
       "com.netflix.atlas.webapi.TagsApi",
       "com.netflix.atlas.webapi.RenderApi",

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/DatabaseProvider.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/DatabaseProvider.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.webapi
+
+import java.lang.reflect.Type
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.inject.Singleton
+
+import com.netflix.atlas.core.db.Database
+import com.netflix.iep.service.ClassFactory
+import com.typesafe.config.Config
+
+/**
+  * Created by brharrington on 7/20/16.
+  */
+@Singleton
+class DatabaseProvider @Inject() (config: Config, classFactory: ClassFactory)
+  extends Provider[Database] {
+
+  private val db = {
+    import scala.compat.java8.FunctionConverters._
+    val cfg = config.getConfig("atlas.core.db")
+    val cls = cfg.getString("class")
+    val overrides = Map[Type, AnyRef](classOf[Config] -> cfg).withDefaultValue(null)
+    classFactory.newInstance[Database](cls, overrides.asJava)
+  }
+
+  override def get(): Database = db
+}

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiMemDbSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiMemDbSuite.scala
@@ -31,12 +31,14 @@ class GraphApiMemDbSuite extends FunSuite with ScalatestRouteTest {
   // issues outside of running with code coverage.
   implicit val routeTestTimeout = RouteTestTimeout(5.seconds)
 
-  val db = new MemoryDatabase(ConfigFactory.parseString(
+  val db = MemoryDatabase(ConfigFactory.parseString(
     """
-      |rebuild-frequency = 10s
-      |num-blocks = 2
-      |block-size = 60
-      |test-mode = true
+      |atlas.core.db {
+      |  rebuild-frequency = 10s
+      |  num-blocks = 2
+      |  block-size = 60
+      |  test-mode = true
+      |}
     """.stripMargin))
   system.actorOf(Props(new LocalDatabaseActor(db)), "db")
 

--- a/conf/memory.conf
+++ b/conf/memory.conf
@@ -33,6 +33,13 @@ atlas {
   }
 
   akka {
+    actors = ${?atlas.akka.actors} [
+      {
+        name = "publish"
+        class = "com.netflix.atlas.webapi.LocalPublishActor"
+      }
+    ]
+
     api-endpoints = ${?atlas.akka.api-endpoints} [
       "com.netflix.atlas.webapi.PublishApi"
     ]

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -38,7 +38,7 @@ object MainBuild extends Build {
     .settings(BuildSettings.noPackaging: _*)
 
   lazy val `atlas-akka` = project
-    .dependsOn(`atlas-config`, `atlas-json`)
+    .dependsOn(`atlas-json`)
     .settings(buildSettings: _*)
     .settings(libraryDependencies ++= commonDeps)
     .settings(libraryDependencies ++= Seq(


### PR DESCRIPTION
Updates the akka helpers to be more DI friendly. In
particular, it removes the dependency on `atlas-config`
and injects the `Config` as well as the `ActorSystem`.

A helper setting `atlas.akka.actors` is now available
in the config to configure an actor to load into the
system.