### PR TITLE
add vary origin to cors responses

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/CustomDirectives.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/CustomDirectives.scala
@@ -125,6 +125,11 @@ object CustomDirectives {
         // a local file we typically see 'null'.
         val allow = if (origin == "null") HttpOriginRange.`*` else HttpOriginRange(HttpOrigin(origin))
 
+        // List of headers to ignore for caching. For more details see:
+        // https://bugs.chromium.org/p/chromium/issues/detail?id=409090
+        // https://www.fastly.com/blog/caching-cors
+        val vary = RawHeader("Vary", "Origin")
+
         // Just allow all methods
         val headers = List(
           `Access-Control-Allow-Origin`(allow),
@@ -133,7 +138,8 @@ object CustomDirectives {
             HttpMethods.PATCH,
             HttpMethods.POST,
             HttpMethods.PUT,
-            HttpMethods.DELETE))
+            HttpMethods.DELETE),
+          vary)
 
         // If specific headers are requested echo those back
         optionalHeaderValueByName("Access-Control-Request-Headers").flatMap {

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerSuite.scala
@@ -72,6 +72,8 @@ class RequestHandlerSuite extends FunSuite with ScalatestRouteTest {
           assert("http://localhost" === v.toString)
         case `Access-Control-Allow-Methods`(vs) =>
           assert("GET,PATCH,POST,PUT,DELETE" === vs.map(_.name()).mkString(","))
+        case h if h.is("vary") =>
+          assert(h.value === "Origin")
         case h =>
           fail(s"unexpected header: $h")
       }


### PR DESCRIPTION
Avoids confusing errors due to requests being
cached with the wrong origin.