### PR TITLE
add macro for stddev of group by

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -59,6 +59,47 @@ object MathVocabulary extends Vocabulary {
       ),
       List("name,sps,:eq,(,nf.cluster,),:by")),
 
+    Macro("stddev", List(
+        // Copy of base query
+        ":dup",
+
+        // If the aggregate function is not explicit, then we need to force
+        // the conversion. Using `fadd` avoids conversion of `NaN` values to
+        // zero.
+        "0", ":fadd", ":dup",
+
+        // N
+        ":count",
+
+        // sum(x^2)
+        ":over", ":dup", ":mul", ":sum",
+
+        // N * sum(x^2)
+        ":mul",
+
+        // sum(x)
+        ":over", ":sum",
+
+        // sum(x)^2
+        ":dup", ":mul",
+
+        // N * sum(x^2) - sum(x)^2
+        ":sub",
+
+        // N^2
+        ":swap", ":count", ":dup", ":mul",
+
+        // v = (N * sum(x^2) - sum(x)^2) / N^2
+        ":div",
+
+        // stddev = sqrt(v)
+        ":sqrt",
+
+        // Avoid expansion when displayed
+        "stddev", ":named-rewrite"
+      ),
+      List("name,sps,:eq,(,nf.cluster,),:by")),
+
     Macro("pct", List(
         ":dup",
         ":dup", ":sum", ":div", "100", ":mul",

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
@@ -185,8 +185,17 @@ class TimeSeriesExprSuite extends FunSuite {
     ":true,1w,:offset"            -> const(ts(unknownTag, "name=unknown (offset=1w)", 55)),
     ":true,5,:add,1w,:offset"     -> const(ts(unknownTag, "(name=unknown (offset=1w) + 5.0)", 60)),
     "issue,283,:eq"               -> const(ts(Map("issue" -> "283"), "NO DATA", Double.NaN)),
+    ":true,(,name,),:by,:stddev"  -> const(ts(Map.empty[String, String], stddevLegend("NO TAGS"), 3.1622776601683795)),
+    ":true,:max,:stddev"          -> const(ts(Map("name" -> "unknown"), stddevLegend("name=unknown"), 0.0)),
+    ":true,:sum,:stddev"          -> const(ts(Map("name" -> "unknown"), stddevLegend("name=unknown"), 0.0)),
+    ":true,:stddev"               -> const(ts(Map("name" -> "unknown"), stddevLegend("name=unknown"), 0.0)),
     "42"                          -> const(ts(42))
   )
+
+  // stddev legend
+  private def stddevLegend(label: String): String = {
+    s"sqrt((((count($label) * sum($label)) - (sum($label) * sum($label))) / (count($label) * count($label))))"
+  }
 
   // Tests that cannot be executed with incremental evaluation
   val globalTests = List(

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Main.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Main.scala
@@ -22,9 +22,6 @@ import java.nio.charset.StandardCharsets
 import java.util.Locale
 import java.util.regex.Pattern
 
-import akka.actor.ActorSystem
-import akka.actor.Props
-import com.netflix.atlas.akka.RequestHandler
 import com.netflix.atlas.core.model.DataVocabulary
 import com.netflix.atlas.core.model.FilterVocabulary
 import com.netflix.atlas.core.model.MathVocabulary
@@ -36,14 +33,9 @@ import com.netflix.atlas.core.stacklang.Vocabulary
 import com.netflix.atlas.core.util.Streams._
 import com.netflix.atlas.json.Json
 import com.netflix.atlas.webapi.ApiSettings
-import com.netflix.atlas.webapi.LocalDatabaseActor
 import com.netflix.atlas.wiki.pages._
-import com.netflix.iep.service.DefaultClassFactory
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
-
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
 
 
 /**
@@ -121,6 +113,7 @@ object Main extends StrictLogging {
     SDesSlow.word      -> SDesSlow,
     SDesSlower.word    -> SDesSlower,
     DistStddev.word    -> DistStddev,
+    Stddev.word        -> Stddev,
 
     Line.word          -> Line,
     Area.word          -> Area,

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/Stddev.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/Stddev.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.wiki.pages
+
+import com.netflix.atlas.core.model.MathVocabulary
+import com.netflix.atlas.core.stacklang.Vocabulary
+import com.netflix.atlas.core.stacklang.Word
+import com.netflix.atlas.wiki.StackWordPage
+
+case object Stddev extends StackWordPage {
+  val vocab: Vocabulary = MathVocabulary
+  val word: Word = vocab.words.find(_.name == "stddev").get
+
+  override def signature: String = s"`GroupBy -- TimeSeriesExpr`"
+
+  override def summary: String = """
+      |Compute the standard deviation for the results of a [group by](data-by). If the
+      |underlying data is for a timer or distribution summary, then [dist-stddev](math-dist‐stddev)
+      |is likely a better choice.
+      |
+      |Since: 1.6
+    """.stripMargin.trim
+}


### PR DESCRIPTION
Helper function for computing the stddev over the
results of a group by operation. Sometimes useful
as an offset for outlier detection.