### PR TITLE
some patterns incorrectly interpretted as indexOf

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
@@ -78,8 +78,24 @@ class QuerySuite extends FunSuite {
     assert(!q.matches(Map("foo2" -> "bar")))
   }
 
+  test("matches re implicit start anchor") {
+    val q = Regex("foo", "b.*")
+    assert(q.matches(Map("foo" -> "bar")))
+    assert(q.matches(Map("foo" -> "bar2")))
+    assert(!q.matches(Map("foo" -> "fubar2")))
+    assert(!q.matches(Map("foo2" -> "bar")))
+  }
+
   test("matches reic") {
     val q = RegexIgnoreCase("foo", "^B.*")
+    assert(q.matches(Map("foo" -> "bar")))
+    assert(q.matches(Map("foo" -> "Bar2")))
+    assert(!q.matches(Map("foo" -> "fubar2")))
+    assert(!q.matches(Map("foo2" -> "bar")))
+  }
+
+  test("matches reic implicit start anchor") {
+    val q = RegexIgnoreCase("foo", "B.*")
     assert(q.matches(Map("foo" -> "bar")))
     assert(q.matches(Map("foo" -> "Bar2")))
     assert(!q.matches(Map("foo" -> "fubar2")))

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringMatcherSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringMatcherSuite.scala
@@ -84,6 +84,14 @@ class StringMatcherSuite extends FunSuite {
     assert(compile("^foo.*", false) === Regex(None, reic("^foo.*")))
   }
 
+  test("compile Equals") {
+    assert(compile("^foo$") === Equals("foo"))
+  }
+
+  test("compile EqualsIgnoreCase") {
+    assert(compile("^foo$", false) === EqualsIgnoreCase("foo"))
+  }
+
   test("compile IndexOf") {
     assert(compile("foo") === IndexOf("foo"))
     assert(compile(".*foo.*") === IndexOf("foo"))
@@ -119,6 +127,14 @@ class StringMatcherSuite extends FunSuite {
     assert(compile("^.*foo[bar]", false) === Regex(None, reic("^.*foo[bar]")))
     assert(compile("^.*foo[bar].*", false) === Regex(None, reic("^.*foo[bar].*")))
     assert(compile("^.*foo[bar].*$", false) === Regex(None, reic("^.*foo[bar].*$")))
+  }
+
+  test("compile Regex end anchor") {
+    assert(compile("^foo[1-3]$") === Regex(Some("foo"), re("^foo[1-3]$")))
+  }
+
+  test("compile RegexIgnoreCase end anchor") {
+    assert(compile("^foo[1-3]$", false) === Regex(None, reic("^foo[1-3]$")))
   }
 
 }


### PR DESCRIPTION
For simple patterns the `StringMatcher` will convert
them to basic string operations that perform better
than using regular expressions.

If a simple pattern had an explicit end anchor, then it
was incorrectly choosing the `IndexOf` matcher rather
than falling back to using `Regex`. This change fixes
the `IndexOf` pattern and also adds an `Equals` matcher
to cover the simple case using `String.equals`.