### PR TITLE
handle :all expressions with streaming eval

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
@@ -17,6 +17,7 @@ package com.netflix.atlas.eval.model
 
 import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.DataExpr.AggregateFunction
+import com.netflix.atlas.core.model.DataExpr.All
 import com.netflix.atlas.core.model.DataExpr.GroupBy
 import com.netflix.atlas.core.model.Datapoint
 import com.netflix.atlas.core.model.TimeSeries
@@ -72,6 +73,7 @@ object AggrDatapoint {
       expr match {
         case af: AggregateFunction => List(applyAF(af, vs))
         case by: GroupBy           => applyGroupBy(by, vs)
+        case _: All                => vs
       }
     }
   }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/AggrDatapointSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/AggrDatapointSuite.scala
@@ -25,7 +25,7 @@ class AggrDatapointSuite extends FunSuite {
     (0 until nodes).toList.map { i =>
       val node = f"i-$i%08d"
       val tags = Map("name" -> "cpu")
-      if (expr.isGrouped)
+      if (!expr.isInstanceOf[DataExpr.AggregateFunction])
         AggrDatapoint(t, expr, node, tags + ("node" -> node), i)
       else
         AggrDatapoint(t, expr, node, tags, i)
@@ -71,6 +71,17 @@ class AggrDatapointSuite extends FunSuite {
     val expr = DataExpr.GroupBy(DataExpr.Sum(Query.True), List("node"))
     val dataset = createDatapoints(expr, 0, 10)
     val result = AggrDatapoint.aggregate(dataset ::: dataset)
+    assert(result.size === 10)
+    result.foreach { d =>
+      val v = d.tags("node").substring(2).toDouble
+      assert(d.value === v)
+    }
+  }
+
+  test("aggregate all") {
+    val expr = DataExpr.All(Query.True)
+    val dataset = createDatapoints(expr, 0, 10)
+    val result = AggrDatapoint.aggregate(dataset)
     assert(result.size === 10)
     result.foreach { d =>
       val v = d.tags("node").substring(2).toDouble


### PR DESCRIPTION
There is a bigger discussion on whether we should
remove `:all`, but for now all DataExpr types should
be supported.