### PR TITLE
add eval lib to root project

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/SourceRef.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/SourceRef.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.atlas.eval.stream
 
 import akka.Done

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ lazy val root = project.in(file("."))
     `atlas-chart`,
     `atlas-config`,
     `atlas-core`,
+    `atlas-eval`,
     `atlas-jmh`,
     `atlas-json`,
     `atlas-lwcapi`,


### PR DESCRIPTION
It wasn't getting published to jfrog/jcenter
since it wasn't part of the root.