### PR TITLE
add more test cases for cors

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/RequestHandler.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/RequestHandler.scala
@@ -111,6 +111,15 @@ object RequestHandler {
     cors { log }
   }
 
+  /**
+    * Wraps a route with error handling to format error messages in a consistent way.
+    */
+  def errorOptions(route: Route): Route = {
+    handleExceptions(exceptionHandler) {
+      handleRejections(rejectionHandler) { route }
+    }
+  }
+
   def errorResponse(t: Throwable): HttpResponse = t match {
     case e @ (_: IllegalArgumentException | _: IllegalStateException | _: JsonProcessingException) =>
       DiagnosticMessage.error(StatusCodes.BadRequest, e)


### PR DESCRIPTION
Add some test cases for cors on error responses. There was
a report CORS headers were not added to errors. That does
not seem to be the case. Most likely they did not handle
the rejections and the filter was not applied to the error.