### PR TITLE
improve performance of SmallHashMap.{+,-}

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
@@ -16,18 +16,18 @@
 package com.netflix.atlas.core.util
 
 object SmallHashMap {
-  def empty[K <: AnyRef, V <: AnyRef]: SmallHashMap[K, V] = new SmallHashMap[K, V](Array.empty, 0)
+  def empty[K <: Any, V <: Any]: SmallHashMap[K, V] = new SmallHashMap[K, V](Array.empty, 0)
 
-  def apply[K <: AnyRef, V <: AnyRef](ts: (K, V)*): SmallHashMap[K, V] = {
+  def apply[K <: Any, V <: Any](ts: (K, V)*): SmallHashMap[K, V] = {
     apply(ts.size, ts.iterator)
   }
 
-  def apply[K <: AnyRef, V <: AnyRef](ts: Iterable[(K, V)]): SmallHashMap[K, V] = {
+  def apply[K <: Any, V <: Any](ts: Iterable[(K, V)]): SmallHashMap[K, V] = {
     val seq = ts.toSeq
     apply(seq.size, seq.iterator)
   }
 
-  def apply[K <: AnyRef, V <: AnyRef](length: Int, iter: Iterator[(K, V)]): SmallHashMap[K, V] = {
+  def apply[K <: Any, V <: Any](length: Int, iter: Iterator[(K, V)]): SmallHashMap[K, V] = {
     val b = new Builder[K, V](length)
     while (iter.hasNext) {
       val t = iter.next()
@@ -36,8 +36,8 @@ object SmallHashMap {
     b.result
   }
 
-  class Builder[K <: AnyRef, V <: AnyRef](size: Int) {
-    private val buf = new Array[AnyRef](size * 2)
+  class Builder[K <: Any, V <: Any](size: Int) {
+    private val buf = new Array[Any](size * 2)
     private var actualSize = 0
 
     def +=(pair: (K, V)): Unit = add(pair._1, pair._2)
@@ -97,7 +97,7 @@ object SmallHashMap {
     }
   }
 
-  class EntryIterator[K <: AnyRef, V <: AnyRef](map: SmallHashMap[K, V]) extends Iterator[(K, V)] {
+  class EntryIterator[K <: Any, V <: Any](map: SmallHashMap[K, V]) extends Iterator[(K, V)] {
     private final val len = map.data.length
     var pos = 0
     skipEmptyEntries()
@@ -142,14 +142,14 @@ object SmallHashMap {
  * @param data        array with the items
  * @param dataLength  number of pairs contained within the array starting at index 0.
  */
-final class SmallHashMap[K <: AnyRef, V <: AnyRef] private (val data: Array[AnyRef], dataLength: Int)
+final class SmallHashMap[K <: Any, V <: Any] private (val data: Array[Any], dataLength: Int)
     extends scala.collection.immutable.Map[K, V] {
 
   require(data.length % 2 == 0)
 
   private[this] var cachedHashCode: Int = 0
 
-  private def hash(k: AnyRef): Int = {
+  private def hash(k: Any): Int = {
     val capacity = data.length / 2
     Hash.absOrZero(k.hashCode) % capacity
   }
@@ -259,12 +259,19 @@ final class SmallHashMap[K <: AnyRef, V <: AnyRef] private (val data: Array[AnyR
     total.toDouble / dataLength
   }
 
-  def +[B1 >: V](kv: (K, B1)): collection.immutable.Map[K, B1] = {
-    Map(toSeq: _*) + kv
+  def +[V1 >: V](kv: (K, V1)): collection.immutable.Map[K, V1] = {
+    val b = new SmallHashMap.Builder[K, V1](size + 1)
+    foreachItem(b.add)
+    b.add(kv._1, kv._2)
+    b.result
   }
 
-  def -(k: K): collection.immutable.Map[K, V] = {
-    Map(toSeq: _*) - k
+  def -(key: K): collection.immutable.Map[K, V] = {
+    val b = new SmallHashMap.Builder[K, V](size - 1)
+    foreachItem { (k, v) =>
+      if (key != k) b.add(k, v)
+    }
+    b.result
   }
 
   def ++(m: Map[K, V]): collection.immutable.Map[K, V] = {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/SmallHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/SmallHashMapSuite.scala
@@ -223,6 +223,20 @@ class SmallHashMapSuite extends FunSuite {
     assert(m1 === m2 - "k2")
   }
 
+  test("retains type after removal of key") {
+    val m1 = SmallHashMap("k1" -> "v1")
+    val m2 = SmallHashMap("k1" -> "v1", "k2" -> "v2")
+    assert(m1 === m2 - "k2")
+    assert((m2 - "k2").isInstanceOf[SmallHashMap[_, _]])
+  }
+
+  test("retains type after adding pair") {
+    val m1 = SmallHashMap("k1" -> "v1")
+    val m2 = SmallHashMap("k1" -> "v1", "k2" -> "v2")
+    assert(m1 + ("k2" -> "v2") === m2)
+    assert((m1 + ("k2" -> "v2")).isInstanceOf[SmallHashMap[_, _]])
+  }
+
   test("empty map") {
     val m = SmallHashMap.empty[String, String]
     assert(m.keySet === Set.empty)

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/SmallHashMapModify.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/SmallHashMapModify.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Threads
+import org.openjdk.jmh.infra.Blackhole
+
+/**
+  * Check performance of creating a copy of the map when adding/removing a single pair.
+  *
+  * ```
+  * > jmh:run -prof jmh.extras.JFR -wi 10 -i 10 -f1 -t1 .*SmallHashMapModify.*
+  * ...
+  * [info] Benchmark                           Mode  Cnt        Score       Error  Units
+  * [info] SmallHashMapModify.addPair         thrpt   10  1637470.772 ± 29948.315  ops/s
+  * [info] SmallHashMapModify.removePair      thrpt   10  2520939.662 ± 32320.759  ops/s
+  * ```
+  */
+@State(Scope.Thread)
+class SmallHashMapModify {
+
+  private val tagMap = Map(
+    "nf.app"     -> "atlas_backend",
+    "nf.cluster" -> "atlas_backend-dev",
+    "nf.asg"     -> "atlas_backend-dev-v001",
+    "nf.stack"   -> "dev",
+    "nf.region"  -> "us-east-1",
+    "nf.zone"    -> "us-east-1e",
+    "nf.node"    -> "i-123456789",
+    "nf.ami"     -> "ami-987654321",
+    "nf.vmtype"  -> "r3.2xlarge",
+    "name"       -> "jvm.gc.pause",
+    "cause"      -> "Allocation_Failure",
+    "action"     -> "end_of_major_GC",
+    "statistic"  -> "totalTime"
+  )
+
+  private val smallTagMap = SmallHashMap(tagMap)
+
+  @Threads(1)
+  @Benchmark
+  def addPair(bh: Blackhole): Unit = {
+    bh.consume(smallTagMap + ("foo" -> "bar"))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def removePair(bh: Blackhole): Unit = {
+    bh.consume(smallTagMap - "nf.ami")
+  }
+}


### PR DESCRIPTION
Changes the small hash map implementation of `+`
and `-` to retain the type. This is primarily to
avoid using a less memory efficient map type if
the map is modified somewhere along the way. A
side benefit is better performance and reduced
allocations.

**Before**

```
Benchmark        Mode  Cnt       Score       Error  Units
addPair         thrpt   10  781344.330 ± 25173.790  ops/s
removePair      thrpt   10  738796.252 ± 44849.997  ops/s
```

**After**

```
Benchmark        Mode  Cnt        Score       Error  Units
addPair         thrpt   10  1637470.772 ± 29948.315  ops/s
removePair      thrpt   10  2520939.662 ± 32320.759  ops/s
```