### PR TITLE
fix rewrite to use new display expr

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -592,8 +592,10 @@ object MathExpr {
 
     def dataExprs: List[DataExpr] = evalExpr.dataExprs
 
-    override def toString: String = {
-      displayExpr match {
+    override def toString: String = toString(displayExpr)
+
+    private def toString(expr: Expr): String = {
+      expr match {
         case q: Query =>
           // If the displayExpr is a query type, then the rewrite is simulating an
           // aggregate function. Modifications to the aggregate need to be represented
@@ -614,7 +616,7 @@ object MathExpr {
 
           buffer.toString()
         case _ =>
-          s"$displayExpr,:$name"
+          s"$expr,:$name"
       }
     }
 
@@ -639,7 +641,7 @@ object MathExpr {
               evalExpr = evalExpr.rewrite(f).asInstanceOf[TimeSeriesExpr])
           case _ =>
             val newDisplayExpr = displayExpr.rewrite(f)
-            val ctxt = context.interpreter.execute(toString)
+            val ctxt = context.interpreter.execute(toString(newDisplayExpr))
             ctxt.stack match {
               case (r: NamedRewrite) :: Nil => r
               case _ => throw new IllegalStateException(s"invalid stack for :$name")

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathExamplesSuite.scala
@@ -21,12 +21,6 @@ import com.netflix.atlas.core.stacklang.Vocabulary
 class MathExamplesSuite extends BaseExamplesSuite {
   override def vocabulary: Vocabulary = MathVocabulary
 
-  private def eval(program: String): TimeSeriesExpr = {
-    interpreter.execute(program).stack match {
-      case ModelExtractors.TimeSeriesType(t) :: Nil => t
-    }
-  }
-
   test("toString with offsets") {
     val expr = eval("name,test,:eq,:sum,1h,:offset")
     assert(expr.toString === "name,test,:eq,:sum,PT1H,:offset")

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/StatefulExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/StatefulExamplesSuite.scala
@@ -20,4 +20,9 @@ import com.netflix.atlas.core.stacklang.Vocabulary
 
 class StatefulExamplesSuite extends BaseExamplesSuite {
   override def vocabulary: Vocabulary = StatefulVocabulary
+
+  test("rewrite toString and cq") {
+    val expr = eval("name,test,:eq,:sum,:des-fast,app,foo,:eq,:cq")
+    assert(expr.toString === "name,test,:eq,app,foo,:eq,:and,:sum,:des-fast")
+  }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/BaseExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/BaseExamplesSuite.scala
@@ -15,6 +15,8 @@
  */
 package com.netflix.atlas.core.stacklang
 
+import com.netflix.atlas.core.model.ModelExtractors
+import com.netflix.atlas.core.model.TimeSeriesExpr
 import org.scalatest.FunSuite
 
 abstract class BaseExamplesSuite extends FunSuite {
@@ -22,6 +24,12 @@ abstract class BaseExamplesSuite extends FunSuite {
   def vocabulary: Vocabulary
 
   protected val interpreter = new Interpreter(vocabulary.allWords)
+
+  protected def eval(program: String): TimeSeriesExpr = {
+    interpreter.execute(program).stack match {
+      case ModelExtractors.TimeSeriesType(t) :: Nil => t
+    }
+  }
 
   for (w <- vocabulary.words; ex <- w.examples) {
     if (ex.startsWith("UNK:")) {


### PR DESCRIPTION
Fixes a regression introduced in #540. The non-query
case was re-evaluating the rewrite command on the
original query rather than the new rewritten display
expression.