### PR TITLE
improve performance of SmallHashMap equality check

### DIFF
--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/SmallHashMapEquals.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/SmallHashMapEquals.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Threads
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.util.Random
+
+/**
+  * Check performance of comparing small hash maps for equality.
+  *
+  * ```
+  * > jmh:run -prof jmh.extras.JFR -wi 10 -i 10 -f1 -t1 .*SmallHashMapEquals.*
+  * ...
+  * [info] Benchmark                     Mode  Cnt          Score          Error  Units
+  *
+  * [info] currentEquals                thrpt   10   47004215.059 ±  2291847.719  ops/s
+  * [info] inheritedEquals              thrpt   10    2134457.383 ±   111821.520  ops/s
+  * [info] dataEquals                   thrpt   10   51326103.645 ±   758297.787  ops/s
+  * [info] selfEquals                   thrpt   10  351279563.043 ± 18578115.816  ops/s
+  *
+  * [info] currentEqualsNot             thrpt   10  273893522.221 ±  7980051.600  ops/s
+  * [info] inheritedEqualsNot           thrpt   10    2341207.187 ±   206356.584  ops/s
+  * [info] dataEqualsNot                thrpt   10   32392263.165 ±  1289262.059  ops/s
+  *
+  * [info] currentEqualHashCodes        thrpt   10   14601802.119 ±   360902.793  ops/s
+  * [info] inheritedEqualHashCodes      thrpt   10     483515.784 ±    10044.781  ops/s
+  * ```
+  */
+@State(Scope.Thread)
+class SmallHashMapEquals {
+
+  private val tagMap = Map(
+    "nf.app"     -> "atlas_backend",
+    "nf.cluster" -> "atlas_backend-dev",
+    "nf.asg"     -> "atlas_backend-dev-v001",
+    "nf.stack"   -> "dev",
+    "nf.region"  -> "us-east-1",
+    "nf.zone"    -> "us-east-1e",
+    "nf.node"    -> "i-123456789",
+    "nf.ami"     -> "ami-987654321",
+    "nf.vmtype"  -> "r3.2xlarge",
+    "name"       -> "jvm.gc.pause",
+    "cause"      -> "Allocation_Failure",
+    "action"     -> "end_of_major_GC",
+    "statistic"  -> "totalTime"
+  )
+
+  private val smallTagMap1 = SmallHashMap(tagMap)
+  private val smallTagMap2 = SmallHashMap(tagMap)
+
+  private val smallTagMap3 = SmallHashMap(tagMap + ("nf.node" -> "i-987654321"))
+
+  private val (randomMap1, randomMap2) = {
+    val n = Random.nextInt(50)
+    val data = (0 until n).map { _ =>
+      val v = Random.nextInt()
+      v.toString -> v.toString
+    }
+    val m1 = SmallHashMap(data)
+    val m2 = SmallHashMap(Random.shuffle(data))
+    m1 -> m2
+  }
+
+  @Threads(1)
+  @Benchmark
+  def selfEquals(bh: Blackhole): Unit = {
+    bh.consume(smallTagMap1.equals(smallTagMap1))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def currentEquals(bh: Blackhole): Unit = {
+    bh.consume(smallTagMap1.equals(smallTagMap2))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def inheritedEquals(bh: Blackhole): Unit = {
+    bh.consume(smallTagMap1.superEquals(smallTagMap2))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def dataEquals(bh: Blackhole): Unit = {
+    bh.consume(smallTagMap1.dataEquals(smallTagMap2))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def currentEqualsNot(bh: Blackhole): Unit = {
+    bh.consume(smallTagMap1.equals(smallTagMap3))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def inheritedEqualsNot(bh: Blackhole): Unit = {
+    bh.consume(smallTagMap1.superEquals(smallTagMap3))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def dataEqualsNot(bh: Blackhole): Unit = {
+    bh.consume(smallTagMap1.dataEquals(smallTagMap3))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def currentEqualHashCodes(bh: Blackhole): Unit = {
+    bh.consume(randomMap1.equals(randomMap2))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def inheritedEqualHashCodes(bh: Blackhole): Unit = {
+    bh.consume(randomMap1.superEquals(randomMap2))
+  }
+}

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/SmallHashMapHashCode.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/SmallHashMapHashCode.scala
@@ -30,10 +30,11 @@ import org.openjdk.jmh.infra.Blackhole
   * ```
   * > jmh:run -prof jmh.extras.JFR -wi 10 -i 10 -f1 -t1 .*SmallHashMapHashCode.*
   * ...
-  * [info] Benchmark                                   Mode  Cnt          Score          Error  Units
-  * [info] SmallHashMapHashCode.murmur3arrayHash      thrpt   10   15239273.579 ±   921707.049  ops/s
-  * [info] SmallHashMapHashCode.murmur3mapHash        thrpt   10    4002229.992 ±   282897.745  ops/s
-  * [info] SmallHashMapHashCode.superWithCaching      thrpt   10  342121377.682 ± 13002291.488  ops/s
+  * [info] Benchmark              Mode  Cnt          Score          Error  Units
+  * [info] computeHashCode       thrpt   10   33962020.269 ±   883664.164  ops/s
+  * [info] currentHashCode       thrpt   10  360180789.347 ± 10164654.707  ops/s
+  * [info] murmur3arrayHash      thrpt   10   13861013.249 ±  3160191.522  ops/s
+  * [info] murmur3mapHash        thrpt   10    4067194.458 ±    78185.171  ops/s
   * ```
   */
 @State(Scope.Thread)
@@ -59,8 +60,14 @@ class SmallHashMapHashCode {
 
   @Threads(1)
   @Benchmark
-  def superWithCaching(bh: Blackhole): Unit = {
+  def currentHashCode(bh: Blackhole): Unit = {
     bh.consume(smallTagMap.hashCode)
+  }
+
+  @Threads(1)
+  @Benchmark
+  def computeHashCode(bh: Blackhole): Unit = {
+    bh.consume(smallTagMap.computeHashCode)
   }
 
   @Threads(1)


### PR DESCRIPTION
Overrides equals for SmallHashMap to improve the performance.
The two main changes are to use the cache hash code as a filter
and simply compare the elements of the array. This does much
better than the default inherited from GenMapLike that more or
less does:

```scala
this.forall { t => other.get(t._1) == Some(t._2) }
```

If the elements are not inserted in the same order, then they
may be in a different order in the array due to collisions.
However, others will be in the correct position and we can
limit the lookups to ones where there is a mismatch.

**Equal Maps**

Checking where the maps being compared are equal:

```
Benchmark                     Mode  Cnt          Score          Error  Units
currentEquals                thrpt   10   47004215.059 ±  2291847.719  ops/s
inheritedEquals              thrpt   10    2134457.383 ±   111821.520  ops/s
dataEquals                   thrpt   10   51326103.645 ±   758297.787  ops/s
selfEquals                   thrpt   10  351279563.043 ± 18578115.816  ops/s
```

Note:

* `currentEquals` - is SmallHashMap.equals, it does some
  sanity checks and then calls `dataEquals`.
* `inheritedEquals` - is the GenMapLike.equals.
* `dataEquals` - is the method used for comparing the array.
* `selfEquals` - is comparing against the same instance of the
  map. Just sanity checks that the special case is fast.

**Not Equal Maps**

Checking maps that are almost equal except that one data value
is different. Using the cached hash code as a pre filter is the
biggest contributor:

```
currentEqualsNot             thrpt   10  273893522.221 ±  7980051.600  ops/s
inheritedEqualsNot           thrpt   10    2341207.187 ±   206356.584  ops/s
dataEqualsNot                thrpt   10   32392263.165 ±  1289262.059  ops/s
```

**Equal with Different Order**

Comparing equal maps, but constructed such that the order in the
underlying array is different. This means we have to do more
lookups rather than just traversing the array. For the examples
though there are typically still quite a few entries that are
in the same position for both maps.

```
currentEqualHashCodes        thrpt   10   14601802.119 ±   360902.793  ops/s
inheritedEqualHashCodes      thrpt   10     483515.784 ±    10044.781  ops/s
```