### PR TITLE
named rewrite expr string now preserves offset

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathExamplesSuite.scala
@@ -20,4 +20,35 @@ import com.netflix.atlas.core.stacklang.Vocabulary
 
 class MathExamplesSuite extends BaseExamplesSuite {
   override def vocabulary: Vocabulary = MathVocabulary
+
+  private def eval(program: String): TimeSeriesExpr = {
+    interpreter.execute(program).stack match {
+      case ModelExtractors.TimeSeriesType(t) :: Nil => t
+    }
+  }
+
+  test("toString with offsets") {
+    val expr = eval("name,test,:eq,:sum,1h,:offset")
+    assert(expr.toString === "name,test,:eq,:sum,PT1H,:offset")
+  }
+
+  test("rewrite toString with offsets") {
+    val expr = eval("name,test,:eq,:dist-avg,1h,:offset")
+    assert(expr.toString === "name,test,:eq,:dist-avg,PT1H,:offset")
+  }
+
+  test("rewrite toString with offsets and cq") {
+    val expr = eval("name,test,:eq,:avg,1h,:offset,app,foo,:eq,:cq")
+    assert(expr.toString === "name,test,:eq,app,foo,:eq,:and,:avg,PT1H,:offset")
+  }
+
+  test("rewrite group by toString with offsets") {
+    val expr = eval("name,test,:eq,:dist-avg,(,cluster,),:by,1h,:offset")
+    assert(expr.toString === "name,test,:eq,:dist-avg,PT1H,:offset,(,cluster,),:by")
+  }
+
+  test("rewrite group by toString with offsets and cq") {
+    val expr = eval("name,test,:eq,:dist-avg,(,cluster,),:by,1h,:offset,app,foo,:eq,:cq")
+    assert(expr.toString === "name,test,:eq,app,foo,:eq,:and,:dist-avg,PT1H,:offset,(,cluster,),:by")
+  }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/BaseExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/BaseExamplesSuite.scala
@@ -21,13 +21,13 @@ abstract class BaseExamplesSuite extends FunSuite {
 
   def vocabulary: Vocabulary
 
-  val i = new Interpreter(vocabulary.allWords)
+  protected val interpreter = new Interpreter(vocabulary.allWords)
 
   for (w <- vocabulary.words; ex <- w.examples) {
     if (ex.startsWith("UNK:")) {
       test(s"noException -- $ex,:${w.name}") {
         val prg = ex.substring("UNK:".length)
-        try i.execute(s"$prg,:${w.name}") catch {
+        try interpreter.execute(s"$prg,:${w.name}") catch {
           case e: IllegalArgumentException if e.getMessage.startsWith("unknown word ") =>
           case e: Exception => throw e
         }
@@ -35,21 +35,21 @@ abstract class BaseExamplesSuite extends FunSuite {
     } else if (ex.startsWith("ERROR:")) {
       test(s"exception -- $ex,:${w.name}") {
         val prg = ex.substring("ERROR:".length)
-        intercept[Exception] { i.execute(s"$prg,:${w.name}") }
+        intercept[Exception] { interpreter.execute(s"$prg,:${w.name}") }
       }
     } else {
       test(s"noException -- $ex,:${w.name}") {
-        i.execute(s"$ex,:${w.name}")
+        interpreter.execute(s"$ex,:${w.name}")
       }
 
       test(s"toString(item) -- $ex,:${w.name}") {
-        val stack = i.execute(s"$ex,:${w.name}").stack
+        val stack = interpreter.execute(s"$ex,:${w.name}").stack
         stack.foreach { item =>
           val prg = item match {
             case vs: List[_] => vs
             case v           => List(v)
           }
-          val stack2 = i.execute(Interpreter.toString(prg)).stack
+          val stack2 = interpreter.execute(Interpreter.toString(prg)).stack
           assert(stack2 === prg)
         }
       }
@@ -57,8 +57,8 @@ abstract class BaseExamplesSuite extends FunSuite {
       // Exclude offset because list form is lazily evaluated and breaks the comparison
       if (w.name != "offset") {
         test(s"toString(stack) -- $ex,:${w.name}") {
-          val stack = i.execute(s"$ex,:${w.name}").stack
-          assert(stack === i.execute(Interpreter.toString(stack)).stack)
+          val stack = interpreter.execute(s"$ex,:${w.name}").stack
+          assert(stack === interpreter.execute(Interpreter.toString(stack)).stack)
         }
       }
     }

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
@@ -207,8 +207,8 @@ object ExprApi {
     import MathExpr.NamedRewrite
     val cleaned = exprs.map { e =>
       val clean = e.rewrite {
-        case NamedRewrite(n, orig: Query,          _) => NamedRewrite(n, orig, DataExpr.Sum(orig))
-        case NamedRewrite(n, orig: TimeSeriesExpr, _) => NamedRewrite(n, orig, orig)
+        case r @ NamedRewrite(_, orig: Query,          _, _) => r.copy(evalExpr = DataExpr.Sum(orig))
+        case r @ NamedRewrite(_, orig: TimeSeriesExpr, _, _) => r.copy(evalExpr = orig)
       }
       clean.asInstanceOf[StyleExpr]
     }


### PR DESCRIPTION
Fixes a bug with the expression string for named rewrites
that contain offsets. If the rewrite is being used similar
to an aggregate function and the display expression is a
query, then the offset was getting lost because that is an
attribute of the aggregate functions that are only present
in the expanded evaluation expression.

Now the named rewrite will extract the offset and group by
information if the display type is a query. For others the
rewrite will be re-evaluated using the same interpreter.