### PR TITLE
track bytes sent, not messages sent, for limiting resource usage

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SSEActor.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SSEActor.scala
@@ -37,47 +37,56 @@ class SSEActor(client: ActorRef,
 
   private val connectsId = registry.createId("atlas.lwcapi.sse.connectCount")
   private val messagesId = registry.createId("atlas.lwcapi.sse.messageCount")
-  private val droppedId = registry.createId("atlas.lwcapi.sse.droppedCount")
+  private val messageBytesId = registry.createId("atlas.lwcapi.sse.messageBytesCount")
+  private val sendsId = registry.createId("atlas.lwcapi.sse.httpSendsCount")
+  private val sendBytesId = registry.createId("atlas.lwcapi.sse.httpSendBytesCount")
+  private val droppedId = registry.createId("atlas.lwcapi.sse.droppedMessageCount")
 
   private val sseCountId = registry.createId("atlas.lwcapi.streams").withTag("streamType", "sse")
   private val sseCount = registry.gauge(sseCountId, new AtomicInteger(1))
 
-  private var outstandingCount = 0
-  private val maxOutstanding = 100
-  private var droppedCount = 0
+  private var outstandingByteCount: Long = 0
+  private val maxOutstandingBytes: Long = 10000000 // 10 megabytes max outstanding request size per SSE stream
+  private var droppedMessageCount: Long = 0 // in messages
+  private val maxBufferLength: Long = 100000 // 100k allowed to buffer before we send it.
 
   private val instanceId = NetflixEnvironment.instanceId()
 
-  private val tickTime = 30.seconds
+  private val tickTime = 100.microseconds
   private var tickCount = 0
+  private val statsTime = 300 // in 100ms increments.
   private val helloMessage = SSEHello(sseId, instanceId, GlobalUUID.get)
+  private var toSend = ""
 
-  client ! ChunkedResponseStart(HttpResponse(StatusCodes.OK)).withAck(Ack)
-  outstandingCount += 1
+  client ! ChunkedResponseStart(HttpResponse(StatusCodes.OK)).withAck(Ack(1))
+  outstandingByteCount += 1 // ignore byte lengh here, just send it.
   registry.counter(connectsId.withTag("streamId", sseId)).increment()
 
   var needsUnregister = true
   sm.register(sseId, self, name)
   send(helloMessage)
+  send(SSEStatistics(0))
 
   var ticker: Cancellable = context.system.scheduler.schedule(tickTime, tickTime) {
     self ! Tick
   }
 
   def receive = {
-    case Ack =>
-      outstandingCount -= 1
+    case Ack(length) =>
+      outstandingByteCount -= length
     case Tick =>
-      if (outstandingCount == 0 || tickCount > 10) {
-        send(SSEStatistics(outstandingCount, droppedCount, maxOutstanding), force = true)
+      tickCount += 1
+      if (tickCount >= statsTime) {
+        val msg = SSEStatistics(droppedMessageCount)
+        send(msg, force = true)
         tickCount = 0
-      } else {
-        tickCount += 1
       }
+      flushBuffer()
     case msg: SSEShutdown =>
-      send(msg)
-      client ! Http.Close
       ticker.cancel()
+      send(msg)
+      flushBuffer()
+      client ! Http.Close
       unregister()
       log.info(s"Closing SSE stream: ${msg.reason}")
     case msg: SSEMessage =>
@@ -88,15 +97,35 @@ class SSEActor(client: ActorRef,
       context.stop(self)
   }
 
+  private def flushBuffer(): Unit = {
+    if (toSend.nonEmpty) {
+      client ! MessageChunk(toSend).withAck(Ack(toSend.length))
+      toSend = ""
+    }
+  }
+
+  private def queueToBuffer(msg: SSEMessage): Unit = {
+    val part = msg.toSSE + "\r\n\r\n"
+    toSend += part
+    // accounting happens prior to actual send
+    outstandingByteCount += part.length
+    registry.counter(messagesId.withTag("action", msg.getWhat)).increment()
+    registry.counter(messageBytesId.withTag("action", msg.getWhat)).increment(part.length)
+    if (toSend.length >= maxBufferLength)
+      flushBuffer()
+  }
+
   private def send(msg: SSEMessage, force: Boolean = false): Unit = {
-    if (outstandingCount < maxOutstanding || force) {
-      val json = msg.toSSE + "\r\n\r\n"
-      client ! MessageChunk(json).withAck(Ack)
-      outstandingCount += 1
-      registry.counter(messagesId.withTag("action", msg.getWhat)).increment()
+    if (force) {
+      queueToBuffer(msg)
+      flushBuffer()
     } else {
-      droppedCount += 1
-      registry.counter(droppedId.withTag("action", msg.getWhat)).increment()
+      if (outstandingByteCount < maxOutstandingBytes) {
+        queueToBuffer(msg)
+      } else {
+        droppedMessageCount += 1
+        registry.counter(droppedId.withTag("action", msg.getWhat)).increment()
+      }
     }
   }
 
@@ -113,9 +142,10 @@ class SSEActor(client: ActorRef,
     ticker.cancel()
     super.postStop()
   }
+
+  case class Ack(length: Long)
 }
 
 object SSEActor {
-  case object Ack
   case object Tick
 }

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
@@ -109,7 +109,7 @@ object StreamApi {
 
   abstract class SSEMessage(msgType: String, what: String, content: JsonSupport) extends SSERenderable {
     def toSSE = s"$msgType: $what ${content.toJson}"
-    def getWhat = what
+    def getWhat: String = what
   }
 
   // Hello message
@@ -121,9 +121,9 @@ object StreamApi {
   case class SSEGenericJson(what: String, msg: JsonSupport) extends SSEMessage("data", what, msg)
 
   // Heartbeat message
-  case class StatisticsContent(outstandingCount: Long, outputFullFailures: Long, maxOutstanding: Long) extends JsonSupport
-  case class SSEStatistics(outstandingCount: Long, outputFullFailures: Long, maxOutstanding: Long)
-    extends SSEMessage("info", "statistics", StatisticsContent(outstandingCount, outputFullFailures, maxOutstanding))
+  case class StatisticsContent(outputFullFailures: Long) extends JsonSupport
+  case class SSEStatistics(outputFullFailures: Long)
+    extends SSEMessage("info", "statistics", StatisticsContent(outputFullFailures))
 
   // Shutdown message
   case class ShutdownReason(reason: String) extends JsonSupport

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/StreamApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/StreamApiSuite.scala
@@ -42,7 +42,7 @@ class StreamApiSuite extends FunSuite with ScalatestRouteTest {
   }
 
   test("SSEStatistics renders") {
-    assert(SSEStatistics(1, 2, 3).toSSE === """info: statistics {"outstandingCount":1,"outputFullFailures":2,"maxOutstanding":3}""")
+    assert(SSEStatistics(1).toSSE === """info: statistics {"outputFullFailures":1}""")
   }
 
   test("SSEShutdown renders") {


### PR DESCRIPTION
This patch changes limiting outstanding messages to limiting outstanding bytes for slower readers.  The limit is set to 10 megabytes per stream.

Also, individual metrics are combined into a single HTTP write request every 100 ms (hard coded) or 100 k of buffered data (hard coded)