### PR TITLE
add mappings for application load balancer stats

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/alb.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/alb.conf
@@ -1,0 +1,206 @@
+
+atlas {
+  cloudwatch {
+
+    // Metrics for the overall load balancer
+    // http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html
+    alb = {
+      namespace = "AWS/ApplicationELB"
+      period = 1m
+
+      dimensions = [
+        "LoadBalancer"
+      ]
+
+      metrics = [
+        {
+          name = "ProcessedBytes"
+          alias = "aws.alb.processedBytes"
+          conversion = "sum,rate"
+        },
+        {
+          name = "ActiveConnectionCount"
+          alias = "aws.alb.activeConnectionCount"
+          conversion = "sum"
+        },
+        {
+          name = "NewConnectionCount"
+          alias = "aws.alb.newConnections"
+          conversion = "sum,rate"
+        },
+        {
+          name = "RejectedConnectionCount"
+          alias = "aws.alb.rejectedConnections"
+          conversion = "sum,rate"
+        },
+        {
+          name = "ConsumedLCUs"
+          alias = "aws.alb.consumedLCUs"
+          conversion = "sum"
+        }
+      ]
+    }
+
+    // Metrics for the overall load balancer by zone
+    // http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html
+    alb-zone = {
+      namespace = "AWS/ApplicationELB"
+      period = 1m
+
+      dimensions = [
+        "LoadBalancer",
+        "AvailabilityZone"
+      ]
+
+      metrics = [
+        {
+          name = "HTTPCode_ELB_4XX_Count"
+          alias = "aws.alb.errors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "4xx"
+            }
+          ]
+        },
+        {
+          name = "HTTPCode_ELB_5XX_Count"
+          alias = "aws.alb.errors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "5xx"
+            }
+          ]
+        },
+        {
+          name = "ClientTLSNegotiationErrorCount"
+          alias = "aws.alb.clientErrors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "error"
+              value = "TLSNegotiation"
+            }
+          ]
+        }
+      ]
+    }
+
+    // Metrics available by target group
+    // http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html
+    alb-tg-zone = {
+      namespace = "AWS/ApplicationELB"
+      period = 1m
+
+      dimensions = [
+        "LoadBalancer",
+        "TargetGroup",
+        "AvailabilityZone"
+      ]
+
+      metrics = [
+        {
+          name = "RequestCount"
+          alias = "aws.alb.requests"
+          conversion = "sum,rate"
+        },
+        {
+          name = "HTTPCode_Target_2XX_Count"
+          alias = "aws.alb.backendResponses"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "2xx"
+            }
+          ]
+        },
+        {
+          name = "HTTPCode_Target_3XX_Count"
+          alias = "aws.alb.backendResponses"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "3xx"
+            }
+          ]
+        },
+        {
+          name = "HTTPCode_Target_4XX_Count"
+          alias = "aws.alb.backendResponses"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "4xx"
+            }
+          ]
+        },
+        {
+          name = "HTTPCode_Target_5XX_Count"
+          alias = "aws.alb.backendResponses"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "5xx"
+            }
+          ]
+        },
+        {
+          name = "TargetConnectionErrorCount"
+          alias = "aws.alb.targetErrors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "error"
+              value = "Connection"
+            }
+          ]
+        },
+        {
+          name = "TargetTLSNegotiationErrorCount"
+          alias = "aws.alb.targetErrors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "error"
+              value = "TLSNegotiation"
+            }
+          ]
+        },
+        {
+          name = "HealthyHostCount"
+          alias = "aws.alb.hostCount"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "healthy"
+            }
+          ]
+        },
+        {
+          name = "UnHealthyHostCount"
+          alias = "aws.alb.hostCount"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "unhealthy"
+            }
+          ]
+        },
+        {
+          name = "TargetResponseTime"
+          alias = "aws.alb.targetLatency"
+          conversion = "timer"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/reference.conf
@@ -75,6 +75,14 @@ atlas {
           alias = "aws.elb"
         },
         {
+          name = "LoadBalancer"
+          alias = "aws.alb"
+        },
+        {
+          name = "TargetGroup"
+          alias = "aws.target"
+        },
+        {
           name = "TopicName"
           alias = "aws.topic"
         },
@@ -195,6 +203,9 @@ atlas {
     // Categories to load. The name will be used to load another config block:
     // atlas.cloudwatch.${name}
     categories = [
+      "alb",
+      "alb-zone",
+      "alb-tg-zone",
       "api-gateway",
       "billing",
       "dynamodb-table-1m",
@@ -222,6 +233,7 @@ atlas {
   }
 }
 
+include "alb.conf"
 include "api-gateway.conf"
 include "billing.conf"
 include "dynamodb.conf"


### PR DESCRIPTION
Adds basic mappings for the ApplicationELB metrics in
CloudWatch. There was a bit of debate on whether the
LoadBalancer and TargetGroup dimensions should be kept
as is or extract the name and only show that. The ids
are rarely useful to the end user and add quite a bit
of noise when selecting in the UI. For now though we
just map the values in as they are provided in CloudWatch.