### PR TITLE
drop cross build for 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: scala
 jdk:
 - oraclejdk8
 scala:
-- 2.11.11
 - 2.12.2
 script:
 - ./scripts/buildViaTravis.sh

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
     val slf4j      = "1.7.25"
     val spectator  = "0.55.0"
 
-    val crossScala = Seq(scala, "2.11.11")
+    val crossScala = Seq(scala)
   }
 
   import Versions._


### PR DESCRIPTION
We have been running on 2.12 for a while now
and internal builds and deployments are mostly
on 2.12 now. The few stragglers are using the
1.5.x Atlas builds which is 2.11.x only and that
will not change.