### PR TITLE
fix #578, incorrect formatting for links

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleVocabulary.scala
@@ -118,8 +118,7 @@ object StyleVocabulary extends Vocabulary {
       """
         |Set the color for the line. The value should be one of:
         |
-        |* [Hex triplet]
-        |  (http://en.wikipedia.org/wiki/Web_colors#Hex_triplet), e.g. f00 is red.
+        |* [Hex triplet](http://en.wikipedia.org/wiki/Web_colors#Hex_triplet), e.g. f00 is red.
         |* 6 digit hex RBG, e.g. ff0000 is red.
         |* 8 digit hex ARGB, e.g. ffff0000 is red. The first byte is the [alpha](style-alpha)
         |  setting to use with the color.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/StandardVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/StandardVocabulary.scala
@@ -223,8 +223,9 @@ object StandardVocabulary extends Vocabulary {
 
     override def summary: String =
       """
-        |Format a string using a printf [style pattern]
-        |(https://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html).
+        |Format a string using a printf [style pattern][formatter].
+        |
+        |[formatter]: https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html
       """.stripMargin.trim
 
     override def signature: String = "pattern:String args:List -- str:String"


### PR DESCRIPTION
Looks like github no longer accepts the a line break
between the display text and href for the link.