### PR TITLE
disable size limit on stream response

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/HostSource.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/HostSource.scala
@@ -110,6 +110,7 @@ object HostSource extends StrictLogging {
 
   private def unzipIfNeeded(res: HttpResponse): Source[ByteString, Any] = {
     val isCompressed = res.headers.contains(`Content-Encoding`(HttpEncodings.gzip))
-    if (isCompressed) res.entity.dataBytes.via(Compression.gunzip()) else res.entity.dataBytes
+    val dataBytes = res.entity.withoutSizeLimit().dataBytes
+    if (isCompressed) dataBytes.via(Compression.gunzip()) else dataBytes
   }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/HostSourceSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/HostSourceSuite.scala
@@ -72,6 +72,17 @@ class HostSourceSuite extends FunSuite {
     assert(result === (0 until 5).map(_ => "ok").toList)
   }
 
+  test("no size limit on data stream") {
+    val entity = HttpEntity(ByteString("ok")).withSizeLimit(1)
+    val response = HttpResponse(StatusCodes.OK, entity = entity)
+    val future = source(Success(response))
+      .take(5)
+      .map(_.decodeString(StandardCharsets.UTF_8))
+      .runWith(Sink.seq[String])
+    val result = Await.result(future, Duration.Inf).toList
+    assert(result === (0 until 5).map(_ => "ok").toList)
+  }
+
   test("handles decompression") {
     val headers = List(`Content-Encoding`(HttpEncodings.gzip))
     val data = ByteString(compress("ok"))


### PR DESCRIPTION
Since these are meant to be long lived, there should
not be a bound on the max size of the stream.

/cc @ruchirj