### PR TITLE
skip value associated with unknown fields

### DIFF
--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
@@ -148,6 +148,8 @@ object PublishApi {
       case "start"     => timestamp = nextLong(parser) // Legacy support
       case "values"    => value = getValue(parser)
       case _           => // Ignore unknown fields
+        parser.nextToken()
+        parser.skipChildren()
     }
     Datapoint(tags, timestamp, value)
   }

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishApiJsonSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishApiJsonSuite.scala
@@ -138,6 +138,38 @@ class PublishApiJsonSuite extends FunSuite {
     assert(decoded.size === 1)
   }
 
+  test("decode list with unknown key") {
+    val decoded = PublishApi.decodeList("""
+      [
+        {
+          "tags": {"name": "test"},
+          "timestamp": 123456789,
+          "unknown": {},
+          "values": 1.0
+        },
+        {
+          "tags": {"name": "test"},
+          "timestamp": 123456789,
+          "unknown": {"a":{"b":"c"},"b":[1,2,3]},
+          "values": 1.0
+        },
+        {
+          "tags": {"name": "test"},
+          "timestamp": 123456789,
+          "unknown": [1,2,3],
+          "values": 1.0
+        },
+        {
+          "tags": {"name": "test"},
+          "timestamp": 123456789,
+          "unknown": "foo",
+          "values": 1.0
+        }
+      ]
+      """)
+    assert(decoded.size === 4)
+  }
+
   test("decode batch bad object") {
     intercept[IllegalArgumentException] {
       PublishApi.decodeBatch("""{"foo":"bar"}""")


### PR DESCRIPTION
If an unknown object field was used in a datapoint it
would result in a NullPointerException by prematurely
closing hitting the end of object.