### PR TITLE
add util for wrapping ByteString as InputStream

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/util/ByteStringInputStream.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/util/ByteStringInputStream.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.util
+
+import java.io.InputStream
+
+import akka.util.ByteString
+
+/**
+  * Wraps an akka [[ByteString]] as an input stream. This is mostly used to allow
+  * the data to be read from other libraries like jackson.
+  */
+class ByteStringInputStream(buf: ByteString) extends InputStream {
+  private[this] val n = buf.size
+  private[this] var pos: Int = 0
+
+  override def read(): Int = {
+    if (pos >= n) -1 else {
+      val i = pos
+      pos += 1
+      buf(i)
+    }
+  }
+
+  override def read(dst: Array[Byte], offset: Int, length: Int): Int = {
+    pos match {
+      case i if i >= n => -1
+      case i if i == 0 => copy(buf, dst, offset, length)
+      case i           => copy(buf.slice(i, n), dst, offset, length)
+    }
+  }
+
+  @inline private def copy(src: ByteString, dst: Array[Byte], offset: Int, length: Int): Int = {
+    src.copyToArray(dst, offset, length)
+    val amount = math.min(n - pos, length)
+    pos += amount
+    amount
+  }
+
+  override def available(): Int = n - pos
+}

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/util/ByteStringInputStreamSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/util/ByteStringInputStreamSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.util
+
+import akka.util.ByteString
+import org.scalatest.FunSuite
+
+class ByteStringInputStreamSuite extends FunSuite {
+  test("read()") {
+    val in = new ByteStringInputStream(ByteString("abc"))
+    assert('a' === in.read())
+    assert('b' === in.read())
+    assert('c' === in.read())
+    assert(-1 === in.read())
+  }
+
+  test("available()") {
+    val in = new ByteStringInputStream(ByteString("a"))
+    assert(1 === in.available())
+    in.read()
+    assert(0 === in.available())
+  }
+
+  test("read(buf, offset, length)") {
+    val in = new ByteStringInputStream(ByteString("abcdefgh"))
+    assert(8 == in.available())
+    val buf = new Array[Byte](3)
+
+    assert(3 === in.read(buf))
+    assert(5 == in.available())
+    assert("abc" === new String(buf, 0, 3))
+
+    assert(3 === in.read(buf))
+    assert(2 == in.available())
+    assert("def" === new String(buf, 0, 3))
+
+    assert(2 === in.read(buf))
+    assert(0 == in.available())
+    assert("gh" === new String(buf, 0, 2))
+
+    assert(-1 === in.read(buf))
+    assert(0 == in.available())
+  }
+}


### PR DESCRIPTION
This makes it easier to quickly pass the ByteString to
jackson and keep the number of additional allocations
minimal.