### PR TITLE
convert invalid characters for polled metrics

### DIFF
--- a/atlas-poller/src/main/resources/reference.conf
+++ b/atlas-poller/src/main/resources/reference.conf
@@ -27,6 +27,21 @@ atlas.poller {
     // explicit response message. Setting to true it will send an ack message to indicate
     // it is done processing the message.
     send-ack = false
+
+    // Characters that are allowed in metric names
+    valid-tag-characters = "-._A-Za-z0-9"
+
+    // Overrides to be more permissive for the values of some keys
+    valid-tag-value-characters = ${?atlas.poller.valid-tag-value-characters} [
+      {
+        key = "nf.cluster"
+        value = "-._A-Za-z0-9^~"
+      },
+      {
+        key = "nf.asg"
+        value = "-._A-Za-z0-9^~"
+      }
+    ]
   }
 
   // List of poller actors to load. See application.conf in tests for examples.


### PR DESCRIPTION
When using an alias with a lambda it will get encoded
as a `:alias` suffix on the resource dimension. Before
those stats were getting dropped as invalid.

Changes were tested manually. Will follow up with some
refactoring to make the testing for this client easier in
general.