### PR TITLE
avoid unused method warnings in guice modules

### DIFF
--- a/atlas-module-akka/src/main/scala/com/netflix/atlas/akka/AkkaModule.scala
+++ b/atlas-module-akka/src/main/scala/com/netflix/atlas/akka/AkkaModule.scala
@@ -39,13 +39,13 @@ final class AkkaModule extends AbstractModule {
   }
 
   @Provides @Singleton
-  private def providesActorSystem(config: Config): ActorSystem = {
+  protected def providesActorSystem(config: Config): ActorSystem = {
     val name = config.getString("atlas.akka.name")
     ActorSystem(name, config)
   }
 
   @Provides @Singleton
-  private def providesActorRefFactory(system: ActorSystem): ActorRefFactory = system
+  protected def providesActorRefFactory(system: ActorSystem): ActorRefFactory = system
 
   override def equals(obj: Any): Boolean = {
     obj != null && getClass.equals(obj.getClass)

--- a/atlas-module-cloudwatch/src/main/scala/com/netflix/atlas/guice/CloudWatchModule.scala
+++ b/atlas-module-cloudwatch/src/main/scala/com/netflix/atlas/guice/CloudWatchModule.scala
@@ -35,7 +35,7 @@ final class CloudWatchModule extends AbstractModule {
 
   @Provides
   @Singleton
-  private def provideCloudWatchClient(factory: AwsClientFactory): AmazonCloudWatch = {
+  protected def provideCloudWatchClient(factory: AwsClientFactory): AmazonCloudWatch = {
     factory.newInstance(classOf[AmazonCloudWatch])
   }
 

--- a/atlas-module-eval/src/main/scala/com/netflix/atlas/eval/EvalModule.scala
+++ b/atlas-module-eval/src/main/scala/com/netflix/atlas/eval/EvalModule.scala
@@ -39,7 +39,7 @@ final class EvalModule extends AbstractModule {
   }
 
   @Provides @Singleton
-  private def providesEvaluator(opts: OptionalInjections): Evaluator = {
+  protected def providesEvaluator(opts: OptionalInjections): Evaluator = {
     new Evaluator(opts.config, opts.registry, opts.getActorSystem)
   }
 

--- a/atlas-module-lwcapi/src/main/scala/com/netflix/atlas/guice/LwcApiModule.scala
+++ b/atlas-module-lwcapi/src/main/scala/com/netflix/atlas/guice/LwcApiModule.scala
@@ -25,24 +25,24 @@ import com.netflix.atlas.lwcapi.ExpressionSplitter
 import com.netflix.atlas.lwcapi.SubscriptionManager
 import com.netflix.iep.guice.LifecycleModule
 
-class LwcApiModule extends AbstractModule {
+final class LwcApiModule extends AbstractModule {
   override def configure(): Unit = {
     install(new LifecycleModule)
     install(new AkkaModule)
   }
 
   @Provides @Singleton
-  private def providesExpressionDatabase(): ExpressionDatabase = {
+  protected def providesExpressionDatabase(): ExpressionDatabase = {
     new ExpressionDatabase()
   }
 
   @Provides @Singleton
-  private def providesExpressionSplitter(): ExpressionSplitter = {
+  protected def providesExpressionSplitter(): ExpressionSplitter = {
     new ExpressionSplitter()
   }
 
   @Provides @Singleton
-  private def providesSubscriptionManager(): SubscriptionManager = {
+  protected def providesSubscriptionManager(): SubscriptionManager = {
     new SubscriptionManager()
   }
 


### PR DESCRIPTION
Since scala 2.12 the private provider methods in the
module cause warnings about unused methods. Unfortunately
scala doesn't provide a way to suppress these on individual
methods (SI-1781). For now the work around is to mark them
as protected rather than private. Note the module class is
final so there will not be any subclasses.