### PR TITLE
remove test sqs filter from config

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/sqs.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/sqs.conf
@@ -11,8 +11,6 @@ atlas {
         "QueueName"
       ]
 
-      filter = "aws.queue,.*[-_](i-[0-9a-z]+|[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})$,:re,aws.queue,(com_netflix_platform_testqueue2|ursula_demux_|prod_mce_link_s3_notifications-prod-|cloudBatchTestQueue|SyncMessageTestQueue|GPS_PRECOMPUTE|GPS_PAGE_BASIS_PRECOMPUTE|GPS_ROW_ADJUSTMENT|ocmon_test_),:re,:or,:not"
-
       metrics = [
         {
           name = "ApproximateNumberOfMessagesDelayed"


### PR DESCRIPTION
The filter for testing was left in the config. As it is
not generally applicable it should not be in the base
config files.