### PR TITLE
fix minor issues with case class deserializer

### DIFF
--- a/atlas-json/src/test/scala/com/netflix/atlas/json/CaseClassDeserializerSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/CaseClassDeserializerSuite.scala
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.json
+
+import com.fasterxml.jackson.core.Version
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.Module
+import com.fasterxml.jackson.databind.Module.SetupContext
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.scalatest.FunSuite
+
+class CaseClassDeserializerSuite extends FunSuite {
+
+  import CaseClassDeserializerSuite._
+
+  private val module = new Module {
+    override def version(): Version = Version.unknownVersion()
+    override def getModuleName: String = "test"
+
+    override def setupModule(context: SetupContext): Unit = {
+      context.addDeserializers(new CaseClassDeserializers)
+    }
+  }
+
+  private val mapper = new ObjectMapper()
+    .registerModule(DefaultScalaModule)
+    .registerModule(module)
+
+  def decode[T: Manifest](json: String): T = {
+    mapper.readValue[T](json, manifest.runtimeClass.asInstanceOf[Class[T]])
+  }
+
+  test("read simple object") {
+    val expected = SimpleObject(123, "abc", Some("def"))
+    val actual = decode[SimpleObject]("""{"foo": 123, "bar": "abc", "baz": "def"}""")
+    assert(actual === expected)
+  }
+
+  test("read array") {
+    intercept[JsonMappingException] {
+      decode[SimpleObject]("""[]""")
+    }
+  }
+
+  test("read int") {
+    intercept[JsonMappingException] {
+      decode[SimpleObject]("""42""")
+    }
+  }
+
+  test("invalid type for field (quoted number)") {
+    val expected = SimpleObject(123, "abc", Some("def"))
+    val actual = decode[SimpleObject]("""{"foo": "123", "bar": "abc", "baz": "def"}""")
+    assert(actual === expected)
+  }
+
+  test("invalid type for field (invalid number)") {
+    intercept[JsonMappingException] {
+      decode[SimpleObject]("""{"foo": "that", "bar": "abc", "baz": "def"}""")
+    }
+  }
+
+  test("read simple object missing Option") {
+    val expected = SimpleObject(42, "abc", None)
+    val actual = decode[SimpleObject]("""{"foo": 42, "bar": "abc"}""")
+    assert(actual === expected)
+  }
+
+  test("read simple object missing required") {
+    val expected = SimpleObject(123, null, Some("def"))
+    val actual = decode[SimpleObject]("""{"foo": 123, "baz": "def"}""")
+    assert(actual === expected)
+  }
+
+  test("read simple object with defaults") {
+    val expected = SimpleObjectWithDefaults()
+    val actual = decode[SimpleObjectWithDefaults]("""{}""")
+    assert(actual === expected)
+  }
+
+  test("read simple object with overridden defaults") {
+    val expected = SimpleObjectWithDefaults(foo = 21)
+    val actual = decode[SimpleObjectWithDefaults]("""{"foo": 21}""")
+    assert(actual === expected)
+  }
+
+  test("read simple object with one default") {
+    val expected = SimpleObjectWithOneDefault(21)
+    val actual = decode[SimpleObjectWithOneDefault]("""{"foo": 21}""")
+    assert(actual === expected)
+  }
+
+  test("read simple object with one default missing required") {
+    val expected = SimpleObjectWithOneDefault(0)
+    val actual = decode[SimpleObjectWithOneDefault]("""{}""")
+    assert(actual === expected)
+  }
+
+  test("read simple object with validation") {
+    val expected = SimpleObjectWithValidation("abc")
+    val actual = decode[SimpleObjectWithValidation]("""{"foo": "abc"}""")
+    assert(actual === expected)
+  }
+
+  test("read with Option[Int] field") {
+    val expected = OptionInt(Some(42))
+    val actual = decode[OptionInt]("""{"v":42}""")
+    assert(actual === expected)
+  }
+
+  test("read with Option[Long] field") {
+    val expected = OptionLong(Some(42L))
+    val actual = decode[OptionLong]("""{"v":42}""")
+    assert(actual === expected)
+  }
+
+  test("read with List[Option[Int]] field") {
+    val expected = ListOptionInt(List(Some(42), Some(21)))
+    val actual = decode[ListOptionInt]("""{"v":[42, 21]}""")
+    assert(actual === expected)
+  }
+}
+
+object CaseClassDeserializerSuite {
+  case class SimpleObject(foo: Int, bar: String, baz: Option[String])
+
+  case class SimpleObjectWithDefaults(foo: Int = 42, bar: String = "abc")
+
+  case class SimpleObjectWithOneDefault(foo: Int, bar: String = "abc")
+
+  case class SimpleObjectWithValidation(foo: String) {
+    require(foo != null)
+  }
+
+  case class SimpleObjectUnknownError(foo: String) {
+    throw new IllegalArgumentException
+  }
+
+  case class OptionInt(v: Option[Int])
+  case class OptionLong(v: Option[Long])
+  case class ListOptionInt(v: List[Option[Int]])
+}

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
@@ -221,7 +221,7 @@ class JsonSuite extends FunSuite {
   }
 
   // Ugly nested generics, just to see if it would work
-  ignore("scala List[Map[String, List[Option[Int]]]]") {
+  test("scala List[Map[String, List[Option[Int]]]]") {
     val v = List(Map("foo" -> List(Some(42), None, Some(43))))
     assert(encode(v) === """[{"foo":[42,null,43]}]""")
     assert(decode[List[Map[String, List[Option[Int]]]]](encode(v)) === v)

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/ReflectionSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/ReflectionSuite.scala
@@ -24,27 +24,28 @@ class ReflectionSuite extends FunSuite {
 
   test("create instance") {
     val desc = Reflection.createDescription(classOf[Simple])
-    val obj = desc.newInstance
-    assert(obj === Simple(27, null))
+    val args = desc.newInstanceArgs
+    assert(desc.newInstance(args) === Simple(27, null))
 
-    desc.setField(obj, "foo", 42)
-    assert(obj === Simple(42, null))
+    desc.setField(args, "foo", 42)
+    assert(desc.newInstance(args) === Simple(42, null))
 
-    desc.setField(obj, "bar", "abc")
-    assert(obj === Simple(42, "abc"))
+    desc.setField(args, "bar", "abc")
+    assert(desc.newInstance(args) === Simple(42, "abc"))
   }
 
   test("create instance, additional field") {
     val desc = Reflection.createDescription(classOf[Simple])
-    val obj = desc.newInstance
-    desc.setField(obj, "notPresent", 42)
-    assert(obj === Simple(27, null))
+    val args = desc.newInstanceArgs
+    desc.setField(args, "notPresent", 42)
+    assert(desc.newInstance(args) === Simple(27, null))
   }
 
   test("create instance, invalid type") {
     val desc = Reflection.createDescription(classOf[Simple])
-    val obj = desc.newInstance
-    intercept[IllegalArgumentException] { desc.setField(obj, "bar", 42) }
+    val args = desc.newInstanceArgs
+    desc.setField(args, "bar", 42)
+    intercept[IllegalArgumentException] { desc.newInstance(args) }
   }
 
   test("isCaseClass") {


### PR DESCRIPTION
This change fixes two issues with the case class
deserializer added in #439:

1. We now check the initial token type to verify
   it is an object.
2. Avoids creating the object before parsing the
   fields. That was done before to avoid the
   allocating the argument array for the constructor.
   However, it prevents users from being able to
   have additional validation as part of the
   constructor logic. Now the object will be
   created after the fields have all been processed
   and placed in the arguments array.