### PR TITLE
fix batch that is written back

### DIFF
--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
@@ -176,7 +176,7 @@ class CloudWatchPoller(config: Config, registry: Registry, client: AmazonCloudWa
       val batch = metricBatch.toList
       metricBatch.clear()
       logger.info(s"writing ${batch.size} metrics to client")
-      responder ! Messages.MetricsPayload(Map.empty, metricBatch.toList)
+      responder ! Messages.MetricsPayload(Map.empty, batch)
     }
   }
 }


### PR DESCRIPTION
Use the immutable copy rather than the mutable
list for the batch that has already been cleared.