### PR TITLE
fix bug with equality check on SmallHashMap

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
@@ -350,27 +350,26 @@ final class SmallHashMap[K <: AnyRef, V <: AnyRef] private (val data: Array[AnyR
     while (i < data.length) {
       val k1 = data(i).asInstanceOf[K]
       val k2 = m.data(i).asInstanceOf[K]
-      if (k1 == null && k1 != k2) {
-        val v1 = getOrNull(k2)
-        val v2 = m.data(i + 1)
-        if (v1 != v2) return false
-      }
-
-      if (k2 == null && k1 != k2) {
-        val v1 = data(i + 1)
-        val v2 = m.getOrNull(k1)
-        if (v1 != v2) return false
-      }
 
       if (k1 == k2) {
         val v1 = data(i + 1)
         val v2 = m.data(i + 1)
         if (v1 != v2) return false
+      } else {
+        if (!keyEquals(m, k1) || !keyEquals(m, k2)) return false
       }
 
       i += 2
     }
     true
+  }
+
+  private def keyEquals(m: SmallHashMap[K, V], k: K): Boolean = {
+    if (k == null) true else {
+      val v1 = getOrNull(k)
+      val v2 = m.getOrNull(k)
+      v1 == v2
+    }
   }
 
   /** This is here to allow for testing and benchmarks. Should note be used otherwise. */

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/SmallHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/SmallHashMapSuite.scala
@@ -379,4 +379,21 @@ class SmallHashMapSuite extends FunSuite {
     assert(100.0 * ref / size >= 97.0)
     assert(100.0 * naive / size >= 97.0)
   }
+
+  test("dataEquals") {
+    val m1 = SmallHashMap("a" -> "1")
+    val m2 = SmallHashMap("b" -> "2")
+    assert(!m1.dataEquals(m2))
+  }
+
+  test("dataEquals with different sizes") {
+    // dataEquals is internal and expects the sizes to match before being
+    // called. For this test case we are verifying the case where the first
+    // item in the two maps are different, but a lookup for the item from
+    // the first map will work. However, the lookup of the item from the
+    // second map will not.
+    val m1 = SmallHashMap("a" -> "1")
+    val m2 = SmallHashMap("a" -> "1", "c" -> "3")
+    assert(!m1.dataEquals(m2))
+  }
 }


### PR DESCRIPTION
For maps with the same length and hashCodes the equality
check would fall back to `dataEquals`. That method had
a bug where if different keys were in the same position
of the underlying data array, then the values would not
get checked and the entry would get skipped. This could
cause some maps to incorrectly get treated as being equal
even though they are not.