### PR TITLE
allow step size for datapoint to be set explicitly

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Datapoint.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Datapoint.scala
@@ -17,9 +17,26 @@ package com.netflix.atlas.core.model
 
 import java.math.BigInteger
 
+/**
+  * Time series with a single value.
+  *
+  * @param tags
+  *     Metadata for the identifying the datapoint.
+  * @param timestamp
+  *     Timestamp for the data point. The time is the end of an interval that
+  *     starts at `timestamp - step`.
+  * @param value
+  *     Value for the interval.
+  * @param step
+  *     Step size for the datapoint. Defaults to the configured step size for the
+  *     service.
+  */
+case class Datapoint(
+  tags: Map[String, String],
+  timestamp: Long,
+  value: Double,
+  step: Long = Datapoint.step) extends TimeSeries with TimeSeq {
 
-case class Datapoint(tags: Map[String, String], timestamp: Long, value: Double)
-    extends TimeSeries with TimeSeq {
   require(tags != null, "tags cannot be null")
   require(timestamp >= 0L, s"invalid timestamp: $timestamp")
 
@@ -29,8 +46,6 @@ case class Datapoint(tags: Map[String, String], timestamp: Long, value: Double)
   def data: TimeSeq = this
 
   def dsType: DsType = DsType(tags)
-
-  def step: Long = Datapoint.step
 
   def apply(t: Long): Double = {
     if (t == timestamp) value else Double.NaN

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
@@ -56,7 +56,7 @@ case class AggrDatapoint(
     * Converts this value to a time series type that can be used for the final evaluation
     * phase.
     */
-  def toTimeSeries: TimeSeries = Datapoint(tags, timestamp, value)
+  def toTimeSeries(step: Long): TimeSeries = Datapoint(tags, timestamp, value, step)
 }
 
 object AggrDatapoint {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/DataExprEval.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/DataExprEval.scala
@@ -54,7 +54,7 @@ class DataExprEval(expr: StyleExpr, step: Long)
       override def onPush(): Unit = {
         val group = grab(in)
         val data = group.values.groupBy(_.expr).map { case (k, vs) =>
-          k -> AggrDatapoint.aggregate(vs).map(_.toTimeSeries)
+          k -> AggrDatapoint.aggregate(vs).map(_.toTimeSeries(step))
         }
         val s = group.timestamp
         val context = EvalContext(s, s + step, step, state)

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/DatapointEvalSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/DatapointEvalSuite.scala
@@ -43,9 +43,9 @@ class DatapointEvalSuite extends FunSuite {
       val node = f"i-$i%08d"
       val tags = Map("name" -> "cpu")
       if (expr.isGrouped)
-        Datapoint(tags + ("node" -> node), t, i)
+        Datapoint(tags + ("node" -> node), t, i, step)
       else
-        Datapoint(tags, t, i)
+        Datapoint(tags, t, i, step)
     }
     TimeGroup(t, datapoints)
   }


### PR DESCRIPTION
Before the step would always come from the global config
setting. This made it impossible to use the datapoint class
with multiple step sizes in play.