### PR TITLE
update default path pattern for StreamSupervisor

### DIFF
--- a/atlas-akka/src/main/resources/reference.conf
+++ b/atlas-akka/src/main/resources/reference.conf
@@ -4,7 +4,7 @@ atlas.akka {
   # Regex that determines how the path tag value to use when mapping data about an
   # actor into a meter. There a should be a single capture group which will be the
   # path to report.
-  path-pattern = "^akka://(?:[^/]+)/(?:system|user)/([^$].+?)(?:/.*)?$"
+  path-pattern = "^akka://(?:[^/]+)/(?:system|user)/([^$\\d/]+).*?$"
 
   # List of additional actor classes to load
   actors = ${?atlas.akka.actors} [

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/PathsSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/PathsSuite.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.akka
+
+import akka.actor.ActorPath
+import com.typesafe.config.ConfigFactory
+import org.scalatest.FunSuite
+
+/** Sanity check the default pattern for extracting an id from the path. */
+class PathsSuite extends FunSuite {
+
+  private val mapper = Paths.createMapper(ConfigFactory.load().getConfig("atlas.akka"))
+
+  private def path(str: String): ActorPath = ActorPath.fromString(str)
+
+  test("contains dashes") {
+    val id = mapper(path("akka://test/system/IO-TCP/$123"))
+    assert("IO-TCP" === id)
+  }
+
+  test("path with child") {
+    val id = mapper(path("akka://test/user/foo/$123"))
+    assert("foo" === id)
+  }
+
+  test("temporary actor") {
+    val id = mapper(path("akka://test/user/$123"))
+    assert("uncategorized" === id)
+  }
+
+  test("stream supervisor") {
+    val id = mapper(path("akka://test/user/StreamSupervisor-99961"))
+    assert("StreamSupervisor-" === id)
+  }
+}


### PR DESCRIPTION
We sometimes see paths for the stream supervisor that look
like:

```
akka://test/user/StreamSupervisor-99961
```

This creates a lot of ids which aren't that useful. This
change updates the default pattern to just extract the
prefix and ignore the counter at the end. So activity for
all stream supervisors will show up as a single metric.