### PR TITLE
change ids to custom class

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/BatchUpdateTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/BatchUpdateTagIndex.scala
@@ -15,11 +15,11 @@
  */
 package com.netflix.atlas.core.index
 
-import java.math.BigInteger
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
+import com.netflix.atlas.core.model.ItemId
 import com.netflix.atlas.core.model.Tag
 import com.netflix.atlas.core.model.TaggedItem
 import com.netflix.spectator.api.Spectator
@@ -76,7 +76,7 @@ class BatchUpdateTagIndex[T <: TaggedItem: ClassTag](newIndex: (Array[T]) => Tag
       val size = pendingUpdates.size
       val updates = new java.util.ArrayList[T](size)
       pendingUpdates.drainTo(updates, size)
-      val items = new java.util.HashMap[BigInteger, T]
+      val items = new java.util.HashMap[ItemId, T]
       updates.forEach { i => items.put(i.id, i) }
 
       // Get set of all items in the current index that are not expired

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndex.scala
@@ -15,10 +15,10 @@
  */
 package com.netflix.atlas.core.index
 
-import java.math.BigInteger
 import java.util
 import java.util.Comparator
 
+import com.netflix.atlas.core.model.ItemId
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.Tag
 import com.netflix.atlas.core.model.TaggedItem
@@ -113,12 +113,12 @@ class RoaringTagIndex[T <: TaggedItem](items: Array[T]) extends TagIndex[T] {
     m
   }
 
-  private def buildItemIndex(): (Array[BigInteger], RoaringKeyMap, RoaringValueMap, Array[Long], Array[IntIntHashMap]) = {
+  private def buildItemIndex(): (Array[ItemId], RoaringKeyMap, RoaringValueMap, Array[Long], Array[IntIntHashMap]) = {
     // Sort items array based on the id, allows for efficient paging of requests using the id
     // as the offset
     logger.debug(s"building index with ${items.length} items, starting sort")
     util.Arrays.sort(items, idComparator)
-    val itemIds = new Array[BigInteger](items.length)
+    val itemIds = new Array[ItemId](items.length)
 
     // Build the main index
     logger.debug(s"building index with ${items.length} items, create main key map")
@@ -317,7 +317,7 @@ class RoaringTagIndex[T <: TaggedItem](items: Array[T]) extends TagIndex[T] {
 
   private def itemOffset(v: String): Int = {
     if (v == null || v == "") 0 else {
-      val offsetV = new BigInteger(v, 16)
+      val offsetV = ItemId(v)
       val pos = util.Arrays.binarySearch(itemIds.asInstanceOf[Array[AnyRef]], offsetV)
       if (pos < 0) -pos - 1 else pos
     }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/SimpleTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/SimpleTagIndex.scala
@@ -15,12 +15,10 @@
  */
 package com.netflix.atlas.core.index
 
-import java.math.BigInteger
-
+import com.netflix.atlas.core.model.ItemId
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.Tag
 import com.netflix.atlas.core.model.TaggedItem
-import com.netflix.atlas.core.util.Strings
 
 import scala.reflect.ClassTag
 
@@ -127,14 +125,14 @@ class SimpleTagIndex[T <: TaggedItem: ClassTag](items: Array[T]) extends TagInde
 
   def findItems(query: TagQuery): List[T] = {
     val matches = findItemsImpl(query.query)
-    val filtered = matches.filter(i => Strings.zeroPad(i.id, 40) > query.offset)
+    val filtered = matches.filter(i => i.idString > query.offset)
     val sorted = filtered.sortWith { (a, b) => a.id.compareTo(b.id) < 0 }
     sorted.take(query.limit)
   }
 
   val size: Int = items.length
 
-  def update(additions: List[T], deletions: List[BigInteger]): TagIndex[T] = {
+  def update(additions: List[T], deletions: List[ItemId]): TagIndex[T] = {
     val itemMap = items.map(i => i.id -> i).toMap -- deletions
     val finalMap = itemMap ++ additions.map(i => i.id -> i)
     val newItems = finalMap.values.toList.sortWith((a, b) => a.id.compareTo(b.id) < 0)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Datapoint.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Datapoint.scala
@@ -15,8 +15,6 @@
  */
 package com.netflix.atlas.core.model
 
-import java.math.BigInteger
-
 /**
   * Time series with a single value.
   *
@@ -40,7 +38,7 @@ case class Datapoint(
   require(tags != null, "tags cannot be null")
   require(timestamp >= 0L, s"invalid timestamp: $timestamp")
 
-  def id: BigInteger = TaggedItem.computeId(tags)
+  def id: ItemId = TaggedItem.computeId(tags)
 
   def label: String = TimeSeries.toLabel(tags)
   def data: TimeSeq = this

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/ItemId.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/ItemId.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import java.math.BigInteger
+
+import com.netflix.atlas.core.util.Strings
+
+import scala.util.hashing.MurmurHash3
+
+/**
+  * Represents an identifier for a tagged item.
+  *
+  * @param data
+  *     Bytes for the id. This is usually the results of computing a SHA1 hash
+  *     over a normalized representation of the tags.
+  * @param hc
+  *     Precomputed hash code for the bytes.
+  */
+class ItemId private (private val data: Array[Byte], private val hc: Int)
+  extends Comparable[ItemId] {
+
+  override def hashCode(): Int = hc
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case other: ItemId => java.util.Arrays.equals(data, other.data)
+      case _             => false
+    }
+  }
+
+  override def compareTo(other: ItemId): Int = {
+    val length = math.min(data.length, other.data.length)
+    var i = 0
+    while (i < length) {
+      val b1 = java.lang.Byte.toUnsignedInt(data(i))
+      val b2 = java.lang.Byte.toUnsignedInt(other.data(i))
+      val cmp = b1 - b2
+      if (cmp != 0) return cmp
+      i += 1
+    }
+    0
+  }
+
+  override def toString: String = {
+    val buffer = new StringBuilder
+    var i = 0
+    while (i < data.length) {
+      val unsigned = java.lang.Byte.toUnsignedInt(data(i))
+      buffer.append(ItemId.hexValueForByte(unsigned))
+      i += 1
+    }
+    buffer.toString()
+  }
+
+  def toBigInteger: BigInteger = new BigInteger(1, data)
+}
+
+object ItemId {
+  private val hexValueForByte = (0 until 256).toArray.map { i => Strings.zeroPad(i, 2) }
+
+  /**
+    * Create a new id from an array of bytes. The pre-computed hash code will be generated
+    * using MurmurHash3.
+    */
+  def apply(data: Array[Byte]): ItemId = {
+    new ItemId(data, MurmurHash3.bytesHash(data))
+  }
+
+  /**
+    * Create a new id from a hex string. The string should match the `toString` output of
+    * an `ItemId`.
+    */
+  def apply(data: String): ItemId = {
+    require(data.length % 2 == 0, s"invalid item id string: $data")
+    val bytes = new Array[Byte](data.length / 2)
+    var i = 0
+    while (i < bytes.length) {
+      val c1 = hexToInt(data.charAt(2 * i))
+      val c2 = hexToInt(data.charAt(2 * i + 1))
+      val v = (c1 << 4) | c2
+      bytes(i) = v.toByte
+      i += 1
+    }
+    ItemId(bytes)
+  }
+
+  private def hexToInt(c: Char): Int = {
+    c match {
+      case _ if c >= '0' && c <= '9' => c - '0'
+      case _ if c >= 'a' && c <= 'f' => c - 'a' + 10
+      case _ if c >= 'A' && c <= 'F' => c - 'A' + 10
+      case _ => throw new IllegalArgumentException(s"invalid hex digit: $c")
+    }
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
@@ -15,7 +15,6 @@
  */
 package com.netflix.atlas.core.model
 
-import java.math.BigInteger
 import java.time.Duration
 
 import com.netflix.atlas.core.algorithm.OnlineDes
@@ -88,7 +87,7 @@ object StatefulExpr {
   object RollingCount {
     case class State(pos: Int, value: Double, buf: Array[Double])
 
-    type StateMap = scala.collection.mutable.AnyRefMap[BigInteger, State]
+    type StateMap = scala.collection.mutable.AnyRefMap[ItemId, State]
   }
 
   //
@@ -142,7 +141,7 @@ object StatefulExpr {
   object Des {
     case class State(desState: OnlineDes.State)
 
-    type StateMap = scala.collection.mutable.AnyRefMap[BigInteger, State]
+    type StateMap = scala.collection.mutable.AnyRefMap[ItemId, State]
   }
 
   //
@@ -209,7 +208,7 @@ object StatefulExpr {
   object SlidingDes {
     case class State(skipUpTo: Long, desState: OnlineSlidingDes.State)
 
-    type StateMap = scala.collection.mutable.AnyRefMap[BigInteger, State]
+    type StateMap = scala.collection.mutable.AnyRefMap[ItemId, State]
   }
 
   //
@@ -273,7 +272,7 @@ object StatefulExpr {
   object Trend {
     case class State(nanCount: Int, pos: Int, value: Double, buf: Array[Double])
 
-    type StateMap = scala.collection.mutable.AnyRefMap[BigInteger, State]
+    type StateMap = scala.collection.mutable.AnyRefMap[ItemId, State]
   }
 
   //
@@ -314,7 +313,7 @@ object StatefulExpr {
   object Integral {
     case class State(value: Double)
 
-    type StateMap = scala.collection.mutable.AnyRefMap[BigInteger, State]
+    type StateMap = scala.collection.mutable.AnyRefMap[ItemId, State]
   }
 
   //
@@ -358,7 +357,7 @@ object StatefulExpr {
   object Derivative {
     case class State(value: Double)
 
-    type StateMap = scala.collection.mutable.AnyRefMap[BigInteger, State]
+    type StateMap = scala.collection.mutable.AnyRefMap[ItemId, State]
   }
 
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TimeSeries.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TimeSeries.scala
@@ -15,8 +15,6 @@
  */
 package com.netflix.atlas.core.model
 
-import java.math.BigInteger
-
 import com.netflix.atlas.core.util.Math
 
 object TimeSeries {
@@ -137,7 +135,7 @@ trait TimeSeries extends TaggedItem {
 }
 
 case class BasicTimeSeries(
-    id: BigInteger,
+    id: ItemId,
     tags: Map[String, String],
     label: String,
     data: TimeSeq) extends TimeSeries
@@ -146,6 +144,6 @@ case class LazyTimeSeries(
     tags: Map[String, String],
     label: String,
     data: TimeSeq) extends TimeSeries {
-  lazy val id: BigInteger = TaggedItem.computeId(tags)
+  lazy val id: ItemId = TaggedItem.computeId(tags)
 }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Hash.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Hash.scala
@@ -64,13 +64,21 @@ object Hash {
     computeHash("SHA1", input.getBytes("UTF-8"))
   }
 
+  def sha1bytes(input: String): Array[Byte] = {
+    computeHashBytes("SHA1", input.getBytes("UTF-8"))
+  }
+
   // If the hash value is `Integer.MIN_VALUE`, then the absolute value will be
   // negative. For our purposes that will get mapped to a starting position of 0.
   private[util] def absOrZero(v: Int): Int = math.max(math.abs(v), 0)
 
-  private def computeHash(algorithm: String, bytes: Array[Byte]) = {
+  private def computeHash(algorithm: String, bytes: Array[Byte]): BigInteger = {
+    new BigInteger(1, computeHashBytes(algorithm, bytes))
+  }
+
+  private def computeHashBytes(algorithm: String, bytes: Array[Byte]): Array[Byte] = {
     val md = get(algorithm)
     md.update(bytes)
-    new BigInteger(1, md.digest)
+    md.digest
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ItemIdSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ItemIdSuite.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.atlas.core.util.Hash
+import com.netflix.atlas.core.util.Strings
+import org.scalatest.FunSuite
+
+import scala.util.hashing.MurmurHash3
+
+class ItemIdSuite extends FunSuite {
+
+  test("create from byte array") {
+    val bytes = Array(1.toByte, 2.toByte)
+    val id = ItemId(bytes)
+    assert(id.hashCode() === MurmurHash3.bytesHash(bytes))
+  }
+
+  test("equals") {
+    val id1 = ItemId(Array(1.toByte, 2.toByte))
+    val id2 = ItemId(Array(1.toByte, 2.toByte))
+    assert(id1 === id1)
+    assert(id1 === id2)
+  }
+
+  test("not equals") {
+    val id1 = ItemId(Array(1.toByte, 2.toByte))
+    val id2 = ItemId(Array(1.toByte, 3.toByte))
+    assert(id1 !== id2)
+    assert(id1.hashCode() !== id2.hashCode())
+  }
+
+  test("does not equal wrong object type") {
+    val id1 = ItemId(Array(1.toByte, 2.toByte))
+    assert(id1 !== "foo")
+  }
+
+  test("does not equal null") {
+    val id1 = ItemId(Array(1.toByte, 2.toByte))
+    assert(id1 !== null)
+  }
+
+  test("toString") {
+    val bytes = Array(1.toByte, 2.toByte)
+    val id = ItemId(bytes)
+    assert(id.toString === "0102")
+  }
+
+  test("toString sha1 bytes 0") {
+    val bytes = new Array[Byte](20)
+    val id = ItemId(bytes)
+    assert(id.toString === "0000000000000000000000000000000000000000")
+    assert(id === ItemId("0000000000000000000000000000000000000000"))
+  }
+
+  test("toString sha1") {
+    (0 until 100).foreach { i =>
+      val sha1 = Hash.sha1(i.toString)
+      val sha1str = Strings.zeroPad(sha1.toString(16), 40)
+      val id = ItemId(Hash.sha1bytes(i.toString))
+      assert(id.toString === sha1str)
+      assert(id === ItemId(sha1str))
+      assert(id.compareTo(ItemId(sha1str)) === 0)
+      assert(sha1 === ItemId(sha1str).toBigInteger)
+    }
+  }
+
+  test("from String lower") {
+    val bytes = Array(10.toByte, 11.toByte)
+    val id = ItemId(bytes)
+    assert(id === ItemId("0a0b"))
+  }
+
+  test("from String upper") {
+    val bytes = Array(10.toByte, 11.toByte)
+    val id = ItemId(bytes)
+    assert(id === ItemId("0A0B"))
+  }
+
+  test("from String invalid") {
+    intercept[IllegalArgumentException] {
+      ItemId("0G")
+    }
+  }
+
+  test("compareTo equals") {
+    val id1 = ItemId(Array(1.toByte, 2.toByte))
+    val id2 = ItemId(Array(1.toByte, 2.toByte))
+    assert(id1.compareTo(id1) === 0)
+    assert(id1.compareTo(id2) === 0)
+  }
+
+  test("compareTo less than/greater than") {
+    val id1 = ItemId(Array(1.toByte, 2.toByte))
+    val id2 = ItemId(Array(1.toByte, 3.toByte))
+    assert(id1.compareTo(id2) < 0)
+    assert(id2.compareTo(id1) > 0)
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TaggedItemSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TaggedItemSuite.scala
@@ -17,14 +17,12 @@ package com.netflix.atlas.core.model
 
 import com.netflix.atlas.core.util.Hash
 
-import java.math.BigInteger
-
 import org.scalatest.FunSuite
 
 class TaggedItemSuite extends FunSuite {
 
-  def expectedId(tags: Map[String, String]): BigInteger = {
-    Hash.sha1(tags.toList.sortWith(_._1 < _._1).map(t => t._1 + "=" + t._2).mkString(","))
+  def expectedId(tags: Map[String, String]): ItemId = {
+    ItemId(Hash.sha1bytes(tags.toList.sortWith(_._1 < _._1).map(t => t._1 + "=" + t._2).mkString(",")))
   }
 
   test("computeId, name only") {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeSeriesMessage.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeSeriesMessage.scala
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.core.JsonGenerator
 import com.netflix.atlas.core.model._
 import com.netflix.atlas.json.JsonSupport
 import com.netflix.atlas.core.util.SmallHashMap
-import com.netflix.atlas.core.util.Strings
 
 /**
   * Message type use for emitting time series data in LWC and fetch responses.
@@ -98,7 +97,7 @@ object TimeSeriesMessage {
     *     Time series to use for the message.
     */
   def apply(query: String, context: EvalContext, ts: TimeSeries): TimeSeriesMessage = {
-    val id = Strings.zeroPad(TaggedItem.computeId(ts.tags + ("atlas.query" -> query)), 40)
+    val id = TaggedItem.computeId(ts.tags + ("atlas.query" -> query)).toString
     val data = ts.data.bounded(context.start, context.end)
     TimeSeriesMessage(
       id,


### PR DESCRIPTION
Before the ids were just a BigInteger. This was mostly
for convenience and it was an easy starting point for
some modifications.

Flame graphs of stateful clusters for some stacks are
showing a significant about of time being spent computing
the hash code for the ids when looking up the blocks. The
custom class in this change uses a precomputed hash code
so that it will be constant time.