### PR TITLE
remove WebApi.getJsonParser

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/WebApi.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/WebApi.scala
@@ -15,29 +15,12 @@
  */
 package com.netflix.atlas.akka
 
-import akka.http.scaladsl.model.HttpEntity
-import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.server.Route
-import com.fasterxml.jackson.core.JsonParser
-import com.netflix.atlas.json.Json
 
 
 /**
  * Base trait for classes providing an API to expose via the Atlas server.
  */
 trait WebApi {
-
   def routes: Route
-
-  protected def getJsonParser(request: HttpRequest): Option[JsonParser] = {
-    request.entity match {
-      case entity: HttpEntity.Strict =>
-        if (entity.contentType.mediaType.subType == "x-jackson-smile")
-          Some(Json.newSmileParser(entity.data.toArray))
-        else
-          Some(Json.newJsonParser(entity.data.toArray))
-      case _ =>
-        throw new IllegalStateException("invalid entity type")
-    }
-  }
 }

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/TestApi.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/TestApi.scala
@@ -38,6 +38,18 @@ class TestApi(val actorRefFactory: ActorRefFactory) extends WebApi {
         }
       }
     } ~
+    path("jsonparse2") {
+      post {
+        jsonParser { p =>
+          try {
+            val v = p.getText
+            complete(HttpResponse(status = OK, entity = v))
+          } finally {
+            p.close()
+          }
+        }
+      }
+    } ~
     accessLog {
       path("chunked") {
         get {


### PR DESCRIPTION
Replaces the old `getJsonParser` helper with a
directive `jsonParser`. The directive will work
for all entity types rather than just strict
entities that have a single `ByteString`.