### PR TITLE
fix warning in test case

### DIFF
--- a/atlas-poller/src/test/scala/com/netflix/atlas/poller/ClientActorSuite.scala
+++ b/atlas-poller/src/test/scala/com/netflix/atlas/poller/ClientActorSuite.scala
@@ -170,7 +170,7 @@ object ClientActorSuite {
     override def receive: Receive = testReceive.orElse(super.receive)
 
     private def testReceive: Receive = {
-      case t: Try[HttpResponse] => response = t
+      case t: Try[_] => response = t.asInstanceOf[Try[HttpResponse]]
     }
   }
 }


### PR DESCRIPTION
Fixes a compiler warning in ClientActorSuite:

```
Warning:(173, 15) non-variable type argument spray.http.HttpResponse in type pattern scala.util.Try[spray.http.HttpResponse] is unchecked since it is eliminated by erasure
      case t: Try[HttpResponse] => response = t.asInstanceOf[Try[HttpResponse]]
```