### PR TITLE
fix internal server error due to access logging

### DIFF
--- a/atlas-akka/src/main/resources/reference.conf
+++ b/atlas-akka/src/main/resources/reference.conf
@@ -111,8 +111,11 @@ akka.http {
 
     verbose-error-messages = on
 
-    parsing.uri-parsing-mode = relaxed
-    parsing.max-uri-length = 4k
-    parsing.max-content-length = 8m
+  }
+
+  parsing {
+    uri-parsing-mode = relaxed
+    max-uri-length = 4k
+    max-content-length = 8m
   }
 }

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/AccessLogger.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/AccessLogger.scala
@@ -15,8 +15,6 @@
  */
 package com.netflix.atlas.akka
 
-import java.net.URI
-
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.HttpResponse
 import com.netflix.spectator.sandbox.HttpLogEntry
@@ -125,7 +123,7 @@ object AccessLogger {
   private def addRequestInfo(entry: HttpLogEntry, request: HttpRequest): Unit = {
     entry
       .withMethod(request.method.name)
-      .withRequestUri(URI.create(request.uri.toString()))
+      .withRequestUri(request.uri.toString(), request.uri.path.toString())
       .withRequestContentLength(request.entity.contentLengthOption.getOrElse(-1))
     request.headers.foreach(h => entry.withRequestHeader(h.name, h.value))
   }

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/TestApi.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/TestApi.scala
@@ -38,15 +38,20 @@ class TestApi(val actorRefFactory: ActorRefFactory) extends WebApi {
         }
       }
     } ~
-    path("jsonparse2") {
-      post {
-        jsonParser { p =>
-          try {
-            val v = p.getText
-            complete(HttpResponse(status = OK, entity = v))
-          } finally {
-            p.close()
-          }
+    path("query-parsing-directive") {
+      get {
+        parameter("regex") { v =>
+          val entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, v)
+          complete(HttpResponse(status = OK, entity = entity))
+        }
+      }
+    } ~
+    path("query-parsing-explicit") {
+      get {
+        extractRequest { req =>
+          val v = req.uri.query().get("regex").get
+          val entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, v)
+          complete(HttpResponse(status = OK, entity = entity))
         }
       }
     } ~

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/TestApiSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/TestApiSuite.scala
@@ -27,9 +27,22 @@ class TestApiSuite extends FunSuite with ScalatestRouteTest {
   implicit val routeTestTimeout = RouteTestTimeout(5.second)
 
   val endpoint = new TestApi(system)
+  val routes = RequestHandler.standardOptions(endpoint.routes)
+
+  test("/query-parsing-directive") {
+    Get("/query-parsing-directive?regex=a|b|c") ~> routes ~> check {
+      assert(responseAs[String] === "a|b|c")
+    }
+  }
+
+  test("/query-parsing-explicit") {
+    Get("/query-parsing-explicit?regex=a|b|c") ~> routes ~> check {
+      assert(responseAs[String] === "a|b|c")
+    }
+  }
 
   test("/chunked") {
-    Get("/chunked") ~> endpoint.routes ~> check {
+    Get("/chunked") ~> routes ~> check {
       assert(response.status.intValue === 200)
       assert(chunks.size === 42)
     }

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/UriParsingSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/UriParsingSuite.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.akka
+
+import java.nio.charset.StandardCharsets
+
+import akka.http.scaladsl.model.IllegalUriException
+import akka.http.scaladsl.model.Uri
+import org.scalatest.FunSuite
+
+class UriParsingSuite extends FunSuite {
+
+  private def query(mode: Uri.ParsingMode): String = {
+    Uri("/foo?regex=a|b|c").query(StandardCharsets.UTF_8, mode).get("regex").get
+  }
+
+  test("relaxed: regex with |") {
+    assert(query(Uri.ParsingMode.Relaxed) === "a|b|c")
+  }
+
+  test("strict: regex with |") {
+    intercept[IllegalUriException] {
+      assert(query(Uri.ParsingMode.Strict) === "a|b|c")
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val log4j      = "2.7"
     val scala      = "2.12.1"
     val slf4j      = "1.7.22"
-    val spectator  = "0.47.0"
+    val spectator  = "0.51.0"
     val spray      = "1.3.4"
 
     val crossScala = Seq(scala, "2.11.8")


### PR DESCRIPTION
The access logger would create a URI instance and the
`java.net.URI` class is strict when parsing. This has
been changed to just pass in the string. It appears
that the `toString` for the spray/akka-http Uri class
changed in akka-http to be more consistent with what
the user actually used.