### PR TITLE
update ids for lwc to be consistent with metrics

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionWithFrequency.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionWithFrequency.scala
@@ -15,8 +15,8 @@
  */
 package com.netflix.atlas.lwcapi
 
-import java.util.Base64
-
+import com.netflix.atlas.core.util.Hash
+import com.netflix.atlas.core.util.Strings
 import com.netflix.atlas.json.JsonSupport
 
 case class ExpressionWithFrequency(
@@ -44,8 +44,6 @@ object ExpressionWithFrequency {
   }
 
   def computeId(e: String, f: Long): String = {
-    val key = s"$f~$e"
-    val md = java.security.MessageDigest.getInstance("SHA-1")
-    Base64.getUrlEncoder.withoutPadding.encodeToString(md.digest(key.getBytes("UTF-8")))
+    Strings.zeroPad(Hash.sha1(s"$f~$e"), 40)
   }
 }

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
@@ -72,7 +72,7 @@ class ExpressionApiSuite extends FunSuite with ScalatestRouteTest {
     }
     exprDB.regenerateQueryIndex()
     Get("/lwc/api/v1/expressions/skan") ~> endpoint.routes ~> check {
-      val expected = s"""{"expressions":[$skanCount,$skanSum]}"""
+      val expected = s"""{"expressions":[$skanSum,$skanCount]}"""
       assert(responseAs[String] === expected)
     }
   }
@@ -84,7 +84,7 @@ class ExpressionApiSuite extends FunSuite with ScalatestRouteTest {
     }
     exprDB.regenerateQueryIndex()
     Get("/lwc/api/v1/expressions") ~> endpoint.routes ~> check {
-      val expected = s"""{"expressions":[$skanCount,$skanSum,$brhMax]}"""
+      val expected = s"""{"expressions":[$brhMax,$skanSum,$skanCount]}"""
       assert(responseAs[String] === expected)
     }
   }
@@ -140,7 +140,7 @@ class ExpressionApiSuite extends FunSuite with ScalatestRouteTest {
     assert(tag_e1 != tag_e2)
   }
 
-  private val skanCount = """{"expression":"nf.cluster,skan,:eq,:count","frequency":60000,"id":"Ynj6YEfAcxbX4mWhAEiCq54QB68"}"""
-  private val skanSum = """{"expression":"nf.cluster,skan,:eq,:sum","frequency":60000,"id":"NuCixhtI4GK7pTYdBZr9MTyCxnQ"}"""
-  private val brhMax = """{"expression":"nf.app,brh,:eq,:max","frequency":60000,"id":"FvGwkwwO6uAiU3TqiMAeFh5Ymv8"}"""
+  private val skanCount = """{"expression":"nf.cluster,skan,:eq,:count","frequency":60000,"id":"6278fa6047c07316d7e265a1004882ab9e1007af"}"""
+  private val skanSum = """{"expression":"nf.cluster,skan,:eq,:sum","frequency":60000,"id":"36e0a2c61b48e062bba5361d059afd313c82c674"}"""
+  private val brhMax = """{"expression":"nf.app,brh,:eq,:max","frequency":60000,"id":"16f1b0930c0eeae0225374ea88c01e161e589aff"}"""
 }

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionDatabaseSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionDatabaseSuite.scala
@@ -52,13 +52,13 @@ class ExpressionDatabaseSuite extends FunSuite {
   test("same expression different frequency") {
     val query1 = "nf.cluster,skan-test,:eq,:sum,:des-fast"
     val freq1 = 30000
-    val id1 = "CxmlI6L5YBQcpWOrayncZKeZekg"
+    val id1 = "0b19a523a2f960141ca563ab6b29dc64a7997a48"
     val ds1a = "nf.cluster,skan-test,:eq,:sum"
     val ret1 = ExpressionWithFrequency(ds1a, freq1, id1)
 
     val query2 = "nf.cluster,skan-test,:eq,:sum,:des-fast"
     val freq2 = 50000
-    val id2 = "xcKZ6tCd4vSMUY-Ug3bToNy3L6k"
+    val id2 = "c5c299ead09de2f48c518f948376d3a0dcb72fa9"
     val ds2a = "nf.cluster,skan-test,:eq,:sum"
     val ret2 = ExpressionWithFrequency(ds2a, freq2, id2)
 
@@ -82,13 +82,13 @@ class ExpressionDatabaseSuite extends FunSuite {
   test("deleting") {
     val query1 = "nf.cluster,skan-test,:eq,:sum,:des-fast"
     val freq1 = 30000
-    val id1 = "CxmlI6L5YBQcpWOrayncZKeZekg"
+    val id1 = "0b19a523a2f960141ca563ab6b29dc64a7997a48"
     val ds1a = "nf.cluster,skan-test,:eq,:sum"
     val ret1 = ExpressionWithFrequency(ds1a, freq1, id1)
 
     val query2 = "nf.cluster,skan-test,:eq,:sum,:des-fast"
     val freq2 = 50000
-    val id2 = "xcKZ6tCd4vSMUY-Ug3bToNy3L6k"
+    val id2 = "c5c299ead09de2f48c518f948376d3a0dcb72fa9"
     val ds2a = "nf.cluster,skan-test,:eq,:sum"
     val ret2 = ExpressionWithFrequency(ds2a, freq2, id2)
 
@@ -142,7 +142,7 @@ class ExpressionDatabaseSuite extends FunSuite {
 
     val query2 = "nf.cluster,foo-test,:eq,:sum,:des-fast"
     val freq2 = 30000
-    val id2 = "TmufMvW12uix44g903buDb-0kH4"
+    val id2 = "4e6b9f32f5b5dae8b1e3883dd376ee0dbfb4907e"
     val ds2a = "nf.cluster,foo-test,:eq,:sum"
     val ret2 = ExpressionWithFrequency(ds2a, freq2, id2)
 

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionWithFrequencySuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionWithFrequencySuite.scala
@@ -45,7 +45,7 @@ class ExpressionWithFrequencySuite extends FunSuite {
 
   test("computes id") {
     val expr = ExpressionWithFrequency("test")
-    assert(expr.id === "JoTTxcskW9L9buTqMKUA6XrOgUE")
+    assert(expr.id === "2684d3c5cb245bd2fd6ee4ea30a500e97ace8141")
   }
 
   test("id computation considers frequency") {
@@ -110,13 +110,13 @@ class ExpressionWithFrequencySuite extends FunSuite {
   }
 
   test("renders as json with default frequency") {
-    val expected = "{\"expression\":\"this\",\"frequency\":60000,\"id\":\"_DoIEIh3HgW9w6qZ_9h3AVff5s4\"}"
+    val expected = "{\"expression\":\"this\",\"frequency\":60000,\"id\":\"fc3a081088771e05bdc3aa99ffd8770157dfe6ce\"}"
     val json = ExpressionWithFrequency("this").toJson
     assert(expected === json)
   }
 
   test("renders as json with frequency of 0") {
-    val expected = "{\"expression\":\"this\",\"frequency\":60000,\"id\":\"_DoIEIh3HgW9w6qZ_9h3AVff5s4\"}"
+    val expected = "{\"expression\":\"this\",\"frequency\":60000,\"id\":\"fc3a081088771e05bdc3aa99ffd8770157dfe6ce\"}"
     val json = ExpressionWithFrequency("this", 0).toJson
     assert(expected === json)
   }


### PR DESCRIPTION
Changes the id strings used for lwc expressions to be
more consistent with how metric ids are generated.