### PR TITLE
more consistent use of access logger

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ConnectionManager.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ConnectionManager.scala
@@ -60,7 +60,7 @@ private[stream] class ConnectionManager(context: StreamContext)
         val path = "/lwc/api/v1/stream/" + context.id
         val sources = added.values.map { instance =>
           val uri = instance.substitute("http://{local-ipv4}:{port}") + path
-          val ref = EvaluationFlows.stoppableSource(HostSource(uri, context.client))
+          val ref = EvaluationFlows.stoppableSource(HostSource(uri, context.httpClient("stream")))
           instanceMap += instance.instanceId -> ref
           ref.source
         }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookup.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookup.scala
@@ -76,7 +76,7 @@ private[stream] class EurekaGroupsLookup(context: StreamContext, frequency: Fini
           .toList
           .distinct
           .map { uri =>
-            EurekaSource(uri, context.client)
+            EurekaSource(uri, context.httpClient("eureka"))
           }
 
         // Perform lookup for each vip and create groups composite

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/package.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/package.scala
@@ -21,6 +21,7 @@ import akka.http.scaladsl.model.HttpResponse
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
+import com.netflix.atlas.akka.AccessLogger
 import com.netflix.atlas.eval.stream.Evaluator.DataSource
 import com.netflix.atlas.eval.stream.Evaluator.DataSources
 import com.netflix.atlas.json.JsonSupport
@@ -29,7 +30,8 @@ import scala.util.Try
 
 package object stream {
 
-  type Client = Flow[(HttpRequest, Any), (Try[HttpResponse], Any), NotUsed]
+  type Client = Flow[(HttpRequest, AccessLogger), (Try[HttpResponse], AccessLogger), NotUsed]
+  type SimpleClient = Flow[HttpRequest, Try[HttpResponse], NotUsed]
 
   type SourcesAndGroups = (DataSources, EurekaSource.Groups)
 

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookupSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookupSuite.scala
@@ -23,6 +23,7 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
+import com.netflix.atlas.akka.AccessLogger
 import com.netflix.atlas.json.Json
 import com.typesafe.config.ConfigFactory
 import org.scalatest.FunSuite
@@ -80,7 +81,7 @@ class EurekaGroupsLookupSuite extends FunSuite {
   }
 
   private def run(input: List[DataSources], n: Int = 1): List[SourcesAndGroups] = {
-    val client = Flow[(HttpRequest, Any)]
+    val client = Flow[(HttpRequest, AccessLogger)]
       .map {
         case (req, v) =>
           val json = Json.encode(eurekaGroup)

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaSourceSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaSourceSuite.scala
@@ -18,7 +18,6 @@ package com.netflix.atlas.eval.stream
 import java.io.IOException
 import java.nio.charset.StandardCharsets
 
-import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.model.HttpRequest
@@ -96,7 +95,7 @@ class EurekaSourceSuite extends FunSuite {
   private implicit val mat = ActorMaterializer()
 
   private def run(uri: String, response: Try[HttpResponse]): GroupResponse = {
-    val client = Flow[(HttpRequest, Any)].map(_ => response -> NotUsed)
+    val client = Flow[HttpRequest].map(_ => response)
     val future = EurekaSource(uri, client).runWith(Sink.head)
     Await.result(future, Duration.Inf)
   }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/HostSourceSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/HostSourceSuite.scala
@@ -51,7 +51,7 @@ class HostSourceSuite extends FunSuite {
   implicit val materializer = ActorMaterializer()
 
   def source(response: => Try[HttpResponse]): Source[ByteString, NotUsed] = {
-    val client = Flow[(HttpRequest, Any)].map(_ => response -> NotUsed)
+    val client = Flow[HttpRequest].map(_ => response)
     HostSource("http://localhost/api/test", client = client, delay = 1.milliseconds)
   }
 

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/SubscriptionManagerSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/SubscriptionManagerSuite.scala
@@ -26,6 +26,7 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
+import com.netflix.atlas.akka.AccessLogger
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfter
 import org.scalatest.FunSuite
@@ -96,7 +97,7 @@ class SubscriptionManagerSuite extends FunSuite with BeforeAndAfter {
   private val requests = new ConcurrentLinkedQueue[HttpRequest]()
 
   private def run(input: List[SourcesAndGroups]): Unit = {
-    val client = Flow[(HttpRequest, Any)]
+    val client = Flow[(HttpRequest, AccessLogger)]
       .map {
         case (req, v) =>
           requests.add(req)


### PR DESCRIPTION
Use access logger for all client requests made
during the eval.