### PR TITLE
do not apply heartbeat interval to rates

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/norm/NormalizationCache.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/norm/NormalizationCache.scala
@@ -73,7 +73,11 @@ class NormalizationCache(step: Long, updateF: Datapoint => Unit, clock: Clock = 
     var value = rateCache.get(meta)
     if (value == null) {
       val update = new UpdateValueFunction(meta, step, updateF)
-      val norm = new NormalizeValueFunction(step, heartbeat, update)
+      // If the client is already converting to a rate, then do not use a heartbeat that is
+      // larger than the step size as it can cause over counting for the final result. For
+      // more details see:
+      // https://github.com/Netflix/atlas/issues/497
+      val norm = new NormalizeValueFunction(step, step, update)
       value = new CacheValue(clock.wallTime, norm)
       rateCache.put(meta, value)
     }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/norm/NormalizationCacheSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/norm/NormalizationCacheSuite.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.norm
+
+import com.netflix.atlas.core.model.Datapoint
+import com.netflix.spectator.api.ManualClock
+import org.scalatest.BeforeAndAfter
+import org.scalatest.FunSuite
+
+class NormalizationCacheSuite extends FunSuite with BeforeAndAfter {
+
+  val clock = new ManualClock()
+  val buffer = scala.collection.mutable.Buffer.empty[Datapoint]
+  val cache = new NormalizationCache(10, buffer += _, clock)
+
+  def dp(t: Long, v: Double): Datapoint = Datapoint(Map.empty, t, v)
+
+  before {
+    buffer.clear()
+  }
+
+  test("update rate on exact interval") {
+    clock.setWallTime(11)
+    cache.updateRate(dp(10, 1.0))
+    clock.setWallTime(21)
+    cache.updateRate(dp(20, 1.0))
+
+    // skip interval, https://github.com/Netflix/atlas/issues/497
+
+    clock.setWallTime(41)
+    cache.updateRate(dp(40, 1.0))
+
+    val expected = List(
+      dp(10, 1.0),
+      dp(20, 1.0),
+      dp(40, 1.0)
+    )
+    val actual = buffer.toList
+
+    assert(actual === expected)
+  }
+
+  test("update counter on exact interval") {
+    clock.setWallTime(11)
+    cache.updateCounter(dp(10, 0.0))
+    clock.setWallTime(21)
+    cache.updateCounter(dp(20, 1.0))
+
+    // skip interval
+
+    clock.setWallTime(41)
+    cache.updateCounter(dp(40, 2.0))
+
+    val expected = List(
+      dp(20, 100.0),
+      dp(30, 50.0),
+      dp(40, 50.0)
+    )
+    val actual = buffer.toList
+
+    assert(actual === expected)
+  }
+
+  test("update gauge on exact interval") {
+    clock.setWallTime(11)
+    cache.updateGauge(dp(10, 0.0))
+    clock.setWallTime(21)
+    cache.updateGauge(dp(20, 1.0))
+
+    // skip interval
+
+    clock.setWallTime(41)
+    cache.updateGauge(dp(40, 2.0))
+
+    val expected = List(
+      dp(10, 0.0),
+      dp(20, 1.0),
+      dp(40, 2.0)
+    )
+    val actual = buffer.toList
+
+    assert(actual === expected)
+  }
+}


### PR DESCRIPTION
If a heartbeat interval larger than the step is applied to
rates, then it can artificially inflate the overall count.
This can happen on occasion with the expiration pattern
used by spectator and servo when reporting counters if
the counter gets an update exactly one interval after it
expired.

Counters should be fine because they will compute the
delta and average over the missed interval. The heartbeat
is retained for this use-case as poller using a fixed
delay may have a reporting interval that is slightly
larger than the specified step.

Fixes #497.