### PR TITLE
disable log4j shutdown hook on default config

### DIFF
--- a/atlas-standalone/src/main/resources/log4j2.xml
+++ b/atlas-standalone/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="warn">
+<Configuration status="warn" shutdownHook="disable">
   <Properties>
     <Property name="dfltPattern">%d{yyyy-MM-dd'T'HH:mm:ss.SSS} %-5level [%t] %class: %msg%n</Property>
   </Properties>


### PR DESCRIPTION
Updates the default logging config for standalone so
that it disables the log4j shutdown hook. This is to
avoid missing log messages for the app shutdown:

https://github.com/Netflix/iep/tree/master/iep-guice#shutdown