### PR TITLE
enable caching of CORS preflight

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/CustomDirectives.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/CustomDirectives.scala
@@ -103,8 +103,8 @@ object CustomDirectives {
   // Make sure that all headers in the response will be readable by the browser
   private def exposeHeaders: Directive0 = {
     mapResponseHeaders { headers =>
-      if (headers.isEmpty) headers else {
-        val exposed = headers.map(_.name)
+      val exposed = headers.map(_.name).filterNot(_.startsWith("Access-Control"))
+      if (exposed.isEmpty) headers else {
         headers ++ scala.collection.immutable.Seq(`Access-Control-Expose-Headers`(exposed))
       }
     }

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/RequestHandler.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/RequestHandler.scala
@@ -20,6 +20,7 @@ import java.lang.reflect.Type
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.model.StatusCode
 import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.server.AuthenticationFailedRejection
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.MalformedRequestContentRejection
@@ -111,7 +112,12 @@ object RequestHandler {
     // Include all requests in the access log
     val corsPreflight = options {
       // Used for CORS pre-flight checks
-      corsFilter { complete(HttpResponse(StatusCodes.OK)) }
+      corsFilter {
+        // Set max age header to minimize the number of round-trips the browser will need
+        // to make. Various browsers limit the max age that can be used. Ten minutes seems
+        // to be a common number (chrome and webkit) so that is what we use here.
+        complete(HttpResponse(StatusCodes.OK).withHeaders(`Access-Control-Max-Age`(600)))
+      }
     }
     accessLog { corsPreflight ~ error }
   }

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerSuite.scala
@@ -72,6 +72,8 @@ class RequestHandlerSuite extends FunSuite with ScalatestRouteTest {
           assert("http://localhost" === v.toString)
         case `Access-Control-Allow-Methods`(vs) =>
           assert("GET,PATCH,POST,PUT,DELETE" === vs.map(_.name()).mkString(","))
+        case `Access-Control-Max-Age`(age) =>
+          assert(age === 600)
         case h if h.is("vary") =>
           assert(h.value === "Origin")
         case h =>


### PR DESCRIPTION
Adds the `Access-Control-Max-Age` to the CORS
preflight response. Age is set to 10 minutes
as that seems to be a common max allowed by
various browsers.