### PR TITLE
less repetitive expression normalization

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/QueryIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/QueryIndex.scala
@@ -128,7 +128,7 @@ object QueryIndex {
    */
   def create[T](entries: List[Entry[T]]): QueryIndex[T] = {
     val annotated = entries.flatMap { entry =>
-      val qs = split(entry.query)
+      val qs = Query.dnfList(entry.query).flatMap(split)
       qs.map(q => annotate(Entry(q, entry.value)))
     }
     val idxMap = new IndexMap[T]

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -553,6 +553,20 @@ object MathExpr {
       }
     }
   }
+
+  case class NamedRewrite(name: String, displayExpr: Expr, evalExpr: TimeSeriesExpr)
+      extends TimeSeriesExpr {
+    def dataExprs: List[DataExpr] = evalExpr.dataExprs
+    override def toString: String = s"$displayExpr,:$name"
+
+    def isGrouped: Boolean = evalExpr.isGrouped
+
+    def groupByKey(tags: Map[String, String]): Option[String] = evalExpr.groupByKey(tags)
+
+    def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
+      evalExpr.eval(context, data).copy(expr = this)
+    }
+  }
 }
 
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -277,11 +277,17 @@ object MathVocabulary extends Vocabulary {
     override def name: String = "named-rewrite"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
-      case (_: String) :: TimeSeriesType(_) :: (_: Expr) :: _ => true
+      case (_: String) :: TimeSeriesType(_) :: TimeSeriesType(_) :: _ => true
     }
 
     protected def executor: PartialFunction[List[Any], List[Any]] = {
       case (n: String) :: TimeSeriesType(rw) :: (orig: Expr) :: stack =>
+        // If the original is already an expr type, e.g. a Query, then we should
+        // preserve it without modification. So we first match for Expr.
+        MathExpr.NamedRewrite(n, orig, rw) :: stack
+      case (n: String) :: TimeSeriesType(rw) :: TimeSeriesType(orig) :: stack =>
+        // This is a more general match that will coerce the original into a
+        // TimeSeriesExpr if it is not one already, e.g., a constant.
         MathExpr.NamedRewrite(n, orig, rw) :: stack
     }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -36,6 +36,7 @@ object MathVocabulary extends Vocabulary {
     Random,
     Time,
     CommonQuery,
+    NamedRewrite,
     Abs, Negate, Sqrt, PerStep,
 
     Add, Subtract, Multiply, Divide,
@@ -51,25 +52,41 @@ object MathVocabulary extends Vocabulary {
 
     Percentiles,
 
-    Macro("avg", List(":dup", ":sum", ":swap", ":count", ":div"), List("name,sps,:eq,(,nf.cluster,),:by")),
+    Macro("avg", List(
+        ":dup",
+        ":dup", ":sum", ":swap", ":count", ":div",
+        "avg", ":named-rewrite"
+      ),
+      List("name,sps,:eq,(,nf.cluster,),:by")),
 
-    Macro("pct", List(":dup", ":sum", ":div", "100", ":mul"), List("name,sps,:eq,(,nf.cluster,),:by")),
+    Macro("pct", List(
+        ":dup",
+        ":dup", ":sum", ":div", "100", ":mul",
+        "pct", ":named-rewrite"
+      ),
+      List("name,sps,:eq,(,nf.cluster,),:by")),
 
     Macro("dist-avg", List(
+        ":dup",
         "statistic", "(", "totalTime", "totalAmount", ")", ":in", ":sum",
         "statistic", "count", ":eq", ":sum",
         ":div",
-        ":swap", ":cq"
+        ":swap", ":cq",
+        "dist-avg", ":named-rewrite"
       ),
       List("name,playback.startLatency,:eq")),
 
     Macro("dist-max", List(
+        ":dup",
         "statistic", "max", ":eq", ":max",
-        ":swap", ":cq"
+        ":swap", ":cq",
+        "dist-max", ":named-rewrite"
       ),
       List("name,playback.startLatency,:eq")),
 
     Macro("dist-stddev", List(
+        ":dup",
+
         // N
         "statistic", "count", ":eq", ":sum",
 
@@ -98,7 +115,10 @@ object MathVocabulary extends Vocabulary {
         ":sqrt",
 
         // Swap and use :cq to apply a common query
-        ":swap", ":cq"
+        ":swap", ":cq",
+
+        // Avoid expansion when displayed
+        "dist-stddev", ":named-rewrite"
       ),
       List("name,playback.startLatency,:eq")),
 
@@ -130,6 +150,17 @@ object MathVocabulary extends Vocabulary {
       case StringListType(keys) :: TimeSeriesType(t) :: stack =>
         // Default data group by applied across math operations
         val f = t.rewrite {
+          case MathExpr.NamedRewrite(n, q: Query, t) =>
+            // A number of macro rewrites are helpers that are meant to look like
+            // aggregate functions to the user. These have an display type that is
+            // as simple query and an arbitrarily complicated eval expression. In
+            // those cases we rewrite the eval expression and generate a new name
+            // that indicates the group by operation over the simple query.
+            val evalExpr = t.rewrite {
+              case af: AggregateFunction => DataExpr.GroupBy(af, keys)
+            }
+            val name = s"$n,(,${keys.mkString(",")},),:by"
+            MathExpr.NamedRewrite(name, q, evalExpr.asInstanceOf[TimeSeriesExpr])
           case af: AggregateFunction => DataExpr.GroupBy(af, keys)
         }
         f :: stack
@@ -240,6 +271,33 @@ object MathVocabulary extends Vocabulary {
     override def examples: List[String] = List(
       "name,ssCpuUser,:eq,name,DiscoveryStatus_UP,:eq,:mul,nf.app,alerttest,:eq",
       "42,nf.app,alerttest,:eq")
+  }
+
+  case object NamedRewrite extends SimpleWord {
+    override def name: String = "named-rewrite"
+
+    protected def matcher: PartialFunction[List[Any], Boolean] = {
+      case (_: String) :: TimeSeriesType(_) :: (_: Expr) :: _ => true
+    }
+
+    protected def executor: PartialFunction[List[Any], List[Any]] = {
+      case (n: String) :: TimeSeriesType(rw) :: (orig: Expr) :: stack =>
+        MathExpr.NamedRewrite(n, orig, rw) :: stack
+    }
+
+    override def summary: String =
+      """
+        |Internal operation used by some macros to provide a more user friendly display
+        |expression. The expanded version will get used for evaluation, but if a new expression
+        |is generated from the parsed expression tree it will use the original version
+        |along with the named of the macro.
+      """.stripMargin.trim
+
+    override def signature: String = {
+      "original:TimeSeriesExpr rewritten:TimeSeriesExpr name:String -- TimeSeriesExpr"
+    }
+
+    override def examples: List[String] = Nil
   }
 
   sealed trait UnaryWord extends SimpleWord {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -220,7 +220,7 @@ object MathVocabulary extends Vocabulary {
     protected def executor: PartialFunction[List[Any], List[Any]] = {
       case (q2: Query) :: (expr: Expr) :: stack =>
         val newExpr = expr.rewrite {
-          case q1: Query => Query.And(q1, q2)
+          case q1: Query => q1 and q2
         }
         newExpr :: stack
       case (_: Query) :: stack =>

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
@@ -32,6 +32,20 @@ sealed trait Query extends Expr {
 
   /** Returns a string that summarizes the query expression in a human readable format. */
   def labelString: String
+
+  def and(query: Query): Query = query match {
+    case Query.True  => this
+    case Query.False => Query.False
+    case q           => Query.And(this, q)
+  }
+
+  def or(query: Query): Query = query match {
+    case Query.True  => Query.True
+    case Query.False => this
+    case q           => Query.Or(this, q)
+  }
+
+  def not: Query = Query.Not(this)
 }
 
 object Query {
@@ -119,6 +133,9 @@ object Query {
     def couldMatch(tags: Map[String, String]): Boolean = true
     def labelString: String = "true"
     override def toString: String = ":true"
+    override def and(query: Query): Query = query
+    override def or(query: Query): Query = Query.True
+    override def not: Query = Query.False
   }
 
   case object False extends Query {
@@ -127,6 +144,9 @@ object Query {
     def couldMatch(tags: Map[String, String]): Boolean = false
     def labelString: String = "false"
     override def toString: String = ":false"
+    override def and(query: Query): Query = Query.False
+    override def or(query: Query): Query = query
+    override def not: Query = Query.True
   }
 
   sealed trait KeyQuery extends Query {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
@@ -42,12 +42,12 @@ object Query {
    */
   def exactKeys(query: Query): Set[String] = {
     query match {
-      case Query.And(q1, q2) => exactKeys(q1) union exactKeys(q2)
-      case Query.Or(q1, q2)  => Set.empty
-      case Query.Not(q)      => Set.empty
-      case Query.Equal(k, _) => Set(k)
-      case q: KeyQuery       => Set.empty
-      case _                 => Set.empty
+      case And(q1, q2)  => exactKeys(q1) union exactKeys(q2)
+      case Or(q1, q2)   => Set.empty
+      case Not(q)       => Set.empty
+      case Equal(k, _)  => Set(k)
+      case q: KeyQuery  => Set.empty
+      case _            => Set.empty
     }
   }
 
@@ -56,13 +56,61 @@ object Query {
     */
   def tags(query: Query): Map[String, String] = {
     query match {
-      case Query.And(q1, q2) => tags(q1) ++ tags(q2)
-      case Query.Or(q1, q2)  => Map.empty
-      case Query.Not(q)      => Map.empty
-      case Query.Equal(k, v) => Map(k -> v)
-      case q: KeyQuery       => Map.empty
-      case _                 => Map.empty
+      case And(q1, q2)  => tags(q1) ++ tags(q2)
+      case Or(q1, q2)   => Map.empty
+      case Not(q)       => Map.empty
+      case Equal(k, v)  => Map(k -> v)
+      case q: KeyQuery  => Map.empty
+      case _            => Map.empty
     }
+  }
+
+  /** Converts the input query into conjunctive normal form. */
+  def cnf(query: Query): Query = {
+    cnfList(query).reduceLeft { (q1, q2) => Query.And(q1, q2) }
+  }
+
+  /**
+    * Converts the input query into a list of sub-queries that should be ANDd
+    * together.
+    */
+  def cnfList(query: Query): List[Query] = {
+    query match {
+      case And(q1, q2)       => cnfList(q1) ::: cnfList(q2)
+      case Or(q1, q2)        => crossOr(cnfList(q1), cnfList(q2))
+      case Not(And(q1, q2))  => cnfList(Or(Not(q1), Not(q2)))
+      case Not(Or(q1, q2))   => cnfList(Not(q1)) ::: cnfList(Not(q2))
+      case Not(Not(q))       => List(q)
+      case q                 => List(q)
+    }
+  }
+
+  /** Converts the input query into disjunctive normal form. */
+  def dnf(query: Query): Query = {
+    dnfList(query).reduceLeft { (q1, q2) => Query.Or(q1, q2) }
+  }
+
+  /**
+    * Converts the input query into a list of sub-queries that should be ORd
+    * together.
+    */
+  def dnfList(query: Query): List[Query] = {
+    query match {
+      case And(q1, q2)       => crossAnd(dnfList(q1), dnfList(q2))
+      case Or(q1, q2)        => dnfList(q1) ::: dnfList(q2)
+      case Not(And(q1, q2))  => dnfList(Not(q1)) ::: dnfList(Not(q2))
+      case Not(Or(q1, q2))   => dnfList(And(Not(q1), Not(q2)))
+      case Not(Not(q))       => List(q)
+      case q                 => List(q)
+    }
+  }
+
+  private def crossOr(qs1: List[Query], qs2: List[Query]): List[Query] = {
+    for (q1 <- qs1; q2 <- qs2) yield Or(q1, q2)
+  }
+
+  private def crossAnd(qs1: List[Query], qs2: List[Query]): List[Query] = {
+    for (q1 <- qs1; q2 <- qs2) yield And(q1, q2)
   }
 
   case object True extends Query {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/QueryVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/QueryVocabulary.scala
@@ -371,11 +371,7 @@ object QueryVocabulary extends Vocabulary {
     }
 
     protected def executor: PartialFunction[List[Any], List[Any]] = {
-      case (_: Query) :: Query.False :: s  => Query.False :: s
-      case Query.False :: (_: Query) :: s  => Query.False :: s
-      case (q: Query) :: Query.True :: s   => q :: s
-      case Query.True :: (q: Query) :: s   => q :: s
-      case (q2: Query) :: (q1: Query) :: s => Query.And(q1, q2) :: s
+      case (q2: Query) :: (q1: Query) :: s => (q1 and q2) :: s
     }
 
     override def summary: String =
@@ -406,11 +402,7 @@ object QueryVocabulary extends Vocabulary {
     }
 
     protected def executor: PartialFunction[List[Any], List[Any]] = {
-      case (q: Query) :: Query.False :: s  => q :: s
-      case Query.False :: (q: Query) :: s  => q :: s
-      case (_: Query) :: Query.True :: s   => Query.True :: s
-      case Query.True :: (_: Query) :: s   => Query.True :: s
-      case (q2: Query) :: (q1: Query) :: s => Query.Or(q1, q2) :: s
+      case (q2: Query) :: (q1: Query) :: s => (q1 or q2) :: s
     }
 
     override def summary: String =
@@ -445,9 +437,7 @@ object QueryVocabulary extends Vocabulary {
     }
 
     protected def executor: PartialFunction[List[Any], List[Any]] = {
-      case Query.False :: s => Query.True :: s
-      case Query.True :: s  => Query.False :: s
-      case (q: Query) :: s  => Query.Not(q) :: s
+      case (q: Query) :: s  => q.not :: s
     }
 
     override def summary: String =

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
@@ -32,17 +32,23 @@ object StatefulVocabulary extends Vocabulary {
 
   val words: List[Word] = List(
     RollingCount, Des, SlidingDes, Trend, Integral, Derivative,
-    Macro("des-simple", List("10", "0.1",  "0.5",  ":des"), List("42")),
-    Macro("des-fast",   List("10", "0.1",  "0.02", ":des"), List("42")),
-    Macro("des-slower", List("10", "0.05", "0.03", ":des"), List("42")),
-    Macro("des-slow",   List("10", "0.03", "0.04", ":des"), List("42")),
-    Macro("sdes-simple", List("10", "0.1",  "0.5",  ":sdes"), List("42")),
-    Macro("sdes-fast",   List("10", "0.1",  "0.02", ":sdes"), List("42")),
-    Macro("sdes-slower", List("10", "0.05", "0.03", ":sdes"), List("42")),
-    Macro("sdes-slow",   List("10", "0.03", "0.04", ":sdes"), List("42")),
+    desMacro("des-simple",  List("10", "0.1",  "0.5",  ":des")),
+    desMacro("des-fast",    List("10", "0.1",  "0.02", ":des")),
+    desMacro("des-slower",  List("10", "0.05", "0.03", ":des")),
+    desMacro("des-slow",    List("10", "0.03", "0.04", ":des")),
+    desMacro("sdes-simple", List("10", "0.1",  "0.5",  ":sdes")),
+    desMacro("sdes-fast",   List("10", "0.1",  "0.02", ":sdes")),
+    desMacro("sdes-slower", List("10", "0.05", "0.03", ":sdes")),
+    desMacro("sdes-slow",   List("10", "0.03", "0.04", ":sdes")),
 
     Macro("des-epic-signal", desEpicSignal, List("name,sps,:eq,:sum,10,0.1,0.5,0.2,0.2,4"))
   )
+
+  private def desMacro(name: String, body: List[String]): Macro = {
+    val example = List("42")
+    val fullBody = (":dup" :: body) ::: List(name, ":named-rewrite")
+    Macro(name, fullBody, example)
+  }
 
   case object RollingCount extends SimpleWord {
     override def name: String = "rolling-count"

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
@@ -25,7 +25,7 @@ import com.netflix.atlas.core.util.Strings
 case class StyleExpr(expr: TimeSeriesExpr, settings: Map[String, String]) extends Expr {
   override def toString: String = {
     val vs = settings.toList.sortWith(_._1 < _._1).map(t => s"${t._2},:${t._1}")
-    s"$expr,${vs.mkString(",")}"
+    if (vs.isEmpty) expr.toString else s"$expr,${vs.mkString(",")}"
   }
 
   def legend(t: TimeSeries): String = {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
@@ -328,6 +328,7 @@ class QuerySuite extends FunSuite {
   val a = HasKey("A")
   val b = HasKey("B")
   val c = HasKey("C")
+  val d = HasKey("D")
 
   test("expr rewrite") {
     val input = Or(a, And(b, c))
@@ -356,5 +357,77 @@ class QuerySuite extends FunSuite {
   test("exactKeys or same key") {
     val q = Or(Equal("k", "v"), Equal("k", "q"))
     assert(Query.exactKeys(q) === Set.empty)
+  }
+
+  test("cnfList (a)") {
+    val q = a
+    assert(Query.cnfList(q) === List(q))
+    assert(Query.cnf(q) === q)
+  }
+
+  test("cnfList (a or b)") {
+    val q = Or(a, b)
+    assert(Query.cnfList(q) === List(q))
+    assert(Query.cnf(q) === q)
+  }
+
+  test("cnfList (a and b) or c)") {
+    val q = Or(And(a, b), c)
+    assert(Query.cnfList(q) === List(Or(a, c), Or(b, c)))
+    assert(Query.cnf(q) === And(Or(a, c), Or(b, c)))
+  }
+
+  test("cnfList (a and b) or (c and d))") {
+    val q = Or(And(a, b), And(c, d))
+    assert(Query.cnfList(q) === List(Or(a, c), Or(a, d), Or(b, c), Or(b, d)))
+    assert(Query.cnf(q) === And(And(And(Or(a, c), Or(a, d)), Or(b, c)), Or(b, d)))
+  }
+
+  test("cnfList not(a or b)") {
+    val q = Not(Or(a, b))
+    assert(Query.cnfList(q) === List(Not(a), Not(b)))
+    assert(Query.cnf(q) === And(Not(a), Not(b)))
+  }
+
+  test("cnfList not(a and b)") {
+    val q = Not(And(a, b))
+    assert(Query.cnfList(q) === List(Or(Not(a), Not(b))))
+    assert(Query.cnf(q) === Or(Not(a), Not(b)))
+  }
+
+  test("dnfList (a)") {
+    val q = a
+    assert(Query.dnfList(q) === List(q))
+    assert(Query.dnf(q) === q)
+  }
+
+  test("dnfList (a and b)") {
+    val q = And(a, b)
+    assert(Query.dnfList(q) === List(q))
+    assert(Query.dnf(q) === q)
+  }
+
+  test("dnfList (a or b) and c)") {
+    val q = And(Or(a, b), c)
+    assert(Query.dnfList(q) === List(And(a, c), And(b, c)))
+    assert(Query.dnf(q) === Or(And(a, c), And(b, c)))
+  }
+
+  test("dnfList (a or b) and (c or d))") {
+    val q = And(Or(a, b), Or(c, d))
+    assert(Query.dnfList(q) === List(And(a, c), And(a, d), And(b, c), And(b, d)))
+    assert(Query.dnf(q) === Or(Or(Or(And(a, c), And(a, d)), And(b, c)), And(b, d)))
+  }
+
+  test("dnfList not(a or b)") {
+    val q = Not(Or(a, b))
+    assert(Query.dnfList(q) === List(And(Not(a), Not(b))))
+    assert(Query.dnf(q) === And(Not(a), Not(b)))
+  }
+
+  test("dnfList not(a and b)") {
+    val q = Not(And(a, b))
+    assert(Query.dnfList(q) === List(Not(a), Not(b)))
+    assert(Query.dnf(q) === Or(Not(a), Not(b)))
   }
 }

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
@@ -17,8 +17,13 @@ package com.netflix.atlas.webapi
 
 import akka.actor.ActorRefFactory
 import com.netflix.atlas.akka.WebApi
+import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.Expr
+import com.netflix.atlas.core.model.MathExpr
 import com.netflix.atlas.core.model.ModelExtractors
+import com.netflix.atlas.core.model.Query
+import com.netflix.atlas.core.model.StyleExpr
+import com.netflix.atlas.core.model.TimeSeriesExpr
 import com.netflix.atlas.core.stacklang.Context
 import com.netflix.atlas.core.stacklang.Interpreter
 import com.netflix.atlas.core.stacklang.Word
@@ -141,8 +146,7 @@ class ExprApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi {
 
   private def processNormalizeRequest(ctx: RequestContext): Unit = {
     val (query, interpreter) = getInterpreter(ctx)
-    val result = interpreter.execute(query)
-    sendJson(ctx, result.stack.reverse.map(_.toString))
+    sendJson(ctx, ExprApi.normalize(query, interpreter))
   }
 
   // This check is needed to be sure an operation will work if matches is not exhaustive. In
@@ -197,5 +201,89 @@ class ExprApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi {
     val data = Json.encode(obj)
     val entity = HttpEntity(MediaTypes.`application/json`, data)
     ctx.responder ! HttpResponse(StatusCodes.OK, entity = entity)
+  }
+}
+
+object ExprApi {
+
+  def normalize(program: String, interpreter: Interpreter): List[String] = {
+    normalize(eval(interpreter, program), interpreter)
+  }
+
+  def normalize(exprs: List[StyleExpr], interpreter: Interpreter): List[String] = {
+    // If named rewrites are used, then map the eval expression to match the display
+    // expression. This avoids the complexity of the eval expression showing up in the
+    // extracted data expressions.
+    import MathExpr.NamedRewrite
+    val cleaned = exprs.map { e =>
+      val clean = e.rewrite {
+        case NamedRewrite(n, orig: Query,          _) => NamedRewrite(n, orig, DataExpr.Sum(orig))
+        case NamedRewrite(n, orig: TimeSeriesExpr, _) => NamedRewrite(n, orig, orig)
+      }
+      clean.asInstanceOf[StyleExpr]
+    }
+
+    // Extract the distinct queries from all data expressions
+    val queries = cleaned.flatMap(_.expr.dataExprs.map(_.query)).distinct
+
+    // Map from original query to CNF form. This is used to find the common clauses that
+    // can be extracted and applied to the overall query using :cq.
+    val cnfQueries = queries.map(q => q -> Query.cnfList(q).toSet).toMap
+
+    // Find the set of common query clauses
+    val commonQueries =
+      if (cnfQueries.isEmpty) Set.empty[Query]
+      else cnfQueries.values.reduceLeft { (s1, s2) => s1.intersect(s2) }
+
+    // Normalize without extracting common queries
+    val normalized = exprStrings(exprs, cnfQueries, Set.empty)
+    val fullExpr = normalized.mkString(",")
+
+    // Normalize with extracting common queries
+    val cq = s":list,(,${sort(commonQueries, Set.empty)},:cq,),:each"
+    val normalizedCQ = cq :: exprStrings(exprs, cnfQueries, commonQueries)
+    val fullExprCQ = normalizedCQ.mkString(",")
+
+    // If needed, then prepend a common query conversion to the list
+    val finalList = if (fullExpr.length < fullExprCQ.length) normalized else normalizedCQ
+
+    // Reverse the list to match the order the user would expect
+    finalList.reverse
+  }
+
+  private def eval(interpreter: Interpreter, expr: String): List[StyleExpr] = {
+    interpreter.execute(expr).stack.collect {
+      case ModelExtractors.PresentationType(t) => t
+    }
+  }
+
+  private def exprStrings(exprs: List[StyleExpr], cnf: Map[Query, Set[Query]], cq: Set[Query]): List[String] = {
+    // Map from original query to sorted query without the common clauses excluded
+    val sortedQueries = cnf.map { case (q, qs) => q -> sort(qs, cq) }
+
+    // Rewrite the expressions and convert to a normalized strings
+    exprs.map { expr =>
+      val rewritten = expr.rewrite {
+        case q: Query => sortedQueries.getOrElse(q, q)
+      }
+      // Remove explicit :const, it can be determined from implicit conversion
+      // and adds visual clutter
+      rewritten.toString.replace(",:const", "")
+    }
+  }
+
+  /**
+    * Combines a set of query clauses together using AND. Common query clauses that can
+    * be applied later using :cq can be added to the exclude set so they will get ignored
+    * here. The clauses will be sorted so any queries with the exact same set of clauses
+    * will have an equal result query even if they were in different orders in the input
+    * expression string.
+    */
+  private def sort(qs: Set[Query], exclude: Set[Query]): Query = {
+    val matches = qs.toList.filter(q => !exclude.contains(q))
+    if (matches.isEmpty)
+      Query.True
+    else
+      matches.sortWith(_.toString < _.toString).reduce { (q1, q2) => Query.And(q1, q2) }
   }
 }


### PR DESCRIPTION
Update the `/api/v1/expr/normalize` endpoint to be
less repetitive. In particular, the macros like `:avg`
and `:dist-stddev` should not get expanded.