### PR TITLE
update to frigga 0.18.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
   val awsS3           = "com.amazonaws" % "aws-java-sdk-s3" % aws
   val caffeine        = "com.github.ben-manes.caffeine" % "caffeine" % "2.4.0"
   val equalsVerifier  = "nl.jqno.equalsverifier" % "equalsverifier" % "2.2.1"
-  val frigga          = "com.netflix.frigga" % "frigga" % "0.17.0"
+  val frigga          = "com.netflix.frigga" % "frigga" % "0.18.0"
   val guiceCore       = "com.google.inject" % "guice" % guice
   val guiceMulti      = "com.google.inject.extensions" % "guice-multibindings" % guice
   val iepGuice        = "com.netflix.iep" % "iep-guice" % iep


### PR DESCRIPTION
Adds support for `~` in the detail for group
names (Netflix/frigga#20).