### PR TITLE
fix endless loop for numProbesPerKey

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
@@ -248,12 +248,13 @@ final class SmallHashMap[K <: Any, V <: Any] private (val data: Array[Any], data
    * full data it would be N/2.
    */
   def numProbesPerKey: Double =  {
+    val capacity = data.length / 2
     var total = 0
     keys.foreach { k =>
       var i = hash(k)
       while (data(i * 2) != k) {
         total += 1
-        i = (i + 1) % dataLength
+        i = (i + 1) % capacity
       }
     }
     total.toDouble / dataLength


### PR DESCRIPTION
This method was incorrectly using the data length rather
than the capacity when looping over the array. If a key
had a collision and was hashed to a position that was
larger than the data length, then it would be an endless
loop because the key entry would never be found.