### PR TITLE
fix bounds exception for Integer.MIN_VALUE hash

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Hash.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Hash.scala
@@ -64,6 +64,10 @@ object Hash {
     computeHash("SHA1", input.getBytes("UTF-8"))
   }
 
+  // If the hash value is `Integer.MIN_VALUE`, then the absolute value will be
+  // negative. For our purposes that will get mapped to a starting position of 0.
+  private[util] def absOrZero(v: Int): Int = math.max(math.abs(v), 0)
+
   private def computeHash(algorithm: String, bytes: Array[Byte]) = {
     val md = get(algorithm)
     md.update(bytes)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntHashSet.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntHashSet.scala
@@ -59,7 +59,7 @@ class IntHashSet(noData: Int, capacity: Int = 10) {
   }
 
   private def add(buffer: Array[Int], v: Int): Boolean = {
-    var pos = math.abs(v) % buffer.length
+    var pos = Hash.absOrZero(v) % buffer.length
     var posV = buffer(pos)
     while (posV != noData && posV != v) {
       pos = (pos + 1) % buffer.length

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntIntHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntIntHashMap.scala
@@ -62,7 +62,7 @@ class IntIntHashMap(noData: Int, capacity: Int = 10) {
   }
 
   private def put(ks: Array[Int], vs: Array[Int], k: Int, v: Int): Boolean = {
-    var pos = math.abs(k) % ks.length
+    var pos = Hash.absOrZero(k) % ks.length
     var posV = ks(pos)
     while (posV != noData && posV != k) {
       pos = (pos + 1) % ks.length
@@ -88,7 +88,7 @@ class IntIntHashMap(noData: Int, capacity: Int = 10) {
     * `dflt` value will be returned.
     */
   def get(k: Int, dflt: Int): Int = {
-    var pos = math.abs(k) % keys.length
+    var pos = Hash.absOrZero(k) % keys.length
     while (true) {
       val prev = keys(pos)
       if (prev == noData)
@@ -113,7 +113,7 @@ class IntIntHashMap(noData: Int, capacity: Int = 10) {
     */
   def increment(k: Int, amount: Int): Unit = {
     if (used >= cutoff) resize()
-    var pos = math.abs(k) % keys.length
+    var pos = Hash.absOrZero(k) % keys.length
     var prev = keys(pos)
     while (prev != noData && prev != k) {
       pos = (pos + 1) % keys.length

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongIntHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongIntHashMap.scala
@@ -61,10 +61,12 @@ class LongIntHashMap(noData: Long, capacity: Int = 10) {
     cutoff = computeCutoff(tmpKS.length)
   }
 
-  private def hash(k: Long): Int = java.lang.Long.hashCode(k)
+  private def hash(ks: Array[Long], k: Long): Int = {
+    Hash.absOrZero(java.lang.Long.hashCode(k)) % ks.length
+  }
 
   private def put(ks: Array[Long], vs: Array[Int], k: Long, v: Int): Boolean = {
-    var pos = math.abs(hash(k)) % ks.length
+    var pos = hash(ks, k)
     var posV = ks(pos)
     while (posV != noData && posV != k) {
       pos = (pos + 1) % ks.length
@@ -90,7 +92,7 @@ class LongIntHashMap(noData: Long, capacity: Int = 10) {
     * `dflt` value will be returned.
     */
   def get(k: Long, dflt: Int): Int = {
-    var pos = math.abs(hash(k)) % keys.length
+    var pos = hash(keys, k)
     while (true) {
       val prev = keys(pos)
       if (prev == noData)
@@ -115,7 +117,7 @@ class LongIntHashMap(noData: Long, capacity: Int = 10) {
     */
   def increment(k: Long, amount: Int): Unit = {
     if (used >= cutoff) resize()
-    var pos = math.abs(hash(k)) % keys.length
+    var pos = hash(keys, k)
     while (true) {
       val prev = keys(pos)
       if (prev == noData || prev == k) {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/RefIntHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/RefIntHashMap.scala
@@ -94,7 +94,7 @@ class RefIntHashMap[T](capacity: Int = 10) {
   }
 
   private def put(ks: Array[T], vs: Array[Int], k: T, v: Int): Boolean = {
-    var pos = math.abs(k.hashCode()) % ks.length
+    var pos = Hash.absOrZero(k.hashCode()) % ks.length
     var posV = ks(pos)
     while (posV != null && posV != k) {
       pos = (pos + 1) % ks.length
@@ -121,7 +121,7 @@ class RefIntHashMap[T](capacity: Int = 10) {
     */
   def putIfAbsent(k: T, v: Int): Boolean = {
     if (used >= cutoff) resize()
-    var pos = math.abs(k.hashCode()) % keys.length
+    var pos = Hash.absOrZero(k.hashCode()) % keys.length
     var posV = keys(pos)
     while (posV != null && posV != k) {
       pos = (pos + 1) % keys.length
@@ -140,7 +140,7 @@ class RefIntHashMap[T](capacity: Int = 10) {
     * `dflt` value will be returned.
     */
   def get(k: T, dflt: Int): Int = {
-    var pos = math.abs(k.hashCode()) % keys.length
+    var pos = Hash.absOrZero(k.hashCode()) % keys.length
     while (true) {
       val prev = keys(pos)
       if (prev == null)
@@ -165,7 +165,7 @@ class RefIntHashMap[T](capacity: Int = 10) {
     */
   def increment(k: T, amount: Int): Unit = {
     if (used >= cutoff) resize()
-    var pos = math.abs(k.hashCode()) % keys.length
+    var pos = Hash.absOrZero(k.hashCode()) % keys.length
     while (true) {
       val prev = keys(pos)
       if (prev == null || prev == k) {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
@@ -43,7 +43,7 @@ object SmallHashMap {
     def +=(pair: (K, V)): Unit = add(pair._1, pair._2)
 
     def add(k: K, v: V) {
-      val pos = math.abs(k.hashCode) % size
+      val pos = Hash.absOrZero(k.hashCode) % size
       var i = pos
       var ki = buf(i * 2)
       var keq = (ki == k)
@@ -151,7 +151,7 @@ final class SmallHashMap[K <: AnyRef, V <: AnyRef] private (val data: Array[AnyR
 
   private def hash(k: AnyRef): Int = {
     val capacity = data.length / 2
-    math.abs(k.hashCode) % capacity
+    Hash.absOrZero(k.hashCode) % capacity
   }
 
   def getOrNull(key: K): V = {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/DoubleIntHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/DoubleIntHashMapSuite.scala
@@ -139,4 +139,17 @@ class DoubleIntHashMapSuite extends FunSuite {
     assert(igraph.totalSize() <= 320000)
   }
 
+  test("negative absolute value") {
+    // hashes to Integer.MIN_VALUE causing: java.lang.ArrayIndexOutOfBoundsException: -2
+    //
+    // scala> math.abs(java.lang.Long.hashCode(java.lang.Double.doubleToLongBits(0.778945326637231)))
+    // res9: Int = -2147483648
+    // scala> math.abs(java.lang.Long.hashCode(java.lang.Double.doubleToLongBits(0.17321881641359504)))
+    // res10: Int = -2147483648
+    // scala> math.abs(java.lang.Long.hashCode(java.lang.Double.doubleToLongBits(0.4182373879985505)))
+    // res11: Int = -2147483648
+    val m = new DoubleIntHashMap
+    assert(m.get(0.778945326637231, 0) === 0)
+  }
+
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntHashSetSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntHashSetSuite.scala
@@ -106,4 +106,9 @@ class IntHashSetSuite extends FunSuite {
     // Sanity check size is < 110kb
     assert(igraph.totalSize() <= 110000)
   }
+
+  test("negative absolute value") {
+    val s = new IntHashSet(-1, 10)
+    s.add(Integer.MIN_VALUE)
+  }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntIntHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntIntHashMapSuite.scala
@@ -146,4 +146,9 @@ class IntIntHashMapSuite extends FunSuite {
     assert(igraph.totalSize() <= 220000)
   }
 
+  test("negative absolute value") {
+    val s = new IntIntHashMap(-1, 10)
+    assert(s.get(Integer.MIN_VALUE, 0) === 0)
+  }
+
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/LongIntHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/LongIntHashMapSuite.scala
@@ -163,4 +163,10 @@ class LongIntHashMapSuite extends FunSuite {
     assert(igraph.totalSize() <= 320000)
   }
 
+  test("negative absolute value") {
+    // hashes to Integer.MIN_VALUE causing: java.lang.ArrayIndexOutOfBoundsException: -2
+    val m = new LongIntHashMap(-1, 10)
+    assert(m.get(Integer.MIN_VALUE.toLong - 1, 0) === 0)
+  }
+
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/RefIntHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/RefIntHashMapSuite.scala
@@ -196,4 +196,14 @@ class RefIntHashMapSuite extends FunSuite {
     assert(igraph.totalSize() <= 500000)
   }
 
+  test("negative absolute value") {
+    val s = new RefIntHashMap[RefIntHashMapSuite.MinHash]()
+    assert(s.get(new RefIntHashMapSuite.MinHash, 0) === 0)
+  }
+}
+
+object RefIntHashMapSuite {
+  class MinHash {
+    override def hashCode: Int = Integer.MIN_VALUE
+  }
 }


### PR DESCRIPTION
If an object hashes to `Integer.MIN_VALUE`, then the
absolute value will be `Integer.MIN_VALUE` and a negative
values was used for looking up data in the underlying
array. This change will map those to be `0` instead.