### PR TITLE
fix multi-threaded reads from long set/map

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongHashSet.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongHashSet.scala
@@ -37,7 +37,8 @@ class LongHashSet(noData: Long, capacity: Int = 10) {
   private[this] var cutoff = computeCutoff(data.length)
 
   // Used for computing the hash code.
-  private[this] var buffer = ByteBuffer.allocate(java.lang.Long.BYTES)
+  private[this] val buffer = ThreadLocal
+    .withInitial[ByteBuffer](() => ByteBuffer.allocate(java.lang.Long.BYTES))
 
   // Set at 50% capacity to get reasonable tradeoff between performance and
   // memory use. See IntIntMap benchmark.
@@ -66,9 +67,10 @@ class LongHashSet(noData: Long, capacity: Int = 10) {
   }
 
   private def hash(v: Long): Int = {
-    buffer.clear()
-    buffer.putLong(v)
-    MurmurHash3.bytesHash(buffer.array())
+    val buf = buffer.get()
+    buf.clear()
+    buf.putLong(v)
+    MurmurHash3.bytesHash(buf.array())
   }
 
   private def add(buffer: Array[Long], v: Long): Boolean = {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongIntHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongIntHashMap.scala
@@ -38,7 +38,8 @@ class LongIntHashMap(noData: Long, capacity: Int = 10) {
   private[this] var cutoff = computeCutoff(keys.length)
 
   // Used for computing the hash code.
-  private[this] var buffer = ByteBuffer.allocate(java.lang.Long.BYTES)
+  private[this] val buffer = ThreadLocal
+    .withInitial[ByteBuffer](() => ByteBuffer.allocate(java.lang.Long.BYTES))
 
   // Set at 50% capacity to get reasonable tradeoff between performance and
   // memory use. See IntIntMap benchmark.
@@ -69,9 +70,10 @@ class LongIntHashMap(noData: Long, capacity: Int = 10) {
   }
 
   private def hash(ks: Array[Long], k: Long): Int = {
-    buffer.clear()
-    buffer.putLong(k)
-    MurmurHash3.bytesHash(buffer.array())
+    val buf = buffer.get()
+    buf.clear()
+    buf.putLong(k)
+    MurmurHash3.bytesHash(buf.array())
     Hash.absOrZero(java.lang.Long.hashCode(k)) % ks.length
   }
 


### PR DESCRIPTION
Several use-cases of the primitive collections assume
multi-threaded read-only access is safe after the collection
is built and effectively immutable. That is nothing will
ever write to it again. The variants with a Long key type
use an internal buffer to avoid allocations when passing
the long value to `MurmurHash3.bytesHash`. The multi-threaded
access could result in errors such as BufferOverflowException
on the buffer.

This changes those collections to use a ThreadLocal for keeping
track of the buffers.