### PR TITLE
helper for merging sorted lists

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/ListHelper.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/ListHelper.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+/**
+  * Helper functions for working with lists.
+  */
+object ListHelper {
+  /**
+    * Merge two sorted lists up to the specified limit.
+    *
+    * @param limit
+    *     Maximum number of items in the resulting list.
+    * @param v1
+    *     A sorted list to merge.
+    * @param v2
+    *     A sorted list to merge.
+    * @return
+    *     Sorted list with a max size of `limit`.
+    */
+  def merge[T <: Comparable[T]](limit: Int, v1: List[T], v2: List[T]): List[T] = {
+    merge(limit, 0, Nil, v1, v2)
+  }
+
+  @scala.annotation.tailrec
+  private def merge[T <: Comparable[T]](limit: Int, size: Int, acc: List[T], v1: List[T], v2: List[T]): List[T] = {
+    if (size == limit)
+      acc.reverse
+    else if (v1.isEmpty)
+      acc.reverse ++ v2
+    else if (v2.isEmpty)
+      acc.reverse ++ v1
+    else if (v1.head.compareTo(v2.head) <= 0)
+      merge(limit, size + 1, v1.head :: acc, v1.tail, v2)
+    else
+      merge(limit, size + 1, v2.head :: acc, v1, v2.tail)
+  }
+
+  /**
+    * Merge sorted lists up to the specified limit.
+    *
+    * @param limit
+    *     Maximum number of items in the resulting list.
+    * @param vs
+    *     A list of sorted lists to merge.
+    * @return
+    *     Sorted list with a max size of `limit`.
+    */
+  def merge[T <: Comparable[T]](limit: Int, vs: List[List[T]]): List[T] = {
+    vs.foldLeft(List.empty[T]) { (v1, v2) => merge(limit, v1, v2) }
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/ListHelperSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/ListHelperSuite.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import org.scalatest.FunSuite
+
+class ListHelperSuite extends FunSuite {
+
+  test("merge two sorted lists") {
+    val v1 = List("a", "c", "d")
+    val v2 = List("b", "e", "f")
+    assert(ListHelper.merge(10, v1, v2) === List("a", "b", "c", "d", "e", "f"))
+  }
+
+  test("merge two sorted lists with limit") {
+    val v1 = List("a", "c", "d")
+    val v2 = List("b", "e")
+    assert(ListHelper.merge(2, v1, v2) === List("a", "b"))
+  }
+
+  test("merge many sorted lists with limit") {
+    val v1 = List("a", "c", "d")
+    val v2 = List("b", "e")
+    val v3 = List("aa", "d")
+    val v4 = List("z")
+    assert(ListHelper.merge(3, List(v1, v2, v3, v4)) === List("a", "aa", "b"))
+  }
+}

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/ListMerge.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/ListMerge.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import java.util.UUID
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.collection.SortedSet
+
+/**
+  * Sanity check performance of utility for merging sorted lists.
+  *
+  * ```
+  * > jmh:run -wi 10 -i 10 -f1 -t1 .*ListMerge.*
+  * ...
+  * [info] Benchmark             Mode  Cnt   Score   Error  Units
+  * [info] ListMerge.hashSet    thrpt   10   0.361 ± 0.038  ops/s
+  * [info] ListMerge.merge      thrpt   10  23.064 ± 5.711  ops/s
+  * [info] ListMerge.sortedSet  thrpt   10   0.239 ± 0.019  ops/s
+  * [info] ListMerge.treeSet    thrpt   10   0.267 ± 0.047  ops/s
+  * ```
+  */
+@State(Scope.Thread)
+class ListMerge {
+
+  private val vs = (0 until 2000)
+    .map(_ => (0 until 1000).map(_ => UUID.randomUUID().toString).toList.sorted)
+    .toList
+
+  @Benchmark
+  def hashSet(bh: Blackhole): Unit = {
+    val set = new java.util.HashSet[String]()
+    vs.foreach(_.foreach(set.add))
+    val sorted = set.toArray(new Array[String](set.size()))
+    java.util.Arrays.sort(sorted.asInstanceOf[Array[AnyRef]])
+    bh.consume(sorted.toList.take(1000))
+  }
+
+  @Benchmark
+  def treeSet(bh: Blackhole): Unit = {
+    import scala.collection.JavaConverters._
+    val set = new java.util.TreeSet[String]()
+    vs.foreach(_.foreach(set.add))
+    bh.consume(set.asScala.toList.take(1000))
+  }
+
+  @Benchmark
+  def sortedSet(bh: Blackhole): Unit = {
+    val set = SortedSet.empty[String]
+    bh.consume(vs.foldLeft(set)(_ ++ _).toList.take(1000))
+  }
+
+  @Benchmark
+  def merge(bh: Blackhole): Unit = {
+    bh.consume(ListHelper.merge(1000, vs))
+  }
+
+}


### PR DESCRIPTION
Broken off from larger effort that is still in-progress.
Basic helper utility for merging a collection of sorted
lists. One such use-case is merging tag list results
coming back from many shards.