### PR TITLE
only run lwc when using the lwcapi.conf

### DIFF
--- a/atlas-standalone/src/main/resources/application.conf
+++ b/atlas-standalone/src/main/resources/application.conf
@@ -1,0 +1,20 @@
+atlas {
+  akka {
+    // These are overridden because the standalone pulls in both webapi and lwc modules.
+    // The user can run the one that is needed for a given test by using one of the specific
+    // profile configurations. The default application config here ignores the setup done
+    // by the reference confs.
+    actors = [
+      {
+        name = "deadLetterStats"
+        class = "com.netflix.atlas.akka.DeadLetterStatsActor"
+      }
+    ]
+
+    api-endpoints = [
+      "com.netflix.atlas.akka.HealthcheckApi",
+      "com.netflix.atlas.akka.ConfigApi",
+      "com.netflix.atlas.akka.StaticPages"
+    ]
+  }
+}

--- a/atlas-standalone/src/main/resources/static.conf
+++ b/atlas-standalone/src/main/resources/static.conf
@@ -1,0 +1,17 @@
+
+atlas {
+  akka {
+    actors = ${?atlas.akka.actors} [
+      {
+        name = "db"
+        class = "com.netflix.atlas.webapi.LocalDatabaseActor"
+      }
+    ]
+
+    api-endpoints = ${?atlas.akka.api-endpoints} [
+      "com.netflix.atlas.webapi.TagsApi",
+      "com.netflix.atlas.webapi.RenderApi",
+      "com.netflix.atlas.webapi.GraphApi"
+    ]
+  }
+}

--- a/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/Main.scala
+++ b/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/Main.scala
@@ -51,14 +51,19 @@ object Main extends StrictLogging {
   private def loadAdditionalConfigFiles(files: Array[String]): Unit = {
     files.foreach { f =>
       logger.info(s"loading config file: $f")
-      val c = ConfigFactory.parseFileAnySyntax(new File(f))
+      val file = new File(f)
+      val c =
+        if (file.exists())
+          ConfigFactory.parseFileAnySyntax(file)
+        else
+          ConfigFactory.parseResourcesAnySyntax(f)
       ConfigManager.update(c)
     }
   }
 
   def main(args: Array[String]): Unit = {
     try {
-      loadAdditionalConfigFiles(args)
+      loadAdditionalConfigFiles(if (args.nonEmpty) args else Array("static.conf"))
       start()
       guice.addShutdownHook()
     } catch {

--- a/conf/lwcapi.conf
+++ b/conf/lwcapi.conf
@@ -7,7 +7,22 @@ atlas {
   }
 
   akka {
-    actors = ${?atlas.akka.actors}
-    api-endpoints = ${?atlas.akka.api-endpoints}
+    actors = ${?atlas.akka.actors} [
+      {
+        name = "lwc.expressiondb"
+        class = "com.netflix.atlas.lwcapi.ExpressionDatabaseActor"
+      },
+      {
+        name = "lwc.subscribe"
+        class = "com.netflix.atlas.lwcapi.SubscribeActor"
+      }
+    ]
+
+    api-endpoints = ${?atlas.akka.api-endpoints} [
+      "com.netflix.atlas.lwcapi.EvaluateApi",
+      "com.netflix.atlas.lwcapi.ExpressionApi",
+      "com.netflix.atlas.lwcapi.SubscribeApi",
+      "com.netflix.atlas.lwcapi.StreamApi"
+    ]
   }
 }

--- a/conf/memory.conf
+++ b/conf/memory.conf
@@ -1,3 +1,4 @@
+include "static.conf"
 
 atlas {
 


### PR DESCRIPTION
Fixes the standalone example to only run the lwc api
and services when using the lwcapi config. The webapi
portions have been restricted in a similar way. This
avoids the need for having redis to run the basic
standalone example.