### PR TITLE
manager for polling data

### DIFF
--- a/atlas-poller/src/main/resources/reference.conf
+++ b/atlas-poller/src/main/resources/reference.conf
@@ -1,0 +1,25 @@
+
+atlas.poller {
+
+  // How often to collect data from the pollers.
+  frequency = 1 m
+
+  sink = {
+    class = "com.netflix.atlas.poller.ClientActor"
+
+    // URL for sending the data
+    uri = "http://localhost:7101/api/v1/publish"
+
+    // Maximum number of datapoints to send in a single HTTP request to the publish
+    // endpoint.
+    batch-size = 10000
+
+    // If set to false, then ClientActor will work in a fire and forget mode with no
+    // explicit response message. Setting to true it will send an ack message to indicate
+    // it is done processing the message.
+    send-ack = false
+  }
+
+  // List of poller actors to load. See application.conf in tests for examples.
+  pollers = []
+}

--- a/atlas-poller/src/main/scala/com/netflix/atlas/poller/ClientActor.scala
+++ b/atlas-poller/src/main/scala/com/netflix/atlas/poller/ClientActor.scala
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.poller
+
+import akka.actor.Actor
+import akka.actor.ActorRef
+import com.netflix.atlas.akka.AccessLogger
+import com.netflix.atlas.akka.CustomMediaTypes
+import com.netflix.atlas.json.Json
+import com.netflix.atlas.poller.Messages.MetricsPayload
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
+import org.slf4j.LoggerFactory
+import spray.client.pipelining._
+import spray.http.HttpEncodingRange
+import spray.http.HttpEncodings
+import spray.http.HttpHeaders
+import spray.http.HttpMethods
+import spray.http.HttpRequest
+import spray.http.HttpResponse
+import spray.httpx.encoding.Gzip
+
+import scala.concurrent.Future
+import scala.util.Failure
+import scala.util.Success
+
+/**
+  * Sink for the poller data that publishes the metrics to Atlas. The actor expects
+  * [[MetricsPayload]] messages and does not send a response. Failures will be logged
+  * and reflected in the `atlas.client.dropped` counter as well as standard client
+  * access logging.
+  */
+class ClientActor(registry: Registry, config: Config) extends Actor {
+
+  private implicit val xc = scala.concurrent.ExecutionContext.global
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private val pipeline: SendReceive = sendReceive ~> decode(Gzip)
+
+  private val uri = config.getString("atlas.poller.sink.uri")
+  private val batchSize = config.getInt("atlas.poller.sink.batch-size")
+
+  private val shouldSendAck = config.getBoolean("atlas.poller.sink.send-ack")
+
+  private val datapointsSent = registry.counter("atlas.client.sent")
+  private val datapointsDropped = registry.createId("atlas.client.dropped")
+
+  def receive: Receive = {
+    case MetricsPayload(_, ms) =>
+      val responder = sender()
+      datapointsSent.increment(ms.size)
+      ms.grouped(batchSize).foreach { batch =>
+        val msg = MetricsPayload(metrics = batch)
+        post(msg).onComplete {
+          case Success(response) => handleResponse(responder, response, batch.size)
+          case Failure(t)        => handleFailure(responder, t, batch.size)
+        }
+      }
+  }
+
+  private def post(data: MetricsPayload): Future[HttpResponse] = {
+    post(Json.smileEncode(data))
+  }
+
+  /**
+    * Encode the data and start post to atlas. Method is protected to allow for
+    * easier testing.
+    */
+  protected def post(data: Array[Byte]): Future[HttpResponse] = {
+    val request = HttpRequest(HttpMethods.POST,
+      uri = uri,
+      headers = ClientActor.headers,
+      entity = data)
+    val accessLogger = AccessLogger.newClientLogger("atlas_publish", request)
+    pipeline(request).andThen { case t => accessLogger.complete(t) }
+  }
+
+  private def handleResponse(responder: ActorRef, response: HttpResponse, size: Int): Unit = {
+    response.status.intValue match {
+      case 200 => // All is well
+      case 202 => // Partial failure
+        val id = datapointsDropped.withTag("id", "PartialFailure")
+        registry.counter(id).increment(determineFailureCount(response, size))
+      case 400 => // Bad message, all data dropped
+        val id = datapointsDropped.withTag("id", "CompleteFailure")
+        registry.counter(id).increment(determineFailureCount(response, size))
+      case v   => // Unexpected, assume all dropped
+        val id = datapointsDropped.withTag("id", s"Status_$v")
+        registry.counter(id).increment(size)
+    }
+    if (shouldSendAck) responder ! Messages.Ack
+  }
+
+  private def determineFailureCount(response: HttpResponse, size: Int): Int = {
+    try {
+      val msg = Json.decode[Messages.FailureResponse](response.entity.data.toByteArray)
+      msg.message.headOption.foreach { reason =>
+        logger.warn("failed to validate some datapoints, first reason: {}", reason)
+      }
+      msg.errorCount
+    } catch {
+      case _: Exception => size
+    }
+  }
+
+  private def handleFailure(responder: ActorRef, t: Throwable, size: Int): Unit = {
+    val id = datapointsDropped.withTag("id", t.getClass.getSimpleName)
+    registry.counter(id).increment(size)
+    if (shouldSendAck) responder ! Messages.Ack
+  }
+}
+
+object ClientActor {
+  private val gzip = HttpEncodingRange(HttpEncodings.gzip)
+  private val headers = List(
+    HttpHeaders.`Accept-Encoding`(Seq(gzip)),
+    HttpHeaders.Accept(CustomMediaTypes.`application/x-jackson-smile`)
+  )
+}

--- a/atlas-poller/src/main/scala/com/netflix/atlas/poller/Messages.scala
+++ b/atlas-poller/src/main/scala/com/netflix/atlas/poller/Messages.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.poller
+
+import com.netflix.atlas.core.model.Datapoint
+
+/**
+  * Messages used for polling actors.
+  */
+object Messages {
+
+  /**
+    * Sent by the ClientActor to the sender to indicate that the message was sent out. This
+    * can be disabled using the `atlas.poller.sink.send-ack` property.
+    */
+  case object Ack
+
+  /**
+    * Sent by the PollerManager to pollers to request data. Pollers should respond with
+    * a MetricsPayload.
+    */
+  case object Tick
+
+  /**
+    * Metrics payload that pollers will send back to the manager.
+    *
+    * @param tags
+    *     Common tags that should get added to all metrics in the payload.
+    * @param metrics
+    *     Metrics collected by the poller.
+    */
+  case class MetricsPayload(tags: Map[String, String] = Map.empty, metrics: List[Datapoint] = Nil)
+
+  /**
+    * Represents a failure response message from the publish endpoint.
+    *
+    * @param `type`
+    *     Message type. Should always be "error".
+    * @param errorCount
+    *     Number of datapoints that failed validation.
+    * @param message
+    *     Reasons for why datapoints were dropped.
+    */
+  case class FailureResponse(`type`: String, errorCount: Int, message: List[String])
+}

--- a/atlas-poller/src/main/scala/com/netflix/atlas/poller/PollerManager.scala
+++ b/atlas-poller/src/main/scala/com/netflix/atlas/poller/PollerManager.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.poller
+
+import java.lang.reflect.Type
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+import akka.actor.Actor
+import akka.actor.ActorInitializationException
+import akka.actor.ActorPath
+import akka.actor.ActorRef
+import akka.actor.OneForOneStrategy
+import akka.actor.Props
+import akka.actor.SupervisorStrategy
+import com.netflix.iep.service.ClassFactory
+import com.netflix.spectator.api.Functions
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+
+/**
+  * Manager for a set of poller actors. The manager will send a Tick message to the pollers
+  * at a regular interval. The pollers should send by a MetricsPayload with the data
+  * collected.
+  */
+class PollerManager(registry: Registry, classFactory: ClassFactory, config: Config)
+  extends Actor with StrictLogging {
+
+  import scala.concurrent.duration._
+  private implicit val xc = scala.concurrent.ExecutionContext.global
+
+  private val pollers = PollerManager.pollers(config)
+  private val lastUpdateTimes = createPollerActors()
+
+  private val sinkRef = createSinkActor()
+
+  override val supervisorStrategy = OneForOneStrategy() {
+    case e: ActorInitializationException =>
+      SupervisorStrategy.Escalate
+    case e: Exception =>
+      logRestart(sender().path, e)
+      SupervisorStrategy.Restart
+  }
+
+  val frequency = FiniteDuration(
+    config.getDuration("atlas.poller.frequency", TimeUnit.NANOSECONDS),
+    TimeUnit.NANOSECONDS)
+  context.system.scheduler.schedule(frequency, frequency, self, Messages.Tick)
+
+  def receive: Receive = {
+    case Messages.Tick =>
+      pollers.foreach { p => context.actorSelection(p.name) ! Messages.Tick }
+    case p @ Messages.MetricsPayload(_, ds) =>
+      val name = sender().path.name
+      registry.counter("atlas.poller.datapoints", "id", name).increment(ds.size)
+      lastUpdateTimes.get(name).foreach(_.set(registry.clock().wallTime()))
+      sinkRef ! p
+  }
+
+  private def createPollerActors(): Map[String, AtomicLong] = {
+    val updateTimes = pollers.map { p =>
+      context.actorOf(Props(classFactory.newInstance[Actor](p.cls)), p.name)
+      val updateTime = new AtomicLong(registry.clock().wallTime())
+      val id = registry.createId("atlas.poller.dataAge", "id", p.name)
+      p.name -> registry.gauge(id, updateTime, Functions.age(registry.clock()))
+    }
+    updateTimes.toMap
+  }
+
+  private def createSinkActor(): ActorRef = {
+    import scala.compat.java8.FunctionConverters._
+    val cfg = config.getConfig("atlas.poller.sink")
+    val cls = cfg.getString("class")
+    val overrides = Map[Type, AnyRef](classOf[Config] -> cfg).withDefaultValue(null)
+    context.actorOf(
+      Props(classFactory.newInstance[Actor](cls, overrides.asJava)),
+      PollerManager.SinkName)
+  }
+
+  private def logRestart(path: ActorPath, e: Exception): Unit = {
+    logger.warn(s"restarting ${path.name}", e)
+    val error = e.getClass.getSimpleName
+    registry.counter("atlas.poller.restarts", "id", path.name, "error", error).increment()
+  }
+}
+
+object PollerManager {
+
+  private val SinkName = "sink"
+
+  private def pollers(config: Config): List[PollerConfig] = {
+    val builder = List.newBuilder[PollerConfig]
+    config.getConfigList("atlas.poller.pollers").forEach { cfg =>
+      builder += PollerConfig(s"poller-${cfg.getString("name")}", cfg.getString("class"))
+    }
+    builder.result()
+  }
+
+  case class PollerConfig(name: String, cls: String)
+}

--- a/atlas-poller/src/test/resources/application.conf
+++ b/atlas-poller/src/test/resources/application.conf
@@ -1,0 +1,19 @@
+
+atlas.poller {
+
+  // Set to a large value because we don't want it running during tests
+  frequency = 60 minutes
+
+  sink = {
+    class = "com.netflix.atlas.poller.TestActor"
+    url = "http://localhost:7101/api/v1/publish"
+    send-ack = true
+  }
+
+  pollers = [
+    {
+      name = "test"
+      class = "com.netflix.atlas.poller.TestActor"
+    }
+  ]
+}

--- a/atlas-poller/src/test/scala/com/netflix/atlas/poller/ClientActorSuite.scala
+++ b/atlas-poller/src/test/scala/com/netflix/atlas/poller/ClientActorSuite.scala
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.poller
+
+import akka.actor.ActorSystem
+import akka.testkit.ImplicitSender
+import akka.testkit.TestActorRef
+import akka.testkit.TestKit
+import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.json.Json
+import com.netflix.atlas.poller.ClientActorSuite.TestClientActor
+import com.netflix.atlas.poller.Messages.MetricsPayload
+import com.netflix.atlas.webapi.PublishApi
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.ManualClock
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.FunSuiteLike
+import spray.http.HttpResponse
+import spray.http.StatusCodes
+
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+
+class ClientActorSuite extends TestKit(ActorSystem())
+  with ImplicitSender
+  with FunSuiteLike
+  with BeforeAndAfterAll {
+
+  import scala.concurrent.duration._
+
+  private val clock = new ManualClock()
+  private val registry = new DefaultRegistry(clock)
+  private val config = ConfigFactory.load()
+  private val ref = TestActorRef(new TestClientActor(registry, config))
+
+  override def afterAll(): Unit = {
+    system.terminate()
+  }
+
+  private def get(k: String): Long = {
+    import scala.collection.JavaConversions._
+    registry.get(registry.createId(k)).measure().head.value.toLong
+  }
+
+  private def waitForCompletion(): Unit = {
+    expectMsgPF(1.minute) { case Messages.Ack => }
+  }
+
+  private def totalDropped: Long = {
+    registry.counters()
+      .filter(_.id().name() == "atlas.client.dropped")
+      .mapToLong(_.count())
+      .sum()
+  }
+
+  private def testSend(datapoints: List[Datapoint], numSent: Int, numDropped: Int, batches: Int = 1): Unit = {
+    val sent = registry.counter("atlas.client.sent")
+
+    val initSent = sent.count()
+    val initDropped = totalDropped
+
+    ref ! MetricsPayload(metrics = datapoints)
+    (0 until batches).foreach { _ => waitForCompletion() }
+
+    assert(sent.count() === initSent + numSent)
+    assert(totalDropped === initDropped + numDropped)
+  }
+
+  test("publish datapoints, exception") {
+    ref ! Failure(new RuntimeException("fail"))
+    val datapoints = (0 until 10)
+      .map(i => Datapoint(Map("name" -> s"foo_$i"), 0L, i.toDouble))
+      .toList
+    testSend(datapoints, 10, 10)
+  }
+
+  test("publish datapoints, ok") {
+    ref ! Success(HttpResponse(StatusCodes.OK))
+    val datapoints = (0 until 10)
+      .map(i => Datapoint(Map("name" -> s"foo_$i"), 0L, i.toDouble))
+      .toList
+    testSend(datapoints, 10, 0)
+  }
+
+  test("publish datapoints, several batches") {
+    ref ! Success(HttpResponse(StatusCodes.OK))
+    val datapoints = (0 until 50000)
+      .map(i => Datapoint(Map("name" -> s"foo_$i"), 0L, i.toDouble))
+      .toList
+    testSend(datapoints, 50000, 0, 5)
+  }
+
+  test("publish datapoints, partial failure") {
+    val json =
+      """
+        |{
+        |  "type": "error",
+        |  "errorCount": 7,
+        |  "message": ["abc"]
+        |}
+      """.stripMargin
+    ref ! Success(HttpResponse(StatusCodes.Accepted, entity = json))
+    val datapoints = (0 until 10)
+      .map(i => Datapoint(Map("name" -> s"foo_$i"), 0L, i.toDouble))
+      .toList
+    testSend(datapoints, 10, 7)
+  }
+
+  test("publish datapoints, partial failure, cannot parse response") {
+    ref ! Success(HttpResponse(StatusCodes.Accepted))
+    val datapoints = Datapoint(Map("name" -> s"invalid name!!"), 0L, 1.0) :: (0 until 10)
+      .map(i => Datapoint(Map("name" -> s"foo_$i"), 0L, i.toDouble))
+      .toList
+    testSend(datapoints, 11, 11)
+  }
+
+  test("publish datapoints, complete failure") {
+    ref ! Success(HttpResponse(StatusCodes.BadRequest))
+    val datapoints = (0 until 10)
+      .map(i => Datapoint(Map("name" -> s"foo_$i"), 0L, i.toDouble))
+      .toList
+    testSend(datapoints, 10, 10)
+  }
+
+  test("publish datapoints, unexpected status code") {
+    ref ! Success(HttpResponse(StatusCodes.InternalServerError))
+    val datapoints = (0 until 10)
+      .map(i => Datapoint(Map("name" -> s"foo_$i"), 0L, i.toDouble))
+      .toList
+    testSend(datapoints, 10, 10)
+  }
+}
+
+object ClientActorSuite {
+
+  object Done
+
+  class TestClientActor(registry: Registry, config: Config) extends ClientActor(registry, config) {
+
+    var response: Try[HttpResponse] = Failure(new RuntimeException("not set"))
+
+    override protected def post(data: Array[Byte]): Future[HttpResponse] = {
+      val t = Try {
+        PublishApi.decodeBatch(Json.newSmileParser(data))
+        response.get
+      }
+      Promise.fromTry(t).future
+    }
+
+    override def receive: Receive = testReceive.orElse(super.receive)
+
+    private def testReceive: Receive = {
+      case t: Try[HttpResponse] => response = t
+    }
+  }
+}

--- a/atlas-poller/src/test/scala/com/netflix/atlas/poller/DataRef.scala
+++ b/atlas-poller/src/test/scala/com/netflix/atlas/poller/DataRef.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.poller
+
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+
+class DataRef {
+
+  private val sendMsg = new AtomicReference[Try[Any]](Failure(new RuntimeException("not set")))
+  private var recvPromise: Promise[AnyRef] = Promise()
+
+  def set(msg: Try[Any]): Unit = sendMsg.set(msg)
+
+  def get: Try[Any] = sendMsg.get()
+
+  def receive(v: AnyRef): Unit = recvPromise.complete(Success(v))
+
+  def complete(): Unit = {
+    if (!recvPromise.isCompleted) recvPromise.complete(Failure(new RuntimeException("done")))
+  }
+
+  def reset(): Unit = {
+    recvPromise = Promise()
+  }
+
+  def future: Future[AnyRef] = recvPromise.future
+}

--- a/atlas-poller/src/test/scala/com/netflix/atlas/poller/PollerManagerSuite.scala
+++ b/atlas-poller/src/test/scala/com/netflix/atlas/poller/PollerManagerSuite.scala
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.poller
+
+import java.lang.reflect.Type
+
+import akka.actor.ActorSystem
+import akka.testkit.ImplicitSender
+import akka.testkit.TestActorRef
+import akka.testkit.TestKit
+import com.netflix.atlas.core.model.Datapoint
+import com.netflix.iep.service.DefaultClassFactory
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.ManualClock
+import com.typesafe.config.ConfigFactory
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.FunSuiteLike
+
+import scala.concurrent.Await
+import scala.util.Failure
+import scala.util.Success
+
+
+class PollerManagerSuite extends TestKit(ActorSystem())
+  with ImplicitSender
+  with FunSuiteLike
+  with BeforeAndAfterAll {
+
+  import scala.concurrent.duration._
+
+  import scala.compat.java8.FunctionConverters._
+  private val dataRef = new DataRef
+  private val bindings = Map[Type, AnyRef](classOf[DataRef] -> dataRef).withDefaultValue(null)
+  private val classFactory = new DefaultClassFactory(bindings.asJava)
+
+  private val clock = new ManualClock()
+  private val registry = new DefaultRegistry(clock)
+  private val config = ConfigFactory.load()
+  private val ref = TestActorRef(new PollerManager(registry, classFactory, config))
+
+  override def afterAll(): Unit = {
+    system.terminate()
+  }
+
+  private def get(k: String): Long = {
+    import scala.collection.JavaConversions._
+    registry.get(registry.createId(k)).measure().head.value.toLong
+  }
+
+  private def dataValue: AnyRef = {
+    val value = Await.result(dataRef.future, 1.minute)
+    dataRef.reset()
+    value
+  }
+
+  private def waitForCompletion(): Unit = {
+    Await.ready(dataRef.future, 1.minute)
+    dataRef.reset()
+  }
+
+  test("datapoints passed to sink") {
+    dataRef.reset()
+    dataRef.set(Success(Messages.MetricsPayload()))
+    ref ! Messages.Tick
+    assert(dataValue === Messages.MetricsPayload())
+
+    val payload = Messages.MetricsPayload(Map.empty, List(Datapoint(Map("name" -> "foo"), 0L, 42.0)))
+
+    dataRef.set(Success(payload))
+    ref ! Messages.Tick
+    assert(dataValue === payload)
+  }
+
+  test("datapoints counter incremented") {
+    dataRef.reset()
+    val datapoints = (0 until 1234)
+      .map(i => Datapoint(Map("name" -> "foo"), 0L, i.toDouble))
+      .toList
+    val payload = Messages.MetricsPayload(Map.empty, datapoints)
+
+    val counter = registry.counter("atlas.poller.datapoints", "id", "poller-test")
+    val init = counter.count()
+
+    dataRef.set(Success(payload))
+    ref ! Messages.Tick
+    assert(dataValue === payload)
+
+    assert(counter.count() === init + datapoints.size)
+  }
+
+  test("restarts counter incremented") {
+    val e1 = new RuntimeException("foo")
+    val e2 = new IllegalArgumentException("bar")
+
+    val c1 = registry.counter("atlas.poller.restarts", "id", "poller-test", "error", "RuntimeException")
+    val c2 = registry.counter("atlas.poller.restarts", "id", "poller-test", "error", "IllegalArgumentException")
+
+    val init1 = c1.count()
+    val init2 = c2.count()
+
+    // Update with RuntimeException
+    dataRef.reset()
+    dataRef.set(Failure(e1))
+    ref ! Messages.Tick
+    waitForCompletion()
+    assert(c1.count() === init1 + 1)
+    assert(c2.count() === init2)
+
+    // Update with IllegalArgumentException
+    dataRef.reset()
+    dataRef.set(Failure(e2))
+    ref ! Messages.Tick
+    waitForCompletion()
+    assert(c1.count() === init1 + 1)
+    assert(c2.count() === init2 + 1)
+  }
+
+  test("age is updated on success") {
+    dataRef.reset()
+    val payload = Messages.MetricsPayload()
+    val m = registry.get(registry.createId("atlas.poller.dataAge", "id", "poller-test"))
+
+    val t = clock.wallTime()
+    assert(m.measure().iterator().next().value() === 0.0)
+
+    clock.setWallTime(t + 60000L)
+    dataRef.set(Success(payload))
+    ref ! Messages.Tick
+    waitForCompletion()
+    assert(m.measure().iterator().next().value() === 0.0)
+
+  }
+
+  test("age is not updated on failure") {
+    dataRef.reset()
+    val e1 = new RuntimeException("foo")
+    val m = registry.get(registry.createId("atlas.poller.dataAge", "id", "poller-test"))
+
+    val t = clock.wallTime()
+    assert(m.measure().iterator().next().value() === 0.0)
+
+    clock.setWallTime(t + 60000L)
+    dataRef.set(Failure(e1))
+    ref ! Messages.Tick
+    waitForCompletion()
+    assert(m.measure().iterator().next().value() === 60.0)
+
+  }
+
+}

--- a/atlas-poller/src/test/scala/com/netflix/atlas/poller/TestActor.scala
+++ b/atlas-poller/src/test/scala/com/netflix/atlas/poller/TestActor.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.poller
+
+import akka.actor.Actor
+
+import scala.util.Failure
+import scala.util.Try
+
+
+class TestActor(ref: DataRef) extends Actor {
+
+  // If there is a failure causing a restart, then we need to mark the
+  // promise completed so test cases can move forward.
+  ref.complete()
+
+  var data: Try[Any] = Failure(new RuntimeException("not set"))
+
+  def receive: Receive = {
+    case Messages.Tick => sender() ! ref.get.get
+    case v: AnyRef     => ref.receive(v)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ lazy val root = project.in(file("."))
     `atlas-json`,
     `atlas-module-akka`,
     `atlas-module-webapi`,
+    `atlas-poller`,
     `atlas-standalone`,
     `atlas-test`,
     `atlas-webapi`,
@@ -78,6 +79,15 @@ lazy val `atlas-module-webapi` = project
   .settings(libraryDependencies ++= Seq(
     Dependencies.guiceCore,
     Dependencies.iepGuice
+  ))
+
+lazy val `atlas-poller` = project
+  .configure(BuildSettings.profile)
+  .dependsOn(`atlas-akka`, `atlas-core`, `atlas-webapi` % "test")
+  .settings(libraryDependencies ++= Seq(
+    Dependencies.sprayClient,
+    Dependencies.akkaTestkit % "test",
+    Dependencies.sprayTestkit % "test"
   ))
 
 lazy val `atlas-standalone` = project


### PR DESCRIPTION
Adds in the base manager that supervises a set of poller
actors. This is used for collecting metrics data from
various other services such as edda, healthcheck service,
cloudwatch, etc.