### PR TITLE
neo-sbt-scalafmt 1.12

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ addSbtPlugin("com.github.gseitz"         % "sbt-release"          % "1.0.6")
 addSbtPlugin("pl.project13.scala"        % "sbt-jmh"              % "0.2.27")
 addSbtPlugin("com.typesafe.sbt"          % "sbt-git"              % "0.9.3")
 
-addSbtPlugin("com.lucidchart"            % "sbt-scalafmt"         % "1.10")
+addSbtPlugin("com.lucidchart"            % "sbt-scalafmt"         % "1.12")
 
 // Convenient helpers, not required
 addSbtPlugin("com.timushev.sbt"          % "sbt-updates"          % "0.3.1")


### PR DESCRIPTION
Fixes the warnings like:

```
Warning: Unknown Scalafmt version 1.2.0; using 1.0 interface
```