### PR TITLE
do not assume stream path for backend

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -68,11 +68,9 @@ private[stream] class StreamContext(
   }
 
   def findEurekaBackendForUri(uri: Uri): EurekaBackend = {
-    val path = s"/lwc/api/v1/stream/$id"
-
     val host = uri.authority.host.address()
     backends.find(_.host == host) match {
-      case Some(backend) => backend.copy(instanceUri = backend.instanceUri + path)
+      case Some(backend) => backend
       case None          => throw new NoSuchElementException(host)
     }
   }


### PR DESCRIPTION
There are multiple paths that will get used now
and the components already know the correct path
for what they are doing. Currently this causes
a problem for the SubscriptionManager because
it is posting to `/stream/$id/subscribe` instead
of `/subscribe`.