### PR TITLE
update merge to also dedup the list

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/ListHelper.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/ListHelper.scala
@@ -20,7 +20,8 @@ package com.netflix.atlas.core.util
   */
 object ListHelper {
   /**
-    * Merge two sorted lists up to the specified limit.
+    * Merge and dedup two sorted lists up to the specified limit. The input lists must already
+    * be sorted and should not contain duplicate values.
     *
     * @param limit
     *     Maximum number of items in the resulting list.
@@ -43,14 +44,20 @@ object ListHelper {
       acc.reverse ++ v2
     else if (v2.isEmpty)
       acc.reverse ++ v1
-    else if (v1.head.compareTo(v2.head) <= 0)
-      merge(limit, size + 1, v1.head :: acc, v1.tail, v2)
     else
-      merge(limit, size + 1, v2.head :: acc, v1, v2.tail)
+      v1.head.compareTo(v2.head) match {
+        case c if c < 0 =>
+          merge(limit, size + 1, v1.head :: acc, v1.tail, v2)
+        case c if c == 0 =>
+          merge(limit, size + 1, v1.head :: acc, v1.tail, v2.tail)
+        case c =>
+          merge(limit, size + 1, v2.head :: acc, v1, v2.tail)
+      }
   }
 
   /**
-    * Merge sorted lists up to the specified limit.
+    * Merge and dedup sorted lists up to the specified limit. The input lists must already
+    * be sorted and should not contain duplicate values.
     *
     * @param limit
     *     Maximum number of items in the resulting list.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/ListHelperSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/ListHelperSuite.scala
@@ -38,4 +38,10 @@ class ListHelperSuite extends FunSuite {
     val v4 = List("z")
     assert(ListHelper.merge(3, List(v1, v2, v3, v4)) === List("a", "aa", "b"))
   }
+
+  test("dedup while merging") {
+    val v1 = List("a", "c", "d")
+    val v2 = List("a", "b", "f")
+    assert(ListHelper.merge(10, v1, v2) === List("a", "b", "c", "d", "f"))
+  }
 }


### PR DESCRIPTION
For the use-cases we care about the input list will
already be sorted and uniqued. This fixes the merge
to also remove duplicate values across the lists.