### PR TITLE
fix #405 possible contract error using desc order

### DIFF
--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphRequestActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphRequestActor.scala
@@ -170,7 +170,8 @@ class GraphRequestActor(registry: Registry) extends Actor with ActorLogging {
           warnings += s"Invalid sort mode '$order'. Using default of 'legend'."
           (a, b) => a.data.label < b.data.label
       }
-      lines.sortWith(if (useDescending) (a, b) => !cmp(a, b) else cmp)
+      val sorted = lines.sortWith(cmp)
+      if (useDescending) sorted.reverse else sorted
     }
   }
 }


### PR DESCRIPTION
If the input set has many equal values it was possible to
get an exception:

```
IllegalArgumentException: Comparison method violates its general contract!
```

This is because the descending order was simply inverting
the ascending order comparator. With this change we sort
in ascending order and simply reverse the list if it should
be descending.