### PR TITLE
make ending '/' optional in path pattern

### DIFF
--- a/atlas-akka/src/main/resources/reference.conf
+++ b/atlas-akka/src/main/resources/reference.conf
@@ -4,7 +4,7 @@ atlas.akka {
   # Regex that determines how the path tag value to use when mapping data about an
   # actor into a meter. There a should be a single capture group which will be the
   # path to report.
-  path-pattern = "^akka://(?:[^/]+)/(?:system|user)/([-a-zA-Z]+)/.*$"
+  path-pattern = "^akka://(?:[^/]+)/(?:system|user)/([^$].+?)(?:/.*)?$"
 
   # List of additional actor classes to load
   actors = ${?atlas.akka.actors} [


### PR DESCRIPTION
Updates the default path pattern to make the ending
slash optional. If it is a simple actor path it is
usually not present. Makes it match the setting we
are typically using internally.