### PR TITLE
Set actor name rather than using a generated one.

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/ActorService.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/ActorService.scala
@@ -43,7 +43,7 @@ class ActorService @Inject() (system: ActorSystem, config: Config, classFactory:
     config.getConfigList("atlas.akka.actors").asScala.foreach { cfg =>
       val name = cfg.getString("name")
       val cls = Class.forName(cfg.getString("class"))
-      val ref = system.actorOf(newActor(name, cls))
+      val ref = system.actorOf(newActor(name, cls), name)
       logger.info(s"created actor '${ref.path}' using class '${cls.getName}'")
     }
   }


### PR DESCRIPTION
Without this change, automatically generated paths are made (such as ```akka://atlas/user/$a```) rather than what we specified in our config.  This change calls the explicit-name version of ```actorOf()``` to fix this.

As a side note, in travis, we should probably fire up the server once and verify we can post something to it.  All the tests pass without this change, but the stand-alone server could not find actors as the names were wrong.