### PR TITLE
docs: remove internal link from wiki

### DIFF
--- a/atlas-wiki/src/main/resources/Getting-Started.md
+++ b/atlas-wiki/src/main/resources/Getting-Started.md
@@ -2,7 +2,6 @@
 The instructions on this page are for quickly getting a sample backend server running on a local
 machine. For other common tasks see:
 
-* [Using Atlas at Netflix](http://go/insightdocs)
 * Querying Data:
     * [Examples](Examples)
     * [Tutorial](Stack-Language)


### PR DESCRIPTION
Looks like it was added to help guide internal users
that might go to this wiki. Other links should suffice
and we'll revisit if it becomes a problem. Fixes #471.