### PR TITLE
support inline rollup of datapoints

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
@@ -126,6 +126,12 @@ class MemoryDatabase(registry: Registry, config: Config) extends Database {
     ds.foreach(update)
   }
 
+  def rollup(dp: Datapoint): Unit = {
+    val blkStore = getOrCreateBlockStore(dp.tags)
+    blkStore.update(dp.timestamp, dp.value, rollup = true)
+    index.update(BlockStoreItem.create(dp.tags, blkStore))
+  }
+
   private def blockAggr(expr: DataExpr): Int = expr match {
     case by: DataExpr.GroupBy          => blockAggr(by.af)
     case _: DataExpr.All               => Block.Sum

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TagKey.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TagKey.scala
@@ -42,6 +42,9 @@ object TagKey {
   /** Data source type for the metric. */
   final val dsType = atlasPrefix + "dstype"
 
+  /** Rollup message id for the metric. */
+  final val rollup = atlasPrefix + "rollup"
+
   /** Indicates the legacy system the metric came from such as epic. */
   final val legacy = atlasPrefix + "legacy"
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/norm/NormalizationCache.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/norm/NormalizationCache.scala
@@ -33,21 +33,21 @@ class NormalizationCache(step: Long, updateF: Datapoint => Unit, clock: Clock = 
 
   type CacheEntry = java.util.Map.Entry[TaggedItem, CacheValue]
 
-  private val counterCache = new LinkedHashMap[TaggedItem, CacheValue](16, 0.75f, true) {
+  private val counterCache = new java.util.LinkedHashMap[TaggedItem, CacheValue](16, 0.75f, true) {
     override def removeEldestEntry(eldest: CacheEntry): Boolean = {
       val ageMillis = clock.wallTime - eldest.getValue.lastAccessTime
       ageMillis > 4 * step
     }
   }
 
-  private val rateCache = new LinkedHashMap[TaggedItem, CacheValue](16, 0.75f, true) {
+  private val rateCache = new java.util.LinkedHashMap[TaggedItem, CacheValue](16, 0.75f, true) {
     override def removeEldestEntry(eldest: CacheEntry): Boolean = {
       val ageMillis = clock.wallTime - eldest.getValue.lastAccessTime
       ageMillis > 4 * step
     }
   }
 
-  private val gaugeCache = new LinkedHashMap[TaggedItem, CacheValue](16, 0.75f, true) {
+  private val gaugeCache = new java.util.LinkedHashMap[TaggedItem, CacheValue](16, 0.75f, true) {
     override def removeEldestEntry(eldest: CacheEntry): Boolean = {
       val ageMillis = clock.wallTime - eldest.getValue.lastAccessTime
       ageMillis > 4 * step

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/LocalPublishActorSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/LocalPublishActorSuite.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.webapi
+
+import com.netflix.atlas.core.db.MemoryDatabase
+import com.netflix.atlas.core.index.TagQuery
+import com.netflix.atlas.core.model.Block
+import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.core.model.Query
+import com.netflix.atlas.core.model.TagKey
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.ManualClock
+import com.typesafe.config.ConfigFactory
+import org.scalatest.FunSuite
+
+
+class LocalPublishActorSuite extends FunSuite {
+
+  private val clock = new ManualClock()
+  private val registry = new DefaultRegistry(clock)
+
+  private def newDB = new MemoryDatabase(registry, ConfigFactory.parseString(
+    """
+      |block-size = 60
+      |num-blocks = 2
+      |rebuild-frequency = 10s
+      |test-mode = true
+      |intern-while-building = true
+    """.stripMargin))
+
+
+  private def newDatapoint(v: Double): Datapoint = {
+    Datapoint(Map("name" -> "test", TagKey.rollup -> "true"), clock.wallTime(), v)
+  }
+
+  test("dedup counter is incremented") {
+    val processor = new LocalPublishActor.DatapointProcessor(registry, newDB)
+    val deduped = registry.counter("atlas.db.numDeduped")
+    val init = deduped.count()
+
+    processor.update("test", Nil)
+    assert(init === deduped.count())
+
+    processor.update("test", Nil)
+    assert(init + 1 === deduped.count())
+  }
+
+  test("honor atlas.rollup tag") {
+    val db = newDB
+    val processor = new LocalPublishActor.DatapointProcessor(registry, db)
+
+    processor.update("a", List(newDatapoint(1.0)))
+    processor.update("b", List(newDatapoint(2.0)))
+    processor.update("c", List(newDatapoint(3.0)))
+    processor.update("a", List(newDatapoint(1.0))) // Should get deduped by id
+
+    db.index.rebuildIndex()
+    val vs = db.index.findItems(TagQuery(Some(Query.True)))
+    assert(vs.size === 1)
+
+    val bs = vs.head.blocks
+    assert(bs.blockList.size === 1)
+
+    val b = bs.blockList.head
+    assert(b.get(0, Block.Sum) === 6.0)
+    assert(b.get(0, Block.Count) === 3.0)
+    assert(b.get(0, Block.Min) === 1.0)
+    assert(b.get(0, Block.Max) === 3.0)
+  }
+
+  test("overcount due to message id limit overflow") {
+    val db = newDB
+    val processor = new LocalPublishActor.DatapointProcessor(registry, db, maxMessageIds = 2)
+
+    processor.update("a", List(newDatapoint(1.0)))
+    processor.update("b", List(newDatapoint(2.0)))
+    processor.update("c", List(newDatapoint(3.0)))
+    processor.update("a", List(newDatapoint(1.0))) // Not deduped, too many ids
+
+    db.index.rebuildIndex()
+    val vs = db.index.findItems(TagQuery(Some(Query.True)))
+    assert(vs.size === 1)
+
+    val bs = vs.head.blocks
+    assert(bs.blockList.size === 1)
+
+    val b = bs.blockList.head
+    assert(b.get(0, Block.Sum) === 7.0)
+    assert(b.get(0, Block.Count) === 4.0)
+    assert(b.get(0, Block.Min) === 1.0)
+    assert(b.get(0, Block.Max) === 3.0)
+  }
+}


### PR DESCRIPTION
This change allows datapoints to be rolled up as they
are flowing into the in memory storage. Typically this
has been done later as part of offline processing using
EMR or via a separate aggregator cluster that would
perform the aggregations prior to being sent to the
in memory storage.

To be eligible for the rollup the data must have already
been normalized to the step boundary and rate conversion
for counters should have already been performed.

The inline rollup will create a rollup block so it will
have more overhead in terms of memory use unless the
reduction multiple is over 4. Data will only go through
the rollup path if it is tagged with `atlas.rollup=true`.

The publish payload can now take an `id` field which will
get used to dedup messages. If used, then it should avoid
over counting if retries are present in the publishing
pipeline as long as the updates for a given datapoint are
always mapped to the same id for a given interval. The
message id should not be used for multiple intervals or
subsequent messages would incorrectly get lost.