### PR TITLE
add `atlas.rollup` to allowed keys

### DIFF
--- a/atlas-webapi/src/main/resources/reference.conf
+++ b/atlas-webapi/src/main/resources/reference.conf
@@ -104,7 +104,8 @@ atlas {
           allowed-keys = [
             "dstype",
             "offset",
-            "legacy"
+            "legacy",
+            "rollup"
           ]
         },
         {


### PR DESCRIPTION
Updates the default allowed keys list for `atlas.`
prefix to include `atlas.rollup`.