### PR TITLE
update findKeys to just return the strings

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/BatchUpdateTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/BatchUpdateTagIndex.scala
@@ -21,7 +21,6 @@ import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
 import com.netflix.atlas.core.model.Tag
-import com.netflix.atlas.core.model.TagKey
 import com.netflix.atlas.core.model.TaggedItem
 import com.netflix.spectator.api.Spectator
 
@@ -106,7 +105,7 @@ class BatchUpdateTagIndex[T <: TaggedItem: ClassTag](newIndex: (Array[T]) => Tag
 
   def findTags(query: TagQuery): List[Tag] = currentIndex.get.findTags(query)
 
-  def findKeys(query: TagQuery): List[TagKey] = currentIndex.get.findKeys(query)
+  def findKeys(query: TagQuery): List[String] = currentIndex.get.findKeys(query)
 
   def findValues(query: TagQuery): List[String] = currentIndex.get.findValues(query)
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/CachingTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/CachingTagIndex.scala
@@ -19,7 +19,6 @@ import com.github.benmanes.caffeine.cache.CacheLoader
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.github.benmanes.caffeine.cache.LoadingCache
 import com.netflix.atlas.core.model.Tag
-import com.netflix.atlas.core.model.TagKey
 import com.netflix.atlas.core.model.TaggedItem
 
 
@@ -31,7 +30,7 @@ import com.netflix.atlas.core.model.TaggedItem
 class CachingTagIndex[T <: TaggedItem](delegate: TagIndex[T]) extends TagIndex[T] {
 
   private val findTagsCache = newCache[List[Tag]](delegate.findTags)
-  private val findKeysCache = newCache[List[TagKey]](delegate.findKeys)
+  private val findKeysCache = newCache[List[String]](delegate.findKeys)
   private val findValuesCache = newCache[List[String]](delegate.findValues)
   private val findItemsCache = newCache[List[T]](delegate.findItems)
 
@@ -46,7 +45,7 @@ class CachingTagIndex[T <: TaggedItem](delegate: TagIndex[T]) extends TagIndex[T
     findTagsCache.get(query)
   }
 
-  def findKeys(query: TagQuery): List[TagKey] = {
+  def findKeys(query: TagQuery): List[String] = {
     findKeysCache.get(query)
   }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/SimpleTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/SimpleTagIndex.scala
@@ -19,7 +19,6 @@ import java.math.BigInteger
 
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.Tag
-import com.netflix.atlas.core.model.TagKey
 import com.netflix.atlas.core.model.TaggedItem
 import com.netflix.atlas.core.util.Strings
 
@@ -102,7 +101,7 @@ class SimpleTagIndex[T <: TaggedItem: ClassTag](items: Array[T]) extends TagInde
     }
   }
 
-  def findKeys(query: TagQuery): List[TagKey] = {
+  def findKeys(query: TagQuery): List[String] = {
     val matches = findItemsImpl(query.query)
     matches
       .flatMap(_.tags)
@@ -111,7 +110,6 @@ class SimpleTagIndex[T <: TaggedItem: ClassTag](items: Array[T]) extends TagInde
       .filter(_ > query.offset)
       .sortWith(_ < _)
       .take(query.limit)
-      .map(v => TagKey(v))
   }
 
   def findValues(query: TagQuery): List[String] = {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/TagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/TagIndex.scala
@@ -16,7 +16,6 @@
 package com.netflix.atlas.core.index
 
 import com.netflix.atlas.core.model.Tag
-import com.netflix.atlas.core.model.TagKey
 import com.netflix.atlas.core.model.TaggedItem
 
 
@@ -24,7 +23,7 @@ trait TagIndex[T <: TaggedItem] {
 
   def findTags(query: TagQuery): List[Tag]
 
-  def findKeys(query: TagQuery): List[TagKey]
+  def findKeys(query: TagQuery): List[String]
 
   def findValues(query: TagQuery): List[String]
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/TagIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/TagIndexSuite.scala
@@ -111,46 +111,46 @@ abstract class TagIndexSuite extends FunSuite {
   }
 
   test("findKeys, with limit") {
-    val result = index.findKeys(TagQuery(None, limit = 3)).map(_.name)
+    val result = index.findKeys(TagQuery(None, limit = 3))
     assert(result === List("atlas.legacy", "name", "nf.app"))
   }
 
   test("findKeys, with offset") {
-    val result = index.findKeys(TagQuery(None, offset = "nf.asg")).map(_.name)
+    val result = index.findKeys(TagQuery(None, offset = "nf.asg"))
     assert(result === List("nf.cluster", "nf.node", "type", "type2"))
   }
 
   test("findKeys, with offset that is not present") {
-    val result = index.findKeys(TagQuery(None, offset = "nf.asg2")).map(_.name)
+    val result = index.findKeys(TagQuery(None, offset = "nf.asg2"))
     assert(result === List("nf.cluster", "nf.node", "type", "type2"))
   }
 
   test("findKeys, with offset and limit") {
-    val result = index.findKeys(TagQuery(None, offset = "nf.asg", limit = 2)).map(_.name)
+    val result = index.findKeys(TagQuery(None, offset = "nf.asg", limit = 2))
     assert(result === List("nf.cluster", "nf.node"))
   }
 
   test("findKeys, with query and limit") {
     val q = Query.Equal("name", "sps_9")
-    val result = index.findKeys(TagQuery(Some(q), limit = 3)).map(_.name)
+    val result = index.findKeys(TagQuery(Some(q), limit = 3))
     assert(result === List("atlas.legacy", "name", "nf.app"))
   }
 
   test("findKeys, with query and offset") {
     val q = Query.Equal("name", "sps_9")
-    val result = index.findKeys(TagQuery(Some(q), offset = "nf.asg")).map(_.name)
+    val result = index.findKeys(TagQuery(Some(q), offset = "nf.asg"))
     assert(result === List("nf.cluster", "nf.node", "type", "type2"))
   }
 
   test("findKeys, with query and offset that is not present") {
     val q = Query.Equal("name", "sps_9")
-    val result = index.findKeys(TagQuery(Some(q), offset = "nf.asg2")).map(_.name)
+    val result = index.findKeys(TagQuery(Some(q), offset = "nf.asg2"))
     assert(result === List("nf.cluster", "nf.node", "type", "type2"))
   }
 
   test("findKeys, with query, offset, and limit") {
     val q = Query.Equal("name", "sps_9")
-    val result = index.findKeys(TagQuery(Some(q), offset = "nf.asg", limit = 2)).map(_.name)
+    val result = index.findKeys(TagQuery(Some(q), offset = "nf.asg", limit = 2))
     assert(result === List("nf.cluster", "nf.node"))
   }
 

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalDatabaseActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalDatabaseActor.scala
@@ -25,9 +25,9 @@ class LocalDatabaseActor(db: Database) extends Actor with ActorLogging {
   import com.netflix.atlas.webapi.GraphApi._
   import com.netflix.atlas.webapi.TagsApi._
 
-  def receive = {
+  def receive: Receive = {
     case ListTagsRequest(tq)    => sender() ! TagListResponse(db.index.findTags(tq))
-    case ListKeysRequest(tq)    => sender() ! KeyListResponse(db.index.findKeys(tq).map(_.name))
+    case ListKeysRequest(tq)    => sender() ! KeyListResponse(db.index.findKeys(tq))
     case ListValuesRequest(tq)  => sender() ! ValueListResponse(db.index.findValues(tq))
     case req: DataRequest       => sender() ! executeDataRequest(req)
   }


### PR DESCRIPTION
Before it was wrapping the string in a TagKey type that
could also provide counts for each key. Since this isn't
supported or used anymore we can avoid the additional
allocations. Also most use-cases were just mapping it
back to strings after getting the response.