### PR TITLE
included rendered image in v2.json response

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/PngImage.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/PngImage.scala
@@ -174,7 +174,7 @@ object PngImage {
   }
 }
 
-case class PngImage(data: RenderedImage, metadata: Map[String, String]) {
+case class PngImage(data: RenderedImage, metadata: Map[String, String] = Map.empty) {
 
   type JList = java.util.List[String]
 


### PR DESCRIPTION
Fixes #564. We may move this behind a flag before 1.6 final,
but for now it is enabled by default. By including in the
v2.json format the UI/dashboard can use the static image
and switch to a dynamic rendering without making another
request.

The message has a type of `graph-image` with a data field
that is a data uri of the image without the legend.

Sample usage:

```html
<html>
<body>
<div id="content"></div>
<script>
var content = document.getElementById('content');

fetch('http://localhost:7101/api/v1/graph?q=name,sps,:eq,(,nf.cluster,),:by&format=v2.json')
  .then(function(response) {
    return response.json();
  })
  .then(function(json) {
    var html = '';
    json.forEach(function(msg) {
      if (msg.type === 'graph-image') {
        html += '<div><img src="' + msg.data + '"/></div>';
      } else if (msg.type === 'timeseries') {
        html += '<div>' + msg.label + '</div>';
      }
    });
    content.innerHTML = html;
  });
</script>
</body>
</html>
```