### PR TITLE
support chaining with SmallHashMap.Builder

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
@@ -42,7 +42,7 @@ object SmallHashMap {
 
     def +=(pair: (K, V)): Unit = add(pair._1, pair._2)
 
-    def add(k: K, v: V) {
+    def add(k: K, v: V): Builder[K, V] = {
       val pos = Hash.absOrZero(k.hashCode) % size
       var i = pos
       var ki = buf(i * 2)
@@ -63,9 +63,10 @@ object SmallHashMap {
         buf(i * 2 + 1) = v
         actualSize += 1
       }
+      this
     }
 
-    def addAll(m: Map[K, V]) {
+    def addAll(m: Map[K, V]): Builder[K, V] = {
       m match {
         case sm: SmallHashMap[K, V] =>
           var i = 0
@@ -76,6 +77,7 @@ object SmallHashMap {
           }
         case _ => m.foreach { t => add(t._1, t._2) }
       }
+      this
     }
 
     def result: SmallHashMap[K, V] = {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/SmallHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/SmallHashMapSuite.scala
@@ -267,6 +267,15 @@ class SmallHashMapSuite extends FunSuite {
     assert(m.toSet === Set("k1" -> "v1", "k2" -> "v2"))
   }
 
+  test("using builder") {
+    val expected = SmallHashMap("k1" -> "v1", "k2" -> "v2")
+    val actual = new SmallHashMap.Builder[String, String](4)
+      .add("k1", "v1")
+      .addAll(Map("k2" -> "v2"))
+      .result
+    assert(expected === actual)
+  }
+
   private def testNumCollisions(m: SmallHashMap[String, String]) {
     //printf("%d: %d collisions, %.2f probes%n", m.size, m.numCollisions, m.numProbesPerKey)
     assert(m.numProbesPerKey < m.size / 4)


### PR DESCRIPTION
Updates the return types for `add` and `addAll` to
return the Builder so they can be chained.