### PR TITLE
fix prefix for cloudwatch sqs metrics

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/sqs.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/sqs.conf
@@ -14,7 +14,7 @@ atlas {
       metrics = [
         {
           name = "ApproximateNumberOfMessagesDelayed"
-          alias = "aws.s3.approximateNumberOfMessages"
+          alias = "aws.sqs.approximateNumberOfMessages"
           conversion = "max"
           tags = [
             {
@@ -25,7 +25,7 @@ atlas {
         },
         {
           name = "ApproximateNumberOfMessagesNotVisible"
-          alias = "aws.s3.approximateNumberOfMessages"
+          alias = "aws.sqs.approximateNumberOfMessages"
           conversion = "max"
           tags = [
             {
@@ -36,7 +36,7 @@ atlas {
         },
         {
           name = "ApproximateNumberOfMessagesVisible"
-          alias = "aws.s3.approximateNumberOfMessages"
+          alias = "aws.sqs.approximateNumberOfMessages"
           conversion = "max"
           tags = [
             {
@@ -47,22 +47,22 @@ atlas {
         },
         {
           name = "NumberOfMessagesSent"
-          alias = "aws.s3.messagesSent"
+          alias = "aws.sqs.messagesSent"
           conversion = "sum,rate"
         },
         {
           name = "NumberOfMessagesReceived"
-          alias = "aws.s3.messagesReceived"
+          alias = "aws.sqs.messagesReceived"
           conversion = "sum,rate"
         },
         {
           name = "NumberOfMessagesDeleted"
-          alias = "aws.s3.messagesDeleted"
+          alias = "aws.sqs.messagesDeleted"
           conversion = "sum,rate"
         },
         {
           name = "NumberOfEmptyReceives"
-          alias = "aws.s3.emptyReceives"
+          alias = "aws.sqs.emptyReceives"
           conversion = "sum,rate"
         },
         {


### PR DESCRIPTION
It was incorrectly specified as `s3`.