### PR TITLE
reduce size of publish failure response

### DIFF
--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
@@ -237,19 +237,19 @@ object PublishApi {
 
   case class PublishRequest(values: List[Datapoint], failures: List[ValidationResult])
 
-  case class FailureMessage(`type`: String, message: List[String]) extends JsonSupport {
+  case class FailureMessage(`type`: String, errorCount: Int, message: List[String]) extends JsonSupport {
     def typeName: String = `type`
   }
 
   object FailureMessage {
     def error(message: List[ValidationResult]): FailureMessage = {
       val failures = message.collect { case ValidationResult.Fail(_, reason) => reason }
-      new FailureMessage(DiagnosticMessage.Error, failures)
+      new FailureMessage(DiagnosticMessage.Error, failures.size, failures.take(5))
     }
 
     def partial(message: List[ValidationResult]): FailureMessage = {
       val failures = message.collect { case ValidationResult.Fail(_, reason) => reason }
-      new FailureMessage("partial", failures)
+      new FailureMessage("partial", failures.size, failures.take(5))
     }
   }
 }


### PR DESCRIPTION
Fixes a bug where the failure message was getting encoded as
a json string inside the message of the json response. Also
changes the behavior on failures to have the error count
explicitly in the response and limit the number of specific
failure messages to the first 5. This significantly reduces
allocations and response sizes for payloads with many failures.