### PR TITLE
fix IllegalFormatConversionException

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
@@ -32,7 +32,7 @@ sealed trait DataExpr extends TimeSeriesExpr {
   def isGrouped: Boolean = false
 
   def groupByKey(tags: Map[String, String]): Option[String] = {
-    Some("%40X".format(TaggedItem.computeId(tags)))
+    Some(TaggedItem.computeId(tags).toString)
   }
 
   def exprString: String

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataExprSuite.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import org.scalatest.FunSuite
+
+class DataExprSuite extends FunSuite {
+  test("groupByKey") {
+    val expr = DataExpr.Sum(Query.True)
+    val tags = Map("name" -> "foo")
+    val expected = Some(TaggedItem.computeId(tags).toString)
+    val key = expr.groupByKey(tags)
+    assert(expected === key)
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataGroupBySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataGroupBySuite.scala
@@ -47,7 +47,7 @@ class DataGroupBySuite extends FunSuite {
     assert(rs.size === 1)
 
     val expected = ts(6).withTags(Map("name" -> "test")).withLabel("(name=test)")
-    assert(rs(0) === expected)
+    assert(rs.head === expected)
   }
 
   test("(,not_present,),:by") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
@@ -25,13 +25,11 @@ class TimeSeriesExprSuite extends FunSuite {
 
   import com.netflix.atlas.core.model.TimeSeriesExprSuite._
 
-  val interpreter = Interpreter(StyleVocabulary.allWords)
-  val data = constants
+  private val interpreter = Interpreter(StyleVocabulary.allWords)
 
-  val noTags = Map.empty[String, String]
-  val unknownTag = "name" -> "unknown"
+  private val unknownTag = "name" -> "unknown"
 
-  val tests = List(
+  private val tests = List(
     ":true,:all"                  -> const(constants),
     ":true"                       -> const(ts(unknownTag, 55)),
     ":true,:sum"                  -> const(ts(unknownTag, 55)),
@@ -192,7 +190,7 @@ class TimeSeriesExprSuite extends FunSuite {
   }
 
   // Tests that cannot be executed with incremental evaluation
-  val globalTests = List(
+  private val globalTests = List(
     "1,:integral,min,:stat"                          -> const(ts(Map("name" -> "1.0"), "stat-min(integral(1.0))", 1.0)),
     "1,:integral,max,:stat"                          -> const(ts(Map("name" -> "1.0"), "stat-max(integral(1.0))", 10.0)),
     "1,:integral,avg,:stat"                          -> const(ts(Map("name" -> "1.0"), "stat-avg(integral(1.0))", 5.5)),


### PR DESCRIPTION
Illegal conversion when trying to access the group by
key for a data expression.

```
java.util.IllegalFormatConversionException: x != com.netflix.atlas.core.model.ItemId
	at java.util.Formatter$FormatSpecifier.failConversion(Formatter.java:4302)
	at java.util.Formatter$FormatSpecifier.printInteger(Formatter.java:2793)
	at java.util.Formatter$FormatSpecifier.print(Formatter.java:2747)
	at java.util.Formatter.format(Formatter.java:2520)
	at java.util.Formatter.format(Formatter.java:2455)
	at java.lang.String.format(String.java:2940)
	at scala.collection.immutable.StringLike.format(StringLike.scala:351)
	at scala.collection.immutable.StringLike.format$(StringLike.scala:350)
	at scala.collection.immutable.StringOps.format(StringOps.scala:29)
	at com.netflix.atlas.core.model.DataExpr.groupByKey(DataExpr.scala:35)
```