### PR TITLE
use built in text/event-stream media type

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/CustomMediaTypes.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/CustomMediaTypes.scala
@@ -15,11 +15,10 @@
  */
 package com.netflix.atlas.akka
 
-import akka.http.scaladsl.model.HttpCharsets
 import akka.http.scaladsl.model.MediaType
 import akka.http.scaladsl.model.MediaType.Compressible
 
 object CustomMediaTypes {
-  val `application/x-jackson-smile` = MediaType.applicationBinary("x-jackson-smile", Compressible)
-  val `text/event-stream` = MediaType.customWithFixedCharset("text", "event-stream", HttpCharsets.`UTF-8`)
+  val `application/x-jackson-smile`: MediaType.Binary =
+    MediaType.applicationBinary("x-jackson-smile", Compressible)
 }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/HostSource.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/HostSource.scala
@@ -19,13 +19,13 @@ import akka.NotUsed
 import akka.http.scaladsl.model.HttpMethods
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.MediaTypes
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers._
 import akka.stream.scaladsl.Compression
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
-import com.netflix.atlas.akka.CustomMediaTypes
 import com.typesafe.scalalogging.StrictLogging
 
 import scala.util.Failure
@@ -66,7 +66,7 @@ object HostSource extends StrictLogging {
   private def singleCall(client: Client)(uri: String): Source[ByteString, Any] = {
     logger.info(s"subscribing to $uri")
     val headers = List(
-      Accept(CustomMediaTypes.`text/event-stream`),
+      Accept(MediaTypes.`text/event-stream`),
       `Accept-Encoding`(HttpEncodings.gzip))
     val request = HttpRequest(HttpMethods.GET, uri, headers)
 

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
@@ -21,12 +21,12 @@ import akka.actor.ActorRefFactory
 import akka.actor.Props
 import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.MediaTypes
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.stream.scaladsl.Source
 import com.netflix.atlas.akka.CustomDirectives._
-import com.netflix.atlas.akka.CustomMediaTypes
 import com.netflix.atlas.akka.WebApi
 import com.netflix.atlas.json.Json
 import com.netflix.atlas.json.JsonSupport
@@ -108,7 +108,7 @@ class StreamApi @Inject()(
 
     val source = Source.actorPublisher(Props(
       new SSEActor(streamId, name.getOrElse("unknown"), sm, subs.toList, registry)))
-    val entity = HttpEntity.Chunked(CustomMediaTypes.`text/event-stream`.toContentType, source)
+    val entity = HttpEntity.Chunked(MediaTypes.`text/event-stream`.toContentType, source)
     HttpResponse(StatusCodes.OK, entity = entity)
   }
 }

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/FetchRequestActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/FetchRequestActor.scala
@@ -24,12 +24,12 @@ import akka.actor.Props
 import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.model.HttpEntity.ChunkStreamPart
 import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.MediaTypes
 import akka.http.scaladsl.model.StatusCodes
 import akka.stream.actor.ActorPublisher
 import akka.stream.actor.ActorPublisherMessage._
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
-import com.netflix.atlas.akka.CustomMediaTypes._
 import com.netflix.atlas.akka.DiagnosticMessage
 import com.netflix.atlas.core.model.EvalContext
 import com.netflix.atlas.core.model.StatefulExpr
@@ -188,7 +188,7 @@ object FetchRequestActor {
     val source = Source.actorPublisher(Props(new FetchRequestActor(request)))
     HttpResponse(
       status = StatusCodes.OK,
-      entity = HttpEntity.Chunked(`text/event-stream`, source)
+      entity = HttpEntity.Chunked(MediaTypes.`text/event-stream`, source)
     )
   }
 


### PR DESCRIPTION
As of 10.0.8 akka-http supports the `text/event-stream`
media type. We no longer need it as a custom one.