### PR TITLE
add mapping for ApproximateAgeOfOldestMessage

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/sqs.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/sqs.conf
@@ -46,6 +46,11 @@ atlas {
           ]
         },
         {
+          name = "ApproximateAgeOfOldestMessage"
+          alias = "aws.sqs.approximateAgeOfOldestMessage"
+          conversion = "max"
+        },
+        {
           name = "NumberOfMessagesSent"
           alias = "aws.sqs.messagesSent"
           conversion = "sum,rate"


### PR DESCRIPTION
New SQS metric that was added a while back:

https://aws.amazon.com/about-aws/whats-new/2016/08/new-amazon-cloudwatch-metric-for-amazon-sqs-monitors-the-age-of-the-oldest-message/