### PR TITLE
move ec2 credit to separate block

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/ec2.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/ec2.conf
@@ -17,17 +17,6 @@ atlas {
           alias = "aws.ec2.cpuUtilization"
           conversion = "max"
         },
-        // http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-instances.html#t2-instances-monitoring-cpu-credits
-        {
-          name = "CPUCreditUsage"
-          alias = "aws.ec2.cpuCreditUsage"
-          conversion = "sum"
-        },
-        {
-          name = "CPUCreditBalance"
-          alias = "aws.ec2.cpuCreditBalance"
-          conversion = "sum"
-        },
         {
           name = "NetworkIn"
           alias = "aws.ec2.networkThroughput"
@@ -144,6 +133,29 @@ atlas {
     ec2-instance = ${atlas.cloudwatch.ec2} {
       dimensions = [
         "InstanceId"
+      ]
+    }
+
+    // http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-instances.html#t2-instances-monitoring-cpu-credits
+    ec2-credit = {
+      namespace = "AWS/EC2"
+      period = 5m
+
+      dimensions = [
+        "AutoScalingGroupName"
+      ]
+
+      metrics = [
+        {
+          name = "CPUCreditUsage"
+          alias = "aws.ec2.cpuCreditUsage"
+          conversion = "sum"
+        },
+        {
+          name = "CPUCreditBalance"
+          alias = "aws.ec2.cpuCreditBalance"
+          conversion = "sum"
+        },
       ]
     }
   }

--- a/atlas-poller-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/reference.conf
@@ -190,6 +190,7 @@ atlas {
       "dynamodb-table-5m",
       "dynamodb-table-ops",
       "ec2",
+      "ec2-credit",
       "elasticache",
       "elb",
       "es",


### PR DESCRIPTION
This makes it easier to query for just the t2 credit
metrics rather than all ec2 metrics.