### PR TITLE
add efs metrics

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/ec2.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/ec2.conf
@@ -68,7 +68,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Read"
+              value = "read"
             }
           ]
         },
@@ -79,7 +79,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Write"
+              value = "write"
             }
           ]
         },
@@ -90,7 +90,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Read"
+              value = "read"
             }
           ]
         },
@@ -101,7 +101,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Write"
+              value = "write"
             }
           ]
         },
@@ -112,7 +112,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Instance"
+              value = "instance"
             }
           ]
         },
@@ -123,7 +123,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "System"
+              value = "system"
             }
           ]
         },

--- a/atlas-poller-cloudwatch/src/main/resources/efs.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/efs.conf
@@ -1,0 +1,76 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/efs-metricscollected.html
+    efs = {
+      namespace = "AWS/EFS"
+      period = 1m
+
+      dimensions = [
+        "FileSystemId"
+      ]
+
+      metrics = [
+        {
+          name = "DataReadIOBytes"
+          alias = "aws.efs.ioThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "DataWriteIOBytes"
+          alias = "aws.efs.ioThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "MetadataIOBytes"
+          alias = "aws.efs.ioThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "metadata"
+            }
+          ]
+        },
+        {
+          name = "PermittedThroughput"
+          alias = "aws.efs.permittedThroughput"
+          conversion = "max"
+          tags = []
+        },
+        {
+          name = "BurstCreditBalance"
+          alias = "aws.efs.burstCreditBalance"
+          conversion = "max"
+          tags = []
+        },
+        {
+          name = "PercentIOLimit"
+          alias = "aws.efs.percentIOLimit"
+          conversion = "max"
+          tags = []
+        },
+        {
+          name = "ClientConnections"
+          alias = "aws.efs.clientConnections"
+          conversion = "sum"
+          tags = []
+        },
+
+      ]
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/resources/elasticache.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/elasticache.conf
@@ -105,7 +105,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "CacheItems"
+              value = "cacheItems"
             }
           ]
         },
@@ -116,7 +116,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "HashTables"
+              value = "hashTables"
             }
           ]
         },
@@ -132,7 +132,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Decr"
+              value = "decr"
             },
             {
               key = "status"
@@ -147,7 +147,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Decr"
+              value = "decr"
             },
             {
               key = "status"
@@ -162,7 +162,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Incr"
+              value = "incr"
             },
             {
               key = "status"
@@ -177,7 +177,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Incr"
+              value = "incr"
             },
             {
               key = "status"
@@ -192,7 +192,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Delete"
+              value = "delete"
             },
             {
               key = "status"
@@ -207,7 +207,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Delete"
+              value = "delete"
             },
             {
               key = "status"
@@ -222,7 +222,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Get"
+              value = "get"
             },
             {
               key = "status"
@@ -237,7 +237,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Get"
+              value = "get"
             },
             {
               key = "status"
@@ -252,7 +252,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Touch"
+              value = "touch"
             },
             {
               key = "status"
@@ -267,7 +267,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Touch"
+              value = "touch"
             },
             {
               key = "status"
@@ -282,7 +282,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Cas"
+              value = "cas"
             },
             {
               key = "status"
@@ -297,7 +297,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Cas"
+              value = "cas"
             },
             {
               key = "status"
@@ -312,7 +312,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Cas"
+              value = "cas"
             },
             {
               key = "status"
@@ -327,7 +327,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Get"
+              value = "get"
             }
           ]
         },
@@ -338,7 +338,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Set"
+              value = "set"
             }
           ]
         },
@@ -349,7 +349,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Flush"
+              value = "flush"
             }
           ]
         },
@@ -360,7 +360,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "ConfigGet"
+              value = "configGet"
             }
           ]
         },
@@ -371,7 +371,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "ConfigSet"
+              value = "configSet"
             }
           ]
         },
@@ -382,7 +382,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Touch"
+              value = "touch"
             }
           ]
         },
@@ -437,7 +437,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "HyperLogLogBased"
+              value = "hyperLogLogBased"
             }
           ]
         },
@@ -448,7 +448,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "GetType"
+              value = "getType"
             }
           ]
         },
@@ -459,7 +459,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "HashBased"
+              value = "hashBased"
             }
           ]
         },
@@ -470,7 +470,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "KeyBased"
+              value = "keyBased"
             }
           ]
         },
@@ -481,7 +481,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "ListBased"
+              value = "listBased"
             }
           ]
         },
@@ -492,7 +492,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "SetBased"
+              value = "setBased"
             }
           ]
         },
@@ -503,7 +503,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "SetType"
+              value = "setType"
             }
           ]
         },
@@ -514,7 +514,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "SortedSetBased"
+              value = "sortedSetBased"
             }
           ]
         },
@@ -525,7 +525,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "StringBased"
+              value = "stringBased"
             }
           ]
         }

--- a/atlas-poller-cloudwatch/src/main/resources/kinesis.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/kinesis.conf
@@ -46,7 +46,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "PutRecords"
+              value = "putRecords"
             }
           ]
         },
@@ -57,7 +57,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "PutRecord"
+              value = "putRecord"
             }
           ]
         },
@@ -68,7 +68,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "GetRecords"
+              value = "getRecords"
             }
           ]
         },
@@ -79,7 +79,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "PutRecords"
+              value = "putRecords"
             }
           ]
         },
@@ -90,7 +90,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "PutRecord"
+              value = "putRecord"
             }
           ]
         },
@@ -101,7 +101,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "GetRecords"
+              value = "getRecords"
             }
           ]
         },
@@ -112,7 +112,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "PutRecords"
+              value = "putRecords"
             }
           ]
         },
@@ -123,7 +123,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "PutRecord"
+              value = "putRecord"
             }
           ]
         },
@@ -134,7 +134,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "GetRecords"
+              value = "getRecords"
             }
           ]
         },
@@ -145,7 +145,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "GetRecords"
+              value = "getRecords"
             }
           ]
         }

--- a/atlas-poller-cloudwatch/src/main/resources/rds.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/rds.conf
@@ -39,7 +39,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "BinLog"
+              value = "binLog"
             }
           ]
         },
@@ -50,7 +50,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "TransactionLog"
+              value = "transactionLog"
             }
           ]
         },
@@ -118,7 +118,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Active"
+              value = "active"
             }
           ]
         },
@@ -129,7 +129,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Blocked"
+              value = "blocked"
             }
           ]
         },
@@ -140,7 +140,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Commit"
+              value = "commit"
             }
           ]
         },
@@ -151,7 +151,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "DDL"
+              value = "ddl"
             }
           ]
         },
@@ -162,7 +162,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "DML"
+              value = "dml"
             }
           ]
         },
@@ -173,7 +173,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Delete"
+              value = "delete"
             }
           ]
         },
@@ -184,7 +184,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Insert"
+              value = "insert"
             }
           ]
         },
@@ -195,7 +195,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Select"
+              value = "select"
             }
           ]
         },
@@ -206,7 +206,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Update"
+              value = "update"
             }
           ]
         },
@@ -217,7 +217,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Commit"
+              value = "commit"
             }
           ]
         },
@@ -228,7 +228,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "DDL"
+              value = "ddl"
             }
           ]
         },
@@ -239,7 +239,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "DML"
+              value = "dml"
             }
           ]
         },
@@ -250,7 +250,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Delete"
+              value = "delete"
             }
           ]
         },
@@ -261,7 +261,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Insert"
+              value = "insert"
             }
           ]
         },
@@ -272,7 +272,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Select"
+              value = "select"
             }
           ]
         },
@@ -283,7 +283,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Update"
+              value = "update"
             }
           ]
         },
@@ -294,7 +294,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Read"
+              value = "read"
             }
           ]
         },
@@ -305,7 +305,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Write"
+              value = "write"
             }
           ]
         },
@@ -316,7 +316,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Read"
+              value = "read"
             }
           ]
         },
@@ -327,7 +327,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Write"
+              value = "write"
             }
           ]
         },
@@ -338,7 +338,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Read"
+              value = "read"
             }
           ]
         },
@@ -349,7 +349,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Write"
+              value = "write"
             }
           ]
         },

--- a/atlas-poller-cloudwatch/src/main/resources/redshift.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/redshift.conf
@@ -62,7 +62,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Read"
+              value = "read"
             }
           ]
         },
@@ -73,7 +73,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Write"
+              value = "write"
             }
           ]
         },
@@ -84,7 +84,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Read"
+              value = "read"
             }
           ]
         },
@@ -95,7 +95,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Write"
+              value = "write"
             }
           ]
         },
@@ -106,7 +106,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Read"
+              value = "read"
             }
           ]
         },
@@ -117,7 +117,7 @@ atlas {
           tags = [
             {
               key = "id"
-              value = "Write"
+              value = "write"
             }
           ]
         },

--- a/atlas-poller-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/reference.conf
@@ -160,6 +160,10 @@ atlas {
           alias = "aws.redshift"
         },
         {
+          name = "FileSystemId"
+          alias = "aws.efs"
+        },
+        {
           name = "NodeID"
           alias = "nf.node"
         },
@@ -191,6 +195,7 @@ atlas {
       "dynamodb-table-ops",
       "ec2",
       "ec2-credit",
+      "efs",
       "elasticache",
       "elb",
       "es",
@@ -215,6 +220,7 @@ include "dynamodb.conf"
 include "ec2.conf"
 include "elasticache.conf"
 include "elb.conf"
+include "efs.conf"
 include "es.conf"
 include "events.conf"
 include "kinesis.conf"


### PR DESCRIPTION
Adds mapping for cloudwatch EFS metrics and adjust
some of the ids to be more consistent with casing.
Some users found it annoying and hard to remember
which ones had a starting capital. This change makes
them more consistent.