### PR TITLE
fix regex matching when prefix is an exact match

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndex.scala
@@ -287,7 +287,7 @@ class RoaringTagIndex[T <: TaggedItem](items: Array[T]) extends TagIndex[T] {
       val set = new RoaringBitmap()
       if (q.pattern.prefix.isDefined) {
         val prefix = q.pattern.prefix.get
-        val vp = findOffset(values, prefix)
+        val vp = findOffset(values, prefix, 0)
         val t = tag(kp, vp)
         var i = tagOffset(t)
         while (i < tagIndex.length

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/TagIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/TagIndexSuite.scala
@@ -84,6 +84,13 @@ abstract class TagIndexSuite extends FunSuite {
     assert(result.size === 6)
   }
 
+  test("findTags query with exact regex") {
+    val q = Query.Regex("name", "sps_9")
+    val result = index.findTags(TagQuery(Some(q), key = Some("nf.cluster"))).map(_.copy(count = -1))
+    assert(result.find(_.value == "nccp-appletv") === Some(Tag("nf.cluster", "nccp-appletv")))
+    assert(result.size === 6)
+  }
+
   test("findValues, with no key") {
     intercept[IllegalArgumentException] {
       index.findValues(TagQuery(None))


### PR DESCRIPTION
When searching for the prefix it was looking for the postion
of the first match that was strictly greater than the prefix.
For cases where the prefix is an exact match to the full value
they would not match. The search now checks for the first
match that is greater than or equal to the prefix.

/cc @svachalek 