### PR TITLE
check for null token in foreachItem helper

### DIFF
--- a/atlas-json/src/main/scala/com/netflix/atlas/json/JsonParserHelper.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/JsonParserHelper.scala
@@ -93,7 +93,16 @@ object JsonParserHelper {
 
   def foreachItem[T](parser: JsonParser)(f: => T): Unit = {
     requireNextToken(parser, JsonToken.START_ARRAY)
-    while (parser.nextToken() != JsonToken.END_ARRAY) { f }
+    var t = parser.nextToken()
+    while (t != null && t != JsonToken.END_ARRAY) {
+      f
+      t = parser.nextToken()
+    }
+
+    if (t == null) {
+      // If we get here, then `f` has a bug and consumed the END_ARRAY token
+      throw new IllegalArgumentException(s"expected END_ARRAY but hit end of stream")
+    }
   }
 
   def foreachField[T](parser: JsonParser)(f: PartialFunction[String, T]): Unit = {

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/JsonParserHelperSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/JsonParserHelperSuite.scala
@@ -61,4 +61,25 @@ class JsonParserHelperSuite extends FunSuite {
       }
     }
   }
+
+  test("foreachItem") {
+    val parser = Json.newJsonParser("""[1,2,3]""")
+    val builder = List.newBuilder[Int]
+    foreachItem(parser) {
+      builder += parser.getIntValue
+    }
+    assert(builder.result() === List(1, 2, 3))
+  }
+
+  test("foreachItem, endless loop bug") {
+    val parser = Json.newJsonParser("""[1,2,3]""")
+    val builder = List.newBuilder[Int]
+    intercept[IllegalArgumentException] {
+      foreachItem(parser) {
+        // if the inner function consumes the end array token it was
+        // causing an endless loop
+        builder += parser.nextIntValue(-1)
+      }
+    }
+  }
 }


### PR DESCRIPTION
If the function `f` has a bug and consumes the `END_ARRAY`
token, then before it would result in an endless loop. With
this change it will fail quickly.