### PR TITLE
propagate exception if thrown in constructor

### DIFF
--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Reflection.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Reflection.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.json
 
+import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.ParameterizedType
 
 import com.fasterxml.jackson.annotation.JsonProperty
@@ -194,7 +195,11 @@ private[json] object Reflection {
     }
 
     /** Create a new instance of the case class using the provided arguments. */
-    def newInstance(args: Array[Any]): AnyRef = ctor.apply(args: _*).asInstanceOf[AnyRef]
+    def newInstance(args: Array[Any]): AnyRef = {
+       try ctor.apply(args: _*).asInstanceOf[AnyRef] catch {
+         case e: InvocationTargetException => throw e.getCause
+       }
+    }
 
     /**
       * Creates a new parameter list for the case class using default values for all parameters.

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/CaseClassDeserializerSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/CaseClassDeserializerSuite.scala
@@ -121,6 +121,12 @@ class CaseClassDeserializerSuite extends FunSuite {
     assert(actual === expected)
   }
 
+  test("read simple object with error") {
+    intercept[IllegalArgumentException] {
+      decode[SimpleObjectUnknownError]("""{"foo": "abc"}""")
+    }
+  }
+
   test("read with Option[Int] field") {
     val expected = OptionInt(Some(42))
     val actual = decode[OptionInt]("""{"v":42}""")

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionWithFrequencySuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionWithFrequencySuite.scala
@@ -86,21 +86,21 @@ class ExpressionWithFrequencySuite extends FunSuite {
 
   test("Fails to parse from json with empty expression") {
     val json = "{\"expression\": \"\"}"
-    intercept[InvocationTargetException] {
+    intercept[IllegalArgumentException] {
       Json.decode[ExpressionWithFrequency](json)
     }
   }
 
   test("Fails to parse from json with null expression") {
     val json = "{\"expression\": null}"
-    intercept[java.lang.reflect.InvocationTargetException] {
+    intercept[IllegalArgumentException] {
       Json.decode[ExpressionWithFrequency](json)
     }
   }
 
   test("Fails to parse from json with missing expression") {
     val json = "{}"
-    intercept[InvocationTargetException] {
+    intercept[IllegalArgumentException] {
       Json.decode[ExpressionWithFrequency](json)
     }
   }


### PR DESCRIPTION
The json decoder will now unwrap the `InvocationTargetException`
and throw the cause. This avoids a bunch of reflection non-sense
the user does not care about and make it easier to see the root
issue for why decoding failed.