### PR TITLE
recover from errors on response source

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EurekaSource.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EurekaSource.scala
@@ -141,7 +141,9 @@ object EurekaSource extends StrictLogging {
           val foundInstances = instances.map(i => i.instanceId -> i).toMap
 
           val added = foundInstances -- currentIds
-          logger.info(s"instances added: ${mkString(added)}")
+          if (added.nonEmpty) {
+            logger.info(s"instances added: ${mkString(added)}")
+          }
           val sources = added.values.map { instance =>
             val uri = instanceUri(instance)
             val ref = EvaluationFlows.stoppableSource(HostSource(uri, client))
@@ -151,7 +153,9 @@ object EurekaSource extends StrictLogging {
           push(out, sources.toList)
 
           val removed = instanceMap.toMap -- foundInstances.keySet
-          logger.info(s"instances removed: ${mkString(removed)}")
+          if (removed.nonEmpty) {
+            logger.info(s"instances removed: ${mkString(removed)}")
+          }
           removed.foreach { case (id, ref) =>
             instanceMap -= id
             ref.stop()


### PR DESCRIPTION
The LWC HostSource was not recovering if there was
a failure on the entity source from the response. This
would cause the overall stream to fail and stop producing
data. With this change the error will get logged and it
will get retried like any other failure.