### PR TITLE
avoid passing JsonParser across threads

### DIFF
--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/CustomDirectivesSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/CustomDirectivesSuite.scala
@@ -64,14 +64,9 @@ class CustomDirectivesSuite extends FunSuite with ScalatestRouteTest {
             } ~
             path("json-parser") {
               post {
-                jsonParser { p =>
-                  try {
-                    val message = Json.decode[Message](p)
-                    val entity = HttpEntity(MediaTypes.`application/json`, Json.encode(message))
-                    complete(HttpResponse(status = StatusCodes.OK, entity = entity))
-                  } finally {
-                    p.close()
-                  }
+                parseEntity(customJson(p => Json.decode[Message](p))) { message =>
+                  val entity = HttpEntity(MediaTypes.`application/json`, Json.encode(message))
+                  complete(HttpResponse(status = StatusCodes.OK, entity = entity))
                 }
               }
             } ~

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
@@ -66,8 +66,7 @@ class PublishApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi {
 
   private def handleReq: Route = {
     extractRequestContext { ctx =>
-      jsonParser { parser =>
-        val data = decodeBatch(parser, internWhileParsing)
+      parseEntity(customJson(p => decodeBatch(p, internWhileParsing))) { data =>
         val (good, bad) = validate(data)
         val promise = Promise[RouteResult]()
         val req = PublishRequest(good, bad, promise, ctx)

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/RenderApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/RenderApi.scala
@@ -37,8 +37,7 @@ class RenderApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi {
   def routes: Route = {
     path("api" / "v1" / "render") {
       post {
-        jsonParser { parser =>
-          val data = Json.decode[GraphApi.Response](parser)
+        parseEntity(json[GraphApi.Response]) { data =>
           val graphDef = data.toGraphDef
 
           val baos = new ByteArrayOutputStream


### PR DESCRIPTION
The `jsonParser` directive could potentially result in
the created parser being created in one thread and then
used in another. Jackson uses some thread local buffers
for keeping track of state and this behavior means multiple
threads could be updating those buffers.

This change removes that directive and adds a `customJson`
that allows the decoding to use the parser directly to
create an object, but keeps it all local to one block that
should all be run on a single thread.