### PR TITLE
fix warnings about adapting argument list to tuple

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
@@ -45,7 +45,7 @@ class StreamApi @Inject()(
 
   def routes: Route = {
     path("lwc" / "api" / "v1" / "stream" / Segment) { streamId =>
-      parameters('name.?, 'expression.?, 'frequency.?) { (name, expr, frequency) =>
+      parameters(('name.?, 'expression.?, 'frequency.?)) { (name, expr, frequency) =>
         get {
           complete(handleReq(None, streamId, name, expr, frequency))
         } ~

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
@@ -50,7 +50,7 @@ class ExprApi extends WebApi {
 
   private val excludedWords = ApiSettings.excludedWords
 
-  def routes: Route = parameters("q", "vocab" ? vocabulary.name) { (q, vocab) =>
+  def routes: Route = parameters(('q, 'vocab ? vocabulary.name)) { (q, vocab) =>
     path("api" / "v1" / "expr") {
       get { complete(processDebugRequest(q, vocab)) }
     } ~


### PR DESCRIPTION
The usage of the parameters directive was giving warnings
like:

```
Warning:(48, 17) Adapting argument list by creating a 3-tuple: this may not be what you want.
        signature: ParameterDirectives.parameters(pdm: akka.http.scaladsl.server.directives.ParameterDirectives.ParamMagnet): pdm.Out
  given arguments: scala.Symbol("name").$qmark, scala.Symbol("expression").$qmark, scala.Symbol("frequency").$qmark
 after adaptation: ParameterDirectives.parameters((scala.Symbol("name").$qmark, scala.Symbol("expression").$qmark, scala.Symbol("frequency").$qmark): akka.http.scaladsl.server.directives.ParameterDirectives.ParamMagnet{type Out = akka.http.scaladsl.server.Directive[(Option[String], Option[String], Option[String])]})
      parameters('name.?, 'expression.?, 'frequency.?) { (name, expr, frequency) =>
```

It is easy to fix, though previous usage does seem to be
inline with examples from docs:

http://doc.akka.io/docs/akka-http/10.0.7/scala/http/routing-dsl/directives/parameter-directives/parameters.html#optional-parameter-with-default-value