### PR TITLE
cache most recent datapoints from cloudwatch

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/reference.conf
@@ -43,6 +43,9 @@ atlas {
     // Batch size for flushing data back to the poller manager
     batch-size = 1000
 
+    // How long to cache datapoints to avoid gaps
+    cache-ttl = 20 minutes
+
     // Class to use for mapping AWS dimensions to a tag map for use in Atlas
     tagger = {
       class = "com.netflix.atlas.cloudwatch.NetflixTagger"


### PR DESCRIPTION
In some cases if there are a lot of cloudwatch metrics,
then the polling can start to get throttled and cannot
keep up at the desired rate. This can cause spotty reporting
until the limit can get raised or the poller config is
changed to be less aggressive. To minimize the visibility
pf the problem for a user consuming the metric the last
datapoint is now cached and the reported value comes
from the local cache.

This does mean that when such a problem is happening the wrong
value might be propagated for several minutes. From recent
testing though in the more typical case it avoids confusion
more often until there is a better way to access cloudwatch
data. If it is a big concern the ttl can be configured to a
smaller value.