### PR TITLE
make ValidCharactersRule more flexible

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ValidCharactersRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ValidCharactersRuleSuite.scala
@@ -23,6 +23,18 @@ class ValidCharactersRuleSuite extends FunSuite {
 
   private val config = ConfigFactory.parseString("")
 
+  private val customPattern = ConfigFactory.parseString(
+    """
+      |default-pattern = ".a-z"
+      |
+      |overrides = [
+      |  {
+      |    key = "nf.asg"
+      |    value = "-_.A-Za-z0-9^~"
+      |  }
+      |]
+    """.stripMargin)
+
   private val alpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._"
 
   test("valid") {
@@ -40,5 +52,27 @@ class ValidCharactersRuleSuite extends FunSuite {
     val rule = new ValidCharactersRule(config)
     val res = rule.validate(alpha, "spaces not allowed")
     assert(res.isFailure)
+  }
+
+  test("custom pattern valid") {
+    val rule = new ValidCharactersRule(customPattern)
+    assert(rule.validate("abcdef", "fedcba") === ValidationResult.Pass)
+  }
+
+  test("custom pattern invalid key") {
+    val rule = new ValidCharactersRule(customPattern)
+    val res = rule.validate(alpha, "fedcba")
+    assert(res.isFailure)
+  }
+
+  test("custom pattern invalid value") {
+    val rule = new ValidCharactersRule(customPattern)
+    val res = rule.validate("abcdef", alpha)
+    assert(res.isFailure)
+  }
+
+  test("custom pattern value override") {
+    val rule = new ValidCharactersRule(customPattern)
+    assert(rule.validate("nf.asg", alpha + "^~") === ValidationResult.Pass)
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,13 +5,13 @@ object Dependencies {
     val akka       = "2.4.16"
     val akkaHttpV  = "10.0.3"
     val aws        = "1.11.93"
-    val iep        = "0.4.16"
+    val iep        = "0.4.17"
     val guice      = "4.1.0"
     val jackson    = "2.8.6"
     val log4j      = "2.7"
     val scala      = "2.12.1"
     val slf4j      = "1.7.23"
-    val spectator  = "0.52.0"
+    val spectator  = "0.53.0"
     val spray      = "1.3.4"
 
     val crossScala = Seq(scala, "2.11.8")


### PR DESCRIPTION
It now allows the set of valid characters to be set
via a pattern in the config and for overrides to be
set for given tag values.

This is mostly to support an internal decision to relax
group names so that they allow `^` and `~`. Others values
should not be relaxed as it could result in backwards
compatibility issues for names that were already being
converted to `_` when published.