### PR TITLE
enable self-reporting for standalone example

### DIFF
--- a/atlas-standalone/src/main/resources/application.conf
+++ b/atlas-standalone/src/main/resources/application.conf
@@ -18,3 +18,7 @@ atlas {
     ]
   }
 }
+
+netflix.iep.atlas {
+  enabled = false
+}

--- a/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/Main.scala
+++ b/atlas-standalone/src/main/scala/com/netflix/atlas/standalone/Main.scala
@@ -78,7 +78,6 @@ object Main extends StrictLogging {
     val configModule = new AbstractModule {
       override def configure(): Unit = {
         bind(classOf[Config]).toInstance(ConfigManager.current)
-        bind(classOf[Registry]).toInstance(Spectator.globalRegistry())
       }
     }
 

--- a/build.sbt
+++ b/build.sbt
@@ -137,6 +137,7 @@ lazy val `atlas-standalone` = project
   .dependsOn(`atlas-module-akka`, `atlas-module-lwcapi`, `atlas-module-webapi`)
   .settings(libraryDependencies ++= Seq(
     Dependencies.iepGuice,
+    Dependencies.iepModuleAtlas,
     Dependencies.guiceCore,
     Dependencies.guiceMulti,
     Dependencies.log4jApi,

--- a/conf/lwcapi.conf
+++ b/conf/lwcapi.conf
@@ -26,3 +26,12 @@ atlas {
     ]
   }
 }
+
+netflix.iep.atlas {
+  // To enable the this atlas server to subscribe to itself uncomment this property. Note,
+  // that there will be errors logged on startup because the plugin will try to connect
+  // before the service is ready. These are harmless, but that it why it is disabled by
+  // default.
+  //lwc.enabled = true
+  step = PT5S
+}

--- a/conf/memory.conf
+++ b/conf/memory.conf
@@ -46,3 +46,7 @@ atlas {
   }
 }
 
+netflix.iep.atlas {
+  enabled = true
+  step = PT10S
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,6 +34,7 @@ object Dependencies {
   val guiceCore       = "com.google.inject" % "guice" % guice
   val guiceMulti      = "com.google.inject.extensions" % "guice-multibindings" % guice
   val iepGuice        = "com.netflix.iep" % "iep-guice" % iep
+  val iepModuleAtlas  = "com.netflix.iep" % "iep-module-atlas" % iep
   val iepModuleAws    = "com.netflix.iep" % "iep-module-aws" % iep
   val iepNflxEnv      = "com.netflix.iep" % "iep-nflxenv" % iep
   val iepService      = "com.netflix.iep" % "iep-service" % iep


### PR DESCRIPTION
The standalone example will not report data to itself
when running with the sample `memory.conf`. A similar
thing can be done with the `lwcapi.conf` by uncommenting
the enabled flag. It is disabled by default since there
are some ordering issues on startup that cause exceptions
in the log.