### PR TITLE
add poller to collect CloudWatch metrics data

### DIFF
--- a/atlas-module-cloudwatch/src/main/resources/META-INF/services/com.google.inject.Module
+++ b/atlas-module-cloudwatch/src/main/resources/META-INF/services/com.google.inject.Module
@@ -1,0 +1,1 @@
+com.netflix.atlas.guice.CloudWatchModule

--- a/atlas-module-cloudwatch/src/main/scala/com/netflix/atlas/guice/CloudWatchModule.scala
+++ b/atlas-module-cloudwatch/src/main/scala/com/netflix/atlas/guice/CloudWatchModule.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.guice
+
+import javax.inject.Singleton
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
+import com.google.inject.AbstractModule
+import com.google.inject.Provides
+import com.netflix.atlas.akka.AkkaModule
+import com.netflix.iep.aws.AwsClientFactory
+import com.netflix.iep.aws.AwsModule
+
+/**
+  * Configures the binding for the cloudwatch client and poller.
+  */
+class CloudWatchModule extends AbstractModule {
+  override def configure(): Unit = {
+    install(new AkkaModule)
+    install(new AwsModule)
+  }
+
+  @Provides
+  @Singleton
+  private def provideCloudWatchClient(factory: AwsClientFactory): AmazonCloudWatch = {
+    factory.newInstance(classOf[AmazonCloudWatch])
+  }
+}

--- a/atlas-module-cloudwatch/src/test/resources/application.conf
+++ b/atlas-module-cloudwatch/src/test/resources/application.conf
@@ -1,0 +1,13 @@
+
+atlas.poller {
+
+  // Set to a large value because we don't want it running during tests
+  frequency = 60 minutes
+
+  pollers = [
+    {
+      name = "cloudwatch"
+      class = "com.netflix.atlas.cloudwatch.CloudWatchPoller"
+    }
+  ]
+}

--- a/atlas-module-cloudwatch/src/test/resources/local.conf
+++ b/atlas-module-cloudwatch/src/test/resources/local.conf
@@ -1,0 +1,12 @@
+
+atlas.poller {
+
+  frequency = 10 s
+
+  pollers = [
+    {
+      name = "cloudwatch"
+      class = "com.netflix.atlas.cloudwatch.CloudWatchPoller"
+    }
+  ]
+}

--- a/atlas-module-cloudwatch/src/test/resources/log4j2.xml
+++ b/atlas-module-cloudwatch/src/test/resources/log4j2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="warn">
+    <Properties>
+        <Property name="dfltPattern">%d{yyyy-MM-dd'T'HH:mm:ss.SSS} %-5level [%t] %class: %msg%n</Property>
+    </Properties>
+    <Appenders>
+        <Console name="STDERR" target="SYSTEM_ERR">
+            <PatternLayout pattern="${dfltPattern}"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="com.netflix.spectator" level="debug"/>
+        <Logger name="com.netflix.atlas" level="info"/>
+        <Root level="info">
+            <AppenderRef ref="STDERR"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/atlas-module-cloudwatch/src/test/scala/com/netflix/atlas/guice/CloudWatchModuleSuite.scala
+++ b/atlas-module-cloudwatch/src/test/scala/com/netflix/atlas/guice/CloudWatchModuleSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.guice
+
+import java.util.concurrent.TimeUnit
+
+import com.google.inject.AbstractModule
+import com.google.inject.Guice
+import com.netflix.atlas.akka.ActorService
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.FunSuite
+
+class CloudWatchModuleSuite extends FunSuite {
+
+  test("load module") {
+    val deps = new AbstractModule {
+      override def configure(): Unit = {
+        bind(classOf[Config]).toInstance(ConfigFactory.load())
+        bind(classOf[Registry]).toInstance(new DefaultRegistry())
+      }
+    }
+    val injector = Guice.createInjector(deps, new CloudWatchModule)
+    val actors = injector.getInstance(classOf[ActorService])
+    assert(actors.isHealthy)
+    actors.stop()
+  }
+
+  ignore("run locally") {
+    val deps = new AbstractModule {
+      override def configure(): Unit = {
+        bind(classOf[Config]).toInstance(ConfigFactory.load("local"))
+        bind(classOf[Registry]).toInstance(new DefaultRegistry())
+      }
+    }
+    val injector = Guice.createInjector(deps, new CloudWatchModule)
+    val actors = injector.getInstance(classOf[ActorService])
+    assert(actors.isHealthy)
+    Thread.sleep(TimeUnit.MILLISECONDS.convert(10, TimeUnit.MINUTES))
+    actors.stop()
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/resources/api-gateway.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/api-gateway.conf
@@ -1,0 +1,51 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-api-dashboard.html
+    api-gateway = {
+      namespace = "ApiGateway"
+      period = 1m
+
+      dimensions = [
+        "ApiName",
+        "Label"
+      ]
+
+      metrics = [
+        {
+          name = "Count"
+          alias = "aws.apigateway.requests"
+          conversion = "sum,rate"
+        },
+        {
+          name = "4XXError"
+          alias = "aws.apigateway.errors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "4xx"
+            }
+          ]
+        },
+        {
+          name = "5XXError"
+          alias = "aws.apigateway.errors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "5xx"
+            }
+          ]
+        },
+        {
+          name = "Latency"
+          alias = "aws.apigateway.latency"
+          conversion = "timer-millis"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/resources/billing.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/billing.conf
@@ -1,0 +1,25 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/monitor_estimated_charges_with_cloudwatch.html
+    billing = {
+      namespace = "AWS/Billing"
+      period = 6h
+
+      dimensions = [
+        "LinkedAccount",
+        "ServiceName",
+        "Currency"
+      ]
+
+      metrics = [
+        {
+          name = "EstimatedCharges"
+          alias = "aws.billing.estimatedMonthlyCharge"
+          conversion = "sum"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/resources/dynamodb.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/dynamodb.conf
@@ -1,0 +1,135 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/MonitoringDynamoDB.html#dynamodb-metrics
+    dynamodb-table-1m = {
+      namespace = "AWS/DynamoDB"
+      period = 1m
+
+      dimensions = [
+        "TableName"
+      ]
+
+      metrics = [
+        {
+          name = "ConditionalCheckFailedRequests"
+          alias = "aws.dynamodb.conditionalCheckFailed"
+          conversion = "sum,rate"
+        },
+        {
+          name = "ConsumedReadCapacityUnits"
+          alias = "aws.dynamodb.consumedCapacity"
+          conversion = "dist-summary"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "ConsumedWriteCapacityUnits"
+          alias = "aws.dynamodb.consumedCapacity"
+          conversion = "dist-summary"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        }
+      ]
+    }
+
+    dynamodb-table-5m = {
+      namespace = "AWS/DynamoDB"
+      period = 5m
+
+      dimensions = [
+        "TableName"
+      ]
+
+      metrics = [
+        {
+          name = "ProvisionedReadCapacityUnits"
+          alias = "aws.dynamodb.provisionedCapacity"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "ProvisionedWriteCapacityUnits"
+          alias = "aws.dynamodb.provisionedCapacity"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        }
+      ]
+    }
+
+    dynamodb-table-ops = {
+      namespace = "AWS/DynamoDB"
+      period = 1m
+
+      dimensions = [
+        "TableName",
+        "Operation"
+      ]
+
+      metrics = [
+        {
+          name = "SuccessfulRequestLatency"
+          alias = "aws.dynamodb.requestLatency"
+          conversion = "timer"
+        },
+        {
+          name = "ReturnedItemCount"
+          alias = "aws.dynamodb.returnedItems"
+          conversion = "dist-summary"
+        },
+        {
+          name = "SystemErrors"
+          alias = "aws.dynamodb.errors"
+          conversion = "sum,rate"
+          tag = [
+            {
+              key = "id"
+              value = "system"
+            }
+          ]
+        },
+        {
+          name = "ThrottledRequests"
+          alias = "aws.dynamodb.errors"
+          conversion = "sum,rate"
+          tag = [
+            {
+              key = "id"
+              value = "throttled"
+            }
+          ]
+        },
+        {
+          name = "UserErrors"
+          alias = "aws.dynamodb.errors"
+          conversion = "sum,rate"
+          tag = [
+            {
+              key = "id"
+              value = "user"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/resources/ec2.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/ec2.conf
@@ -1,0 +1,139 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/ec2-metricscollected.html
+    ec2 = {
+      namespace = "AWS/EC2"
+      period = 5m
+
+      dimensions = [
+        "AutoScalingGroupName"
+      ]
+
+      metrics = [
+        {
+          name = "CPUUtilization"
+          alias = "aws.ec2.cpuUtilization"
+          conversion = "max"
+        },
+        {
+          name = "NetworkIn"
+          alias = "aws.ec2.networkThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "NetworkOut"
+          alias = "aws.ec2.networkThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+        {
+          name = "NetworkPacketsIn"
+          alias = "aws.ec2.networkPackets"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "NetworkPacketsOut"
+          alias = "aws.ec2.networkPackets"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+        {
+          name = "DiskReadBytes"
+          alias = "aws.ec2.ioThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Read"
+            }
+          ]
+        },
+        {
+          name = "DiskWriteBytes"
+          alias = "aws.ec2.ioThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Write"
+            }
+          ]
+        },
+        {
+          name = "DiskReadOps"
+          alias = "aws.ec2.iops"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Read"
+            }
+          ]
+        },
+        {
+          name = "DiskWriteOps"
+          alias = "aws.ec2.iops"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Write"
+            }
+          ]
+        },
+        {
+          name = "StatusCheckFailed_Instance"
+          alias = "aws.ec2.badInstances"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "Instance"
+            }
+          ]
+        },
+        {
+          name = "StatusCheckFailed_Instance"
+          alias = "aws.ec2.badInstances"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "System"
+            }
+          ]
+        },
+      ]
+    }
+
+    ec2-instance = ${atlas.cloudwatch.ec2} {
+      dimensions = [
+        "InstanceId"
+      ]
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/resources/elasticache.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/elasticache.conf
@@ -1,0 +1,535 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheMetrics.html
+    elasticache = {
+      namespace = "AWS/ElastiCache"
+      period = 1m
+
+      dimensions = [
+        "CacheClusterId",
+        "CacheNodeId"
+      ]
+
+      metrics = [
+        // http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheMetrics.HostLevel.html
+        {
+          name = "CPUUtilization"
+          alias = "aws.elasticache.cpuUtilization"
+          conversion = "max"
+        },
+        {
+          name = "FreeableMemory"
+          alias = "aws.elasticache.memoryFree"
+          conversion = "max"
+        },
+        {
+          name = "NetworkBytesIn"
+          alias = "aws.elasticache.networkThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "NetworkBytesOut"
+          alias = "aws.elasticache.networkThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+        {
+          name = "SwapUsage"
+          alias = "aws.elasticache.swapUsage"
+          conversion = "max"
+        },
+
+        // Both memcache and redis
+        {
+          name = "Evictions"
+          alias = "aws.elasticache.itemsRemoved"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "evicted"
+            }
+          ]
+        },
+        {
+          name = "Reclaimed"
+          alias = "aws.elasticache.itemsRemoved"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "reclaimed"
+            }
+          ]
+        },
+        {
+          name = "CurrConnections"
+          alias = "aws.elasticache.numConnections"
+          conversion = "max"
+        },
+        {
+          name = "CurrItems"
+          alias = "aws.elasticache.numItems"
+          conversion = "max"
+        },
+        {
+          name = "NewConnections"
+          alias = "aws.elasticache.connections"
+          conversion = "sum,rate"
+        },
+
+
+        // http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheMetrics.Memcached.html
+        {
+          name = "NewItems"
+          alias = "aws.elasticache.items"
+          conversion = "sum,rate"
+        },
+        {
+          name = "BytesUsedForCacheItems"
+          alias = "aws.elasticache.memoryUsed"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "CacheItems"
+            }
+          ]
+        },
+        {
+          name = "BytesUsedForHash"
+          alias = "aws.elasticache.memoryUsed"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "HashTables"
+            }
+          ]
+        },
+        {
+          name = "SlabsMoved"
+          alias = "aws.elasticache.slabsMoved"
+          conversion = "sum"
+        },
+        {
+          name = "DecrHits"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Decr"
+            },
+            {
+              key = "status"
+              value = "hit"
+            }
+          ]
+        },
+        {
+          name = "DecrMisses"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Decr"
+            },
+            {
+              key = "status"
+              value = "miss"
+            }
+          ]
+        },
+        {
+          name = "IncrHits"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Incr"
+            },
+            {
+              key = "status"
+              value = "hit"
+            }
+          ]
+        },
+        {
+          name = "IncrMisses"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Incr"
+            },
+            {
+              key = "status"
+              value = "miss"
+            }
+          ]
+        },
+        {
+          name = "DeleteHits"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Delete"
+            },
+            {
+              key = "status"
+              value = "hit"
+            }
+          ]
+        },
+        {
+          name = "DeleteMisses"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Delete"
+            },
+            {
+              key = "status"
+              value = "miss"
+            }
+          ]
+        },
+        {
+          name = "GetHits"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Get"
+            },
+            {
+              key = "status"
+              value = "hit"
+            }
+          ]
+        },
+        {
+          name = "GetMisses"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Get"
+            },
+            {
+              key = "status"
+              value = "miss"
+            }
+          ]
+        },
+        {
+          name = "TouchHits"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Touch"
+            },
+            {
+              key = "status"
+              value = "hit"
+            }
+          ]
+        },
+        {
+          name = "TouchMisses"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Touch"
+            },
+            {
+              key = "status"
+              value = "miss"
+            }
+          ]
+        },
+        {
+          name = "CasHits"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Cas"
+            },
+            {
+              key = "status"
+              value = "hit"
+            }
+          ]
+        },
+        {
+          name = "CasMisses"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Cas"
+            },
+            {
+              key = "status"
+              value = "miss"
+            }
+          ]
+        },
+        {
+          name = "CasBadval"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Cas"
+            },
+            {
+              key = "status"
+              value = "badval"
+            }
+          ]
+        },
+        {
+          name = "CmdGet"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Get"
+            }
+          ]
+        },
+        {
+          name = "CmdSet"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Set"
+            }
+          ]
+        },
+        {
+          name = "CmdFlush"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Flush"
+            }
+          ]
+        },
+        {
+          name = "CmdConfigGet"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "ConfigGet"
+            }
+          ]
+        },
+        {
+          name = "CmdConfigSet"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "ConfigSet"
+            }
+          ]
+        },
+        {
+          name = "CmdTouch"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Touch"
+            }
+          ]
+        },
+
+        // http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheMetrics.Redis.html
+        {
+          name = "CacheHits"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "hit"
+            }
+          ]
+        },
+        {
+          name = "CacheMisses"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "miss"
+            }
+          ]
+        },
+        {
+          name = "ReplicationBytes"
+          alias = "aws.elasticache.replicationThroughput"
+          conversion = "sum,rate"
+        },
+        {
+          name = "ReplicationLag"
+          alias = "aws.elasticache.replicationLag"
+          conversion = "max"
+        },
+        {
+          name = "SaveInProgress"
+          alias = "aws.elasticache.saveInProgress"
+          conversion = "max"
+        },
+        {
+          name = "BytesUsedForCache"
+          alias = "aws.elasticache.memoryUsed"
+          conversion = "max"
+        },
+        {
+          name = "HyperLogLogBasedCmds"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "HyperLogLogBased"
+            }
+          ]
+        },
+        {
+          name = "GetTypeCmds"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "GetType"
+            }
+          ]
+        },
+        {
+          name = "HashBasedCmds"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "HashBased"
+            }
+          ]
+        },
+        {
+          name = "KeyBasedCmds"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "KeyBased"
+            }
+          ]
+        },
+        {
+          name = "ListBasedCmds"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "ListBased"
+            }
+          ]
+        },
+        {
+          name = "SetBasedCmds"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "SetBased"
+            }
+          ]
+        },
+        {
+          name = "SetTypeCmds"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "SetType"
+            }
+          ]
+        },
+        {
+          name = "SortedSetBasedCmds"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "SortedSetBased"
+            }
+          ]
+        },
+        {
+          name = "StringBasedCmds"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "StringBased"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/resources/elb.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/elb.conf
@@ -1,0 +1,138 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/elb-cloudwatch-metrics.html
+    elb = {
+      namespace = "AWS/ELB"
+      period = 1m
+
+      dimensions = [
+        "LoadBalancerName",
+        "AvailabilityZone"
+      ]
+
+      metrics = [
+        {
+          name = "RequestCount"
+          alias = "aws.elb.requests"
+          conversion = "sum,rate"
+        },
+        {
+          name = "HTTPCode_ELB_4XX"
+          alias = "aws.elb.errors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "4xx"
+            }
+          ]
+        },
+        {
+          name = "HTTPCode_ELB_5XX"
+          alias = "aws.elb.errors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "5xx"
+            }
+          ]
+        },
+        {
+          name = "HTTPCode_Backend_2XX"
+          alias = "aws.elb.backendResponses"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "2xx"
+            }
+          ]
+        },
+        {
+          name = "HTTPCode_Backend_3XX"
+          alias = "aws.elb.backendResponses"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "3xx"
+            }
+          ]
+        },
+        {
+          name = "HTTPCode_Backend_4XX"
+          alias = "aws.elb.backendResponses"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "4xx"
+            }
+          ]
+        },
+        {
+          name = "HTTPCode_Backend_5XX"
+          alias = "aws.elb.backendResponses"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "5xx"
+            }
+          ]
+        },
+        {
+          name = "BackendConnectionErrors"
+          alias = "aws.elb.backendErrors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "error"
+              value = "connection"
+            }
+          ]
+        },
+        {
+          name = "HealthyHostCount"
+          alias = "aws.elb.hostCount"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "healthy"
+            }
+          ]
+        },
+        {
+          name = "UnHealthyHostCount"
+          alias = "aws.elb.hostCount"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "unhealthy"
+            }
+          ]
+        },
+        {
+          name = "Latency"
+          alias = "aws.elb.latency"
+          conversion = "timer"
+        },
+        {
+          name = "SurgeQueueLength"
+          alias = "aws.elb.surgeQueueLength"
+          conversion = "max"
+        },
+        {
+          name = "SpilloverCount"
+          alias = "aws.elb.spillover"
+          conversion = "sum,rate"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/resources/es.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/es.conf
@@ -1,0 +1,180 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/es-metricscollected.html
+    es = {
+      namespace = "AWS/ES"
+      period = 5m
+
+      dimensions = [
+        "ClientId",
+        "DomainName"
+      ]
+
+      metrics = [
+        {
+          name = "Nodes"
+          alias = "aws.es.clusterSize"
+          conversion = "max"
+        },
+        {
+          name = "SearchableDocuments"
+          alias = "aws.es.indexSize"
+          conversion = "max"
+          tags = [
+            {
+              key = "status"
+              value = "searchable"
+            }
+          ]
+        },
+        {
+          name = "DeletedDocuments"
+          alias = "aws.es.indexSize"
+          conversion = "max"
+          tags = [
+            {
+              key = "status"
+              value = "deleted"
+            }
+          ]
+        },
+        {
+          name = "DiskQueueDepth"
+          alias = "aws.es.diskQueueDepth"
+          conversion = "max"
+        },
+        {
+          name = "ReadLatency"
+          alias = "aws.es.ioLatency"
+          conversion = "timer"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "WriteLatency"
+          alias = "aws.es.ioLatency"
+          conversion = "timer"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "ReadThroughput"
+          alias = "aws.es.ioThroughput"
+          conversion = "sum"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "WriteThroughput"
+          alias = "aws.es.ioThroughput"
+          conversion = "sum"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "ReadIOPS"
+          alias = "aws.es.iops"
+          conversion = "sum"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "WriteIOPS"
+          alias = "aws.es.iops"
+          conversion = "sum"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "FreeStorageSpace"
+          alias = "aws.es.freeStorageSpace"
+          conversion = "min"
+        },
+        {
+          name = "MasterFreeStorageSpace"
+          alias = "aws.esmaster.freeStorageSpace"
+          conversion = "min"
+        },
+        {
+          name = "JVMMemoryPressure"
+          alias = "aws.es.jvmMemoryPressure"
+          conversion = "max"
+        },
+        {
+          name = "MasterJVMMemoryPressure"
+          alias = "aws.esmaster.jvmMemoryPressure"
+          conversion = "max"
+        },
+        {
+          name = "CPUUtilization"
+          alias = "aws.es.cpuUtilization"
+          conversion = "max"
+        },
+        {
+          name = "MasterCPUUtilization"
+          alias = "aws.esmaster.cpuUtilization"
+          conversion = "max"
+        },
+        {
+          name = "ClusterStatus.green"
+          alias = "aws.es.clusterStatus"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "green"
+            }
+          ]
+        },
+        {
+          name = "ClusterStatus.yellow"
+          alias = "aws.es.clusterStatus"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "yellow"
+            }
+          ]
+        },
+        {
+          name = "ClusterStatus.red"
+          alias = "aws.es.clusterStatus"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "red"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/resources/events.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/events.conf
@@ -1,0 +1,38 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cwe-metricscollected.html
+    events = {
+      namespace = "AWS/Events"
+      period = 1m
+
+      dimensions = [
+        "RuleName"
+      ]
+
+      metrics = [
+        {
+          name = "Invocations"
+          alias = "aws.events.invocations"
+          conversion = "sum,rate"
+        },
+        {
+          name = "FailedInvocations"
+          alias = "aws.events.failedInvocations"
+          conversion = "sum,rate"
+        },
+        {
+          name = "TriggeredRules"
+          alias = "aws.events.rulesTriggered"
+          conversion = "sum,rate"
+        },
+        {
+          name = "ThrottledRules"
+          alias = "aws.events.rulesThrottled"
+          conversion = "sum,rate"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/resources/kinesis.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/kinesis.conf
@@ -1,0 +1,155 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/streams/latest/dev/monitoring-with-cloudwatch.html
+    kinesis = {
+      namespace = "AWS/Kinesis"
+      period = 1m
+
+      dimensions = [
+        "StreamName"
+      ]
+
+      metrics = [
+        {
+          name = "ReadProvisionedThroughputExceeded"
+          alias = "aws.kinesis.provisionedThroughputExceeded"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "WriteProvisionedThroughputExceeded"
+          alias = "aws.kinesis.provisionedThroughputExceeded"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "GetRecords.IteratorAgeMilliseconds"
+          alias = "aws.kinesis.iteratorAge"
+          conversion = "max"
+        },
+        {
+          name = "PutRecords.Success"
+          alias = "aws.kinesis.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "PutRecords"
+            }
+          ]
+        },
+        {
+          name = "PutRecord.Success"
+          alias = "aws.kinesis.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "PutRecord"
+            }
+          ]
+        },
+        {
+          name = "GetRecords.Success"
+          alias = "aws.kinesis.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "GetRecords"
+            }
+          ]
+        },
+        {
+          name = "PutRecords.Latency"
+          alias = "aws.kinesis.latency"
+          conversion = "timer"
+          tags = [
+            {
+              key = "id"
+              value = "PutRecords"
+            }
+          ]
+        },
+        {
+          name = "PutRecord.Latency"
+          alias = "aws.kinesis.latency"
+          conversion = "timer"
+          tags = [
+            {
+              key = "id"
+              value = "PutRecord"
+            }
+          ]
+        },
+        {
+          name = "GetRecords.Latency"
+          alias = "aws.kinesis.latency"
+          conversion = "timer"
+          tags = [
+            {
+              key = "id"
+              value = "GetRecords"
+            }
+          ]
+        },
+        {
+          name = "PutRecords.Bytes"
+          alias = "aws.kinesis.messageSize"
+          conversion = "dist-summary"
+          tags = [
+            {
+              key = "id"
+              value = "PutRecords"
+            }
+          ]
+        },
+        {
+          name = "PutRecord.Bytes"
+          alias = "aws.kinesis.messageSize"
+          conversion = "dist-summary"
+          tags = [
+            {
+              key = "id"
+              value = "PutRecord"
+            }
+          ]
+        },
+        {
+          name = "GetRecords.Bytes"
+          alias = "aws.kinesis.messageSize"
+          conversion = "dist-summary"
+          tags = [
+            {
+              key = "id"
+              value = "GetRecords"
+            }
+          ]
+        },
+        {
+          name = "GetRecords.Bytes"
+          alias = "aws.kinesis.messageSize"
+          conversion = "dist-summary"
+          tags = [
+            {
+              key = "id"
+              value = "GetRecords"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/resources/lambda.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/lambda.conf
@@ -1,0 +1,39 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/lambda/latest/dg/monitoring-functions-metrics.html
+    lambda = {
+      namespace = "AWS/Lambda"
+      period = 1m
+
+      dimensions = [
+        "FunctionName",
+        "Resource"
+      ]
+
+      metrics = [
+        {
+          name = "Invocations"
+          alias = "aws.lambda.invocations"
+          conversion = "sum,rate"
+        },
+        {
+          name = "Errors"
+          alias = "aws.lambda.errors"
+          conversion = "sum,rate"
+        },
+        {
+          name = "Throttles"
+          alias = "aws.lambda.throttles"
+          conversion = "sum,rate"
+        },
+        {
+          name = "Duration"
+          alias = "aws.lambda.duration"
+          conversion = "timer-millis"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/resources/rds.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/rds.conf
@@ -1,0 +1,359 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/rds-metricscollected.html
+    rds = {
+      namespace = "AWS/RDS"
+      period = 1m
+
+      dimensions = [
+        "DBInstanceIdentifier"
+      ]
+
+      metrics = [
+        {
+          name = "CPUUtilization"
+          alias = "aws.rds.cpuUtilization"
+          conversion = "max"
+        },
+        {
+          name = "DatabaseConnections"
+          alias = "aws.rds.numConnections"
+          conversion = "max"
+        },
+        {
+          name = "FreeableMemory"
+          alias = "aws.rds.memoryFree"
+          conversion = "max"
+        },
+        {
+          name = "FreeLocalStorage"
+          alias = "aws.rds.diskFree"
+          conversion = "max"
+        },
+        {
+          name = "BinLogDiskUsage"
+          alias = "aws.rds.diskUsageLogs"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "BinLog"
+            }
+          ]
+        },
+        {
+          name = "TransactionLogsDiskUsage"
+          alias = "aws.rds.diskUsageLogs"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "TransactionLog"
+            }
+          ]
+        },
+        {
+          name = "AuroraBinLogReplicaLag"
+          alias = "aws.rds.binLogReplicaLag"
+          conversion = "max"
+        },
+        {
+          name = "SwapUsage"
+          alias = "aws.rds.swapUsage"
+          conversion = "max"
+        },
+        {
+          name = "DiskQueueDepth"
+          alias = "aws.rds.diskQueueDepth"
+          conversion = "max"
+        },
+        {
+          name = "Deadlocks"
+          alias = "aws.rds.deadlocks"
+          conversion = "sum,rate"
+        },
+        {
+          name = "LoginFailures"
+          alias = "aws.rds.loginFailures"
+          conversion = "sum,rate"
+        },
+        {
+          name = "BufferCacheHitRatio"
+          alias = "aws.rds.bufferCacheHitPercent"
+          conversion = "max"
+        },
+        {
+          name = "ResultSetCacheHitRatio"
+          alias = "aws.rds.resultSetCacheHitPercent"
+          conversion = "max"
+        },
+        {
+          name = "NetworkReceiveThroughput"
+          alias = "aws.rds.networkThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "NetworkTransmitThroughput"
+          alias = "aws.rds.networkThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+        {
+          name = "ActiveTransactions"
+          alias = "aws.rds.transactions"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Active"
+            }
+          ]
+        },
+        {
+          name = "BlockedTransactions"
+          alias = "aws.rds.transactions"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Blocked"
+            }
+          ]
+        },
+        {
+          name = "CommitLatency"
+          alias = "aws.rds.queryLatency"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "Commit"
+            }
+          ]
+        },
+        {
+          name = "DDLLatency"
+          alias = "aws.rds.queryLatency"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "DDL"
+            }
+          ]
+        },
+        {
+          name = "DMLLatency"
+          alias = "aws.rds.queryLatency"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "DML"
+            }
+          ]
+        },
+        {
+          name = "DeleteLatency"
+          alias = "aws.rds.queryLatency"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "Delete"
+            }
+          ]
+        },
+        {
+          name = "InsertLatency"
+          alias = "aws.rds.queryLatency"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "Insert"
+            }
+          ]
+        },
+        {
+          name = "SelectLatency"
+          alias = "aws.rds.queryLatency"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "Select"
+            }
+          ]
+        },
+        {
+          name = "UpdateLatency"
+          alias = "aws.rds.queryLatency"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "Update"
+            }
+          ]
+        },
+        {
+          name = "CommitThroughput"
+          alias = "aws.rds.queries"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Commit"
+            }
+          ]
+        },
+        {
+          name = "DDLThroughput"
+          alias = "aws.rds.queries"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "DDL"
+            }
+          ]
+        },
+        {
+          name = "DMLThroughput"
+          alias = "aws.rds.queries"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "DML"
+            }
+          ]
+        },
+        {
+          name = "DeleteThroughput"
+          alias = "aws.rds.queries"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Delete"
+            }
+          ]
+        },
+        {
+          name = "InsertThroughput"
+          alias = "aws.rds.queries"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Insert"
+            }
+          ]
+        },
+        {
+          name = "SelectThroughput"
+          alias = "aws.rds.queries"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Select"
+            }
+          ]
+        },
+        {
+          name = "UpdateThroughput"
+          alias = "aws.rds.queries"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Update"
+            }
+          ]
+        },
+        {
+          name = "ReadLatency"
+          alias = "aws.rds.ioLatency"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "Read"
+            }
+          ]
+        },
+        {
+          name = "WriteLatency"
+          alias = "aws.rds.ioLatency"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "Write"
+            }
+          ]
+        },
+        {
+          name = "ReadThroughput"
+          alias = "aws.rds.ioThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Read"
+            }
+          ]
+        },
+        {
+          name = "WriteThroughput"
+          alias = "aws.rds.ioThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Write"
+            }
+          ]
+        },
+        {
+          name = "ReadIOPS"
+          alias = "aws.rds.iops"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Read"
+            }
+          ]
+        },
+        {
+          name = "WriteIOPS"
+          alias = "aws.rds.iops"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Write"
+            }
+          ]
+        },
+      ]
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/resources/redshift.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/redshift.conf
@@ -1,0 +1,132 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/redshift/latest/mgmt/metrics-listing.html
+    redshift = {
+      namespace = "AWS/Redshift"
+      period = 1m
+
+      dimensions = [
+        "ClusterIdentifier",
+        "NodeID"
+      ]
+
+      metrics = [
+        {
+          name = "CPUUtilization"
+          alias = "aws.redshift.cpuUtilization"
+          conversion = "max"
+        },
+        {
+          name = "DatabaseConnections"
+          alias = "aws.redshift.numConnections"
+          conversion = "max"
+        },
+        {
+          name = "HealthStatus"
+          alias = "aws.redshift.healthStatus"
+          conversion = "max"
+        },
+        {
+          name = "MaintenanceMode"
+          alias = "aws.redshift.maintenanceMode"
+          conversion = "max"
+        },
+        {
+          name = "NetworkReceiveThroughput"
+          alias = "aws.redshift.networkThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "NetworkTransmitThroughput"
+          alias = "aws.redshift.networkThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+        {
+          name = "ReadLatency"
+          alias = "aws.redshift.ioLatency"
+          conversion = "timer"
+          tags = [
+            {
+              key = "id"
+              value = "Read"
+            }
+          ]
+        },
+        {
+          name = "WriteLatency"
+          alias = "aws.redshift.ioLatency"
+          conversion = "timer"
+          tags = [
+            {
+              key = "id"
+              value = "Write"
+            }
+          ]
+        },
+        {
+          name = "ReadThroughput"
+          alias = "aws.redshift.ioThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Read"
+            }
+          ]
+        },
+        {
+          name = "WriteThroughput"
+          alias = "aws.redshift.ioThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Write"
+            }
+          ]
+        },
+        {
+          name = "ReadIOPS"
+          alias = "aws.redshift.iops"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Read"
+            }
+          ]
+        },
+        {
+          name = "WriteIOPS"
+          alias = "aws.redshift.iops"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Write"
+            }
+          ]
+        },
+        {
+          name = "PercentageDiskSpaceUsed"
+          alias = "aws.redshift.diskUsedPercent"
+          conversion = "max"
+        },
+      ]
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/reference.conf
@@ -1,0 +1,225 @@
+
+akka.actor.deployment {
+  /poller/poller-cloudwatch/metrics-get {
+    router = "round-robin-pool"
+    nr-of-instances = 100
+    pool-dispatcher {
+      executor = "thread-pool-executor"
+      thread-pool-executor {
+        core-pool-size-min = 100
+        core-pool-size-max = 100
+        core-pool-size-factor = 1.0
+      }
+    }
+  }
+
+  /poller/poller-cloudwatch/metrics-list {
+    router = "round-robin-pool"
+    nr-of-instances = 2
+    pool-dispatcher {
+      executor = "thread-pool-executor"
+      thread-pool-executor {
+        core-pool-size-min = 1
+        core-pool-size-max = 2
+        core-pool-size-factor = 1.0
+      }
+    }
+  }
+}
+
+atlas {
+
+  poller {
+    pollers = ${?atlas.poller.pollers} [
+      {
+        class = "com.netflix.atlas.cloudwatch.CloudWatchPoller"
+        name = "cloudwatch"
+      }
+    ]
+  }
+
+  cloudwatch {
+
+    // Batch size for flushing data back to the poller manager
+    batch-size = 1000
+
+    // Class to use for mapping AWS dimensions to a tag map for use in Atlas
+    tagger = {
+      class = "com.netflix.atlas.cloudwatch.NetflixTagger"
+
+      // Allows the dimension names to be mapped to values that are more
+      // familiar internally at Netflix. If no explicit mapping is found,
+      // then the value from cloudwatch will be used as is.
+      mappings = [
+        {
+          name = "AutoScalingGroupName"
+          alias = "nf.asg"
+        },
+        {
+          name = "AvailabilityZone"
+          alias = "nf.zone"
+        },
+        {
+          name = "LinkedAccount"
+          alias = "aws.account"
+        },
+        {
+          name = "Currency"
+          alias = "aws.currency"
+        },
+        {
+          name = "LoadBalancerName"
+          alias = "aws.elb"
+        },
+        {
+          name = "TopicName"
+          alias = "aws.topic"
+        },
+        {
+          name = "QueueName"
+          alias = "aws.queue"
+        },
+        {
+          name = "ServiceName"
+          alias = "aws.service"
+        },
+        {
+          name = "BucketName"
+          alias = "aws.bucket"
+        },
+        {
+          name = "StorageType"
+          alias = "aws.storage"
+        },
+        {
+          name = "FunctionName"
+          alias = "aws.function"
+        },
+        {
+          name = "StreamName"
+          alias = "aws.stream"
+        },
+        {
+          name = "RuleName"
+          alias = "aws.rule"
+        },
+        {
+          name = "Resource"
+          alias = "aws.resource"
+        },
+        {
+          name = "Domain"
+          alias = "aws.domain"
+        },
+        {
+          name = "Operation"
+          alias = "aws.op"
+        },
+        {
+          name = "TableName"
+          alias = "aws.table"
+        },
+        {
+          name = "DomainName"
+          alias = "aws.domain"
+        },
+        {
+          name = "WorkflowTypeName"
+          alias = "id"
+        },
+        {
+          name = "WorkflowTypeVersion"
+          alias = "aws.version"
+        },
+        {
+          name = "ActivityTypeName"
+          alias = "id"
+        },
+        {
+          name = "ActivityTypeVersion"
+          alias = "aws.version"
+        },
+        {
+          name = "ClientId"
+          alias = "aws.client"
+        },
+        {
+          name = "CacheClusterId"
+          alias = "aws.cache"
+        },
+        {
+          name = "CacheNodeId"
+          alias = "aws.node"
+        },
+        {
+          name = "DBInstanceIdentifier"
+          alias = "aws.dbname"
+        },
+        {
+          name = "ClusterIdentifier"
+          alias = "aws.redshift"
+        },
+        {
+          name = "NodeID"
+          alias = "nf.node"
+        },
+      ]
+
+      // Tags that should get applied to all metrics from cloudwatch.
+      common-tags = [
+        {
+          key = "nf.region"
+          value = "us-west-2"
+        }
+      ]
+
+      // When using the netflix mapper, this setting specifies which keys should get
+      // processed via frigga to extract tags based on the internal naming conventions.
+      netflix-keys = [
+        "nf.asg",
+        "aws.elb"
+      ]
+    }
+
+    // Categories to load. The name will be used to load another config block:
+    // atlas.cloudwatch.${name}
+    categories = [
+      "api-gateway",
+      "billing",
+      "dynamodb-table-1m",
+      "dynamodb-table-5m",
+      "dynamodb-table-ops",
+      "ec2",
+      "elasticache",
+      "elb",
+      "es",
+      "events",
+      "kinesis",
+      "rds",
+      "redshift",
+      "s3",
+      "sns",
+      "sqs",
+      "workflow",
+      "workflow-activity"
+    ]
+
+  }
+}
+
+include "api-gateway.conf"
+include "billing.conf"
+include "dynamodb.conf"
+include "ec2.conf"
+include "elasticache.conf"
+include "elb.conf"
+include "es.conf"
+include "events.conf"
+include "kinesis.conf"
+include "lambda.conf"
+include "rds.conf"
+include "redshift.conf"
+include "s3.conf"
+include "sns.conf"
+include "sqs.conf"
+include "swf.conf"

--- a/atlas-poller-cloudwatch/src/main/resources/s3.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/s3.conf
@@ -1,0 +1,29 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html
+    s3 = {
+      namespace = "AWS/S3"
+      period = 1d
+
+      dimensions = [
+        "BucketName",
+        "StorageType"
+      ]
+
+      metrics = [
+        {
+          name = "BucketSizeBytes"
+          alias = "aws.s3.bucketSizeBytes"
+          conversion = "max"
+        },
+        {
+          name = "NumberOfObjects"
+          alias = "aws.s3.numberOfObjects"
+          conversion = "max"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/resources/sns.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/sns.conf
@@ -1,0 +1,50 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/sns/latest/dg/MonitorSNSwithCloudWatch.html
+    sns = {
+      namespace = "AWS/SNS"
+      period = 5m
+
+      dimensions = [
+        "TopicName"
+      ]
+
+      metrics = [
+        {
+          name = "NumberOfMessagesPublished"
+          alias = "aws.sns.messagesPublished"
+          conversion = "sum,rate"
+        },
+        {
+          name = "NumberOfNotificationsDelivered"
+          alias = "aws.sns.notifications"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "delivered"
+            }
+          ]
+        },
+        {
+          name = "NumberOfNotificationsFailed"
+          alias = "aws.sns.notifications"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "failed"
+            }
+          ]
+        },
+        {
+          name = "PublishSize"
+          alias = "aws.sns.messageSize"
+          conversion = "dist-summary"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/resources/sqs.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/sqs.conf
@@ -1,0 +1,78 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQS_metricscollected.html
+    sqs = {
+      namespace = "AWS/SQS"
+      period = 5m
+
+      dimensions = [
+        "QueueName"
+      ]
+
+      filter = "aws.queue,.*[-_](i-[0-9a-z]+|[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})$,:re,aws.queue,(com_netflix_platform_testqueue2|ursula_demux_|prod_mce_link_s3_notifications-prod-|cloudBatchTestQueue|SyncMessageTestQueue|GPS_PRECOMPUTE|GPS_PAGE_BASIS_PRECOMPUTE|GPS_ROW_ADJUSTMENT|ocmon_test_),:re,:or,:not"
+
+      metrics = [
+        {
+          name = "ApproximateNumberOfMessagesDelayed"
+          alias = "aws.s3.approximateNumberOfMessages"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "delayed"
+            }
+          ]
+        },
+        {
+          name = "ApproximateNumberOfMessagesNotVisible"
+          alias = "aws.s3.approximateNumberOfMessages"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "not-visible"
+            }
+          ]
+        },
+        {
+          name = "ApproximateNumberOfMessagesVisible"
+          alias = "aws.s3.approximateNumberOfMessages"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "visible"
+            }
+          ]
+        },
+        {
+          name = "NumberOfMessagesSent"
+          alias = "aws.s3.messagesSent"
+          conversion = "sum,rate"
+        },
+        {
+          name = "NumberOfMessagesReceived"
+          alias = "aws.s3.messagesReceived"
+          conversion = "sum,rate"
+        },
+        {
+          name = "NumberOfMessagesDeleted"
+          alias = "aws.s3.messagesDeleted"
+          conversion = "sum,rate"
+        },
+        {
+          name = "NumberOfEmptyReceives"
+          alias = "aws.s3.emptyReceives"
+          conversion = "sum,rate"
+        },
+        {
+          name = "SentMessageSize"
+          alias = "aws.sns.messageSize"
+          conversion = "dist-summary"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/resources/swf.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/swf.conf
@@ -1,0 +1,231 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/amazonswf/latest/developerguide/cw-metrics.html
+    workflow = {
+      namespace = "AWS/SWF"
+      period = 1m
+
+      dimensions = [
+        "Domain",
+        "WorkflowTypeName",
+        "WorkflowTypeVersion"
+      ]
+
+      metrics = [
+        {
+          name = "DecisionTaskScheduleToStartTime"
+          alias = "aws.swf.decisionTaskTime"
+          conversion = "timer"
+          tags = [
+            {
+              key = "phase"
+              value = "scheduleToStart"
+            }
+          ]
+        },
+        {
+          name = "DecisionTaskStartToCloseTime"
+          alias = "aws.swf.decisionTaskTime"
+          conversion = "timer"
+          tags = [
+            {
+              key = "phase"
+              value = "startToClose"
+            }
+          ]
+        },
+        {
+          name = "DecisionTasksCompleted"
+          alias = "aws.swf.decisionTasksCompleted"
+          conversion = "sum,rate"
+        },
+        {
+          name = "WorkflowStartToCloseTime"
+          alias = "aws.swf.workflowExecutionTime"
+          conversion = "timer"
+        },
+        {
+          name = "WorkflowsCanceled"
+          alias = "aws.swf.workflows"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "cancelled"
+            }
+          ]
+        },
+        {
+          name = "WorkflowsCompleted"
+          alias = "aws.swf.workflows"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "completed"
+            }
+          ]
+        },
+        {
+          name = "WorkflowsContinuedAsNew"
+          alias = "aws.swf.workflows"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "continuedAsNew"
+            }
+          ]
+        },
+        {
+          name = "WorkflowsFailed"
+          alias = "aws.swf.workflows"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "failed"
+            }
+          ]
+        },
+        {
+          name = "WorkflowsTerminated"
+          alias = "aws.swf.workflows"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "terminated"
+            }
+          ]
+        },
+        {
+          name = "WorkflowsTimedOut"
+          alias = "aws.swf.workflows"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "timedOut"
+            }
+          ]
+        }
+      ]
+    }
+
+    workflow-activity = {
+      namespace = "AWS/SWF"
+      period = 1m
+
+      dimensions = [
+        "Domain",
+        "ActivityTypeName",
+        "ActivityTypeVersion"
+      ]
+
+      metrics = [
+        {
+          name = "ActivityTaskScheduleToStartTime"
+          alias = "aws.swf.activityTaskTime"
+          conversion = "timer"
+          tags = [
+            {
+              key = "phase"
+              value = "scheduleToStart"
+            }
+          ]
+        },
+        {
+          name = "ActivityTaskStartToCloseTime"
+          alias = "aws.swf.activityTaskTime"
+          conversion = "timer"
+          tags = [
+            {
+              key = "phase"
+              value = "startToClose"
+            }
+          ]
+        },
+        {
+          name = "ActivityTasksCanceled"
+          alias = "aws.swf.activityTasks"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "cancelled"
+            }
+          ]
+        },
+        {
+          name = "ActivityTasksCompleted"
+          alias = "aws.swf.activityTasks"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "completed"
+            }
+          ]
+        },
+        {
+          name = "ActivityTasksFailed"
+          alias = "aws.swf.activityTasks"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "failed"
+            }
+          ]
+        },
+        {
+          name = "ScheduledActivityTasksTimedOutOnClose"
+          alias = "aws.swf.activityTaskFailures"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "scheduledTimedOutOnClose"
+            }
+          ]
+        },
+        {
+          name = "ScheduledActivityTasksTimedOutOnStart"
+          alias = "aws.swf.activityTaskFailures"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "scheduledTimedOutOnStart"
+            }
+          ]
+        },
+        {
+          name = "StartedActivityTasksTimedOutOnClose"
+          alias = "aws.swf.activityTaskFailures"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "startedTimedOutOnClose"
+            }
+          ]
+        },
+        {
+          name = "StartedActivityTasksTimedOutOnHeartbeat"
+          alias = "aws.swf.activityTaskFailures"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "startedTimedOutOnHeartbeat"
+            }
+          ]
+        },
+      ]
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+
+import akka.actor.Actor
+import akka.actor.ActorRef
+import akka.actor.Props
+import akka.routing.FromConfig
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
+import com.amazonaws.services.cloudwatch.model.Datapoint
+import com.netflix.atlas.poller.Messages
+import com.netflix.spectator.api.Functions
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+
+/**
+  * Poller for fetching data from CloudWatch and reporting the data into Atlas.
+  *
+  * @param config
+  *     Config for setting up the poller. See the reference.conf for more details
+  *     about the settings.
+  * @param registry
+  *     Registry for reporting metrics. The primary metrics are:
+  *
+  *     - `atlas.cloudwatch.listAge`: gauge showing the age in seconds of the list
+  *       metadata.
+  *     - `atlas.cloudwatch.listSize`: gauge showing the number of metrics found
+  *       by calling list metrics on CloudWatch.
+  *     - `atlas.cloudwatch.pendingGets`: gauge showing the number of metric get
+  *       requests that are currently in-flight. This should be less than the
+  *       list size or the system is starting to back up.
+  *
+  *     More detailed metrics on the specific AWS calls can be used by configuring
+  *     the `spectator-ext-aws` metric collector with the SDK.
+  * @param client
+  *     AWS CloudWatch client.
+  */
+class CloudWatchPoller(config: Config, registry: Registry, client: AmazonCloudWatch)
+  extends Actor with StrictLogging {
+
+  import CloudWatchPoller._
+
+  // Load the categories and tagger based on the config settings
+  private val categories = getCategories(config)
+  private val tagger = getTagger(config)
+
+  // Metadata for the metrics in CloudWatch that we need to fetch and how to
+  // map them into Atlas metrics.
+  private val metricsMetadata = new AtomicReference[List[MetricMetadata]](Nil)
+
+  // Child actor for getting the data for a metric. This will do the call using the
+  // AWS SDK which is blocking and should be run in an isolated dispatcher.
+  private val metricsGetRef = context.actorOf(
+    FromConfig.props(Props(new GetMetricActor(client))), "metrics-get")
+
+  // Child actor for listing metrics. This will do the call using the
+  // AWS SDK which is blocking and should be run in an isolated dispatcher.
+  private val metricsListRef = context.actorOf(
+    FromConfig.props(Props(new ListMetricsActor(client, tagger))), "metrics-list")
+
+  // Batch size to use for flushing data back to the poller manager.
+  private val batchSize = config.getInt("atlas.cloudwatch.batch-size")
+
+  // Actor that sent the Tick message and that should receive the response.
+  private var responder: ActorRef = _
+
+  // Indicates if a list operation is currently in-flight. Only one list operation
+  // should be running at a time.
+  private var pendingList: Boolean = false
+
+  // Last time the metadata list was successfully updated.
+  private val listUpdateTime: AtomicLong = registry.gauge(
+    "atlas.cloudwatch.listAge",
+    new AtomicLong(registry.clock().wallTime()),
+    Functions.age(registry.clock()))
+
+  // Size of the metadata list. Compare with pending gets to get an idea of
+  // how well we are keeping up with polling all of the data.
+  private val listSize: AtomicLong = registry.gauge(
+    "atlas.cloudwatch.listSize",
+    new AtomicLong(0L))
+
+  // Number of get requests that are in-flight.
+  private val pendingGets: AtomicLong = registry.gauge(
+    "atlas.cloudwatch.pendingGets",
+    new AtomicLong(0L))
+
+  // List keeping track of current batch of metric data.
+  private var metricBatch: MList = new MList
+
+  def receive: Receive = {
+    case Messages.Tick   => refresh()               // From PollerManager
+    case m: MetricData   => processMetricData(m)    // Response from GetMetricActor
+    case MetricList(ms)  => processMetricList(ms)   // Response from ListMetricsActor
+  }
+
+  private def refresh(): Unit = {
+    responder = sender()
+    refreshMetricsList()
+    fetchMetricsData()
+  }
+
+  /** Refresh the metadata list if one is not already in progress. */
+  private def refreshMetricsList(): Unit = {
+    if (pendingList) {
+      logger.debug(s"list already in progress, skipping")
+    } else {
+      logger.info(s"refreshing list of cloudwatch metrics for ${categories.size} categories")
+      pendingList = true
+      metricsListRef ! ListMetrics(categories)
+    }
+  }
+
+  /** Schedule all metrics in the metadata list for a refresh. */
+  private def fetchMetricsData(): Unit = {
+    if (pendingGets.get() > 0) {
+      logger.warn(s"not keeping up, still have ${pendingGets.get()} metrics pending")
+    }
+    val ms = metricsMetadata.get()
+    pendingGets.addAndGet(ms.size)
+    logger.info(s"requesting data for ${ms.size} metrics")
+    ms.foreach { m => metricsGetRef ! m }
+  }
+
+  /**
+    * Process the returned list of metrics. An empty list will get ignored as it is likely
+    * in error. The `atlas.cloudwatch.listAge` metric can be used to monitor how long it
+    * has been since the metadata was succesfully updated.
+    */
+  private def processMetricList(ms: List[MetricMetadata]): Unit = {
+    pendingList = false
+    if (ms.nonEmpty) {
+      listUpdateTime.set(registry.clock().wallTime())
+      val size = ms.size
+      logger.info(s"found $size cloudwatch metrics")
+      listSize.set(size)
+      metricsMetadata.set(ms)
+    } else {
+      logger.warn("no cloudwatch metrics found")
+    }
+  }
+
+  /** Add a datapoint to the current batch. */
+  private def processMetricData(data: MetricData): Unit = {
+    pendingGets.decrementAndGet()
+    data.data.foreach { d =>
+      val meta = data.meta
+      val ts = tagger(meta.dimensions) ++ meta.definition.tags + ("name" -> meta.definition.alias)
+      val now = System.currentTimeMillis()
+      val newValue = meta.convert(d)
+      metricBatch += new AtlasDatapoint(ts, now, newValue)
+    }
+    flush()
+  }
+
+  /** Flush data if the batch size is big enough or we are done with the current iteration. */
+  private def flush(): Unit = {
+    if (metricBatch.nonEmpty && (pendingGets.get() <= 0 || metricBatch.size > batchSize)) {
+      val batch = metricBatch.toList
+      metricBatch.clear()
+      logger.info(s"writing ${batch.size} metrics to client")
+      responder ! Messages.MetricsPayload(Map.empty, metricBatch.toList)
+    }
+  }
+}
+
+object CloudWatchPoller {
+
+  private def getCategories(config: Config): List[MetricCategory] = {
+    import scala.collection.JavaConverters._
+    val categories = config.getStringList("atlas.cloudwatch.categories").asScala.map { name =>
+      val cfg = config.getConfig(s"atlas.cloudwatch.$name")
+      MetricCategory.fromConfig(cfg)
+    }
+    categories.toList
+  }
+
+  private def getTagger(config: Config): Tagger = {
+    val cfg = config.getConfig("atlas.cloudwatch.tagger")
+    val cls = Class.forName(cfg.getString("class"))
+    cls.getConstructor(classOf[Config]).newInstance(cfg).asInstanceOf[Tagger]
+  }
+
+  case class GetMetricData(metric: MetricMetadata)
+
+  case class MetricData(meta: MetricMetadata, data: Option[Datapoint])
+
+  case class ListMetrics(categories: List[MetricCategory])
+
+  case class MetricList(data: List[MetricMetadata])
+}

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/Conversions.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/Conversions.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import com.amazonaws.services.cloudwatch.model.Datapoint
+import com.amazonaws.services.cloudwatch.model.StandardUnit
+
+/**
+  * Helpers for creating conversion functions to extract the value from a cloudwatch
+  * datapoint and normalize it to follow Atlas conventions.
+  */
+object Conversions {
+
+  /**
+    * Create a new conversion based on a simple comma separated list of known mappings.
+    * The first element should be the statistic to extract. Allowed values are: `min`,
+    * `max`, `sum`, `count`, and `avg`.
+    *
+    * This can optionally be followed by a rate conversion, e.g., `sum,rate`. The rate
+    * will divide the value by the sample period from the cloudwatch metadata to get a
+    * rate per second for the value. The rate conversion is unit aware, so if the unit
+    * for the datapoint is already a rate, then no conversion will take place.
+    *
+    * In addition to the conversions specified by name, a unit conversion will automatically
+    * be applied to the data. This ensures that a base unit is reported.
+    */
+  def fromName(name: String): Conversion = {
+    val conversions = name.split(",").toList.reverse
+    unit(from(name, conversions))
+  }
+
+  private def from(name: String, conversions: List[String]): Conversion = {
+    conversions match {
+      case "min"    :: Nil => min
+      case "max"    :: Nil => max
+      case "sum"    :: Nil => sum
+      case "count"  :: Nil => count
+      case "avg"    :: Nil => avg
+      case "rate"   :: cs  => rate(from(name, cs))
+      case v        :: cs  => throw new IllegalArgumentException(s"unknown conversion '$v' ($name)")
+      case Nil             => throw new IllegalArgumentException(s"empty conversion list ($name)")
+    }
+  }
+
+  private def min:   Conversion = (_, d) => d.getMinimum
+  private def max:   Conversion = (_, d) => d.getMaximum
+  private def sum:   Conversion = (_, d) => d.getSum
+  private def count: Conversion = (_, d) => d.getSampleCount
+  private def avg:   Conversion = (_, d) => d.getSum / d.getSampleCount
+
+  private def unit(f: Conversion): Conversion = (m, d) => {
+    val factor = unitFactor(d.getUnit)
+    val newDatapoint = new Datapoint()
+      .withMinimum(d.getMinimum * factor)
+      .withMaximum(d.getMaximum * factor)
+      .withSum(d.getSum * factor)
+      .withSampleCount(d.getSampleCount)
+      .withTimestamp(d.getTimestamp)
+      .withUnit(d.getUnit)
+    f(m, newDatapoint)
+  }
+
+  /**
+    * Convert the result to a rate per second if it is not already. If the unit
+    * for the datapoint indicates it is already a rate, then the value will not
+    * be modified.
+    */
+  private def rate(f: Conversion): Conversion = (m, d) => {
+    val v = f(m, d)
+    val unit = d.getUnit
+    if (unit.endsWith("/Second")) v else v / m.category.period
+  }
+
+  /** Modifies a conversion `f` to multiply the result by `v`. */
+  def multiply(f: Conversion, v: Double): Conversion = (m, d) => f(m, d) * v
+
+  /** Modifies a datapoint so that it has the specified unit. */
+  def toUnit(f: Conversion, unit: StandardUnit): Conversion = (m, d) => {
+    val newDatapoint = new Datapoint()
+      .withMinimum(d.getMinimum)
+      .withMaximum(d.getMaximum)
+      .withSum(d.getSum)
+      .withSampleCount(d.getSampleCount)
+      .withTimestamp(d.getTimestamp)
+      .withUnit(unit)
+    f(m, newDatapoint)
+  }
+
+  private def unitFactor(unit: String): Double = {
+    StandardUnit.fromValue(unit) match {
+      case StandardUnit.Count           => 1.0
+
+      //  Use a base unit of bytes
+      case StandardUnit.Bits            => 1.0  / 8.0
+      case StandardUnit.Kilobits        => 1e3  / 8.0
+      case StandardUnit.Megabits        => 1e6  / 8.0
+      case StandardUnit.Gigabits        => 1e9  / 8.0
+      case StandardUnit.Terabits        => 1e12 / 8.0
+
+      // Use a base unit of bytes. Assumes that the raw input is using
+      // a decimal multiple, i.e., multiples of 1000 not 1024.
+      case StandardUnit.Bytes           => 1.0
+      case StandardUnit.Kilobytes       => 1e3
+      case StandardUnit.Megabytes       => 1e6
+      case StandardUnit.Gigabytes       => 1e9
+      case StandardUnit.Terabytes       => 1e12
+
+      case StandardUnit.CountSecond     => 1.0
+
+      // Use base unit of bytes/second
+      case StandardUnit.BitsSecond      => 1.0  / 8.0
+      case StandardUnit.KilobitsSecond  => 1e3  / 8.0
+      case StandardUnit.MegabitsSecond  => 1e6  / 8.0
+      case StandardUnit.GigabitsSecond  => 1e9  / 8.0
+      case StandardUnit.TerabitsSecond  => 1e12 / 8.0
+
+      // Use base unit of bytes/second
+      case StandardUnit.BytesSecond     => 1.0
+      case StandardUnit.KilobytesSecond => 1e3
+      case StandardUnit.MegabytesSecond => 1e6
+      case StandardUnit.GigabytesSecond => 1e9
+      case StandardUnit.TerabytesSecond => 1e12
+
+      // Use base unit of seconds
+      case StandardUnit.Microseconds    => 1e-6
+      case StandardUnit.Milliseconds    => 1e-3
+      case StandardUnit.Seconds         => 1.0
+
+      case StandardUnit.Percent         => 1.0
+      case StandardUnit.None            => 1.0
+    }
+  }
+
+}

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/DefaultTagger.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/DefaultTagger.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import com.amazonaws.services.cloudwatch.model.Dimension
+import com.typesafe.config.Config
+
+/**
+  * Tag datapoints with a set of common tags. Also allows mapping cloudwatch
+  * dimension names to names that match some other convention. For example,
+  * the cloudwatch dimension name AutoScalingGroupName corresponds to nf.asg
+  * and we would rather have a single key in use for common concepts.
+  */
+class DefaultTagger(config: Config) extends Tagger {
+  import scala.collection.JavaConverters._
+
+  private val mappings: Map[String, String] = config.getConfigList("mappings")
+    .asScala
+    .map(c => c.getString("name") -> c.getString("alias"))
+    .toMap
+
+  private val commonTags: Map[String, String] = config.getConfigList("common-tags")
+    .asScala
+    .map(c => c.getString("key") -> c.getString("value"))
+    .toMap
+
+  private def toTag(dimension: Dimension): (String, String) = {
+    mappings.getOrElse(dimension.getName, dimension.getName) -> dimension.getValue
+  }
+
+  override def apply(dimensions: List[Dimension]): Map[String, String] = {
+    commonTags ++ dimensions.map(toTag).toMap
+  }
+}
+

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/GetMetricActor.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/GetMetricActor.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import java.time.Instant
+
+import akka.actor.Actor
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
+import com.amazonaws.services.cloudwatch.model.Datapoint
+import com.typesafe.scalalogging.StrictLogging
+
+/**
+  * Queries CloudWatch to get a datapoint for given metric. This actor makes blocking
+  * calls to the Amazon SDK, it should be run in a dedicated dispatcher.
+  */
+class GetMetricActor(client: AmazonCloudWatch) extends Actor with StrictLogging {
+  import CloudWatchPoller._
+
+  def receive: Receive = {
+    case m: MetricMetadata => sender() ! MetricData(m, getMetric(m))
+  }
+
+  /**
+    * Queries cloudwatch for two periods of the metric and returns the most recent
+    * value or None if no values were reported in that window.
+    */
+  private def getMetric(m: MetricMetadata): Option[Datapoint] = {
+    try {
+      import scala.collection.JavaConverters._
+      val e = Instant.now().minusSeconds(m.category.period)
+      val s = e.minusSeconds(2 * m.category.period)
+      val request = m.toGetRequest(s, e)
+      val result = client.getMetricStatistics(request)
+
+      // Datapoints might not be ordered by time, sort before using
+      val datapoints = result.getDatapoints.asScala.toList
+      val sorted = datapoints
+        .filter(!_.getSum.isNaN)
+        .sortWith(_.getTimestamp.getTime > _.getTimestamp.getTime)
+      sorted.headOption
+    } catch {
+      case e: Exception =>
+        logger.warn(s"failed to get data for ${m.category.namespace}/${m.definition.name}", e)
+        None
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/ListMetricsActor.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/ListMetricsActor.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import akka.actor.Actor
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
+import com.amazonaws.services.cloudwatch.model.ListMetricsRequest
+import com.amazonaws.services.cloudwatch.model.Metric
+import com.typesafe.scalalogging.StrictLogging
+
+/**
+  * Queries CloudWatch to get a list of for available metrics. This actor makes blocking
+  * calls to the Amazon SDK, it should be run in a dedicated dispatcher.
+  */
+class ListMetricsActor(client: AmazonCloudWatch, tagger: Tagger) extends Actor with StrictLogging {
+  import CloudWatchPoller._
+
+  def receive: Receive = {
+    case ListMetrics(categories) => sender() ! MetricList(listMetrics(categories))
+  }
+
+  private def listMetrics(categories: List[MetricCategory]): List[MetricMetadata] = {
+    try {
+      val builder = categories.foldLeft(List.newBuilder[MetricMetadata]) { (acc, c) =>
+        acc ++= listMetrics(c)
+      }
+      builder.result()
+    } catch {
+      case e: Exception =>
+        logger.warn("failed to list metrics", e)
+        Nil
+    }
+  }
+
+  private def listMetrics(category: MetricCategory): List[MetricMetadata] = {
+    import scala.collection.JavaConverters._
+    category.toListRequests.flatMap { case (definition, request) =>
+      val mname = s"${category.namespace}/${definition.name}"
+      logger.debug(s"refreshing list for $mname")
+      val candidates = listMetrics(request, Nil).map { m =>
+        MetricMetadata(category, definition, m.getDimensions.asScala.toList)
+      }
+      logger.debug(s"before filtering, found ${candidates.size} metrics for $mname")
+      val after = candidates.filter { m => category.filter.matches(tagger(m.dimensions)) }
+      logger.debug(s"after filtering, found ${after.size} metrics for $mname")
+      after
+    }
+  }
+
+  @scala.annotation.tailrec
+  private def listMetrics(request: ListMetricsRequest, metrics: List[Metric]): List[Metric] = {
+    import scala.collection.JavaConverters._
+    val result = client.listMetrics(request)
+    val ms = metrics ++ result.getMetrics.asScala
+    if (result.getNextToken == null) ms else {
+      listMetrics(request.withNextToken(result.getNextToken), ms)
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricCategory.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricCategory.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import java.util.concurrent.TimeUnit
+
+import com.amazonaws.services.cloudwatch.model.DimensionFilter
+import com.amazonaws.services.cloudwatch.model.ListMetricsRequest
+import com.netflix.atlas.core.model.Query
+import com.netflix.atlas.core.model.QueryVocabulary
+import com.netflix.atlas.core.stacklang.Interpreter
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+
+/**
+  * Category of metrics to fetch from cloudwatch. This will typically correspond with
+  * a CloudWatch namespace, though there may be multiple categories per namespace if
+  * there is some variation in the behavior. For example, some namespaces will use a
+  * different period for some metrics.
+  *
+  * @param namespace
+  *     CloudWatch namespace for the data.
+  * @param period
+  *     How frequently data in this category is updated. Atlas is meant for data that
+  *     is continuously reported and requires a consistent step. To minimize confusion
+  *     for cloudwatch data we use the last reported value in cloudwatch as long as it
+  *     is within one period from the polling time. The period is also needed for
+  *     performing rate conversions on some metrics.
+  * @param dimensions
+  *     The dimensions to query for when getting data from cloudwatch. For the
+  *     GetMetricData calls we have to explicitly specify all of the dimensions. In some
+  *     cases CloudWatch has duplicate data for pre-computed aggregates. For example,
+  *     ELB data is reported overall for the load balancer and by zone. For Atlas it
+  *     is better to map in the most granular form and allow the aggregate to be done
+  *     dynamically at query time.
+  * @param metrics
+  *     The set of metrics to fetch and metadata for how to convert them.
+  * @param filter
+  *     Query expression used to select the set of metrics which should get published.
+  *     This can sometimes be useful for debugging or if there are many "spammy" metrics
+  *     for a given category.
+  */
+case class MetricCategory(
+  namespace: String,
+  period: Int,
+  dimensions: List[String],
+  metrics: List[MetricDefinition],
+  filter: Query) {
+
+  /**
+    * Returns a set of list requests to fetch the metadata for the metrics matching
+    * this category. As there may be a lot of data in cloudwatch that we are not
+    * interested in, the list is used to restrict to the subset we actually care
+    * about rather than a single request fetching everything for the namespace.
+    */
+  def toListRequests: List[(MetricDefinition, ListMetricsRequest)] = {
+    import scala.collection.JavaConverters._
+    metrics.map { m =>
+      m -> new ListMetricsRequest()
+        .withNamespace(namespace)
+        .withMetricName(m.name)
+        .withDimensions(dimensions.map(d => new DimensionFilter().withName(d)).asJava)
+    }
+  }
+}
+
+object MetricCategory extends StrictLogging {
+
+  private val interpreter = Interpreter(QueryVocabulary.allWords)
+
+  private def parseQuery(query: String): Query = {
+    interpreter.execute(query).stack match {
+      case (q: Query) :: Nil => q
+      case _  =>
+        logger.warn(s"invalid query '$query', using default of ':true'")
+        Query.True
+    }
+  }
+
+  def fromConfig(config: Config): MetricCategory = {
+    import scala.collection.JavaConverters._
+    val metrics = config.getConfigList("metrics").asScala.toList
+    val filter = if (!config.hasPath("filter")) Query.True else {
+      parseQuery(config.getString("filter"))
+    }
+    apply(
+      namespace = config.getString("namespace"),
+      period = config.getDuration("period", TimeUnit.SECONDS).toInt,
+      dimensions = config.getStringList("dimensions").asScala.toList,
+      metrics = metrics.flatMap(MetricDefinition.fromConfig),
+      filter = filter
+    )
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricDefinition.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricDefinition.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import com.amazonaws.services.cloudwatch.model.Datapoint
+import com.amazonaws.services.cloudwatch.model.StandardUnit
+import com.typesafe.config.Config
+
+/**
+  * Definition for a particular cloudwatch metric.
+  *
+  * @param name
+  *     Name of the metric as it is stored in CloudWatch.
+  * @param alias
+  *     Alias to make the metric follow Atlas naming conventions.
+  * @param conversion
+  *     Conversion to apply to the datapoint when extracting the value. See [[Conversions]]
+  *     for more information.
+  * @param tags
+  *     Tags that should be applied to the metric.
+  */
+case class MetricDefinition(
+  name: String,
+  alias: String,
+  conversion: (MetricMetadata, Datapoint) => Double,
+  tags: Map[String, String])
+
+object MetricDefinition {
+
+  /**
+    * Create a set of metric definitions from a config. In most cases the list will have
+    * a single item if using a standard conversion from [[Conversions]]. Three composite
+    * types are supported: `timer`, `timer-millis`, and `dist-summary`. These will get
+    * mapped in as close as possible to way spectator would map in those types. The primary
+    * gap is that with CloudWatch we cannot get a totalOfSquares so the standard deviation
+    * cannot be computed.
+    *
+    * Note, `timer` should generally be preferred over `timer-millis`. If the unit is
+    * specified on the datapoint, then it will automatically convert to seconds. When using
+    * `timer-millis` the unit is ignored and the data will be assumed to be in milliseconds.
+    * It is mostly intended for use with some latency values that do not explicitly mark the
+    * unit.
+    */
+  def fromConfig(config: Config): List[MetricDefinition] = {
+    import scala.collection.JavaConverters._
+    val tags = if (!config.hasPath("tags")) Map.empty[String, String] else {
+      config.getConfigList("tags").asScala
+        .map(c => c.getString("key") -> c.getString("value"))
+        .toMap
+    }
+
+    config.getString("conversion") match {
+      case "timer"          => newDist(config, "totalTime", tags)
+      case "timer-millis"   => milliTimer(config, tags)
+      case "dist-summary"   => newDist(config, "totalAmount", tags)
+      case cnv              => List(newMetricDef(config, cnv, tags))
+    }
+  }
+
+  /**
+    * Note, count must come first so it is easy to skip for other unit conversions. See
+    * [[milliTimer]] for example.
+    */
+  private def newDist(config: Config, total: String, tags: Tags): List[MetricDefinition] = {
+    List(
+      newMetricDef(config, "count,rate", tags + ("statistic" -> "count")),
+      newMetricDef(config, "sum,rate",   tags + ("statistic" -> total)),
+      newMetricDef(config, "max",        tags + ("statistic" -> "max"))
+    )
+  }
+
+  /**
+    * Timer where the input unit is milliseconds and we need to perform an unit conversion
+    * on the totalTime and max results.
+    */
+  private def milliTimer(config: Config, tags: Tags): List[MetricDefinition] = {
+    val ms = newDist(config, "totalTime", tags)
+    ms.head :: ms.tail.map { m =>
+      m.copy(conversion = Conversions.toUnit(m.conversion, StandardUnit.Milliseconds))
+    }
+  }
+
+  private def newMetricDef(config: Config, cnv: String, tags: Tags): MetricDefinition = {
+    MetricDefinition(
+      name = config.getString("name"),
+      alias = config.getString("alias"),
+      conversion = Conversions.fromName(cnv),
+      tags = tags
+    )
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricMetadata.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricMetadata.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import java.time.Instant
+import java.util.Date
+
+import com.amazonaws.services.cloudwatch.model.Datapoint
+import com.amazonaws.services.cloudwatch.model.Dimension
+import com.amazonaws.services.cloudwatch.model.GetMetricStatisticsRequest
+import com.amazonaws.services.cloudwatch.model.Statistic
+
+/**
+  * Metadata for a particular metric to retrieve from CloudWatch.
+  */
+case class MetricMetadata(
+  category: MetricCategory,
+  definition: MetricDefinition,
+  dimensions: List[Dimension]) {
+
+  def convert(d: Datapoint): Double = definition.conversion(this, d)
+
+  def toGetRequest(s: Instant, e: Instant): GetMetricStatisticsRequest = {
+    import scala.collection.JavaConverters._
+    new GetMetricStatisticsRequest()
+      .withMetricName(definition.name)
+      .withNamespace(category.namespace)
+      .withDimensions(dimensions.asJava)
+      .withStatistics(Statistic.Maximum, Statistic.Minimum, Statistic.Sum, Statistic.SampleCount)
+      .withPeriod(category.period)
+      .withStartTime(new Date(s.toEpochMilli))
+      .withEndTime(new Date(e.toEpochMilli))
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/NetflixTagger.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/NetflixTagger.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import com.amazonaws.services.cloudwatch.model.Dimension
+import com.netflix.frigga.Names
+import com.typesafe.config.Config
+
+/**
+  * Tag the datapoints using Frigga to extract app and cluster information based
+  * on naming conventions used by Spinnaker and Asgard.
+  */
+class NetflixTagger(config: Config) extends DefaultTagger(config) {
+  import scala.collection.JavaConverters._
+
+  private val keys = config.getStringList("netflix-keys").asScala
+
+  private def opt(k: String, s: String): Option[(String, String)] = {
+    Option(s).filter(_ != "").map(v => k -> v)
+  }
+
+  override def apply(dimensions: List[Dimension]): Map[String, String] = {
+    val baseTags = super.apply(dimensions)
+    val extractedTags = keys.flatMap { k =>
+      baseTags.get(k).map { v =>
+        val name = Names.parseName(v)
+        List(
+          opt("nf.app",     name.getApp),
+          opt("nf.cluster", name.getCluster),
+          opt("nf.stack",   name.getStack)
+        ).flatten
+      }
+    }
+    extractedTags.flatten.toMap ++ baseTags
+  }
+}
+

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/package.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/package.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas
+
+import com.amazonaws.services.cloudwatch.model.Datapoint
+import com.amazonaws.services.cloudwatch.model.Dimension
+
+/**
+  * Helper types used in this package.
+  */
+package object cloudwatch {
+  type Tags = Map[String, String]
+
+  /**
+    * Converts a list of cloudwatch dimensions into a tag map that can be used
+    * for Atlas.
+    */
+  type Tagger = List[Dimension] => Tags
+
+  /**
+    * Converts a cloudwatch datapoint to a floating point value. The conversion is
+    * based on the corresponding [[MetricDefinition]]. The full metadata is passed
+    * in to allow access to other information that can be useful, such as the period
+    * used for reporting the data into cloudwatch.
+    */
+  type Conversion = (MetricMetadata, Datapoint) => Double
+
+  type AtlasDatapoint = com.netflix.atlas.core.model.Datapoint
+  type MList = scala.collection.mutable.ListBuffer[AtlasDatapoint]
+}

--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionsSuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionsSuite.scala
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import java.util.Date
+
+import com.amazonaws.services.cloudwatch.model.Datapoint
+import com.amazonaws.services.cloudwatch.model.StandardUnit
+import com.netflix.atlas.core.model.Query
+import org.scalatest.FunSuite
+
+class ConversionsSuite extends FunSuite {
+
+  private val dp = new Datapoint()
+    .withMinimum(1.0)
+    .withMaximum(5.0)
+    .withSum(6.0)
+    .withSampleCount(2.0)
+    .withTimestamp(new Date)
+    .withUnit(StandardUnit.None)
+
+  private def newDatapoint(v: Double, unit: StandardUnit = StandardUnit.None): Datapoint = {
+    new Datapoint()
+      .withMinimum(v)
+      .withMaximum(v)
+      .withSum(v)
+      .withSampleCount(1.0)
+      .withTimestamp(new Date)
+      .withUnit(unit)
+  }
+
+  test("min") {
+    val cnv = Conversions.fromName("min")
+    val v = cnv(null, dp)
+    assert(v === 1.0)
+  }
+
+  test("max") {
+    val cnv = Conversions.fromName("max")
+    val v = cnv(null, dp)
+    assert(v === 5.0)
+  }
+
+  test("sum") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, dp)
+    assert(v === 6.0)
+  }
+
+  test("count") {
+    val cnv = Conversions.fromName("count")
+    val v = cnv(null, dp)
+    assert(v === 2.0)
+  }
+
+  test("avg") {
+    val cnv = Conversions.fromName("avg")
+    val v = cnv(null, dp)
+    assert(v === 3.0)
+  }
+
+  test("rate") {
+    val cnv = Conversions.fromName("sum,rate")
+    val meta = MetricMetadata(
+      MetricCategory("NFLX/Test", 300, Nil, Nil, Query.True),
+      MetricDefinition("test", "test-alias", cnv, Map.empty),
+      Nil)
+    val v = cnv(meta, dp)
+    assert(v === 6.0 / 300.0)
+  }
+
+  test("rate already") {
+    val cnv = Conversions.fromName("sum,rate")
+    val meta = MetricMetadata(
+      MetricCategory("NFLX/Test", 300, Nil, Nil, Query.True),
+      MetricDefinition("test", "test-alias", cnv, Map.empty),
+      Nil)
+    val v = cnv(meta, newDatapoint(6.0, StandardUnit.BytesSecond))
+    assert(v === 6.0)
+  }
+
+  test("bad conversion") {
+    intercept[IllegalArgumentException] {
+      Conversions.fromName("foo")
+    }
+  }
+
+  test("empty conversion") {
+    intercept[IllegalArgumentException] {
+      Conversions.fromName("")
+    }
+  }
+
+  test("missing conversion") {
+    intercept[IllegalArgumentException] {
+      Conversions.fromName("rate") // Rate must be used with another conversion
+    }
+  }
+
+  test("unit count") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.Count))
+    assert(v === 42.0)
+  }
+
+  test("unit bits") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.Bits))
+    assert(v === 42.0 / 8.0)
+  }
+
+  test("unit kilobits") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.Kilobits))
+    assert(v === 1e3 * 42.0 / 8.0)
+  }
+
+  test("unit megabits") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.Megabits))
+    assert(v === 1e6 * 42.0 / 8.0)
+  }
+
+  test("unit gigabits") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.Gigabits))
+    assert(v === 1e9 * 42.0 / 8.0)
+  }
+
+  test("unit terabits") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.Terabits))
+    assert(v === 1e12 * 42.0 / 8.0)
+  }
+
+  test("unit bytes") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.Bytes))
+    assert(v === 42.0)
+  }
+
+  test("unit kilobytes") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.Kilobytes))
+    assert(v === 1e3 * 42.0)
+  }
+
+  test("unit megabytes") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.Megabytes))
+    assert(v === 1e6 * 42.0)
+  }
+
+  test("unit gigabytes") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.Gigabytes))
+    assert(v === 1e9 * 42.0)
+  }
+
+  test("unit terabytes") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.Terabytes))
+    assert(v === 1e12 * 42.0)
+  }
+
+  test("unit bits/second") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.BitsSecond))
+    assert(v === 42.0 / 8.0)
+  }
+
+  test("unit kilobits/second") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.KilobitsSecond))
+    assert(v === 1e3 * 42.0 / 8.0)
+  }
+
+  test("unit megabits/second") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.MegabitsSecond))
+    assert(v === 1e6 * 42.0 / 8.0)
+  }
+
+  test("unit gigabits/second") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.GigabitsSecond))
+    assert(v === 1e9 * 42.0 / 8.0)
+  }
+
+  test("unit terabits/second") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.TerabitsSecond))
+    assert(v === 1e12 * 42.0 / 8.0)
+  }
+
+  test("unit bytes/second") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.BytesSecond))
+    assert(v === 42.0)
+  }
+
+  test("unit kilobytes/second") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.KilobytesSecond))
+    assert(v === 1e3 * 42.0)
+  }
+
+  test("unit megabytes/second") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.MegabytesSecond))
+    assert(v === 1e6 * 42.0)
+  }
+
+  test("unit gigabytes/second") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.GigabytesSecond))
+    assert(v === 1e9 * 42.0)
+  }
+
+  test("unit terabytes/second") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.TerabytesSecond))
+    assert(v === 1e12 * 42.0)
+  }
+
+  test("unit microseconds") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.Microseconds))
+    assert(v === 1e-6 * 42.0)
+  }
+
+  test("unit milliseconds") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.Milliseconds))
+    assert(v === 1e-3 * 42.0)
+  }
+
+  test("unit seconds") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.Seconds))
+    assert(v === 42.0)
+  }
+
+  test("unit percent") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.Percent))
+    assert(v === 42.0)
+  }
+
+  test("unit none") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.None))
+    assert(v === 42.0)
+  }
+
+  test("multiply") {
+    val cnv = Conversions.multiply(Conversions.fromName("sum"), 100.0)
+    val v = cnv(null, newDatapoint(42.0))
+    assert(v === 4200.0)
+  }
+}

--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/DefaultTaggerSuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/DefaultTaggerSuite.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import com.amazonaws.services.cloudwatch.model.Dimension
+import com.typesafe.config.ConfigException
+import com.typesafe.config.ConfigFactory
+import org.scalatest.FunSuite
+
+class DefaultTaggerSuite extends FunSuite {
+
+  private val dimensions = List(
+    new Dimension().withName("CloudWatch").withValue("abc"),
+    new Dimension().withName("NoMapping").withValue("def")
+  )
+
+  test("bad config") {
+    val cfg = ConfigFactory.parseString("")
+    intercept[ConfigException] {
+      new DefaultTagger(cfg)
+    }
+  }
+
+  test("add common tags") {
+    val cfg = ConfigFactory.parseString(
+      """
+        |mappings = []
+        |common-tags = [
+        |  {
+        |    key = "foo"
+        |    value = "bar"
+        |  }
+        |]
+      """.stripMargin)
+
+    val expected = Map(
+      "foo"           -> "bar",
+      "CloudWatch"    -> "abc",
+      "NoMapping"     -> "def"
+    )
+
+    val tagger = new DefaultTagger(cfg)
+    assert(tagger(dimensions) === expected)
+  }
+
+  test("apply key mappings") {
+    val cfg = ConfigFactory.parseString(
+      """
+        |mappings = [
+        |  {
+        |    name = "CloudWatch"
+        |    alias = "InternalAlias"
+        |  }
+        |]
+        |common-tags = []
+      """.stripMargin)
+
+    val expected = Map(
+      "InternalAlias" -> "abc",
+      "NoMapping"     -> "def"
+    )
+
+    val tagger = new DefaultTagger(cfg)
+    assert(tagger(dimensions) === expected)
+  }
+
+  test("dimensions override common tags") {
+    val cfg = ConfigFactory.parseString(
+      """
+        |mappings = [
+        |  {
+        |    name = "CloudWatch"
+        |    alias = "foo"
+        |  }
+        |]
+        |common-tags = [
+        |  {
+        |    key = "foo"
+        |    value = "bar"
+        |  }
+        |]
+      """.stripMargin)
+
+    val expected = Map(
+      "foo"           -> "abc",
+      "NoMapping"     -> "def"
+    )
+
+    val tagger = new DefaultTagger(cfg)
+    assert(tagger(dimensions) === expected)
+  }
+}

--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricCategorySuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricCategorySuite.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import com.netflix.atlas.core.model.Query
+import com.typesafe.config.ConfigException
+import com.typesafe.config.ConfigFactory
+import org.scalatest.FunSuite
+
+class MetricCategorySuite extends FunSuite {
+  test("bad config") {
+    val cfg = ConfigFactory.empty()
+    intercept[ConfigException] {
+      MetricCategory.fromConfig(cfg)
+    }
+  }
+
+  test("load from config") {
+    val cfg = ConfigFactory.parseString(
+      """
+        |namespace = "AWS/ELB"
+        |period = 1 m
+        |dimensions = ["LoadBalancerName"]
+        |metrics = [
+        |  {
+        |    name = "RequestCount"
+        |    alias = "aws.elb.requests"
+        |    conversion = "sum,rate"
+        |  },
+        |  {
+        |    name = "HTTPCode_ELB_4XX"
+        |    alias = "aws.elb.errors"
+        |    conversion = "sum,rate"
+        |    tags = [
+        |      {
+        |        key = "status"
+        |        value = "4xx"
+        |      }
+        |    ]
+        |  }
+        |]
+      """.stripMargin)
+
+    val category = MetricCategory.fromConfig(cfg)
+    assert(category.namespace === "AWS/ELB")
+    assert(category.period === 60)
+    assert(category.toListRequests.size === 2)
+    assert(category.filter === Query.True)
+  }
+
+  test("config with filter") {
+    val cfg = ConfigFactory.parseString(
+      """
+        |namespace = "AWS/ELB"
+        |period = 1 m
+        |dimensions = ["LoadBalancerName"]
+        |metrics = [
+        |  {
+        |    name = "RequestCount"
+        |    alias = "aws.elb.requests"
+        |    conversion = "sum,rate"
+        |  }
+        |]
+        |filter = "name,RequestCount,:eq"
+      """.stripMargin)
+
+    val category = MetricCategory.fromConfig(cfg)
+    assert(category.filter === Query.Equal("name", "RequestCount"))
+  }
+
+  test("config with invalid filter") {
+    val cfg = ConfigFactory.parseString(
+      """
+        |namespace = "AWS/ELB"
+        |period = 1 m
+        |dimensions = ["LoadBalancerName"]
+        |metrics = [
+        |  {
+        |    name = "RequestCount"
+        |    alias = "aws.elb.requests"
+        |    conversion = "sum,rate"
+        |  }
+        |]
+        |filter = "name,:invalid-command"
+      """.stripMargin)
+
+    intercept[IllegalStateException] {
+      MetricCategory.fromConfig(cfg)
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDefinitionSuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDefinitionSuite.scala
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import java.util.Date
+
+import com.amazonaws.services.cloudwatch.model.Datapoint
+import com.amazonaws.services.cloudwatch.model.StandardUnit
+import com.netflix.atlas.core.model.Query
+import com.typesafe.config.ConfigException
+import com.typesafe.config.ConfigFactory
+import org.scalatest.FunSuite
+
+class MetricDefinitionSuite extends FunSuite {
+
+  private val meta = MetricMetadata(
+    MetricCategory("AWS/ELB", 60, Nil, Nil, Query.True),
+    null,
+    Nil
+  )
+
+  test("bad config") {
+    val cfg = ConfigFactory.empty()
+    intercept[ConfigException] {
+      MetricCategory.fromConfig(cfg)
+    }
+  }
+
+  test("config with no tags") {
+    val cfg = ConfigFactory.parseString(
+      """
+        |name = "RequestCount"
+        |alias = "aws.elb.requests"
+        |conversion = "sum,rate"
+      """.stripMargin)
+
+    val definitions = MetricDefinition.fromConfig(cfg)
+    assert(definitions.size === 1)
+    assert(definitions.head.name === "RequestCount")
+    assert(definitions.head.alias === "aws.elb.requests")
+  }
+
+  test("config for timer") {
+    val cfg = ConfigFactory.parseString(
+      """
+        |name = "Latency"
+        |alias = "aws.elb.latency"
+        |conversion = "timer"
+      """.stripMargin)
+
+    val definitions = MetricDefinition.fromConfig(cfg)
+    assert(definitions.size === 3)
+    assert(definitions.map(_.tags("statistic")).toSet === Set("totalTime", "count", "max"))
+
+    val dp = new Datapoint()
+      .withMaximum(6.0)
+      .withMinimum(0.0)
+      .withSum(600.0)
+      .withSampleCount(1000.0)
+      .withUnit(StandardUnit.Seconds)
+      .withTimestamp(new Date)
+
+    definitions.find(_.tags("statistic") == "totalTime").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 10.0)
+    }
+
+    definitions.find(_.tags("statistic") == "count").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 1000.0 / 60.0)
+    }
+
+    definitions.find(_.tags("statistic") == "max").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 6.0)
+    }
+  }
+
+  test("config for timer-millis no unit") {
+    val cfg = ConfigFactory.parseString(
+      """
+        |name = "Latency"
+        |alias = "aws.elb.latency"
+        |conversion = "timer-millis"
+      """.stripMargin)
+
+    val definitions = MetricDefinition.fromConfig(cfg)
+    assert(definitions.size === 3)
+    assert(definitions.map(_.tags("statistic")).toSet === Set("totalTime", "count", "max"))
+
+    val dp = new Datapoint()
+      .withMaximum(6.0)
+      .withMinimum(0.0)
+      .withSum(600.0)
+      .withSampleCount(1000.0)
+      .withUnit(StandardUnit.None)
+      .withTimestamp(new Date)
+
+    definitions.find(_.tags("statistic") == "totalTime").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 10.0 / 1000.0)
+    }
+
+    definitions.find(_.tags("statistic") == "count").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 1000.0 / 60.0)
+    }
+
+    definitions.find(_.tags("statistic") == "max").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 6.0 / 1000.0)
+    }
+  }
+
+  test("config for timer-millis correct unit") {
+    val cfg = ConfigFactory.parseString(
+      """
+        |name = "Latency"
+        |alias = "aws.elb.latency"
+        |conversion = "timer-millis"
+      """.stripMargin)
+
+    val definitions = MetricDefinition.fromConfig(cfg)
+    assert(definitions.size === 3)
+    assert(definitions.map(_.tags("statistic")).toSet === Set("totalTime", "count", "max"))
+
+    val dp = new Datapoint()
+      .withMaximum(6.0)
+      .withMinimum(0.0)
+      .withSum(600.0)
+      .withSampleCount(1000.0)
+      .withUnit(StandardUnit.Milliseconds)
+      .withTimestamp(new Date)
+
+    definitions.find(_.tags("statistic") == "totalTime").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 10.0 / 1000.0)
+    }
+
+    definitions.find(_.tags("statistic") == "count").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 1000.0 / 60.0)
+    }
+
+    definitions.find(_.tags("statistic") == "max").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 6.0 / 1000.0)
+    }
+  }
+
+  test("config for dist-summary") {
+    val cfg = ConfigFactory.parseString(
+      """
+        |name = "Latency"
+        |alias = "aws.elb.latency"
+        |conversion = "dist-summary"
+      """.stripMargin)
+
+    val definitions = MetricDefinition.fromConfig(cfg)
+    assert(definitions.size === 3)
+    assert(definitions.map(_.tags("statistic")).toSet === Set("totalAmount", "count", "max"))
+
+    val dp = new Datapoint()
+      .withMaximum(6.0)
+      .withMinimum(0.0)
+      .withSum(600.0)
+      .withSampleCount(1000.0)
+      .withUnit(StandardUnit.Bytes)
+      .withTimestamp(new Date)
+
+    definitions.find(_.tags("statistic") == "totalAmount").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 10.0)
+    }
+
+    definitions.find(_.tags("statistic") == "count").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 1000.0 / 60.0)
+    }
+
+    definitions.find(_.tags("statistic") == "max").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 6.0)
+    }
+  }
+
+}

--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/NetflixTaggerSuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/NetflixTaggerSuite.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import com.amazonaws.services.cloudwatch.model.Dimension
+import com.typesafe.config.ConfigException
+import com.typesafe.config.ConfigFactory
+import org.scalatest.FunSuite
+
+class NetflixTaggerSuite extends FunSuite {
+
+  private val dimensions = List(
+    new Dimension().withName("AutoScalingGroupName").withValue("app_name-stack-detail-v001"),
+    new Dimension().withName("ClusterName").withValue("different_name-foo-bar-v002")
+  )
+
+  test("bad config") {
+    val cfg = ConfigFactory.parseString("")
+    intercept[ConfigException] {
+      new NetflixTagger(cfg)
+    }
+  }
+
+  test("extract tags using naming conventions") {
+    val cfg = ConfigFactory.parseString(
+      """
+        |mappings = [
+        |  {
+        |    name = "AutoScalingGroupName"
+        |    alias = "nf.asg"
+        |  }
+        |]
+        |common-tags = []
+        |netflix-keys = ["nf.asg"]
+      """.stripMargin)
+
+    val expected = Map(
+      "nf.app"      -> "app_name",
+      "nf.cluster"  -> "app_name-stack-detail",
+      "nf.asg"      -> "app_name-stack-detail-v001",
+      "nf.stack"    -> "stack",
+      "ClusterName" -> "different_name-foo-bar-v002"
+    )
+
+    val tagger = new NetflixTagger(cfg)
+    assert(tagger(dimensions) === expected)
+  }
+
+}

--- a/atlas-poller/src/main/resources/reference.conf
+++ b/atlas-poller/src/main/resources/reference.conf
@@ -1,4 +1,13 @@
 
+atlas.akka {
+  actors = ${?atlas.akka.actors} [
+    {
+      name = "poller"
+      class = "com.netflix.atlas.poller.PollerManager"
+    }
+  ]
+}
+
 atlas.poller {
 
   // How often to collect data from the pollers.

--- a/atlas-poller/src/main/scala/com/netflix/atlas/poller/ClientActor.scala
+++ b/atlas-poller/src/main/scala/com/netflix/atlas/poller/ClientActor.scala
@@ -53,10 +53,10 @@ class ClientActor(registry: Registry, config: Config) extends Actor {
 
   private val pipeline: SendReceive = sendReceive ~> decode(Gzip)
 
-  private val uri = config.getString("atlas.poller.sink.uri")
-  private val batchSize = config.getInt("atlas.poller.sink.batch-size")
+  private val uri = config.getString("uri")
+  private val batchSize = config.getInt("batch-size")
 
-  private val shouldSendAck = config.getBoolean("atlas.poller.sink.send-ack")
+  private val shouldSendAck = config.getBoolean("send-ack")
 
   private val datapointsSent = registry.counter("atlas.client.sent")
   private val datapointsDropped = registry.createId("atlas.client.dropped")

--- a/atlas-poller/src/test/scala/com/netflix/atlas/poller/ClientActorSuite.scala
+++ b/atlas-poller/src/test/scala/com/netflix/atlas/poller/ClientActorSuite.scala
@@ -50,7 +50,7 @@ class ClientActorSuite extends TestKit(ActorSystem())
 
   private val clock = new ManualClock()
   private val registry = new DefaultRegistry(clock)
-  private val config = ConfigFactory.load()
+  private val config = ConfigFactory.load().getConfig("atlas.poller.sink")
   private val ref = TestActorRef(new TestClientActor(registry, config))
 
   override def afterAll(): Unit = {

--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,10 @@ lazy val root = project.in(file("."))
     `atlas-jmh`,
     `atlas-json`,
     `atlas-module-akka`,
+    `atlas-module-cloudwatch`,
     `atlas-module-webapi`,
     `atlas-poller`,
+    `atlas-poller-cloudwatch`,
     `atlas-standalone`,
     `atlas-test`,
     `atlas-webapi`,
@@ -73,6 +75,16 @@ lazy val `atlas-module-akka` = project
     Dependencies.iepGuice
   ))
 
+lazy val `atlas-module-cloudwatch` = project
+  .configure(BuildSettings.profile)
+  .dependsOn(`atlas-module-akka`, `atlas-poller-cloudwatch`)
+  .settings(libraryDependencies ++= Seq(
+    Dependencies.guiceCore,
+    Dependencies.guiceMulti,
+    Dependencies.iepGuice,
+    Dependencies.iepModuleAws
+  ))
+
 lazy val `atlas-module-webapi` = project
   .configure(BuildSettings.profile)
   .dependsOn(`atlas-webapi`)
@@ -88,6 +100,15 @@ lazy val `atlas-poller` = project
     Dependencies.sprayClient,
     Dependencies.akkaTestkit % "test",
     Dependencies.sprayTestkit % "test"
+  ))
+
+lazy val `atlas-poller-cloudwatch` = project
+  .configure(BuildSettings.profile)
+  .dependsOn(`atlas-core`, `atlas-poller`)
+  .settings(libraryDependencies ++= Seq(
+    Dependencies.awsCloudWatch,
+    Dependencies.frigga,
+    Dependencies.iepService
   ))
 
 lazy val `atlas-standalone` = project

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   object Versions {
     val akka       = "2.4.8"
     val aws        = "1.11.18"
-    val iep        = "0.4.4"
+    val iep        = "0.4.6"
     val guice      = "4.1.0"
     val jackson    = "2.7.4"
     val log4j      = "2.6.2"
@@ -27,9 +27,11 @@ object Dependencies {
   val awsS3           = "com.amazonaws" % "aws-java-sdk-s3" % aws
   val caffeine        = "com.github.ben-manes.caffeine" % "caffeine" % "2.3.1"
   val equalsVerifier  = "nl.jqno.equalsverifier" % "equalsverifier" % "2.1.3"
+  val frigga          = "com.netflix.frigga" % "frigga" % "0.15.0"
   val guiceCore       = "com.google.inject" % "guice" % guice
   val guiceMulti      = "com.google.inject.extensions" % "guice-multibindings" % guice
   val iepGuice        = "com.netflix.iep" % "iep-guice" % iep
+  val iepModuleAws    = "com.netflix.iep" % "iep-module-aws" % iep
   val iepService      = "com.netflix.iep" % "iep-service" % iep
   val jacksonAnno2    = "com.fasterxml.jackson.core" % "jackson-annotations" % jackson
   val jacksonCore2    = "com.fasterxml.jackson.core" % "jackson-core" % jackson


### PR DESCRIPTION
Poller for collecting CloudWatch data and publishing
it into Atlas. This is a restructured from the legacy
db implementation used internally to wrap CloudWatch.
Overall the polling approach is preferred because:

* It makes CloudWatch data follow the same path as
  all other data. This means it is available for teeing
  to stream processing systems, long term storage in
  hive, etc.
* Querying CloudWatch on-demand does not scale well
  and it fails frequently due to throttles. In this
  case there is a consistent load all the time, but
  we can tune that for the needed set and avoid the
  really high bursts needed for on-demand queries.
* If we are lucky Amazon will support a way to get a
  stream of all CloudWatch metric data and we can
  switch to consuming that in the future. In the
  mean time we can make it look like a stream for
  most of our use-cases.