### PR TITLE
emit subscriptions back in the sse response

### DIFF
--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SSEActorSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SSEActorSuite.scala
@@ -36,7 +36,8 @@ class SSEActorSuite extends FunSuite with BeforeAndAfter with ScalatestRouteTest
 
   test("tick and unsubscribe") {
     val mockSM = MockSubscriptionManager()
-    val sse = Source.actorPublisher[HttpEntity.Chunk](Props(new SSEActor("mySSEId", "myName", mockSM, registry)))
+    val sse = Source.actorPublisher[HttpEntity.Chunk](Props(
+      new SSEActor("mySSEId", "myName", mockSM, Nil, registry)))
     val invocations = sse.runFold(List.empty[String]){ (acc, msg) =>
       msg.data.decodeString(StandardCharsets.UTF_8).trim :: acc
     }


### PR DESCRIPTION
Cleanup a TODO in the code from when we switched to
akka-http. The subscriptions objects are passed into
the stream source actor.

Also fixes a bug where we would only write the chunks
on receive, but not when we had messages and available
room based on `totalDemand`.