### PR TITLE
fix unit for s3 request timers

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/s3-request.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/s3-request.conf
@@ -131,12 +131,12 @@ atlas {
         {
           name = "FirstByteLatency"
           alias = "aws.s3.firstByteLatency"
-          conversion = "timer"
+          conversion = "timer-millis"
         },
         {
           name = "TotalRequestLatency"
           alias = "aws.s3.totalRequestLatency"
-          conversion = "timer"
+          conversion = "timer-millis"
         }
       ]
     }


### PR DESCRIPTION
The latency is in milliseconds and we were treating it
as seconds.