### PR TITLE
fix unit used when partitioning a context

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/EvalContext.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/EvalContext.scala
@@ -24,17 +24,17 @@ case class EvalContext(
     end: Long,
     step: Long,
     state: Map[StatefulExpr, Any] = Map.empty) {
-  require(start < end, "start time must be less than end time")
+  require(start < end, s"start time must be less than end time ($start >= $end)")
 
   val noData: TimeSeries = TimeSeries.noData(step)
 
   def partition(oneStep: Long, unit: ChronoUnit): List[EvalContext] = {
     val builder = List.newBuilder[EvalContext]
-    var t = Instant.ofEpochMilli(start).truncatedTo(ChronoUnit.HOURS).toEpochMilli
+    var t = Instant.ofEpochMilli(start).truncatedTo(unit).toEpochMilli
     while (t < end) {
       val e = t + oneStep
-      val stime = if (t >= start) t else start
-      val etime = if (e >= end) end else e
+      val stime = math.max(t, start)
+      val etime = math.min(e, end)
       builder += EvalContext(stime, etime, step)
       t = e
     }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/EvalContextSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/EvalContextSuite.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+import org.scalatest.FunSuite
+import org.scalatest.Matchers._
+
+class EvalContextSuite extends FunSuite {
+
+  // Was throwing:
+  // requirement failed: start time must be less than end time (1495052210000 >= 1495051800000)
+  test("partition by millis") {
+    val s = Instant.parse("2017-05-17T20:16:50Z").toEpochMilli
+    val e = Instant.parse("2017-05-17T20:46:50Z").toEpochMilli
+    val step = 10000L
+    val size = 60 * step
+    val partitions = EvalContext(s, e, step).partition(size, ChronoUnit.MILLIS)
+    assert(partitions.size === 3)
+  }
+}


### PR DESCRIPTION
The context was ignoring the unit parameter passed into
partition. This would result in an IAE under some situations.
See test case for more details.