### PR TITLE
add vpc and subnet to default allowed-keys

### DIFF
--- a/atlas-webapi/src/main/resources/reference.conf
+++ b/atlas-webapi/src/main/resources/reference.conf
@@ -122,8 +122,10 @@ atlas {
             "node",
             "region",
             "stack",
+            "subnet",
             "task",
             "vmtype",
+            "vpc",
             "zone"
           ]
         }


### PR DESCRIPTION
Updates the allowed `nf.` keys to include vpc and subnet.