### PR TITLE
move appender setup to log4j config

### DIFF
--- a/atlas-standalone/src/main/resources/log4j2.xml
+++ b/atlas-standalone/src/main/resources/log4j2.xml
@@ -7,11 +7,13 @@
     <Console name="STDERR" target="SYSTEM_ERR">
       <PatternLayout pattern="${dfltPattern}"/>
     </Console>
+    <Spectator name="SPECTATOR"/>
   </Appenders>
   <Loggers>
     <Logger name="com.netflix.spectator" level="debug"/>
     <Root level="info">
       <AppenderRef ref="STDERR"/>
+      <AppenderRef ref="SPECTATOR"/>
     </Root>
   </Loggers>
 </Configuration>

--- a/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/Main.scala
+++ b/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/Main.scala
@@ -34,7 +34,6 @@ import com.netflix.iep.service.Service
 import com.netflix.iep.service.ServiceManager
 import com.netflix.spectator.api.Registry
 import com.netflix.spectator.api.Spectator
-import com.netflix.spectator.log4j.SpectatorAppender
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
@@ -60,8 +59,6 @@ object Main extends StrictLogging {
 
   def main(args: Array[String]): Unit = {
     try {
-      val registry = Spectator.globalRegistry()
-      SpectatorAppender.addToRootLogger(registry, "spectator", false)
       loadAdditionalConfigFiles(args)
       start()
       guice.addShutdownHook()


### PR DESCRIPTION
For more details see:

http://netflix.github.io/spectator/en/latest/ext/log4j2/

Which is a bit out of date, with the change below the
ordering issues are no longer a problem when using the
appender via the config:

https://github.com/Netflix/spectator/commit/33825db0b96e3337f68b85e9ecbc78567071aecc#diff-9bc272482ec3aa21411ff595a1f4225f