### PR TITLE
fix #436, QueryIndex misses some entries

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/QueryIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/QueryIndex.scala
@@ -50,9 +50,9 @@ case class QueryIndex[T](
       case q :: qs =>
         val children = indexes.get(q) match {
           case Some(qt) => qt.matches(tags, qs)
-          case None     => matches(tags, qs)
+          case None     => false
         }
-        children || entries.exists(_.query.matches(tags))
+        children || entries.exists(_.query.matches(tags)) || matches(tags, qs)
       case Nil =>
         entries.exists(_.query.matches(tags))
     }
@@ -69,9 +69,9 @@ case class QueryIndex[T](
       case q :: qs =>
         val children = indexes.get(q) match {
           case Some(qt) => qt.matchingEntries(tags, qs)
-          case None     => matchingEntries(tags, qs)
+          case None     => Nil
         }
-        children ::: entries.filter(_.query.matches(tags)).map(_.value)
+        children ::: entries.filter(_.query.matches(tags)).map(_.value) ::: matchingEntries(tags, qs)
       case Nil =>
         entries.filter(_.query.matches(tags)).map(_.value)
     }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/QueryIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/QueryIndexSuite.scala
@@ -187,6 +187,28 @@ class QueryIndexSuite extends FunSuite {
     assert(Set(expr2) === index.matchingEntries(Map("name" -> "numCores")).toSet)
   }
 
+  test("queries for both nf.app and nf.cluster") {
+    val appQuery = Query.Equal("nf.app", "testapp")
+    val clusterQuery = Query.Equal("nf.cluster", "testapp-test")
+    val queries = List(appQuery, clusterQuery)
+    val index = QueryIndex(queries)
+
+    val tags = Map("nf.app" -> "testapp", "nf.cluster" -> "testapp-test")
+    assert(index.matches(tags))
+    assert(index.matchingEntries(tags) === queries)
+  }
+
+  test("queries for both nf.app w/ nf.cluster miss and nf.cluster") {
+    val appQuery = Query.And(Query.Equal("nf.app", "testapp"), Query.Equal("nf.cluster", "testapp-miss"))
+    val clusterQuery = Query.Equal("nf.cluster", "testapp-test")
+    val queries = List(appQuery, clusterQuery)
+    val index = QueryIndex(queries)
+
+    val tags = Map("nf.app" -> "testapp", "nf.cluster" -> "testapp-test")
+    assert(index.matches(tags))
+    assert(index.matchingEntries(tags) === List(clusterQuery))
+  }
+
   type QueryInterner = scala.collection.mutable.AnyRefMap[Query, Query]
 
   private def intern(interner: QueryInterner, query: Query): Query = {

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/index/QueryIndexMatching.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/index/QueryIndexMatching.scala
@@ -30,7 +30,7 @@ import org.openjdk.jmh.infra.Blackhole
  * regex being used in real queries and not being used in this synthetic data.
  *
  * ```
- * > run -wi 10 -i 10 -f1 -t1 .*QueryIndexMatching.*
+ * > jmh:run -wi 10 -i 10 -f1 -t1 .*QueryIndexMatching.*
  * ```
  *
  * Initial results:


### PR DESCRIPTION
Once there was a match at a given level it would
check the sub-tree, but never check for matches
among siblings. Adds the test case from the issue
and a second that demonstrates the issue for the
`matches` function as well. The original test case
would pass for `matches` because both sub-trees
in the index would match.