### PR TITLE
initial streaming eval library

### DIFF
--- a/atlas-eval/README.md
+++ b/atlas-eval/README.md
@@ -1,0 +1,18 @@
+## Description
+
+Helper library for evaluating Atlas expressions. This library is still a work in
+progress and for now is mostly focused on some of the streaming evaluation use-cases.
+
+## Usage
+
+The goal is to be able to simply create a [reactive streams publisher] from an Atlas
+graph URI. For example:
+
+[publisher]: https://github.com/reactive-streams/reactive-streams-jvm#1-publisher-code
+
+```java
+String uri = "http://localhost:7101/api/v1/graph?q=name,ssCpuUser,:eq,:avg";
+Publisher<TimeSeriesMessage> publisher = Evaluator.createPublisher(uri);
+```
+
+This can then be consumed using any implementation of reactive streams.

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+import com.netflix.atlas.core.model.DataExpr
+import com.netflix.atlas.core.model.DataExpr.AggregateFunction
+import com.netflix.atlas.core.model.DataExpr.GroupBy
+import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.core.model.TimeSeries
+
+/**
+  * Datapoint for an aggregate data expression. This type is used for the intermediate
+  * results during evaluation of an expression until we get the final aggregated value
+  * for a given query.
+  *
+  * @param timestamp
+  *     Timestamp for all values that contributed to the aggregate. It should already
+  *     be normalized to the step interval for the data stream prior to aggregation
+  *     taking place.
+  * @param expr
+  *     Data expression associated with the value. This is needed if further aggregation
+  *     is necessary and later for matching in the final evaluation phase.
+  * @param source
+  *     The source combined with the expression are used for deduping the intermediate
+  *     aggregates. This can be ignored at the risk of some values being included in the
+  *     final result multiple times.
+  * @param tags
+  *     Tags associated with the datapoint.
+  * @param value
+  *     Value for the datapoint.
+  */
+case class AggrDatapoint(
+  timestamp: Long,
+  expr: DataExpr,
+  source: String,
+  tags: Map[String, String],
+  value: Double) {
+
+  /** Identifier used for deduping intermediate aggregates. */
+  def id: String = s"$source:$expr"
+
+  /**
+    * Converts this value to a time series type that can be used for the final evaluation
+    * phase.
+    */
+  def toTimeSeries: TimeSeries = Datapoint(tags, timestamp, value)
+}
+
+object AggrDatapoint {
+
+  /**
+    * Aggregate intermediate aggregates from each source to get the final aggregate for
+    * a given expression. All values are expected to be for the same data expression.
+    */
+  def aggregate(values: List[AggrDatapoint]): List[AggrDatapoint] = {
+    if (values.isEmpty) Nil else {
+      val vs = dedup(values)
+      val expr = vs.head.expr
+      expr match {
+        case af: AggregateFunction => List(applyAF(af, vs))
+        case by: GroupBy           => applyGroupBy(by, vs)
+      }
+    }
+  }
+
+  /**
+    * Dedup the values using the ids for each value. This will take into account the
+    * group by keys such that values with different grouping keys will not be considered
+    * as duplicates.
+    */
+  private def dedup(values: List[AggrDatapoint]): List[AggrDatapoint] = {
+    values.groupBy(_.id).map(_._2.head).toList
+  }
+
+  /** Apply an aggregate function over the set of values to get the final aggregate. */
+  private def applyAF(af: AggregateFunction, values: List[AggrDatapoint]): AggrDatapoint = {
+    require(values.nonEmpty, "cannot apply aggregation function over empty list")
+    val dp = values.head
+    val value = values.map(_.value).reduce(af)
+    dp.copy(value = value)
+  }
+
+  /** Apply the aggregate function for each grouping. */
+  private def applyGroupBy(by: GroupBy, values: List[AggrDatapoint]): List[AggrDatapoint] = {
+    val groups = values.groupBy(_.tags).map { case (_, vs) => applyAF(by.af, vs) }
+    groups.toList
+  }
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/ChunkData.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/ChunkData.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.netflix.atlas.json.JsonSupport
+
+/**
+  * Chunk of data for LWC and fetch responses.
+  */
+sealed trait ChunkData extends JsonSupport {
+  def typeName: String
+}
+
+/**
+  * This is a set of values with a fixed start time and step. The additional
+  * metadata can be found on the [[TimeSeriesMessage]] object that contains
+  * this chunk.
+  *
+  * @param values
+  *     Time series values assocated with a [[TimeSeriesMessage]].
+  */
+final case class ArrayData(values: Array[Double]) extends ChunkData {
+  def typeName: String = "array"
+
+  override def encode(gen: JsonGenerator) {
+    gen.writeStartObject()
+    gen.writeStringField("type", "array")
+    gen.writeArrayFieldStart("values")
+    var i = 0
+    while (i < values.length) {
+      val v = values(i)
+      if (v.isNaN || v.isInfinite) gen.writeString(v.toString) else gen.writeNumber(v)
+      i += 1
+    }
+    gen.writeEndArray()
+    gen.writeEndObject()
+  }
+
+  override def toString: String = values.mkString("ArrayData(", ",", ")")
+
+  override def equals(other: Any): Boolean = {
+    // Follows guidelines from: http://www.artima.com/pins1ed/object-equality.html#28.4
+    other match {
+      case that: ArrayData =>
+        that.canEqual(this) && java.util.Arrays.equals(values, that.values)
+      case _ => false
+    }
+  }
+
+  override def hashCode: Int = {
+    java.util.Arrays.hashCode(values)
+  }
+
+  def canEqual(other: Any): Boolean = {
+    other.isInstanceOf[ArrayData]
+  }
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcDatapoint.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+/**
+  * Datapoint read in from the LWC service.
+  *
+  * @param timestamp
+  *     Timestamp for the value. It should already be normalized to the step interval
+  *     for the data stream.
+  * @param id
+  *     Identifies the expression that resulted in this datapoint being generated. See
+  *     [[AggrDatapoint]] for more information.
+  * @param tags
+  *     Tags associated with the datapoint.
+  * @param value
+  *     Value for the datapoint.
+  */
+case class LwcDatapoint(timestamp: Long, id: String, tags: Map[String, String], value: Double)

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcSubscription.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcSubscription.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+import com.netflix.atlas.core.model.DataExpr
+import com.netflix.atlas.core.model.DataVocabulary
+import com.netflix.atlas.core.stacklang.Interpreter
+
+/**
+  * Subscription message that is returned by the LWC service.
+  *
+  * @param expression
+  *     Expression that was used for the initial subscription.
+  * @param metrics
+  *     Data expressions that result from the root expression.
+  */
+case class LwcSubscription(expression: String, metrics: List[LwcDataExpr])
+
+/**
+  * Triple representing the id, data expression, and frequency for a given data
+  * flow. The id is needed to match [[LwcDatapoint]]s to the data expression they
+  * were generated for.
+  *
+  * @param id
+  *     Id used by LWC service for this expression. Data generated coming in will
+  *     be tagged with this id.
+  * @param expression
+  *     Data expression that was used to generate the intermediate result on each
+  *     client and that can be used for the final aggregation step during consumption.
+  * @param frequency
+  *     The step size used for this stream of data.
+  */
+case class LwcDataExpr(id: String, expression: String, frequency: Long) {
+  val expr: DataExpr = LwcDataExpr.parseExpr(expression)
+}
+
+object LwcDataExpr {
+
+  private val interpreter = Interpreter(DataVocabulary.allWords)
+
+  private def parseExpr(input: String): DataExpr = {
+    interpreter.execute(input).stack match {
+      case (expr: DataExpr) :: Nil => expr
+      case _                       => throw new IllegalArgumentException(s"invalid expr: $input")
+    }
+  }
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/ServoMessage.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/ServoMessage.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+import com.netflix.atlas.core.model.Datapoint
+
+/**
+  * Message from legacy mantis source integrated with base-server.
+  *
+  * @param metrics
+  *     Datapoints that matched the query.
+  */
+case class ServoMessage(metrics: List[ServoDatapoint])
+
+/**
+  * Datapoint from the servo source. The timestamps may or may not already be normalized
+  * to the step boundary. Note, the step size is fixed based on the `servo.pollers`
+  * setting of the plugin and cannot be negotiated as part of the subscription.
+  *
+  * @param config
+  *     Pair with the name and other tags.
+  * @param timestamp
+  *     Timestamp for the datapoint. Depending on client settings it may or may not be
+  *     normalized to the step boundary.
+  * @param value
+  *     Value for the datapoint.
+  */
+case class ServoDatapoint(config: ServoConfig, timestamp: Long, value: Double) {
+  def toDatapoint(step: Long): Datapoint = {
+    val boundary = if (timestamp % step == 0) timestamp else timestamp / step * step
+    Datapoint(config.tags + ("name" -> config.name), boundary, value)
+  }
+}
+
+/**
+  * Config used to identify a servo metric. See servo's MonitorConfig for more information.
+  *
+  * @param name
+  *     Name used to describe the measurement.
+  * @param tags
+  *     Other dimensions for drilling into the data.
+  */
+case class ServoConfig(name: String, tags: Map[String, String])

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeGroup.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeGroup.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+/**
+  * A group of values for the same timestamp. This type is typically created as the result
+  * of using the [[com.netflix.atlas.eval.stream.TimeGrouped]] operator on the stream.
+  *
+  * @param timestamp
+  *     Timestamp that applies to all values within the group.
+  * @param values
+  *     Values associated with this time.
+  */
+case class TimeGroup[T](timestamp: Long, values: List[T])

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeSeriesMessage.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeSeriesMessage.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.netflix.atlas.core.model._
+import com.netflix.atlas.json.JsonSupport
+import com.netflix.atlas.core.util.SmallHashMap
+import com.netflix.atlas.core.util.Strings
+
+/**
+  * Message type use for emitting time series data in LWC and fetch responses.
+  *
+  * @param id
+  *     Identifier for the time series. This can be used to stitch together messages for
+  *     the same time series over time. For example in a streaming use-case you get one
+  *     message per interval for each time series. To get all of the message for a given
+  *     time series group by this id.
+  * @param query
+  *     Expression for the time series. Note, the same expression can result in many time
+  *     series when using group by. For matching the data for a particular time series the
+  *     id field should be used.
+  * @param start
+  *     Start time for the data.
+  * @param end
+  *     End time for the data.
+  * @param step
+  *     Time interval between data points.
+  * @param label
+  *     Label associated with the time series. This is either the auto-generated string
+  *     based on the expression or the value specified by the legend.
+  * @param tags
+  *     Tags associated with the final expression result. This is the set of exact matches
+  *     from the query plus any keys used in the group by clause.
+  * @param data
+  *     Data for the time series.
+  */
+case class TimeSeriesMessage(
+  id: String,
+  query: String,
+  start: Long,
+  end: Long,
+  step: Long,
+  label: String,
+  tags: Map[String, String],
+  data: ChunkData) extends JsonSupport {
+
+  override def encode(gen: JsonGenerator) {
+    gen.writeStartObject()
+    gen.writeStringField("type", "timeseries")
+    gen.writeStringField("id", id)
+    gen.writeStringField("query", query)
+    gen.writeStringField("label", label)
+    encodeTags(gen, tags)
+    gen.writeNumberField("start", start)
+    gen.writeNumberField("end", end)
+    gen.writeNumberField("step", step)
+    gen.writeFieldName("data")
+    data.encode(gen)
+    gen.writeEndObject()
+  }
+
+  private def encodeTags(gen: JsonGenerator, tags: Map[String, String]) {
+    gen.writeObjectFieldStart("tags")
+    tags match {
+      case m: SmallHashMap[String, String] => m.foreachItem { (k, v) => gen.writeStringField(k, v) }
+      case m: Map[String, String]          => m.foreach { t => gen.writeStringField(t._1, t._2) }
+    }
+    gen.writeEndObject()
+  }
+}
+
+object TimeSeriesMessage {
+  /**
+    * Create a new time series message.
+    *
+    * @param query
+    *     Expression for the time series. Note, the same expression can result in many time
+    *     series when using group by. For matching the data for a particular time series the
+    *     id field should be used.
+    * @param context
+    *     Evaluation context that is used for getting the start, end, and step size used
+    *     for the message.
+    * @param ts
+    *     Time series to use for the message.
+    */
+  def apply(query: String, context: EvalContext, ts: TimeSeries): TimeSeriesMessage = {
+    val id = Strings.zeroPad(TaggedItem.computeId(ts.tags + ("atlas.query" -> query)), 40)
+    val data = ts.data.bounded(context.start, context.end)
+    TimeSeriesMessage(
+      id,
+      query,
+      context.start,
+      context.end,
+      context.step,
+      ts.label,
+      ts.tags,
+      ArrayData(data.data))
+  }
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/DataExprEval.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/DataExprEval.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import akka.stream.Attributes
+import akka.stream.FlowShape
+import akka.stream.Inlet
+import akka.stream.Outlet
+import akka.stream.stage.GraphStage
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.InHandler
+import akka.stream.stage.OutHandler
+import com.netflix.atlas.core.model.EvalContext
+import com.netflix.atlas.core.model.StatefulExpr
+import com.netflix.atlas.core.model.StyleExpr
+import com.netflix.atlas.eval.model.AggrDatapoint
+import com.netflix.atlas.eval.model.TimeGroup
+import com.netflix.atlas.eval.model.TimeSeriesMessage
+
+/**
+  * Perform the final evaluation for an expression based on intermediate aggregates
+  * computed locally on the instances.
+  *
+  * @param expr
+  *     High level expression to evaluate.
+  * @param step
+  *     Step size for the input data.
+  */
+class DataExprEval(expr: StyleExpr, step: Long)
+  extends GraphStage[FlowShape[TimeGroup[AggrDatapoint], List[TimeSeriesMessage]]] {
+
+  private val in = Inlet[TimeGroup[AggrDatapoint]]("DataExprEval.in")
+  private val out = Outlet[List[TimeSeriesMessage]]("DataExprEval.out")
+
+  override val shape: FlowShape[TimeGroup[AggrDatapoint], List[TimeSeriesMessage]] = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
+    new GraphStageLogic(shape) with InHandler with OutHandler {
+      private var state = Map.empty[StatefulExpr, Any]
+
+      override def onPush(): Unit = {
+        val group = grab(in)
+        val data = group.values.groupBy(_.expr).map { case (k, vs) =>
+          k -> AggrDatapoint.aggregate(vs).map(_.toTimeSeries)
+        }
+        val s = group.timestamp
+        val context = EvalContext(s, s + step, step, state)
+        val result = expr.expr.eval(context, data)
+        state = result.state
+        val msgs = result.data.map { t =>
+          TimeSeriesMessage(expr.toString, context, t)
+        }
+        push(out, msgs)
+      }
+
+      override def onPull(): Unit = {
+        pull(in)
+      }
+
+      override def onUpstreamFinish(): Unit = {
+        completeStage()
+      }
+
+      setHandlers(in, out, this)
+    }
+  }
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/DatapointEval.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/DatapointEval.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import akka.stream.Attributes
+import akka.stream.FlowShape
+import akka.stream.Inlet
+import akka.stream.Outlet
+import akka.stream.stage.GraphStage
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.InHandler
+import akka.stream.stage.OutHandler
+import com.netflix.atlas.core.model.EvalContext
+import com.netflix.atlas.core.model.StatefulExpr
+import com.netflix.atlas.core.model.StyleExpr
+import com.netflix.atlas.core.model.TimeSeries
+import com.netflix.atlas.eval.model.TimeGroup
+import com.netflix.atlas.eval.model.TimeSeriesMessage
+
+/**
+  * Perform the final evaluation for an expression based on the raw datapoints
+  * from the source.
+  *
+  * @param expr
+  *     High level expression to evaluate.
+  * @param step
+  *     Step size for the input data.
+  */
+class DatapointEval[T <: TimeSeries](expr: StyleExpr, step: Long)
+  extends GraphStage[FlowShape[TimeGroup[T], List[TimeSeriesMessage]]] {
+
+  private val in = Inlet[TimeGroup[T]]("DatapointEval.in")
+  private val out = Outlet[List[TimeSeriesMessage]]("DatapointEval.out")
+
+  override val shape: FlowShape[TimeGroup[T], List[TimeSeriesMessage]] = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
+    new GraphStageLogic(shape) with InHandler with OutHandler {
+      private var state = Map.empty[StatefulExpr, Any]
+
+      override def onPush(): Unit = {
+        val group = grab(in)
+        val vs = group.values
+        if (vs.isEmpty) push(out, List.empty) else {
+          val s = group.timestamp
+          val context = EvalContext(s, s + step, step, state)
+          val result = expr.expr.eval(context, vs)
+          state = result.state
+          val msgs = result.data.map { t =>
+            TimeSeriesMessage(expr.toString, context, t)
+          }
+          push(out, msgs)
+        }
+      }
+
+      override def onPull(): Unit = {
+        pull(in)
+      }
+
+      override def onUpstreamFinish(): Unit = {
+        completeStage()
+      }
+
+      setHandlers(in, out, this)
+    }
+  }
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EurekaSourceActor.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EurekaSourceActor.scala
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import java.util.UUID
+
+import akka.actor.Actor
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.HttpMethods
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.MediaTypes
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers._
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Compression
+import akka.stream.scaladsl.Sink
+import akka.util.ByteString
+import com.netflix.atlas.json.Json
+import com.typesafe.scalalogging.StrictLogging
+
+import scala.concurrent.duration._
+import scala.util.Failure
+import scala.util.Success
+
+/**
+  * Subscribes to all instances that are available for an app or a vip in eureka.
+  *
+  * @param eurekaUri
+  *     Should be either the `/v2/apps/{app}` or `/v2/vips/{vip}` endpoint for a
+  *     Eureka service. Depending on the Eureka service configuration there may be
+  *     some variation in the path.
+  * @param instanceUriPattern
+  *     Pattern for constructing the URI for each instance in Eureka. The allowed
+  *     substitutions are `{port}` and any key in the data center info metadata
+  *     block for an instance. Example:
+  *
+  *     ```
+  *     http://{local-ipv4}:{port}/metrics?q=name,cpu,:eq,:sum
+  *     ```
+  * @param sink
+  *     Sink to use for all data coming from instances. The response streams from
+  *     each instance will get framed by new line and then fed into the sink.
+  */
+class EurekaSourceActor(
+  eurekaUri: String,
+  instanceUriPattern: String,
+  sink: Sink[ByteString, _]) extends Actor with StrictLogging {
+
+  import EurekaSourceActor._
+
+  import context.dispatcher
+
+  private implicit val system = context.system
+  private implicit val materializer = ActorMaterializer()
+
+  private val useVipFormat = eurekaUri.contains("/vips/")
+
+  private val ticker = system.scheduler.schedule(0.seconds, 5.seconds, self, Tick)
+
+  private val instanceMap = new collection.mutable.AnyRefMap[String, StreamRef[_]]
+
+  def receive: Receive = {
+    case Tick                      => fetchEurekaData()
+    case Success(res: VipResponse) => updateInstanceMap(res.instances)
+    case Success(res: AppResponse) => updateInstanceMap(res.instances)
+    case Failure(t)                => logger.warn("failed to refresh eureka data", t)
+  }
+
+  private def updateInstanceMap(instances: List[Instance]): Unit = {
+    val currentIds = instanceMap.keySet
+    val foundInstances = instances.map(i => i.instanceId -> i).toMap
+    handleAddedInstances(foundInstances -- currentIds)
+    handleRemovedInstances(instanceMap.toMap -- foundInstances.keySet)
+  }
+
+  private def handleAddedInstances(instances: Map[String, Instance]): Unit = {
+    if (instances.keySet.nonEmpty)
+      logger.info(s"added instances: ${instances.keySet.mkString(", ")}")
+    instances.values.foreach(subscribe)
+  }
+
+  private def handleRemovedInstances(instances: Map[String, StreamRef[_]]): Unit = {
+    if (instances.keySet.nonEmpty)
+      logger.info(s"removed instances: ${instances.keySet.mkString(", ")}")
+    instanceMap --= instances.keySet
+    instances.values.foreach(_.killSwitch.shutdown())
+  }
+
+  private def instanceUri(instance: Instance): String = {
+    var uri = instanceUriPattern
+    instance.dataCenterInfo.metadata.foreach { case (k, v) =>
+      uri = uri.replace(s"{$k}", v)
+    }
+    uri = uri.replace("{port}", instance.port.toString)
+    uri
+  }
+
+  private def subscribe(instance: Instance): Unit = {
+    val uri = instanceUri(instance)
+    instanceMap += instance.instanceId -> Evaluator.runForHost(uri, sink)
+  }
+
+  private def fetchEurekaData(): Unit = {
+    val headers = List(
+      Accept(MediaTypes.`application/json`),
+      `Accept-Encoding`(HttpEncodings.gzip))
+    val request = HttpRequest(HttpMethods.GET, eurekaUri, headers)
+    Http().singleRequest(request)
+      .flatMap { res =>
+        if (res.status != StatusCodes.OK) {
+          throw new IllegalStateException(s"request failed: ${res.status}")
+        }
+        val isCompressed = res.headers.contains(`Content-Encoding`(HttpEncodings.gzip))
+        val source = if (isCompressed) res.entity.dataBytes.via(Compression.gunzip()) else res.entity.dataBytes
+        source
+          .runReduce(_ ++ _)
+          .map { bs =>
+            if (useVipFormat)
+              Json.decode[VipResponse](bs.toArray)
+            else
+              Json.decode[AppResponse](bs.toArray)
+          }
+      }
+      .onComplete(r => self ! r)
+  }
+
+  override def postStop(): Unit = {
+    ticker.cancel()
+    instanceMap.values.foreach(_.killSwitch.shutdown())
+    super.postStop()
+  }
+}
+
+object EurekaSourceActor {
+
+  case object Tick
+
+  case class VipResponse(applications: Apps) {
+    def instances: List[Instance] = applications.application.flatMap(_.instance)
+  }
+
+  case class AppResponse(application: App) {
+    def instances: List[Instance] = application.instance
+  }
+
+  case class Apps(application: List[App])
+
+  case class App(name: String, instance: List[Instance])
+
+  case class Instance(
+    instanceId: String,
+    status: String,
+    dataCenterInfo: DataCenterInfo,
+    port: PortInfo
+  )
+
+  case class DataCenterInfo(name: String, metadata: Map[String, String])
+
+  case class PortInfo(`$`: Int) {
+    def port: Int = `$`
+    override def toString: String = `$`.toString
+  }
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/Evaluator.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/Evaluator.scala
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.actor.Props
+import akka.stream.ActorMaterializer
+import akka.stream.KillSwitch
+import akka.stream.KillSwitches
+import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.Keep
+import akka.stream.scaladsl.MergeHub
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.core.model.StyleExpr
+import com.netflix.atlas.eval.model.AggrDatapoint
+import com.netflix.atlas.eval.model.ServoMessage
+import com.netflix.atlas.eval.model.TimeSeriesMessage
+import com.netflix.atlas.json.Json
+import com.netflix.spectator.api.Counter
+
+
+/**
+  * Helpers for evaluating Atlas expressions over streaming data sources.
+  */
+object Evaluator {
+
+  /**
+    * Run a stream that collects data from `uri` and feeds it to the provided sink. The
+    * stream will not stop on its own. Use the kill switch in the provided stream ref to
+    * shutdown when the data is no longer of interest.
+    */
+  def runForHost[T](uri: String, sink: Sink[ByteString, T])
+    (implicit system: ActorSystem, materializer: ActorMaterializer): StreamRef[T] = {
+
+    val (killSwitch, value) = HostSource(uri)
+      .viaMat(KillSwitches.single)(Keep.right)
+      .toMat(sink)(Keep.both)
+      .run()
+
+    StreamRef(killSwitch, value)
+  }
+
+  /**
+    * Run a stream that collects data from all instances registered in Eureka for a give
+    * application or vip and feed it to the provided sink. The stream will not stop on its
+    * own. Use the kill switch in the provided stream ref to shutdown when the data is no
+    * longer of interest.
+    */
+  def runForEurekaVip[T](eurekaUri: String, instanceUri: String, sink: Sink[ByteString, T])
+    (implicit system: ActorSystem, materializer: ActorMaterializer): StreamRef[T] = {
+
+    val runnableGraph = MergeHub
+      .source[ByteString](perProducerBufferSize = 16)
+      .viaMat(KillSwitches.single)(Keep.both)
+      .toMat(sink)(Keep.both)
+    val ((toConsumer, killSwitch), value) = runnableGraph.run()
+
+    val actorRef = system.actorOf(Props(new EurekaSourceActor(eurekaUri, instanceUri, toConsumer)))
+    val switch = new KillSwitch {
+      override def abort(ex: Throwable): Unit = shutdown()
+      override def shutdown(): Unit = {
+        system.stop(actorRef)
+        killSwitch.shutdown()
+      }
+    }
+    StreamRef(switch, value)
+  }
+
+  /**
+    * Creates a flow that increments the counter foreach item that comes through. The items
+    * themselves are not modified in any way.
+    *
+    * @param c
+    *     Counter to increment.
+    * @tparam T
+    *     Types of the items flowing through.
+    * @return
+    *     Flow for counting the number of events flowing through.
+    */
+  def countEvents[T](c: Counter): Flow[T, T, NotUsed] = {
+    Flow[T].map { v => c.increment(); v }
+  }
+
+  /**
+    * Creates a flow that maps an SSE stream from the LWC service into a stream of
+    * [[AggrDatapoint]] objects.
+    */
+  def lwcToAggrDatapoint: Flow[String, AggrDatapoint, NotUsed] = {
+    Flow[String].via(new LwcToAggrDatapoint)
+  }
+
+  /**
+    * Creates a flow that converts a servo SSE stream into a stream of [[Datapoint]]
+    * objects.
+    *
+    * @param step
+    *     Step size used for the input source. To ensure accurate results this should
+    *     match the step size actually used on the source.
+    * @return
+    *     Stream of datapoints.
+    */
+  def servoMessagesToDatapoints(step: Long): Flow[String, Datapoint, NotUsed] = {
+    Flow[String]
+      .filter(_.startsWith("data: "))
+      .map(s => Json.decode[ServoMessage](s.substring("data: ".length)))
+      .flatMapConcat(msg => Source(msg.metrics.map(_.toDatapoint(step))))
+  }
+
+  /**
+    * Creates a flow that will perform an online evaluation of raw datapoints.
+    *
+    * @param expr
+    *     User expression to evaluate. Note, that the online evaluation does not support
+    *     time shifts. TODO, what behavior should we have for time shifts?
+    * @param step
+    *     Step size used for the input source. To ensure accurate results this should
+    *     match the step size actually used on the source.
+    * @return
+    *     Time series messages containing the results of the evaluation.
+    */
+  def forDatapoints(expr: StyleExpr, step: Long): Flow[Datapoint, TimeSeriesMessage, NotUsed] = {
+    Flow[Datapoint]
+      .via(new TimeGrouped[Datapoint](2, 50, _.timestamp))
+      .via(new DatapointEval[Datapoint](expr, step))
+      .flatMapConcat(msgs => Source(msgs))
+  }
+
+  /**
+    * Creates a flow that will perform an online evaluation of partially aggregated
+    * datapoints.
+    *
+    * @param expr
+    *     User expression to evaluate. Note, that the online evaluation does not support
+    *     time shifts. TODO, what behavior should we have for time shifts?
+    * @param step
+    *     Step size used for the input source. To ensure accurate results this should
+    *     match the step size actually used on the source.
+    * @return
+    *     Time series messages containing the results of the evaluation.
+    */
+  def forPartialAggregates(expr: StyleExpr, step: Long): Flow[AggrDatapoint, TimeSeriesMessage, NotUsed] = {
+    Flow[AggrDatapoint]
+      .via(new TimeGrouped[AggrDatapoint](2, 50, _.timestamp))
+      .via(new DataExprEval(expr, step))
+      .flatMapConcat(msgs => Source(msgs))
+  }
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/HostSource.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/HostSource.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import java.util.UUID
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.HttpMethods
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers._
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Compression
+import akka.stream.scaladsl.Framing
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import com.netflix.atlas.akka.CustomMediaTypes
+import com.typesafe.scalalogging.StrictLogging
+
+import scala.concurrent.Future
+import scala.util.Failure
+import scala.util.Success
+
+/**
+  * Helper for creating a stream source for a given host.
+  */
+object HostSource extends StrictLogging {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+  import scala.concurrent.duration._
+
+  type Client = HttpRequest => Future[HttpResponse]
+
+  /**
+    * Create a new stream source for the response of `uri`. The URI should be a streaming
+    * source such as SSE that can have the messages framed by the new line and will be
+    * continuously emitting data. If the response ends for any reason, then the source
+    * will attempt to reconnect. Use a kill switch to shut it down.
+    *
+    * @param uri
+    *     URI for the remote stream. Typically this should be an endpoint that returns an
+    *     SSE stream.
+    * @param delay
+    *     How long to delay between attempts to connect to the host.
+    * @param client
+    *     Client to use for making the request. This is typically used in tests to provide
+    *     responses without actually making network calls.
+    * @param system
+    *     Actor system to use for the streams.
+    * @param materializer
+    *     Materializer to use for the streams.
+    * @return
+    *     Source that emits the response stream from the host.
+    */
+  def apply(uri: String, delay: FiniteDuration = 1.second, client: Option[Client] = None)
+    (implicit system: ActorSystem, materializer: ActorMaterializer): Source[ByteString, NotUsed] = {
+
+    Source.repeat(uri).delay(delay).flatMapConcat(singleCall(client))
+  }
+
+  private def singleCall(client: Option[Client])(uri: String)
+    (implicit system: ActorSystem, materializer: ActorMaterializer): Source[ByteString, Any] = {
+
+    logger.info(s"subscribing to $uri")
+    val headers = List(
+      Accept(CustomMediaTypes.`text/event-stream`),
+      `Accept-Encoding`(HttpEncodings.gzip))
+    val request = HttpRequest(HttpMethods.GET, uri, headers)
+    val future = client.fold(Http().singleRequest(request))(c => c(request))
+      .map {
+        case res: HttpResponse if res.status == StatusCodes.OK =>
+          // Framing needs to take place on the byte stream before merging chunks
+          // with other hosts
+          unzipIfNeeded(res)
+            .via(Framing.delimiter(ByteString("\n"), 65536, allowTruncation = true))
+            .watchTermination() { (_, f) =>
+              f.onComplete {
+                case Success(_) =>
+                  logger.info(s"lost connection to $uri")
+                case Failure(t) =>
+                  logger.warn(s"stream failed $uri", t)
+              }
+            }
+        case res: HttpResponse =>
+          logger.warn(s"subscription attempt failed with status ${res.status}")
+          empty
+      }
+      .recoverWith { case t: Exception =>
+        logger.warn(s"subscription attempt failed with exception", t)
+        Future.successful(empty)
+      }
+    Source.fromFuture(future).flatMapConcat(v => v)
+  }
+
+  private def empty: Source[ByteString, NotUsed] = {
+    Source.empty[ByteString]
+  }
+
+  private def unzipIfNeeded(res: HttpResponse): Source[ByteString, Any] = {
+    val isCompressed = res.headers.contains(`Content-Encoding`(HttpEncodings.gzip))
+    if (isCompressed) res.entity.dataBytes.via(Compression.gunzip()) else res.entity.dataBytes
+  }
+}
+

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapoint.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import akka.stream.Attributes
+import akka.stream.FlowShape
+import akka.stream.Inlet
+import akka.stream.Outlet
+import akka.stream.stage.GraphStage
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.InHandler
+import akka.stream.stage.OutHandler
+import com.netflix.atlas.core.model.DataExpr
+import com.netflix.atlas.eval.model.AggrDatapoint
+import com.netflix.atlas.eval.model.LwcDatapoint
+import com.netflix.atlas.eval.model.LwcSubscription
+import com.netflix.atlas.json.Json
+
+/**
+  * Process the SSE output from an LWC service and convert it into a stream of
+  * [[AggrDatapoint]]s that can be used for evaluation.
+  */
+class LwcToAggrDatapoint
+  extends GraphStage[FlowShape[String, AggrDatapoint]] {
+
+  private val in = Inlet[String]("LwcToAggrDatapoint.in")
+  private val out = Outlet[AggrDatapoint]("LwcToAggrDatapoint.out")
+
+  override val shape: FlowShape[String, AggrDatapoint] = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
+    new GraphStageLogic(shape) with InHandler with OutHandler {
+      import LwcToAggrDatapoint._
+
+      private var state: Map[String, DataExpr] = Map.empty
+
+      // HACK: needed until we can plumb the actual source through the system
+      private var nextSource: Int = 0
+
+      override def onPush(): Unit = {
+        grab(in).trim match {
+          case msg: String if msg.startsWith(subscribePrefix)  => updateState(msg)
+          case msg: String if msg.startsWith(metricDataPrefix) => pushDatapoint(msg)
+          case msg: String                                     => ignoreMessage(msg)
+        }
+      }
+
+      private def updateState(msg: String): Unit = {
+        val json = msg.substring(subscribePrefix.length)
+        val sub = Json.decode[LwcSubscription](json)
+        state = sub.metrics.map(m => m.id -> m.expr).toMap
+        pull(in)
+      }
+
+      private def pushDatapoint(msg: String): Unit = {
+        val json = msg.substring(metricDataPrefix.length)
+        val d = Json.decode[LwcDatapoint](json)
+        state.get(d.id) match {
+          case Some(expr) =>
+            // TODO, put in source, for now make it random to avoid dedup
+            nextSource += 1
+            push(out, AggrDatapoint(d.timestamp, expr, nextSource.toString, d.tags, d.value))
+          case None =>
+            pull(in)
+        }
+      }
+
+      private def ignoreMessage(msg: String): Unit = {
+        pull(in)
+      }
+
+      override def onPull(): Unit = {
+        pull(in)
+      }
+
+      override def onUpstreamFinish(): Unit = {
+        completeStage()
+      }
+
+      setHandlers(in, out, this)
+    }
+  }
+}
+
+object LwcToAggrDatapoint {
+  private val subscribePrefix = "info: subscribe "
+  private val metricDataPrefix = "data: metric "
+}
+

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamRef.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamRef.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import akka.stream.KillSwitch
+
+/**
+  * Reference to a running stream. Has handle to terminate the stream as
+  * well as a result value.
+  */
+case class StreamRef[T](killSwitch: KillSwitch, value: T)

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import akka.stream.Attributes
+import akka.stream.FlowShape
+import akka.stream.Inlet
+import akka.stream.Outlet
+import akka.stream.stage.GraphStage
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.InHandler
+import akka.stream.stage.OutHandler
+import com.netflix.atlas.eval.model.TimeGroup
+
+/**
+  * Operator for grouping data into buckets by time. The expectation is that the data
+  * is roughly time ordered and that data from later times is a good indicator that
+  * older times are complete.
+  *
+  * @param numBuffers
+  *     Number of time buffers to maintain. The buffers are stored in a rolling array
+  *     and the data for a given buffer will be emitted when the first data comes in
+  *     for a new time that would evict the buffer with the minimum time.
+  * @param max
+  *     Maximum number of items that can be accumulated for a given time.
+  * @param ts
+  *     Function that extracts the timestamp for an item.
+  * @tparam T
+  *     Item from the input stream.
+  */
+class TimeGrouped[T](numBuffers: Int, max: Int, ts: T => Long)
+  extends GraphStage[FlowShape[T, TimeGroup[T]]] {
+
+  private val in = Inlet[T]("TimeGrouped.in")
+  private val out = Outlet[TimeGroup[T]]("TimeGrouped.out")
+
+  override val shape: FlowShape[T, TimeGroup[T]] = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
+    new GraphStageLogic(shape) with InHandler with OutHandler {
+      private val buf = new Array[List[T]](numBuffers)
+      buf.indices.foreach { i => buf(i) = Nil }
+
+      private val timestamps = new Array[Long](numBuffers)
+
+      private var cutoffTime = 0L
+
+      private var pending: List[TimeGroup[T]] = Nil
+
+      private def findBuffer(t: Long): Int = {
+        var i = 0
+        var min = 0
+        while (i < timestamps.length) {
+          if (timestamps(i) == t) return i
+          if (i > 0 && timestamps(i) < timestamps(i - 1)) min = i
+          i += 1
+        }
+        -min - 1
+      }
+
+      override def onPush(): Unit = {
+        val v = grab(in)
+        val t = ts(v)
+        if (t <= cutoffTime) pull(in) else {
+          val i = findBuffer(t)
+          if (i >= 0) {
+            buf(i) = v :: buf(i)
+            pull(in)
+          } else {
+            val pos = -i - 1
+            val vs = buf(pos)
+            if (vs.nonEmpty) push(out, TimeGroup(timestamps(pos), vs)) else pull(in)
+            cutoffTime = timestamps(pos)
+            buf(pos) = List(v)
+            timestamps(pos) = t
+          }
+        }
+      }
+
+      override def onPull(): Unit = {
+        if (isClosed(in))
+          flush()
+        else
+          pull(in)
+      }
+
+      override def onUpstreamFinish(): Unit = {
+        val groups = buf.indices.map(i => TimeGroup(timestamps(i), buf(i))).toList
+        pending = groups.filter(_.values.nonEmpty).sortWith(_.timestamp < _.timestamp)
+        flush()
+      }
+
+      private def flush(): Unit = {
+        if (pending.nonEmpty) {
+          push(out, pending.head)
+          pending = pending.tail
+        }
+        if (pending.isEmpty) {
+          completeStage()
+        }
+      }
+
+      setHandlers(in, out, this)
+    }
+  }
+}
+

--- a/atlas-eval/src/test/resources/application.conf
+++ b/atlas-eval/src/test/resources/application.conf
@@ -1,0 +1,8 @@
+atlas {
+  core {
+    model {
+      // Needed because datapoint gets the step from the config
+      step = 10 seconds
+    }
+  }
+}

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/AggrDatapointSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/AggrDatapointSuite.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+import com.netflix.atlas.core.model.DataExpr
+import com.netflix.atlas.core.model.Query
+import org.scalatest.FunSuite
+
+class AggrDatapointSuite extends FunSuite {
+
+  private def createDatapoints(expr: DataExpr, t: Long, nodes: Int): List[AggrDatapoint] = {
+    (0 until nodes).toList.map { i =>
+      val node = f"i-$i%08d"
+      val tags = Map("name" -> "cpu")
+      if (expr.isGrouped)
+        AggrDatapoint(t, expr, node, tags + ("node" -> node), i)
+      else
+        AggrDatapoint(t, expr, node, tags, i)
+    }
+  }
+
+  test("aggregate empty") {
+    assert(AggrDatapoint.aggregate(Nil) === Nil)
+  }
+
+  test("aggregate simple") {
+    val expr = DataExpr.Sum(Query.True)
+    val dataset = createDatapoints(expr, 0, 10)
+    val result = AggrDatapoint.aggregate(dataset)
+    assert(result.size === 1)
+    assert(result.head.timestamp === 0L)
+    assert(result.head.tags === Map("name" -> "cpu"))
+    assert(result.head.value === 45.0)
+  }
+
+  test("aggregate dedups using source") {
+    val expr = DataExpr.Sum(Query.True)
+    val dataset = createDatapoints(expr, 0, 10)
+    val result = AggrDatapoint.aggregate(dataset ::: dataset)
+    assert(result.size === 1)
+    assert(result.head.timestamp === 0L)
+    assert(result.head.tags === Map("name" -> "cpu"))
+    assert(result.head.value === 45.0)
+  }
+
+  test("aggregate group by") {
+    val expr = DataExpr.GroupBy(DataExpr.Sum(Query.True), List("node"))
+    val dataset = createDatapoints(expr, 0, 10)
+    val result = AggrDatapoint.aggregate(dataset)
+    assert(result.size === 10)
+    result.foreach { d =>
+      val v = d.tags("node").substring(2).toDouble
+      assert(d.value === v)
+    }
+  }
+
+  test("aggregate, dedup and group by") {
+    val expr = DataExpr.GroupBy(DataExpr.Sum(Query.True), List("node"))
+    val dataset = createDatapoints(expr, 0, 10)
+    val result = AggrDatapoint.aggregate(dataset ::: dataset)
+    assert(result.size === 10)
+    result.foreach { d =>
+      val v = d.tags("node").substring(2).toDouble
+      assert(d.value === v)
+    }
+  }
+}

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/ChunkDataSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/ChunkDataSuite.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+import nl.jqno.equalsverifier.EqualsVerifier
+import nl.jqno.equalsverifier.Warning
+import org.scalatest.FunSuite
+
+class ChunkDataSuite extends FunSuite {
+  test("ArrayData equals") {
+    EqualsVerifier
+      .forClass(classOf[ArrayData])
+      .suppress(Warning.NULL_FIELDS)
+      .verify()
+  }
+
+  test("ArrayData encode empty") {
+    val empty = ArrayData(Array())
+    assert(empty.toJson === """{"type":"array","values":[]}""")
+  }
+
+  test("ArrayData encode values") {
+    val data = ArrayData(Array(1.0, 2.0, 3.0))
+    assert(data.toJson === """{"type":"array","values":[1.0,2.0,3.0]}""")
+  }
+}

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcDataExprSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcDataExprSuite.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+import com.netflix.atlas.core.model.ModelExtractors
+import com.netflix.atlas.core.model.StyleExpr
+import com.netflix.atlas.core.model.StyleVocabulary
+import com.netflix.atlas.core.stacklang.Interpreter
+import org.scalatest.FunSuite
+
+class LwcDataExprSuite extends FunSuite {
+
+  private def styleExpr(str: String): StyleExpr = {
+    val interpreter = new Interpreter(StyleVocabulary.allWords)
+    interpreter.execute(str).stack match {
+      case ModelExtractors.PresentationType(v) :: Nil => v
+      case _ => throw new IllegalArgumentException(s"invalid expr: $str")
+    }
+  }
+
+  test("group by equals") {
+    val exprStr = "statistic,max,:eq,name,foo,:eq,:and,:max,(,nf.asg,),:by"
+    val distExprStr = "name,foo,:eq,:dist-max,(,nf.asg,),:by"
+    val lwcExpr = LwcDataExpr("123", exprStr, 10L)
+    assert(lwcExpr.expr === styleExpr(distExprStr).expr.dataExprs.head)
+    assert(lwcExpr.expr.hashCode() === styleExpr(exprStr).expr.hashCode())
+  }
+}

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/DataExprEvalSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/DataExprEvalSuite.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import com.netflix.atlas.core.model.DataExpr
+import com.netflix.atlas.core.model.Query
+import com.netflix.atlas.core.model.StyleExpr
+import com.netflix.atlas.eval.model.AggrDatapoint
+import com.netflix.atlas.eval.model.ArrayData
+import com.netflix.atlas.eval.model.TimeGroup
+import com.netflix.atlas.eval.model.TimeSeriesMessage
+import com.netflix.spectator.api.ManualClock
+import org.scalatest.FunSuite
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+class DataExprEvalSuite extends FunSuite {
+
+  implicit val system = ActorSystem(getClass.getSimpleName)
+  implicit val materializer = ActorMaterializer()
+
+  private val step = 10000
+
+  private def createGroup(expr: DataExpr, t: Long, nodes: Int): TimeGroup[AggrDatapoint] = {
+    val datapoints = (0 until nodes).toList.map { i =>
+      val node = f"i-$i%08d"
+      val tags = Map("name" -> "cpu")
+      if (expr.isGrouped)
+        AggrDatapoint(t, expr, node, tags + ("node" -> node), i)
+      else
+        AggrDatapoint(t, expr, node, tags, i)
+    }
+    TimeGroup(t, datapoints)
+  }
+
+  private def createDataSet(expr: DataExpr, window: Int, nodes: Int): List[TimeGroup[AggrDatapoint]] = {
+    (0 until window).toList.map { i =>
+      createGroup(expr, i * step, nodes)
+    }
+  }
+
+  private def eval(expr: DataExpr, dataSet: List[TimeGroup[AggrDatapoint]]): List[List[TimeSeriesMessage]] = {
+    val styleExpr = StyleExpr(expr, Map.empty)
+    val future = Source(dataSet)
+      .via(new DataExprEval(styleExpr, step))
+      .runWith(Sink.seq[List[TimeSeriesMessage]])
+    Await.result(future, Duration.Inf).toList
+  }
+
+  test("eval sum") {
+    val expr = DataExpr.Sum(Query.True)
+    val dataSet = createDataSet(expr, 5, 10)
+    val results = eval(expr, dataSet)
+    assert(results.size === 5)
+    results.foreach { vs =>
+      assert(vs.size === 1)
+      vs.foreach { case TimeSeriesMessage(_, _, _, _, _, _, _, ArrayData(values)) =>
+        assert(values === Array(45.0))
+      }
+    }
+  }
+
+  test("eval max") {
+    val expr = DataExpr.Max(Query.True)
+    val dataSet = createDataSet(expr, 5, 10)
+    val results = eval(expr, dataSet)
+    assert(results.size === 5)
+    results.foreach { vs =>
+      assert(vs.size === 1)
+      vs.foreach { case TimeSeriesMessage(_, _, _, _, _, _, _, ArrayData(values)) =>
+        assert(values === Array(9.0))
+      }
+    }
+  }
+
+  test("eval by") {
+    val expr = DataExpr.GroupBy(DataExpr.Max(Query.True), List("node"))
+    val dataSet = createDataSet(expr, 5, 10)
+    val results = eval(expr, dataSet)
+    assert(results.size === 5)
+    results.foreach { vs =>
+      assert(vs.size === 10)
+      vs.foreach { case TimeSeriesMessage(_, _, _, _, _, _, tags, ArrayData(values)) =>
+        val v = tags("node").substring(2).toDouble
+        assert(values === Array(v))
+      }
+    }
+  }
+
+}
+

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/DatapointEvalSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/DatapointEvalSuite.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import com.netflix.atlas.core.model.DataExpr
+import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.core.model.Query
+import com.netflix.atlas.core.model.StyleExpr
+import com.netflix.atlas.eval.model.ArrayData
+import com.netflix.atlas.eval.model.TimeGroup
+import com.netflix.atlas.eval.model.TimeSeriesMessage
+import com.netflix.spectator.api.ManualClock
+import org.scalatest.FunSuite
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+class DatapointEvalSuite extends FunSuite {
+
+  implicit val system = ActorSystem(getClass.getSimpleName)
+  implicit val materializer = ActorMaterializer()
+
+  private val step = 10000
+
+  private def createGroup(expr: DataExpr, t: Long, nodes: Int): TimeGroup[Datapoint] = {
+    val datapoints = (0 until nodes).toList.map { i =>
+      val node = f"i-$i%08d"
+      val tags = Map("name" -> "cpu")
+      if (expr.isGrouped)
+        Datapoint(tags + ("node" -> node), t, i)
+      else
+        Datapoint(tags, t, i)
+    }
+    TimeGroup(t, datapoints)
+  }
+
+  private def createDataSet(expr: DataExpr, window: Int, nodes: Int): List[TimeGroup[Datapoint]] = {
+    (0 until window).toList.map { i =>
+      createGroup(expr, i * step, nodes)
+    }
+  }
+
+  private def eval(expr: DataExpr, dataSet: List[TimeGroup[Datapoint]]): List[List[TimeSeriesMessage]] = {
+    val styleExpr = StyleExpr(expr, Map.empty)
+    val future = Source(dataSet)
+      .via(new DatapointEval(styleExpr, step))
+      .runWith(Sink.seq[List[TimeSeriesMessage]])
+    Await.result(future, Duration.Inf).toList
+  }
+
+  test("eval sum") {
+    val expr = DataExpr.Sum(Query.True)
+    val dataSet = createDataSet(expr, 5, 10)
+    val results = eval(expr, dataSet)
+    assert(results.size === 5)
+    results.foreach { vs =>
+      assert(vs.size === 1)
+      vs.foreach { case TimeSeriesMessage(_, _, _, _, _, _, _, ArrayData(values)) =>
+        assert(values === Array(45.0))
+      }
+    }
+  }
+
+  test("eval max") {
+    val expr = DataExpr.Max(Query.True)
+    val dataSet = createDataSet(expr, 5, 10)
+    val results = eval(expr, dataSet)
+    assert(results.size === 5)
+    results.foreach { vs =>
+      assert(vs.size === 1)
+      vs.foreach { case TimeSeriesMessage(_, _, _, _, _, _, _, ArrayData(values)) =>
+        assert(values === Array(9.0))
+      }
+    }
+  }
+
+  test("eval by") {
+    val expr = DataExpr.GroupBy(DataExpr.Max(Query.True), List("node"))
+    val dataSet = createDataSet(expr, 5, 10)
+    val results = eval(expr, dataSet)
+    assert(results.size === 5)
+    results.foreach { vs =>
+      assert(vs.size === 10)
+      vs.foreach { case TimeSeriesMessage(_, _, _, _, _, _, tags, ArrayData(values)) =>
+        val v = tags("node").substring(2).toDouble
+        assert(values === Array(v))
+      }
+    }
+  }
+
+}
+

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/HostSourceSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/HostSourceSuite.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers._
+import akka.stream.ActorMaterializer
+import akka.stream.KillSwitches
+import akka.stream.scaladsl.Keep
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import org.scalatest.FunSuite
+
+import scala.concurrent.Await
+import scala.concurrent.Promise
+
+class HostSourceSuite extends FunSuite {
+
+  import scala.concurrent.duration._
+
+  implicit val system = ActorSystem(getClass.getSimpleName)
+  implicit val materializer = ActorMaterializer()
+
+  def source(client: HostSource.Client): Source[ByteString, NotUsed] = {
+    HostSource("http://localhost/api/test", delay = 0.seconds, client = Some(client))
+  }
+
+  def compress(str: String): Array[Byte] = {
+    import com.netflix.atlas.core.util.Streams._
+    byteArray { out =>
+      scope(gzip(out))(_.write(str.getBytes(StandardCharsets.UTF_8)))
+    }
+  }
+
+  test("ok") {
+    val response = HttpResponse(StatusCodes.OK, entity = ByteString("ok"))
+    val client: HostSource.Client = _ => Promise.successful(response).future
+    val future = source(client)
+      .take(5)
+      .map(_.decodeString(StandardCharsets.UTF_8))
+      .runWith(Sink.seq[String])
+    val result = Await.result(future, Duration.Inf).toList
+    assert(result === (0 until 5).map(_ => "ok").toList)
+  }
+
+  test("handles decompression") {
+    val headers = List(`Content-Encoding`(HttpEncodings.gzip))
+    val data = ByteString(compress("ok"))
+    val response = HttpResponse(StatusCodes.OK, headers = headers, entity = data)
+    val client: HostSource.Client = _ => Promise.successful(response).future
+    val future = source(client)
+      .take(5)
+      .map(_.decodeString(StandardCharsets.UTF_8))
+      .runWith(Sink.seq[String])
+    val result = Await.result(future, Duration.Inf).toList
+    assert(result === (0 until 5).map(_ => "ok").toList)
+  }
+
+  test("retries on error response from host") {
+    val response = HttpResponse(StatusCodes.BadRequest, entity = ByteString("error"))
+    val latch = new CountDownLatch(5)
+    val client: HostSource.Client = _ => {
+      latch.countDown()
+      Promise.successful(response).future
+    }
+    val (switch, future) = source(client)
+      .viaMat(KillSwitches.single)(Keep.right)
+      .toMat(Sink.ignore)(Keep.both)
+      .run()
+
+    // If it doesn't retry successfully this should time out and fail the test
+    latch.await(60, TimeUnit.SECONDS)
+
+    switch.shutdown()
+    Await.result(future, Duration.Inf)
+  }
+
+  test("retries on exception from host") {
+    val latch = new CountDownLatch(5)
+    val client: HostSource.Client = _ => {
+      latch.countDown()
+      Promise.failed(new IOException("cannot connect")).future
+    }
+    val (switch, future) = source(client)
+      .viaMat(KillSwitches.single)(Keep.right)
+      .toMat(Sink.ignore)(Keep.both)
+      .run()
+
+    // If it doesn't retry successfully this should time out and fail the test
+    latch.await(60, TimeUnit.SECONDS)
+
+    switch.shutdown()
+    Await.result(future, Duration.Inf)
+  }
+
+}

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import com.netflix.atlas.core.model.DataExpr
+import com.netflix.atlas.core.model.Query
+import com.netflix.atlas.eval.model.AggrDatapoint
+import org.scalatest.FunSuite
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+class LwcToAggrDatapointSuite extends FunSuite {
+
+  implicit val system = ActorSystem(getClass.getSimpleName)
+  implicit val materializer = ActorMaterializer()
+
+  private val step = 10000
+
+  private val sumMetric = s"""{"id":"sum","expression":"name,cpu,:eq,:sum","frequency":$step}"""
+  private val countMetric = s"""{"id":"count","expression":"name,cpu,:eq,:count","frequency":$step}"""
+
+  private val input = List(
+    s"""info: subscribe {"expression":"name,cpu,:eq,:avg","metrics":[$sumMetric,$countMetric]}""",
+    """info: other {"type":"info","msg":"something"}""",
+    """data: metric {"timestamp":0,"id":"sum","tags":{"name":"cpu"},"value":1.0}""",
+    """data: metric {"timestamp":0,"id":"count","tags":{"name":"cpu"},"value":4.0}""",
+    """data: metric {"timestamp":10000,"id":"sum","tags":{"name":"cpu"},"value":2.0}""",
+    """data: metric {"timestamp":10000,"id":"count","tags":{"name":"cpu"},"value":4.0}""",
+    """data: other {"type":"info","msg":"something"}""",
+    """data: other {"type":"info","msg":"something"}""",
+    """data: other {"type":"info","msg":"something"}""",
+    """data: other {"type":"info","msg":"something"}""",
+    """data: metric {"timestamp":20000,"id":"sum","tags":{"name":"cpu"},"value":3.0}""",
+    """data: metric {"timestamp":20000,"id":"count","tags":{"name":"cpu"},"value":4.0}""",
+    """data: metric {"timestamp":30000,"id":"count","tags":{"name":"cpu"},"value":4.0}""",
+    """data: metric {"timestamp":30000,"id":"sum","tags":{"name":"cpu"},"value":4.0}"""
+  )
+
+  private def eval(data: List[String]): List[AggrDatapoint] = {
+    val future = Source(data)
+      .via(new LwcToAggrDatapoint)
+      .runWith(Sink.seq[AggrDatapoint])
+    Await.result(future, Duration.Inf).toList
+  }
+
+  test("eval") {
+    val results = eval(input)
+    assert(results.size === 8)
+
+    val groups = results.groupBy(_.expr)
+    assert(groups.size === 2)
+
+    val sumData = groups(DataExpr.Sum(Query.Equal("name", "cpu")))
+    assert(sumData.map(_.value).toSet === Set(1.0, 2.0, 3.0, 4.0))
+
+    val countData = groups(DataExpr.Count(Query.Equal("name", "cpu")))
+    assert(countData.size === 4)
+    assert(countData.map(_.value).toSet === Set(4.0))
+  }
+}

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Source
+import com.netflix.atlas.eval.model.TimeGroup
+import com.netflix.spectator.api.ManualClock
+import org.scalatest.FunSuite
+
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+
+class TimeGroupedSuite extends FunSuite {
+
+  import TimeGroupedSuite._
+
+  implicit val system = ActorSystem(getClass.getSimpleName)
+  implicit val materializer = ActorMaterializer()
+
+  private def result(future: Future[List[TimeGroup[Event]]]): List[TimeGroup[Event]] = {
+    Await.result(future, Duration.Inf)
+      .reverse
+      .map(g => g.copy(values = g.values.sortWith(_.i < _.i)))
+  }
+
+  test("in order list") {
+    val data = List(
+      Event(10, 1), Event(10, 2), Event(10, 3),
+      Event(20, 1),
+      Event(30, 1), Event(30, 2))
+
+    val future = Source(data)
+      .via(new TimeGrouped[Event](2, 10, _.timestamp))
+      .runFold(List.empty[TimeGroup[Event]])((acc, g) => g :: acc)
+
+    val groups = result(future)
+    assert(groups === List(
+      TimeGroup(10, List(Event(10, 1), Event(10, 2), Event(10, 3))),
+      TimeGroup(20, List(Event(20, 1))),
+      TimeGroup(30, List(Event(30, 1), Event(30, 2)))
+    ))
+  }
+
+  test("out of order list") {
+    val data = List(
+      Event(20, 1), Event(10, 2), Event(10, 3),
+      Event(10, 1),
+      Event(30, 1), Event(30, 2))
+
+    val future = Source(data)
+      .via(new TimeGrouped[Event](2, 10, _.timestamp))
+      .runFold(List.empty[TimeGroup[Event]])((acc, g) => g :: acc)
+
+    val groups = result(future)
+    assert(groups === List(
+      TimeGroup(10, List(Event(10, 1), Event(10, 2), Event(10, 3))),
+      TimeGroup(20, List(Event(20, 1))),
+      TimeGroup(30, List(Event(30, 1), Event(30, 2)))
+    ))
+  }
+
+  test("late events dropped") {
+    val data = List(
+      Event(20, 1), Event(10, 2), Event(10, 3),
+      Event(10, 1),
+      Event(30, 1), Event(30, 2),
+      Event(10, 4) // Dropped, came in late and out of window
+    )
+
+    val future = Source(data)
+      .via(new TimeGrouped[Event](2, 10, _.timestamp))
+      .runFold(List.empty[TimeGroup[Event]])((acc, g) => g :: acc)
+
+    val groups = result(future)
+    assert(groups === List(
+      TimeGroup(10, List(Event(10, 1), Event(10, 2), Event(10, 3))),
+      TimeGroup(20, List(Event(20, 1))),
+      TimeGroup(30, List(Event(30, 1), Event(30, 2)))
+    ))
+  }
+}
+
+object TimeGroupedSuite {
+  case class Event(timestamp: Long, i: Int)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,15 @@ lazy val `atlas-core` = project
     Dependencies.jol % "test"
   ))
 
+lazy val `atlas-eval` = project
+  .configure(BuildSettings.profile)
+  .dependsOn(`atlas-akka`, `atlas-core`)
+  .settings(libraryDependencies ++= Seq(
+    Dependencies.akkaHttpTestkit % "test",
+    Dependencies.akkaTestkit % "test",
+    Dependencies.equalsVerifier % "test"
+  ))
+
 lazy val `atlas-jmh` = project
   .configure(BuildSettings.profile)
   .dependsOn(`atlas-chart`, `atlas-core`, `atlas-json`)


### PR DESCRIPTION
This isn't yet fully baked or hardened, but is a good
enough check point. This is an initial version of a
library to evaluate expressions using the LWC service
as a source.

Still left to do:

1. Expose simple and stable java API for accessing
   the stream for a corresponding graph uri. This is
   to make it really easy to transition between the
   backend graph and a streaming source.
2. Source identification in LWC so we can reliably
   dedup messages.
3. Improving test coverage of Eureka source and
   evaluator helpers. This is really sparse right
   now.
4. Refactor Datapoint so that the step size is provided
   rather than coming from a static config.
5. Performance testing and tuning.

These follow up items will be addressed in later PRs.