### PR TITLE
update to spectator 0.57.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val log4j      = "2.8.2"
     val scala      = "2.12.3"
     val slf4j      = "1.7.25"
-    val spectator  = "0.56.0"
+    val spectator  = "0.57.1"
 
     val crossScala = Seq(scala)
   }


### PR DESCRIPTION
Fixes issues when running on jdk9:

```
Cause: java.lang.IllegalAccessException: access to public member failed: com.netflix.spectator.api.RegistryConfig.gaugePollingFrequency()Duration/invokeSpecial, from com.netflix.spectator.api.RegistryConfig/2 (unnamed module @7d3cb5af)
   at java.base/java.lang.invoke.MemberName.makeAccessException(MemberName.java:914)
   at java.base/java.lang.invoke.MethodHandles$Lookup.checkAccess(MethodHandles.java:2193)
   at java.base/java.lang.invoke.MethodHandles$Lookup.checkMethod(MethodHandles.java:2133)
   at java.base/java.lang.invoke.MethodHandles$Lookup.getDirectMethodCommon(MethodHandles.java:2282)
   at java.base/java.lang.invoke.MethodHandles$Lookup.getDirectMethodNoSecurityManager(MethodHandles.java:2276)
   at java.base/java.lang.invoke.MethodHandles$Lookup.unreflectSpecial(MethodHandles.java:1800)
   at com.netflix.spectator.impl.Config.lambda$createProxy$3(Config.java:131)
```