### PR TITLE
short circuit AND queries in roaring index

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/BatchUpdateTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/BatchUpdateTagIndex.scala
@@ -32,6 +32,10 @@ object BatchUpdateTagIndex {
   def newLazyIndex[T <: TaggedItem: ClassTag]: BatchUpdateTagIndex[T] = {
     new BatchUpdateTagIndex[T](items => new CachingTagIndex(new LazyTagIndex(items)))
   }
+
+  def newRoaringIndex[T <: TaggedItem: ClassTag]: BatchUpdateTagIndex[T] = {
+    new BatchUpdateTagIndex[T](items => new CachingTagIndex(new RoaringTagIndex(items)))
+  }
 }
 
 /**

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndex.scala
@@ -259,9 +259,12 @@ class RoaringTagIndex[T <: TaggedItem](
 
   private def and(q1: Query, q2: Query, offset: Int): RoaringBitmap = {
     val s1 = findImpl(q1, offset)
-    val s2 = findImpl(q2, offset)
-    s1.and(s2)
-    s1
+    if (s1.isEmpty) s1 else {
+      // Short circuit, only perform second query if s1 is not empty
+      val s2 = findImpl(q2, offset)
+      s1.and(s2)
+      s1
+    }
   }
 
   private def or(q1: Query, q2: Query, offset: Int): RoaringBitmap = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -53,7 +53,7 @@ object Dependencies {
   val log4jJul        = "org.apache.logging.log4j" % "log4j-jul" % log4j
   val log4jSlf4j      = "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4j
   val redisclient     = "net.debasishg" %% "redisclient" % "3.3"
-  val roaringBitmap   = "org.roaringbitmap" % "RoaringBitmap" % "0.6.32"
+  val roaringBitmap   = "org.roaringbitmap" % "RoaringBitmap" % "0.6.36"
   val scalaCompiler   = "org.scala-lang" % "scala-compiler"
   val scalaLibrary    = "org.scala-lang" % "scala-library"
   val scalaLibraryAll = "org.scala-lang" % "scala-library-all"


### PR DESCRIPTION
Updates the `RoaringTagIndex` to short-circuit AND queries
just like `LazyTagIndex`. The second query will not only
be performed if the first query has a non-empty result set.
In the test environment this was the main cause of slower
results when using `RoaringTagIndex` instead of `LazyTagIndex`.

Also updates the version to 0.6.36.