### PR TITLE
use hash code to short-circuit equals check

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/ItemId.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/ItemId.scala
@@ -37,7 +37,7 @@ class ItemId private (private val data: Array[Byte], private val hc: Int)
 
   override def equals(obj: Any): Boolean = {
     obj match {
-      case other: ItemId => java.util.Arrays.equals(data, other.data)
+      case other: ItemId => hc == other.hc && java.util.Arrays.equals(data, other.data)
       case _             => false
     }
   }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/RefIntHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/RefIntHashMap.scala
@@ -23,7 +23,7 @@ package com.netflix.atlas.core.util
   *     Initial capacity guideline. The actual size of the underlying buffer
   *     will be the next prime >= `capacity`. Default is 10.
   */
-class RefIntHashMap[T](capacity: Int = 10) {
+class RefIntHashMap[T <: AnyRef](capacity: Int = 10) {
 
   private[this] var keys = newArray(capacity)
   private[this] var values = new Array[Int](keys.length)
@@ -104,7 +104,7 @@ class RefIntHashMap[T](capacity: Int = 10) {
       val prev = keys(pos)
       if (prev == null)
         return dflt
-      else if (prev == k)
+      else if (prev.equals(k))
         return values(pos)
       else
         pos = (pos + 1) % keys.length


### PR DESCRIPTION
Since the hash code is precomputed it can be a cheap
way to short circuit the equality check on the array.