### PR TITLE
fix key for adding tags to dynamodb errors

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/dynamodb.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/dynamodb.conf
@@ -100,7 +100,7 @@ atlas {
           name = "SystemErrors"
           alias = "aws.dynamodb.errors"
           conversion = "sum,rate"
-          tag = [
+          tags = [
             {
               key = "id"
               value = "system"
@@ -111,7 +111,7 @@ atlas {
           name = "ThrottledRequests"
           alias = "aws.dynamodb.errors"
           conversion = "sum,rate"
-          tag = [
+          tags = [
             {
               key = "id"
               value = "throttled"
@@ -122,7 +122,7 @@ atlas {
           name = "UserErrors"
           alias = "aws.dynamodb.errors"
           conversion = "sum,rate"
-          tag = [
+          tags = [
             {
               key = "id"
               value = "user"


### PR DESCRIPTION
The key in the configuration was singular instead of
plural. Need to think about a better way to validate
this in the future.