### PR TITLE
reduce allocations for computing ids

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TaggedItemSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TaggedItemSuite.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.atlas.core.util.Hash
+
+import java.math.BigInteger
+
+import org.scalatest.FunSuite
+
+class TaggedItemSuite extends FunSuite {
+
+  def expectedId(tags: Map[String, String]): BigInteger = {
+    Hash.sha1(tags.toList.sortWith(_._1 < _._1).map(t => t._1 + "=" + t._2).mkString(","))
+  }
+
+  test("computeId, name only") {
+    val t1 = Map("name" -> "foo")
+    val t2 = Map("name" -> "bar")
+    assert(TaggedItem.computeId(t1) === expectedId(t1))
+    assert(TaggedItem.computeId(t2) === expectedId(t2))
+    assert(TaggedItem.computeId(t1) != TaggedItem.computeId(t2))
+  }
+
+  test("computeId, multi") {
+    val t1 = Map("name" -> "foo", "cluster" -> "abc", "app" -> "a", "zone" -> "1")
+    val t2 = Map("name" -> "foo", "cluster" -> "abc", "app" -> "a", "zone" -> "2")
+    assert(TaggedItem.computeId(t1) === expectedId(t1))
+    assert(TaggedItem.computeId(t2) === expectedId(t2))
+    assert(TaggedItem.computeId(t1) != TaggedItem.computeId(t2))
+  }
+
+}

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/model/ComputeId.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/model/ComputeId.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.atlas.core.util.SmallHashMap
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Threads
+import org.openjdk.jmh.infra.Blackhole
+
+/**
+  * Check performance of TaggedItem.computeId. It is in the hot path when processing
+  * new metrics that come in via publish.
+  *
+  * ```
+  * > jmh:run -prof jmh.extras.JFR -wi 10 -i 10 -f1 -t1 .*ComputeId.*
+  * ...
+  * [info] Benchmark                            Mode  Cnt       Score       Error  Units
+  * [info] ComputeId.computeIdSmallTagMap      thrpt   10  252703.940 ± 11424.615  ops/s
+  * [info] ComputeId.computeIdTagMap           thrpt   10  248390.915 ± 10755.616  ops/s
+  * ```
+  */
+@State(Scope.Thread)
+class ComputeId {
+
+  private val tagMap = Map(
+    "nf.app"     -> "atlas_backend",
+    "nf.cluster" -> "atlas_backend-dev",
+    "nf.asg"     -> "atlas_backend-dev-v001",
+    "nf.stack"   -> "dev",
+    "nf.region"  -> "us-east-1",
+    "nf.zone"    -> "us-east-1e",
+    "nf.node"    -> "i-123456789",
+    "nf.ami"     -> "ami-987654321",
+    "nf.vmtype"  -> "r3.2xlarge",
+    "name"       -> "jvm.gc.pause",
+    "cause"      -> "Allocation_Failure",
+    "action"     -> "end_of_major_GC",
+    "statistic"  -> "totalTime"
+  )
+
+  private val smallTagMap = SmallHashMap(tagMap)
+
+  @Threads(1)
+  @Benchmark
+  def computeIdTagMap(bh: Blackhole): Unit = {
+    bh.consume(TaggedItem.computeId(tagMap))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def computeIdSmallTagMap(bh: Blackhole): Unit = {
+    bh.consume(TaggedItem.computeId(smallTagMap))
+  }
+}


### PR DESCRIPTION
Computing the id for a tag map is in the hot path when publishing metrics. It is currently the biggest chunk of allocations on that path and it looks like there are a few simple changes that would reduce it significantly.