### PR TITLE
update to akka 2.5.0

### DIFF
--- a/atlas-jmh/src/main/scala/com/netflix/atlas/eval/ServoMessageToDatapoint.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/eval/ServoMessageToDatapoint.scala
@@ -39,7 +39,7 @@ import scala.concurrent.duration.Duration
   * > jmh:run -prof jmh.extras.JFR -wi 10 -i 10 -f1 -t1 .*ServoMessageToDatapoint.*
   * ...
   * [info] Benchmark                       Mode  Cnt  Score   Error  Units
-  * [info] servoMessagesToDatapoints      thrpt   10  6.082 ± 0.268  ops/s
+  * [info] servoMessagesToDatapoints      thrpt   10  7.677 ± 0.325  ops/s
   * ```
   */
 @State(Scope.Thread)

--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,7 @@ lazy val `atlas-akka` = project
   .settings(libraryDependencies ++= Seq(
     Dependencies.akkaActor,
     Dependencies.akkaSlf4j,
+    Dependencies.akkaStream,
     Dependencies.iepService,
     Dependencies.spectatorSandbox,
     Dependencies.akkaHttp,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   object Versions {
-    val akka       = "2.4.17"
+    val akka       = "2.5.0"
     val akkaHttpV  = "10.0.5"
     val aws        = "1.11.105"
     val iep        = "0.4.17"
@@ -23,6 +23,7 @@ object Dependencies {
   val akkaHttpCore    = "com.typesafe.akka" %% "akka-http-core" % akkaHttpV
   val akkaHttpTestkit = "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV
   val akkaSlf4j       = "com.typesafe.akka" %% "akka-slf4j" % akka
+  val akkaStream      = "com.typesafe.akka" %% "akka-stream" % akka
   val akkaTestkit     = "com.typesafe.akka" %% "akka-testkit" % akka
   val awsCloudWatch   = "com.amazonaws" % "aws-java-sdk-cloudwatch" % aws
   val awsCore         = "com.amazonaws" % "aws-java-sdk-core" % aws


### PR DESCRIPTION
Switch to akka 2.5.0 to get improved materialization
performance for streams. Throughput for the simple
benchmark in #541 improved by 26%.