### PR TITLE
add method to explicitly rotate blocks

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
@@ -89,13 +89,15 @@ class MemoryDatabase(registry: Registry, config: Config) extends Database {
     }
   }
 
+  private def now: Long = registry.clock().wallTime()
+
   def rebuild(): Unit = {
-    if (!testMode && System.currentTimeMillis - index.buildTime > rebuildAge) {
+    if (!testMode && now - index.buildTime > rebuildAge) {
       logger.info("rebuilding metadata index")
       index.rebuildIndex()
 
       val windowSize = numBlocks * blockSize * step
-      val cutoff = System.currentTimeMillis - windowSize
+      val cutoff = now - windowSize
       val iter = data.entrySet.iterator
       while (iter.hasNext) {
         val entry = iter.next()

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryBlockStoreSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryBlockStoreSuite.scala
@@ -16,6 +16,7 @@
 package com.netflix.atlas.core.db
 
 import com.netflix.atlas.core.model.Block
+import com.netflix.atlas.core.model.ConstantBlock
 import org.scalatest.FunSuite
 
 
@@ -124,6 +125,15 @@ class MemoryBlockStoreSuite extends FunSuite {
     assert(bs.fetch(0, 1, Block.Sum).forall(_.isNaN))
     assert(bs.fetch(2, 6, Block.Sum).toList === List(3.0, 4.0, 5.0, 6.0, 7.0))
     assert(bs.fetch(7, 10, Block.Sum).forall(_.isNaN))
+  }
+
+  test("update, with no data") {
+    val bs = new MemoryBlockStore(1, 10, 4)
+    (0 until 10).foreach { i => bs.update(i, 2.0) }
+    assert(bs.currentBlock !== null)
+    bs.update(0)
+    assert(bs.currentBlock === null)
+    assert(bs.blockList === List(ConstantBlock(0, 10, 2.0)))
   }
 
   test("cleanup, nothing to do") {


### PR DESCRIPTION
Adds a method to the block store to explicitly
rotate and compress the blocks. Before it would
only happen when there was data written for a given
time series. So if no data comes in after the time
boundary it would not get automatically rotated.