### PR TITLE
fix CORS headers on preflight request

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/RequestHandler.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/RequestHandler.scala
@@ -85,10 +85,6 @@ object RequestHandler {
   def standardOptions(route: Route): Route = {
 
     // Default paths to always include
-    val corsPreflight = options {
-      // Used for CORS pre-flight checks
-      complete(HttpResponse(StatusCodes.OK))
-    }
     val ok = path("ok") {
       // Default endpoint for testing that always returns 200
       extractClientIP { ip =>
@@ -113,6 +109,10 @@ object RequestHandler {
     }
 
     // Include all requests in the access log
+    val corsPreflight = options {
+      // Used for CORS pre-flight checks
+      corsFilter { complete(HttpResponse(StatusCodes.OK)) }
+    }
     accessLog { corsPreflight ~ error }
   }
 

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/CustomDirectivesSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/CustomDirectivesSuite.scala
@@ -198,7 +198,7 @@ class CustomDirectivesSuite extends FunSuite with ScalatestRouteTest {
     val headers = List(Origin(HttpOrigin("http://localhost")))
     val req = HttpRequest(HttpMethods.GET, Uri("/json"), headers)
     req ~> endpoint.routes ~> check {
-      assert(headers.nonEmpty)
+      assert(response.headers.nonEmpty)
       response.headers.foreach {
         case `Access-Control-Allow-Origin`(v) =>
           assert("http://localhost" === v.toString)

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerSuite.scala
@@ -62,6 +62,22 @@ class RequestHandlerSuite extends FunSuite with ScalatestRouteTest {
     }
   }
 
+  test("cors preflight has cors headers") {
+    val header = Origin(HttpOrigin("http://localhost"))
+    Options("/api/v2/ip").addHeader(header) ~> routes ~> check {
+      assert(response.status === StatusCodes.OK)
+      assert(response.headers.nonEmpty)
+      response.headers.foreach {
+        case `Access-Control-Allow-Origin`(v) =>
+          assert("http://localhost" === v.toString)
+        case `Access-Control-Allow-Methods`(vs) =>
+          assert("GET,PATCH,POST,PUT,DELETE" === vs.map(_.name()).mkString(","))
+        case h =>
+          fail(s"unexpected header: $h")
+      }
+    }
+  }
+
   private def gzip(data: Array[Byte]): Array[Byte] = {
     val baos = new ByteArrayOutputStream
     val out = new GZIPOutputStream(baos)


### PR DESCRIPTION
When switching to akka-http there was a regression
in the routes. The CORS headers were no longer
getting added to the OPTIONS preflight request.

For the original issue see #259. This passes the
test case in that commit comment using chrome. Also
adds local unit test that verifies the headers are
present.