### PR TITLE
search and replace over legend text

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
@@ -310,9 +310,17 @@ object Strings {
   }
 
   /**
-   * Substitute variables into a string.
-   */
+    * Substitute variables from the map into a string. If a key used in the
+    * input string is not set, then the key will be used as the value.
+    */
   def substitute(str: String, vars: Map[String, String]): String = {
+    substitute(str, k => vars.getOrElse(k, k))
+  }
+
+  /**
+    * Substitute variables into a string.
+    */
+  def substitute(str: String, vars: String => String): String = {
     val key = new StringBuilder(str.length)
     val buf = new StringBuilder(str.length * 2)
     var i = 0
@@ -324,7 +332,7 @@ object Strings {
       } else {
         i = getKey(str, i, key)
         val k = key.toString()
-        if (!k.isEmpty) buf.append(vars.getOrElse(k, k))
+        if (!k.isEmpty) buf.append(vars(k))
         key.clear()
       }
     }


### PR DESCRIPTION
This allows some simple manipulation of the legend
text using a sed like search and replace. The main
use-case is for massaging the results of a group by
to be more presentable.

/cc @vfilanovsky @tregoning 