### PR TITLE
disable jackson buffer recycling

### DIFF
--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
@@ -66,6 +66,9 @@ object Json {
     factory.enable(AUTO_CLOSE_SOURCE)
     factory.enable(AUTO_CLOSE_TARGET)
     factory.disable(QUOTE_NON_NUMERIC_NUMBERS)
+
+    // The buffer recycling causes data corruption
+    factory.disable(JsonFactory.Feature.USE_THREAD_LOCAL_FOR_BUFFER_RECYCLING)
   }
 
   private def newMapper(factory: JsonFactory): ObjectMapper = {


### PR DESCRIPTION
The thread local buffer recycling in jackson seems to
cause corruption in some cases. It is hard to reproduce
in a controlled setting, but we see it pretty reliably
on a big cluster. After disabling, the corruption is
no longer being seen. First observed in jackson 2.7.x.

Current tests do not show much performance impact for
our use-cases.