### PR TITLE
add custom case class deserializer

### DIFF
--- a/atlas-json/src/main/scala/com/netflix/atlas/json/AtlasModule.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/AtlasModule.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.json
+
+import com.fasterxml.jackson.core.Version
+import com.fasterxml.jackson.databind.Module
+import com.fasterxml.jackson.databind.Module.SetupContext
+
+/**
+  * Adds custom serializers and deserializers for our use cases.
+  */
+private[json] class AtlasModule extends Module {
+  override def getModuleName: String = "atlas"
+
+  override def setupModule(context: SetupContext): Unit = {
+    context.addDeserializers(new CaseClassDeserializers)
+  }
+
+  override def version(): Version = Version.unknownVersion()
+}

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/CaseClassDeserializer.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/CaseClassDeserializer.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.json
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.JsonToken
+import com.fasterxml.jackson.databind.BeanDescription
+import com.fasterxml.jackson.databind.DeserializationConfig
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JavaType
+import com.fasterxml.jackson.databind.JsonDeserializer
+
+/**
+  * Custom deserializer for case classes. The primary difference is that it honors the
+  * default values specified on the primary constructor if a field is not explicitly
+  * set.
+  */
+class CaseClassDeserializer(
+    javaType: JavaType,
+    config: DeserializationConfig,
+    beanDesc: BeanDescription) extends JsonDeserializer[AnyRef] {
+
+  private val desc = Reflection.createDescription(javaType.getRawClass)
+
+  override def deserialize(p: JsonParser, ctxt: DeserializationContext): AnyRef = {
+    val obj = desc.newInstance
+    p.nextToken()
+    while (p.getCurrentToken == JsonToken.FIELD_NAME) {
+      val field = p.getText
+      p.nextToken()
+      val ftype = desc.fieldType(field)
+      if (ftype.isEmpty) {
+        p.skipChildren()
+      } else {
+        val jt = config.getTypeFactory.constructType(ftype.get)
+        desc.setField(obj, field, ctxt.readValue(p, jt))
+      }
+      p.nextToken()
+    }
+    obj
+  }
+}

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/CaseClassDeserializers.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/CaseClassDeserializers.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.json
+
+import com.fasterxml.jackson.databind.BeanDescription
+import com.fasterxml.jackson.databind.DeserializationConfig
+import com.fasterxml.jackson.databind.JavaType
+import com.fasterxml.jackson.databind.deser.Deserializers
+
+/**
+  * Identifies classes that are eligible for using the custom case class
+  * deserializer.
+  */
+class CaseClassDeserializers extends Deserializers.Base {
+
+  override def findBeanDeserializer(
+    javaType: JavaType,
+    config: DeserializationConfig,
+    beanDesc: BeanDescription) = {
+
+    if (Reflection.isCaseClass(javaType.getRawClass))
+      new CaseClassDeserializer(javaType, config, beanDesc)
+    else
+      null
+  }
+}

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
@@ -76,6 +76,7 @@ object Json {
     mapper.setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     mapper.registerModule(DefaultScalaModule)
+    mapper.registerModule(new AtlasModule)
     mapper.registerModule(new JodaModule)
     mapper
   }

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Reflection.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Reflection.scala
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.json
+
+import com.fasterxml.jackson.databind.util.ClassUtil
+
+import scala.language.existentials
+import scala.reflect.runtime.currentMirror
+import scala.reflect.runtime.universe._
+
+/**
+  * Helper functions for using reflection to access information about case
+  * classes.
+  */
+private[json] object Reflection {
+
+  /**
+    * Create a description object for a case class. Use [[isCaseClass()]] to verify
+    * before creating the description.
+    */
+  def createDescription(cls: Class[_]): CaseClassDesc = {
+    createDescription(cls, currentMirror.classSymbol(cls).asClass)
+  }
+
+  private def createDescription(cls: Class[_], csym: ClassSymbol): CaseClassDesc = {
+    val ctor = csym.primaryConstructor.asMethod
+
+    val companion = currentMirror.reflectModule(csym.companion.asModule).instance
+    val instanceMirror = currentMirror.reflect(companion)
+
+    // See http://www.scala-lang.org/files/archive/spec/2.11/04-basic-declarations-and-definitions.html#default-arguments
+    // for details. This is looking for the default value accessor for the apply on the
+    // companion object.
+    val ms = csym.companion.asModule
+    val params = ctor.paramLists.head.zipWithIndex.map { case (p, i) =>
+      val name = p.name.toString
+      val dflt = if (!p.asTerm.isParamWithDefault) None else {
+        val ts = instanceMirror.symbol.typeSignature
+        val name = s"apply$$default$$${i + 1}"
+        val dfltArg = ts.member(TermName(name))
+        if (dfltArg == NoSymbol) None else {
+          Some(instanceMirror.reflectMethod(dfltArg.asMethod).apply())
+        }
+      }
+      Param(name, dflt)
+    }
+
+    CaseClassDesc(cls, currentMirror.reflectClass(csym).reflectConstructor(ctor), params)
+  }
+
+  /**
+    * Check to see if a class is a case class. Currently this will ignore all classes that
+    * are in sub-packages of `scala.` such as option and tuples. That check maybe overly
+    * broad, but seems to work for existing use-cases.
+    */
+  def isCaseClass(cls: Class[_]): Boolean = {
+    !cls.getName.startsWith("scala.") && currentMirror.classSymbol(cls).asClass.isCaseClass
+  }
+
+  /**
+    * Parameter for a case class constructor.
+    *
+    * @param name
+    *     Name of the parameter.
+    * @param dflt
+    *     Default value or `None` if no default is specified.
+    */
+  case class Param(name: String, dflt: Option[Any])
+
+  /**
+    * Description of a case class and its parameters.
+    *
+    * @param cls
+    *     Raw class to be created.
+    * @param ctor
+    *     Handle to the constructor for creating an instance of the case class.
+    * @param params
+    *     Parameters for the primary constructor.
+    */
+  case class CaseClassDesc(cls: Class[_], ctor: MethodMirror, params: List[Param]) {
+
+    // Create a map to allow quick lookup of the field and ensure that we have
+    // allowed access to all fields.
+    private val fields = {
+      val fs = ClassUtil.getDeclaredFields(cls)
+      fs.foreach(f => ClassUtil.checkAndFixAccess(f, true))
+      fs.map(f => f.getName -> f).toMap
+    }
+
+    // Default parameter values used when constructing the object.
+    private val dfltParams = params.map { p =>
+      p.dflt.getOrElse {
+        val fieldCls = fields(p.name).getType
+        if (fieldCls.isPrimitive) ClassUtil.defaultValue(fieldCls)
+        else if (fieldCls.isAssignableFrom(classOf[Option[_]])) None
+        else null
+      }
+    }
+
+    /**
+      * Creates a new instance of the case class using default values for all parameters.
+      * If there is a default specified in the code, then it will be used. Otherwise, the
+      * value will be `null` or `None` if the field is an `Option`.
+      */
+    def newInstance: AnyRef = {
+      ctor.apply(dfltParams: _*).asInstanceOf[AnyRef]
+    }
+
+    /**
+      * Set the value for a particular field on the instance.
+      */
+    def setField(instance: AnyRef, name: String, value: Any): Unit = {
+      fields.get(name).foreach { f => f.set(instance, value) }
+    }
+
+    /**
+      * Determine the type for a given field. This is used to deserialize the field
+      * values.
+      */
+    def fieldType(name: String): Option[java.lang.reflect.Type] = {
+      fields.get(name).map(_.getGenericType)
+    }
+  }
+}

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
@@ -19,6 +19,7 @@ import java.math.BigInteger
 import java.util
 import java.util.regex.Pattern
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.core.JsonToken
 import org.joda.time.DateTime
@@ -413,6 +414,18 @@ class JsonSuite extends FunSuite {
     val json = Json.encode(obj)
     assert(json === """{"foo":"abc"}""")
   }
+
+  test("object with defaults") {
+    val obj = Json.decode[JsonSuiteObjectWithDefaults]("{}")
+    val json = Json.encode(obj)
+    assert(json === """{"foo":42,"bar":"abc","values":[]}""")
+  }
+
+  test("object with missing key") {
+    val obj = Json.decode[JsonSuiteSimple]("{}")
+    val json = Json.encode(obj)
+    assert(json === """{"foo":0}""")
+  }
 }
 
 case object JsonSuiteObject
@@ -433,3 +446,5 @@ object JsonSuiteObjectWithClass {
 }
 
 case class JsonSuiteListDouble(vs: List[Double])
+
+case class JsonSuiteObjectWithDefaults(foo: Int = 42, bar: String = "abc", values: List[String] = Nil)

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/ReflectionSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/ReflectionSuite.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.json
+
+import org.scalatest.FunSuite
+
+import scala.util.Try
+
+class ReflectionSuite extends FunSuite {
+  import ReflectionSuite._
+
+  test("create instance") {
+    val desc = Reflection.createDescription(classOf[Simple])
+    val obj = desc.newInstance
+    assert(obj === Simple(27, null))
+
+    desc.setField(obj, "foo", 42)
+    assert(obj === Simple(42, null))
+
+    desc.setField(obj, "bar", "abc")
+    assert(obj === Simple(42, "abc"))
+  }
+
+  test("create instance, additional field") {
+    val desc = Reflection.createDescription(classOf[Simple])
+    val obj = desc.newInstance
+    desc.setField(obj, "notPresent", 42)
+    assert(obj === Simple(27, null))
+  }
+
+  test("create instance, invalid type") {
+    val desc = Reflection.createDescription(classOf[Simple])
+    val obj = desc.newInstance
+    intercept[IllegalArgumentException] { desc.setField(obj, "bar", 42) }
+  }
+
+  test("isCaseClass") {
+    assert(Reflection.isCaseClass(classOf[Simple]) === true)
+    assert(Reflection.isCaseClass(classOf[Bar]) === false)
+  }
+
+  test("isCaseClass Option") {
+    assert(Reflection.isCaseClass(classOf[Option[_]]) === false)
+  }
+
+  test("isCaseClass Either") {
+    assert(Reflection.isCaseClass(classOf[Either[_, _]]) === false)
+  }
+
+  test("isCaseClass Try") {
+    assert(Reflection.isCaseClass(classOf[Try[_]]) === false)
+  }
+}
+
+object ReflectionSuite {
+
+  case class SimpleInner(foo: Int, bar: String = "abc")
+
+  class Bar(foo: Int)
+
+}
+
+case class Simple(foo: Int = 27, bar: String)


### PR DESCRIPTION
Adds a custom case class deserializer to the json
helper that supports default values used in the
case class constructor.

This is the more intuitive behavior most users
expect and avoids the need for wrapping in Option
or having custom deserializers for a given type
to fill in the defaults.