### PR TITLE
reduce allocations for processing messages

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/ServoMessage.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/ServoMessage.scala
@@ -15,7 +15,9 @@
  */
 package com.netflix.atlas.eval.model
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.eval.util.SmallHashMapDeserializer
 
 /**
   * Message from legacy mantis source integrated with base-server.
@@ -53,4 +55,6 @@ case class ServoDatapoint(config: ServoConfig, timestamp: Long, value: Double) {
   * @param tags
   *     Other dimensions for drilling into the data.
   */
-case class ServoConfig(name: String, tags: Map[String, String])
+case class ServoConfig(
+  name: String,
+  @JsonDeserialize(using = classOf[SmallHashMapDeserializer]) tags: Map[String, String])

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/util/SmallHashMapDeserializer.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/util/SmallHashMapDeserializer.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.util
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.netflix.atlas.core.util.SmallHashMap
+
+/**
+  * Custom deserializer for tag maps to go directly to [[SmallHashMap]] type. It is assumed
+  * that each tag map should have a relatively small number of entries.
+  */
+class SmallHashMapDeserializer extends JsonDeserializer[SmallHashMap[String, String]] {
+  override def deserialize(p: JsonParser, ctxt: DeserializationContext): SmallHashMap[String, String] = {
+    val builder = new SmallHashMap.Builder[String, String](5)
+    var k = p.nextFieldName()
+    while (k != null) {
+      val v = p.nextTextValue()
+      builder.add(k, v)
+      k = p.nextFieldName()
+    }
+    builder.result
+  }
+}

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/eval/ServoMessageToDatapoint.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/eval/ServoMessageToDatapoint.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.eval.stream.Evaluator
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Threads
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+/**
+  * Check performance of json deserialization of messages.
+  *
+  * ```
+  * > jmh:run -prof jmh.extras.JFR -wi 10 -i 10 -f1 -t1 .*ServoMessageToDatapoint.*
+  * ...
+  * [info] Benchmark                       Mode  Cnt  Score   Error  Units
+  * [info] servoMessagesToDatapoints      thrpt   10  6.082 ± 0.268  ops/s
+  * ```
+  */
+@State(Scope.Thread)
+class ServoMessageToDatapoint {
+
+  private val servoMetrics = (0 until 100).toList.map { i =>
+    val node = f"i-$i%017d"
+    val config = s"""{"name":"jvm.gc.pause","tags":{"nf.cluster":"foo-test","nf.node":"$node"}}"""
+    s"""{"config":$config,"timestamp":1492462554000,"value":$i.0}"""
+  }
+  private val servoMsg = s"""data: {"metrics":[${servoMetrics.mkString(",")}]}"""
+
+  private val servoMsgs = (0 until 1000).map(_ => ByteString(servoMsg)).toList
+
+  private implicit val system = ActorSystem()
+  private implicit val materializer = ActorMaterializer()
+
+  @Threads(1)
+  @Benchmark
+  def servoMessagesToDatapoints(bh: Blackhole): Unit = {
+    val future = Source(servoMsgs)
+      .via(Evaluator.servoMessagesToDatapoints(60000))
+      .runWith(Sink.seq[Datapoint])
+    val result = Await.result(future, Duration.Inf)
+    bh.consume(result)
+  }
+
+  @TearDown
+  def shutdown(): Unit = {
+    materializer.shutdown()
+    system.terminate()
+  }
+
+}

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
@@ -38,6 +38,7 @@ object Json {
   final class Decoder[T: Manifest](reader: ObjectReader, factory: JsonFactory) {
 
     def decode(json: Array[Byte]): T = decode(factory.createParser(json))
+    def decode(json: Array[Byte], offset: Int, length: Int): T = decode(factory.createParser(json, offset, length))
     def decode(json: String): T = decode(factory.createParser(json))
     def decode(input: InputStream): T = decode(factory.createParser(input))
     def decode(input: Reader): T = decode(factory.createParser(input))
@@ -66,9 +67,6 @@ object Json {
     factory.enable(AUTO_CLOSE_SOURCE)
     factory.enable(AUTO_CLOSE_TARGET)
     factory.disable(QUOTE_NON_NUMERIC_NUMBERS)
-
-    // The buffer recycling causes data corruption
-    factory.disable(JsonFactory.Feature.USE_THREAD_LOCAL_FOR_BUFFER_RECYCLING)
   }
 
   private def newMapper(factory: JsonFactory): ObjectMapper = {
@@ -154,6 +152,8 @@ object Json {
   }
 
   def decode[T: Manifest](json: Array[Byte]): T = decoder[T].decode(json)
+
+  def decode[T: Manifest](json: Array[Byte], offset: Int, length: Int): T = decoder[T].decode(json, offset, length)
 
   def decode[T: Manifest](json: String): T = decoder[T].decode(json)
 

--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ lazy val `atlas-eval` = project
 
 lazy val `atlas-jmh` = project
   .configure(BuildSettings.profile)
-  .dependsOn(`atlas-chart`, `atlas-core`, `atlas-json`)
+  .dependsOn(`atlas-chart`, `atlas-core`, `atlas-eval`, `atlas-json`)
   .enablePlugins(pl.project13.scala.sbt.SbtJmh)
 
 lazy val `atlas-json` = project


### PR DESCRIPTION
Some initial performance checks on the streaming
evaluation show a lot of allocations. The biggest
contributor was converting from ByteString to
a form that jackson could parse. This has been
reduced by reusing buffers. Some other minor
changes have been made to reduce allocations for
fields and to go direct to SmallHashMap for the
tag data.

Biggest bottlenecks right now are parsing the
json messages from the SSE stream followed by
the materialization speed. The materialization
speed should be less of an issue in practice
because the streams will be longer lived and is
supposed to be improved in akka 2.5.0.