### PR TITLE
improve generic type detection

### DIFF
--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
@@ -81,23 +81,6 @@ object Json {
     mapper
   }
 
-  // Taken from com.fasterxml.jackson.module.scala.deser.DeserializerTest.scala
-  private def typeReference[T: Manifest] = new TypeReference[T] {
-    override def getType = typeFromManifest(manifest[T])
-  }
-
-  // Taken from com.fasterxml.jackson.module.scala.deser.DeserializerTest.scala
-  private def typeFromManifest(m: Manifest[_]): Type = {
-    if (m.typeArguments.isEmpty) { m.runtimeClass }
-    else new ParameterizedType {
-      def getRawType = m.runtimeClass
-
-      def getActualTypeArguments = m.typeArguments.map(typeFromManifest).toArray
-
-      def getOwnerType = null
-    }
-  }
-
   /**
     * Register additional modules with the default mappers used for JSON and Smile.
     *
@@ -183,7 +166,7 @@ object Json {
       if (manifest.runtimeClass.isArray)
         jsonMapper.readerFor(manifest.runtimeClass.asInstanceOf[Class[T]])
       else
-        jsonMapper.readerFor(typeReference[T])
+        jsonMapper.readerFor(Reflection.typeReference[T])
     val value = reader.readValue[T](parser)
     require(parser.nextToken() == null, "invalid json, additional content after value")
     value
@@ -194,7 +177,7 @@ object Json {
       if (manifest.runtimeClass.isArray)
         jsonMapper.readerFor(manifest.runtimeClass.asInstanceOf[Class[T]])
       else
-        jsonMapper.readerFor(typeReference[T])
+        jsonMapper.readerFor(Reflection.typeReference[T])
     new Decoder[T](reader, jsonFactory)
   }
 
@@ -215,7 +198,7 @@ object Json {
       if (manifest.runtimeClass.isArray)
         jsonMapper.readerFor(manifest.runtimeClass.asInstanceOf[Class[T]])
       else
-        jsonMapper.readerFor(typeReference[T])
+        jsonMapper.readerFor(Reflection.typeReference[T])
     new Decoder[T](reader, smileFactory)
   }
 }

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/CaseClassDeserializerSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/CaseClassDeserializerSuite.scala
@@ -41,7 +41,7 @@ class CaseClassDeserializerSuite extends FunSuite {
     .registerModule(module)
 
   def decode[T: Manifest](json: String): T = {
-    mapper.readValue[T](json, manifest.runtimeClass.asInstanceOf[Class[T]])
+    mapper.readValue[T](json, Reflection.typeReference[T])
   }
 
   test("read simple object") {
@@ -157,6 +157,18 @@ class CaseClassDeserializerSuite extends FunSuite {
     val actual = decode[ListStringDflt]("""{"vs":null}""")
     assert(actual === expected)
   }
+
+  test("generics") {
+    val expected = Outer(List(List(Inner("a"), Inner("b")), List(Inner("c"))))
+    val actual = decode[Outer]("""{"vs":[[{"v":"a"},{"v":"b"}],[{"v":"c"}]]}""")
+    assert(actual === expected)
+  }
+
+  test("generics 2") {
+    val expected = OuterT(List(List(Inner("a"), Inner("b")), List(Inner("c"))))
+    val actual = decode[OuterT[List[List[Inner]]]]("""{"vs":[[{"v":"a"},{"v":"b"}],[{"v":"c"}]]}""")
+    assert(actual === expected)
+  }
 }
 
 object CaseClassDeserializerSuite {
@@ -179,4 +191,8 @@ object CaseClassDeserializerSuite {
   case class ListOptionInt(v: List[Option[Int]])
   case class ListString(vs: List[String])
   case class ListStringDflt(vs: List[String] = Nil)
+
+  case class Inner(v: String)
+  case class Outer(vs: List[List[Inner]])
+  case class OuterT[T](vs: T)
 }


### PR DESCRIPTION
Uses the type information from the bean description
when available so we have more context as to the requested
types for generic parameters.

The `generics 2` test case would fail before this change
because it would decode to a `Map` instead of `Inner`.