### PR TITLE
turn off interning while building the index

### DIFF
--- a/atlas-core/src/main/resources/reference.conf
+++ b/atlas-core/src/main/resources/reference.conf
@@ -23,6 +23,16 @@ atlas {
       max-lines = 1024
 
       max-datapoints = 500000
+
+      // Should strings get interned while building the index? The safe option is to
+      // leave this set to true. If you know the strings have already been interned,
+      // then it can be set to false to improve performance. For example, it is common
+      // that strings will get interned while the data is being processed in which case
+      // the interning in the index is redundant.
+      //
+      // Note: if strings are not properly interned then the results will not be correct
+      // as we rely on default reference comparisons.
+      intern-while-building = true
     }
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
@@ -21,6 +21,9 @@ import java.util.concurrent.TimeUnit
 
 import com.netflix.atlas.config.ConfigManager
 import com.netflix.atlas.core.index.BatchUpdateTagIndex
+import com.netflix.atlas.core.index.CachingTagIndex
+import com.netflix.atlas.core.index.LazyTagIndex
+import com.netflix.atlas.core.index.TagIndex
 import com.netflix.atlas.core.index.TagQuery
 import com.netflix.atlas.core.model.Block
 import com.netflix.atlas.core.model.DataExpr
@@ -58,10 +61,13 @@ class MemoryDatabase(registry: Registry, config: Config) extends Database {
   private val blockSize = config.getInt("block-size")
   private val numBlocks = config.getInt("num-blocks")
   private val testMode = config.getBoolean("test-mode")
+  private val internWhileBuilding = config.getBoolean("intern-while-building")
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  val index = BatchUpdateTagIndex.newLazyIndex[BlockStoreItem]
+  val index = new BatchUpdateTagIndex[BlockStoreItem]({ items =>
+    new CachingTagIndex(new LazyTagIndex(items, internWhileBuilding))
+  })
 
   // If the last update time for the index is older than the rebuild age force an update
   private val rebuildAge = config.getDuration("rebuild-frequency", TimeUnit.MILLISECONDS)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/BatchUpdateTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/BatchUpdateTagIndex.scala
@@ -40,7 +40,7 @@ object BatchUpdateTagIndex {
  *
  * @param newIndex  function to create a new index from the set of items
  */
-class BatchUpdateTagIndex[T <: TaggedItem: ClassTag](newIndex: Array[T] => TagIndex[T])
+class BatchUpdateTagIndex[T <: TaggedItem: ClassTag](newIndex: (Array[T]) => TagIndex[T])
     extends MutableTagIndex[T] {
 
   private def registry = Spectator.globalRegistry()

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
@@ -33,6 +33,7 @@ class MemoryDatabaseSuite extends FunSuite {
       |  num-blocks = 2
       |  rebuild-frequency = 10s
       |  test-mode = true
+      |  intern-while-building = true
       |}
     """.stripMargin))
 

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiMemDbSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiMemDbSuite.scala
@@ -38,6 +38,7 @@ class GraphApiMemDbSuite extends FunSuite with ScalatestRouteTest {
       |  num-blocks = 2
       |  block-size = 60
       |  test-mode = true
+      |  intern-while-building = true
       |}
     """.stripMargin))
   system.actorOf(Props(new LocalDatabaseActor(db)), "db")


### PR DESCRIPTION
Adds an option to support turning off string interning while
building the index. In many cases the strings will already
have been interned while parsing the incoming payload and this
additional step is redundant.