### PR TITLE
update flow types to allow DiagnosticMessages

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/EvalContextSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/EvalContextSuite.scala
@@ -19,7 +19,6 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 
 import org.scalatest.FunSuite
-import org.scalatest.Matchers._
 
 class EvalContextSuite extends FunSuite {
 

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/DataSourceManager.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/DataSourceManager.scala
@@ -27,7 +27,7 @@ import akka.stream.stage.GraphStage
 import akka.stream.stage.GraphStageLogic
 import akka.stream.stage.InHandler
 import akka.stream.stage.OutHandler
-import com.netflix.atlas.eval.model.TimeSeriesMessage
+import com.netflix.atlas.json.JsonSupport
 import com.typesafe.scalalogging.StrictLogging
 
 /**
@@ -36,7 +36,7 @@ import com.typesafe.scalalogging.StrictLogging
   * @param newEvalSource
   *     Factory method for creating a new evaluation stream based on a data source.
   */
-class DataSourceManager(newEvalSource: Evaluator.DataSource => Source[TimeSeriesMessage, NotUsed])
+class DataSourceManager(newEvalSource: Evaluator.DataSource => Source[JsonSupport, NotUsed])
   extends GraphStage[FlowShape[Evaluator.DataSources, Source[Evaluator.MessageEnvelope, NotUsed]]]
   with StrictLogging {
 

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluationFlows.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluationFlows.scala
@@ -35,6 +35,7 @@ import com.netflix.atlas.eval.model.ServoMessage
 import com.netflix.atlas.eval.model.TimeSeriesMessage
 import com.netflix.atlas.eval.util.ByteStringInputStream
 import com.netflix.atlas.json.Json
+import com.netflix.atlas.json.JsonSupport
 import com.netflix.spectator.api.Counter
 
 import scala.concurrent.Promise
@@ -171,7 +172,7 @@ object EvaluationFlows {
     * @return
     *     Time series messages containing the results of the evaluation.
     */
-  def forPartialAggregates(expr: StyleExpr, step: Long): Flow[AggrDatapoint, TimeSeriesMessage, NotUsed] = {
+  def forPartialAggregates(expr: StyleExpr, step: Long): Flow[AggrDatapoint, JsonSupport, NotUsed] = {
     // TODO: number of buffers should be configurable by user, need to discuss how best to
     // map some that into the api... for now it is set to 1 to reduce the delay during testing
     Flow[AggrDatapoint]
@@ -180,7 +181,7 @@ object EvaluationFlows {
       .flatMapConcat(msgs => Source(msgs))
   }
 
-  def lwcEval(expr: StyleExpr, step: Long): Flow[ByteString, TimeSeriesMessage, NotUsed] = {
+  def lwcEval(expr: StyleExpr, step: Long): Flow[ByteString, JsonSupport, NotUsed] = {
     Flow[ByteString]
       .map(_.decodeString(StandardCharsets.UTF_8))
       .via(EvaluationFlows.lwcToAggrDatapoint)

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/Evaluator.java
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/Evaluator.java
@@ -17,6 +17,8 @@ package com.netflix.atlas.eval.stream;
 
 import akka.actor.ActorSystem;
 import com.netflix.atlas.eval.model.TimeSeriesMessage;
+import com.netflix.atlas.json.Json;
+import com.netflix.atlas.json.JsonSupport;
 import com.netflix.spectator.api.Registry;
 import com.typesafe.config.Config;
 import org.reactivestreams.Processor;
@@ -70,7 +72,7 @@ public final class Evaluator extends EvaluatorImpl {
    *     Publisher that produces events representing the evaluation results for the
    *     expression in the URI.
    */
-  public Publisher<TimeSeriesMessage> createPublisher(String uri) {
+  public Publisher<JsonSupport> createPublisher(String uri) {
     return createPublisherImpl(uri);
   }
 
@@ -188,10 +190,10 @@ public final class Evaluator extends EvaluatorImpl {
    */
   public final static class MessageEnvelope {
     private final String id;
-    private final TimeSeriesMessage message;
+    private final JsonSupport message;
 
     /** Create a new instance. */
-    public MessageEnvelope(String id, TimeSeriesMessage message) {
+    public MessageEnvelope(String id, JsonSupport message) {
       this.id = id;
       this.message = message;
     }
@@ -202,7 +204,7 @@ public final class Evaluator extends EvaluatorImpl {
     }
 
     /** Returns the message. */
-    public TimeSeriesMessage getMessage() {
+    public JsonSupport getMessage() {
       return message;
     }
 

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -40,7 +40,7 @@ import com.netflix.atlas.core.model.StyleExpr
 import com.netflix.atlas.core.model.StyleVocabulary
 import com.netflix.atlas.core.stacklang.Interpreter
 import com.netflix.atlas.core.util.Streams
-import com.netflix.atlas.eval.model.TimeSeriesMessage
+import com.netflix.atlas.json.JsonSupport
 import com.netflix.spectator.api.Registry
 import com.typesafe.config.Config
 import org.reactivestreams.Processor
@@ -130,11 +130,11 @@ private[stream] abstract class EvaluatorImpl(
     }
   }
 
-  protected def createPublisherImpl(uri: String): Publisher[TimeSeriesMessage] = {
+  protected def createPublisherImpl(uri: String): Publisher[JsonSupport] = {
     createPublisherImpl(Uri(uri))
   }
 
-  protected def createPublisherImpl(uri: Uri): Publisher[TimeSeriesMessage] = {
+  protected def createPublisherImpl(uri: Uri): Publisher[JsonSupport] = {
     val backend = findBackendForUri(uri)
 
     val expr = eval(uri.query().get("q").get).head


### PR DESCRIPTION
Updates the high level processor to pass JsonSupport
messages instead of TimeSeriesMessage specifically. This
gives a lot of flexibility to send through other types
like DiagnosticMessage or other helpful information when
processing the stream.

Addresses issue #575.