### PR TITLE
add :clamp-min and :clamp-max

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -116,6 +116,40 @@ object MathExpr {
     }
   }
 
+  case class ClampMin(expr: TimeSeriesExpr, min: Double) extends TimeSeriesExpr with UnaryOp {
+    def name: String = "clamp-min"
+    def dataExprs: List[DataExpr] = expr.dataExprs
+    override def toString: String = s"$expr,$min,:$name"
+
+    def isGrouped: Boolean = expr.isGrouped
+
+    def groupByKey(tags: Map[String, String]): Option[String] = expr.groupByKey(tags)
+
+    def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
+      val rs = expr.eval(context, data)
+      ResultSet(this, rs.data.map { t => t.unaryOp(s"$name(%s, $min)", this) }, rs.state)
+    }
+
+    def apply(v: Double): Double = if (v < min) min else v
+  }
+
+  case class ClampMax(expr: TimeSeriesExpr, max: Double) extends TimeSeriesExpr with UnaryOp {
+    def name: String = "clamp-max"
+    def dataExprs: List[DataExpr] = expr.dataExprs
+    override def toString: String = s"$expr,$max,:$name"
+
+    def isGrouped: Boolean = expr.isGrouped
+
+    def groupByKey(tags: Map[String, String]): Option[String] = expr.groupByKey(tags)
+
+    def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
+      val rs = expr.eval(context, data)
+      ResultSet(this, rs.data.map { t => t.unaryOp(s"$name(%s, $max)", this) }, rs.state)
+    }
+
+    def apply(v: Double): Double = if (v > max) max else v
+  }
+
   trait UnaryMathExpr extends TimeSeriesExpr with UnaryOp {
     def name: String
     def expr: TimeSeriesExpr

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -26,6 +26,7 @@ import com.netflix.atlas.core.stacklang.Word
 object MathVocabulary extends Vocabulary {
 
   import com.netflix.atlas.core.model.ModelExtractors._
+  import com.netflix.atlas.core.stacklang.Extractors._
 
   val name: String = "math"
 
@@ -38,6 +39,7 @@ object MathVocabulary extends Vocabulary {
     Time,
     CommonQuery,
     NamedRewrite,
+    ClampMin, ClampMax,
     Abs, Negate, Sqrt, PerStep,
 
     Add, Subtract, Multiply, Divide,
@@ -348,6 +350,52 @@ object MathVocabulary extends Vocabulary {
     }
 
     override def examples: List[String] = Nil
+  }
+
+  case object ClampMin extends SimpleWord {
+    override def name: String = "clamp-min"
+
+    protected def matcher: PartialFunction[List[Any], Boolean] = {
+      case DoubleType(_) :: TimeSeriesType(_) :: _ => true
+    }
+
+    protected def executor: PartialFunction[List[Any], List[Any]] = {
+      case DoubleType(mn) :: TimeSeriesType(t) :: stack => MathExpr.ClampMin(t, mn) :: stack
+    }
+
+    override def summary: String =
+      """
+        |Restricts the minimum value of the output time series to the specified value. Values
+        |from the input time series that are greater than or equal to the minimum will not be
+        |changed. A common use-case is to allow for auto-scaled axis up to a specified bound.
+      """.stripMargin.trim
+
+    override def signature: String = "TimeSeriesExpr Double -- TimeSeriesExpr"
+
+    override def examples: List[String] = List("name,sps,:eq,:sum,200e3")
+  }
+
+  case object ClampMax extends SimpleWord {
+    override def name: String = "clamp-max"
+
+    protected def matcher: PartialFunction[List[Any], Boolean] = {
+      case DoubleType(_) :: TimeSeriesType(_) :: _ => true
+    }
+
+    protected def executor: PartialFunction[List[Any], List[Any]] = {
+      case DoubleType(mx) :: TimeSeriesType(t) :: stack => MathExpr.ClampMax(t, mx) :: stack
+    }
+
+    override def summary: String =
+      """
+        |Restricts the maximum value of the output time series to the specified value. Values
+        |from the input time series that are less than or equal to the maximum will not be
+        |changed. A common use-case is to allow for auto-scaled axis up to a specified bound.
+      """.stripMargin.trim
+
+    override def signature: String = "TimeSeriesExpr Double -- TimeSeriesExpr"
+
+    override def examples: List[String] = List("name,sps,:eq,:sum,200e3")
   }
 
   sealed trait UnaryWord extends SimpleWord {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ClampSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ClampSuite.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import org.scalatest.FunSuite
+
+class ClampSuite extends FunSuite {
+
+  val step = 60000L
+  val dataTags = Map("name" -> "cpu", "node" -> "i-1")
+
+  val inputTS = TimeSeries(dataTags, new ArrayTimeSeq(DsType.Gauge, 0L, step,
+    Array[Double](1.0, 1.5, 1.6, 1.7, 1.4, 1.3, 1.2, 1.0, 0.0, 0.0)))
+
+  val des = StatefulExpr.Des(DataExpr.Sum(Query.Equal("name" , "cpu")), 2, 0.1, 0.02)
+
+  def eval(expr: TimeSeriesExpr, data: List[List[Datapoint]]): List[List[TimeSeries]] = {
+    var state = Map.empty[StatefulExpr, Any]
+    data.map { ts =>
+      val t = ts.head.timestamp
+      val context = EvalContext(t, t + step, step, state)
+      val rs = expr.eval(context, ts)
+      state = rs.state
+      rs.data
+    }
+  }
+
+  test("clamp-min") {
+    val s = 0L
+    val e = 10L * step
+    val context = EvalContext(s, e, step, Map.empty)
+    val clamp = MathExpr.ClampMin(DataExpr.Sum(Query.Equal("name" , "cpu")), 1.1)
+    val actual = clamp.eval(context, List(inputTS)).data.head.data.bounded(s, e).data
+    val expected = Array[Double](1.1, 1.5, 1.6, 1.7, 1.4, 1.3, 1.2, 1.1, 1.1, 1.1)
+    assert(actual === expected)
+  }
+
+  test("clamp-max") {
+    val s = 0L
+    val e = 10L * step
+    val context = EvalContext(s, e, step, Map.empty)
+    val clamp = MathExpr.ClampMax(DataExpr.Sum(Query.Equal("name" , "cpu")), 1.1)
+    val actual = clamp.eval(context, List(inputTS)).data.head.data.bounded(s, e).data
+    val expected = Array[Double](1.0, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.0, 0.0, 0.0)
+    assert(actual === expected)
+  }
+
+}


### PR DESCRIPTION
Allows the user to restrict the min and max values of
the input respectively. The most common use-case motivating
this is to be able to support a bounded auto-scaling for
data on an axis. The axis lower and upper limits are either
explicit or automatic. These operators give more flexiblity
and can be set for a given line to tune its behavior.

Name was chosen to match the same operators in Promoetheus.