### PR TITLE
avoid using String.format in hot code paths

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonCodec.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonCodec.scala
@@ -202,7 +202,7 @@ private[this] object JsonCodec {
   }
 
   private def writeColor(gen: JsonGenerator, color: Color): Unit = {
-    gen.writeString(f"${color.getRGB}%08X")
+    gen.writeString(Strings.zeroPad(color.getRGB, 8))
   }
 
   private def readGraphDef(parser: JsonParser): GraphDef = {

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonGraphEngine.scala
@@ -33,7 +33,6 @@ class JsonGraphEngine(quoteNonNumeric: Boolean) extends GraphEngine {
     val writer = new OutputStreamWriter(output, "UTF-8")
     val seriesList = config.plots.flatMap(_.lines)
     val count = seriesList.size
-    val numberFmt = config.numberFormat
     val gen = jsonFactory.createGenerator(writer)
 
     gen.writeStartObject()
@@ -66,10 +65,12 @@ class JsonGraphEngine(quoteNonNumeric: Boolean) extends GraphEngine {
       gen.writeStartArray()
       seriesList.foreach { series =>
         val v = series.data.data(timestamp)
-        if (!quoteNonNumeric || java.lang.Double.isFinite(v))
-          gen.writeRawValue(numberFmt.format(v))
-        else
+        if (java.lang.Double.isFinite(v))
+          gen.writeNumber(v)
+        else if (quoteNonNumeric)
           gen.writeString(v.toString)
+        else
+          gen.writeRawValue(v.toString)
       }
       gen.writeEndArray()
       timestamp += step

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/JsonGraphEngineSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/JsonGraphEngineSuite.scala
@@ -67,7 +67,7 @@ class JsonGraphEngineSuite extends FunSuite {
         |"step":60000,
         |"legend":["0","1"],
         |"metrics":[{"name":"42.0"},{"name":"NaN"}],
-        |"values":[[42.000000,NaN],[42.000000,NaN],[42.000000,NaN]],
+        |"values":[[42.0,NaN],[42.0,NaN],[42.0,NaN]],
         |"notices":[]
         |}"""
 
@@ -81,7 +81,7 @@ class JsonGraphEngineSuite extends FunSuite {
         |"step":60000,
         |"legend":["0","1"],
         |"metrics":[{"name":"42.0"},{"name":"NaN"}],
-        |"values":[[42.000000,"NaN"],[42.000000,"NaN"],[42.000000,"NaN"]],
+        |"values":[[42.0,"NaN"],[42.0,"NaN"],[42.0,"NaN"]],
         |"notices":[]
         |}"""
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/SimpleTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/SimpleTagIndex.scala
@@ -21,6 +21,7 @@ import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.Tag
 import com.netflix.atlas.core.model.TagKey
 import com.netflix.atlas.core.model.TaggedItem
+import com.netflix.atlas.core.util.Strings
 
 import scala.reflect.ClassTag
 
@@ -116,7 +117,7 @@ class SimpleTagIndex[T <: TaggedItem: ClassTag](items: Array[T]) extends TagInde
 
   def findItems(query: TagQuery): List[T] = {
     val matches = findItemsImpl(query.query)
-    val filtered = matches.filter(i => "%040x".format(i.id) > query.offset)
+    val filtered = matches.filter(i => Strings.zeroPad(i.id, 40) > query.offset)
     val sorted = filtered.sortWith { (a, b) => a.id.compareTo(b.id) < 0 }
     sorted.take(query.limit)
   }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TaggedItem.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TaggedItem.scala
@@ -27,6 +27,7 @@ import com.netflix.atlas.core.util.Hash
 import com.netflix.atlas.core.util.InternMap
 import com.netflix.atlas.core.util.Interner
 import com.netflix.atlas.core.util.SmallHashMap
+import com.netflix.atlas.core.util.Strings
 
 
 /**
@@ -160,7 +161,7 @@ trait TaggedItem {
   def id: BigInteger
 
   /** Standard string representation of the id. */
-  def idString: String = "%040x".format(id)
+  def idString: String = Strings.zeroPad(id, 40)
 
   /** The tags associated with this item. */
   def tags: Map[String, String]

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
@@ -16,6 +16,7 @@
 package com.netflix.atlas.core.util
 
 import java.awt.Color
+import java.math.BigInteger
 import java.net.URLDecoder
 import java.net.URLEncoder
 import java.time.Duration
@@ -479,4 +480,38 @@ object Strings {
       replaceAll("\n", " ").
       replaceAll("@@@", "\n\n")
   }
+
+  /**
+    * Left pad the input string with zeros to the specified width. This is
+    * typically used as an alternative to performing zero padding using
+    * `String.format`.
+    */
+  def zeroPad(s: String, width: Int): String = {
+    val n = width - s.length
+    if (n <= 0) s else {
+      val builder = new StringBuilder(width)
+      var i = 0
+      while (i < n) {
+        builder.append('0')
+        i += 1
+      }
+      builder.append(s)
+      builder.toString()
+    }
+  }
+
+  /**
+    * Convert integer value to hex string and zero pad. It is intended for positive values
+    * and the integer value will be treated as unsigned.
+    */
+  def zeroPad(v: Int, width: Int): String = zeroPad(Integer.toHexString(v), width)
+
+  /**
+    * Convert long value to hex string and zero pad. It is intended for positive values
+    * and the integer value will be treated as unsigned.
+    */
+  def zeroPad(v: Long, width: Int): String = zeroPad(java.lang.Long.toHexString(v), width)
+
+  /** Convert BigInteger value to hex string and zero pad. */
+  def zeroPad(v: BigInteger, width: Int): String = zeroPad(v.toString(16), width)
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
@@ -16,6 +16,7 @@
 package com.netflix.atlas.core.util
 
 import java.awt.Color
+import java.math.BigInteger
 import java.time.Duration
 import java.time.ZoneId
 import java.time.ZoneOffset
@@ -466,5 +467,31 @@ class StringsSuite extends FunSuite {
     assert(substitute("$(foo) ::: $(bar)", vars) === "bar ::: baz")
     assert(substitute("$(missing) ::: $(bar)", vars) === "missing ::: baz")
     assert(substitute("$missing ::: $bar", vars) === "missing ::: baz")
+  }
+
+  test("zeroPad int") {
+    assert(zeroPad(42, 1) === "2a")
+    assert(zeroPad(42, 2) === "2a")
+    assert(zeroPad(42, 3) === "02a")
+    assert(zeroPad(42, 8) === "0000002a")
+    assert(zeroPad(-42, 8) === "ffffffd6")
+    assert(zeroPad(-42, 12) === "0000ffffffd6")
+  }
+
+  test("zeroPad long") {
+    assert(zeroPad(42L, 1) === "2a")
+    assert(zeroPad(42L, 2) === "2a")
+    assert(zeroPad(42L, 3) === "02a")
+    assert(zeroPad(42L, 8) === "0000002a")
+    assert(zeroPad(-42L, 8) === "ffffffffffffffd6")
+    assert(zeroPad(-42L, 18) === "00ffffffffffffffd6")
+  }
+
+  test("zeroPad BigInteger") {
+    val b = new BigInteger("42")
+    assert(zeroPad(b, 1) === "2a")
+    assert(zeroPad(b, 2) === "2a")
+    assert(zeroPad(b, 3) === "02a")
+    assert(zeroPad(b, 8) === "0000002a")
   }
 }

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/chart/GraphEngines.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/chart/GraphEngines.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.chart
+
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+
+import com.netflix.atlas.chart.model.GraphDef
+import com.netflix.atlas.chart.model.LineDef
+import com.netflix.atlas.chart.model.PlotDef
+import com.netflix.atlas.core.model.DsType
+import com.netflix.atlas.core.model.FunctionTimeSeq
+import com.netflix.atlas.core.model.TimeSeries
+import com.netflix.atlas.core.util.Streams
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Threads
+import org.openjdk.jmh.infra.Blackhole
+
+/**
+  * Check performance of graph engines.
+  *
+  * ```
+  * > jmh:run -prof jmh.extras.JFR -wi 10 -i 10 -f1 -t1 .*GraphEngines.*
+  * ...
+  * [info] Benchmark               Mode  Cnt       Score      Error  Units
+  * [info] GraphEngines.json      thrpt   10  133959.616 ± 7774.240  ops/s
+  * ```
+  */
+@State(Scope.Thread)
+class GraphEngines {
+
+  val step = 60000
+
+  def constant(v: Double): TimeSeries = {
+    TimeSeries(Map("name" -> v.toString), new FunctionTimeSeq(DsType.Gauge, step, _ => v))
+  }
+
+  def constantSeriesDef(value: Double): LineDef = LineDef(constant(value))
+
+  val data = PlotDef(List(constantSeriesDef(42), constantSeriesDef(1.0 / 3.0)))
+
+  val graphDef = GraphDef(
+    plots = List(data),
+    startTime = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant,
+    endTime = ZonedDateTime.of(2012, 1, 1, 0, 12, 0, 0, ZoneOffset.UTC).toInstant
+  )
+
+  val json = new JsonGraphEngine()
+
+  @Threads(1)
+  @Benchmark
+  def json(bh: Blackhole): Unit = {
+    val bytes = Streams.byteArray { out => json.write(graphDef, out) }
+    bh.consume(bytes)
+  }
+}
+

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/chart/GraphEngines.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/chart/GraphEngines.scala
@@ -37,8 +37,9 @@ import org.openjdk.jmh.infra.Blackhole
   * ```
   * > jmh:run -prof jmh.extras.JFR -wi 10 -i 10 -f1 -t1 .*GraphEngines.*
   * ...
-  * [info] Benchmark               Mode  Cnt       Score      Error  Units
-  * [info] GraphEngines.json      thrpt   10  133959.616 ± 7774.240  ops/s
+  * [info] Benchmark                 Mode  Cnt       Score      Error  Units
+  * [info] GraphEngines.json        thrpt   10  133984.991 ± 7703.042  ops/s
+  * [info] GraphEngines.v2json      thrpt   10  142775.471 ± 6897.508  ops/s
   * ```
   */
 @State(Scope.Thread)
@@ -61,11 +62,19 @@ class GraphEngines {
   )
 
   val json = new JsonGraphEngine()
+  val v2json = new V2JsonGraphEngine()
 
   @Threads(1)
   @Benchmark
   def json(bh: Blackhole): Unit = {
     val bytes = Streams.byteArray { out => json.write(graphDef, out) }
+    bh.consume(bytes)
+  }
+
+  @Threads(1)
+  @Benchmark
+  def v2json(bh: Blackhole): Unit = {
+    val bytes = Streams.byteArray { out => v2json.write(graphDef, out) }
     bh.consume(bytes)
   }
 }

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/ZeroPad.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/ZeroPad.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import java.math.BigInteger
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Threads
+import org.openjdk.jmh.infra.Blackhole
+
+/**
+  * Check use of `String.format` against just padding with our custom
+  * `Strings.zeroPad`.
+  *
+  * ```
+  * > jmh:run -prof jmh.extras.JFR -wi 10 -i 10 -f1 -t1 .*ZeroPad.*
+  * ```
+  *
+  * Initial results:
+  *
+  * ```
+  * [info] Benchmark                Mode  Cnt        Score        Error  Units
+  * [info] ZeroPad.hashFormat      thrpt   10   494319.963 ±  28396.222  ops/s
+  * [info] ZeroPad.hashPad         thrpt   10   794528.844 ±  47922.416  ops/s
+  * [info] ZeroPad.oneFormat       thrpt   10   904410.430 ±  55786.780  ops/s
+  * [info] ZeroPad.onePad          thrpt   10  3391001.622 ± 288190.044  ops/s
+  * ```
+  */
+@State(Scope.Thread)
+class ZeroPad {
+
+  private val hash = Hash.sha1("zero-pad")
+
+  @Threads(1)
+  @Benchmark
+  def oneFormat(bh: Blackhole): Unit = {
+    // Needs a lot of padding
+    bh.consume("%040x".format(BigInteger.ONE))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def onePad(bh: Blackhole): Unit = {
+    // Needs a lot of padding
+    bh.consume(Strings.zeroPad(BigInteger.ONE, 40))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def hashFormat(bh: Blackhole): Unit = {
+    // Common case, hash value that will likely not need much if any padding
+    bh.consume("%040x".format(hash))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def hashPad(bh: Blackhole): Unit = {
+    // Common case, hash value that will likely not need much if any padding
+    bh.consume(Strings.zeroPad(hash, 40))
+  }
+}

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
@@ -70,7 +70,6 @@ object GraphApi {
       step: Option[String],
       flags: ImageFlags,
       format: String,
-      numberFormat: String,
       id: String,
       isBrowser: Boolean,
       isAllowedFromBrowser: Boolean,
@@ -167,7 +166,6 @@ object GraphApi {
         zoom = flags.zoom,
         legendType = legendType,
         onlyGraph = flags.showOnlyGraph,
-        numberFormat = numberFormat,
         plots = plots,
         source = if (ApiSettings.metadataEnabled) Some(uri) else None,
         warnings = warnings
@@ -294,7 +292,6 @@ object GraphApi {
       step = params.get("step"),
       flags = flags,
       format = params.get("format").getOrElse("png"),
-      numberFormat = params.get("number_format").getOrElse("%f"),
       id = id,
       isBrowser = false,
       isAllowedFromBrowser = true,

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiSuite.scala
@@ -20,6 +20,7 @@ import com.netflix.atlas.core.db.StaticDatabase
 import com.netflix.atlas.core.util.Hash
 import com.netflix.atlas.core.util.PngImage
 import com.netflix.atlas.core.util.Streams
+import com.netflix.atlas.core.util.Strings
 import com.netflix.atlas.test.GraphAssertions
 import com.netflix.atlas.test.SrcPath
 import org.scalatest.FunSuite
@@ -83,7 +84,7 @@ class GraphApiSuite extends FunSuite with ScalatestRouteTest {
   }
 
   private def imageFileName(uri: String): String = {
-    s"${"%040x".format(Hash.sha1(uri)).substring(0, 8)}.png"
+    s"${Strings.zeroPad(Hash.sha1(uri), 40).substring(0, 8)}.png"
   }
 
 }

--- a/atlas-wiki/src/main/resources/Graph.md
+++ b/atlas-wiki/src/main/resources/Graph.md
@@ -55,12 +55,6 @@ There are four parameters to control the image size and layout used for a graph:
 
 For more information on the behavior see the [graph layout](Graph-Layout) page.
 
-### Text Flags
-
-| Name            | Description                                  | Default   | Type                                  |
-|-----------------|----------------------------------------------|-----------|---------------------------------------|
-| `number_format` | How to format numbers for text output types  | `%f`     | [float format](https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html#dndec) |
-
 ### Y-Axis
 
 | Name             | Description                                        | Default      | Type                               |

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/GraphHelper.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/GraphHelper.scala
@@ -141,7 +141,7 @@ class GraphHelper(webApi: ActorRef, dir: File, path: String) extends StrictLoggi
   }
 
   private def imageFileName(uri: String): String = {
-    s"${"%040x".format(Hash.sha1(uri)).substring(0, 8)}.png"
+    s"${Strings.zeroPad(Hash.sha1(uri), 40).substring(0, 8)}.png"
   }
 
   def formatQuery(line: String): String = {

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ lazy val `atlas-core` = project
 
 lazy val `atlas-jmh` = project
   .configure(BuildSettings.profile)
-  .dependsOn(`atlas-core`, `atlas-json`)
+  .dependsOn(`atlas-chart`, `atlas-core`, `atlas-json`)
   .enablePlugins(pl.project13.scala.sbt.SbtJmh)
 
 lazy val `atlas-json` = project


### PR DESCRIPTION
String.format uses regex internally to parse the format
string. This makes it quite expensive and removing the
usage is an easy win.