### PR TITLE
update reference.conf to use akka-http settings

### DIFF
--- a/atlas-akka/src/main/resources/reference.conf
+++ b/atlas-akka/src/main/resources/reference.conf
@@ -86,21 +86,18 @@ akka {
   }
 }
 
-spray.can {
+akka.http {
   client {
-    response-chunk-aggregation-limit = 0
   }
 
-  host-connector {
+  host-connection-pool {
     max-connections = 10
     max-retries = 0
-    max-redirects = 0
-    pipelining = off
     idle-timeout = 30 s
   }
 
   server {
-    server-header = atlas/1.3
+    server-header = atlas/1.6
 
     # uncomment the next line for making this an HTTPS example
     # ssl-encryption = on
@@ -114,15 +111,8 @@ spray.can {
 
     verbose-error-messages = on
 
-    # https://groups.google.com/forum/#!msg/spray-user/TqkPlxjDlm8/fl33xVIlnIcJ
-    # Lots of remote closed
-    #registration-timeout = infinite
-
-    request-chunk-aggregation-limit = 0
-
-    parsing.uri-parsing-mode=relaxed
+    parsing.uri-parsing-mode = relaxed
     parsing.max-uri-length = 4k
     parsing.max-content-length = 8m
-    parsing.incoming-auto-chunking-threshold-size = 8m
   }
 }


### PR DESCRIPTION
Updates our reference.conf to use the settings from
akka-http rather than spray.