### PR TITLE
update to sbt 0.13.15

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15


### PR DESCRIPTION
This version seems to fix `formatLicenseHeaders` so it
will work when run from the root. In #553 it was noticed
that it worked when running for a particular subproject,
but not when run for the root project.