### PR TITLE
add lambda to default list of categories

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/reference.conf
@@ -195,6 +195,7 @@ atlas {
       "es",
       "events",
       "kinesis",
+      "lambda",
       "rds",
       "redshift",
       "s3",


### PR DESCRIPTION
The conf file is already there, but it got left out
of the main list.