### PR TITLE
add configuration option for allowed cors origins

### DIFF
--- a/atlas-akka/src/main/resources/reference.conf
+++ b/atlas-akka/src/main/resources/reference.conf
@@ -21,6 +21,15 @@ atlas.akka {
     "com.netflix.atlas.akka.StaticPages"
   ]
 
+  # Hosts that are allowed to make cross origin requests
+  # 1. '*' match any host
+  # 2. Starts with '.', indicates a sub-domain, for example `.netflix.com`. The origin must
+  #    end with the exact string.
+  # 3. Otherwise the hostname for the origin must match an entry exactly.
+  #
+  # An empty list means that CORS headers will not be added.
+  cors-host-patterns = ["*"]
+
   # Settings for the StaticPages API
   static {
     # Default page to redirect to when hitting /

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/CustomDirectivesSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/CustomDirectivesSuite.scala
@@ -27,21 +27,27 @@ import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit.RouteTestTimeout
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.util.ByteString
 import com.netflix.atlas.json.Json
 import org.scalatest.FunSuite
+
+import scala.concurrent.duration._
 
 class CustomDirectivesSuite extends FunSuite with ScalatestRouteTest {
 
   import CustomDirectives._
   import CustomDirectivesSuite._
 
+  // Some of the tests were a bit flakey with default of 1 second on slower machines
+  implicit val timeout = RouteTestTimeout(5.seconds)
+
   class TestService(val actorRefFactory: ActorRefFactory) {
 
     def routes: Route = {
       accessLog {
-        corsFilter {
+        respondWithCorsHeaders(List("*")) {
           jsonpFilter {
             path("text") {
               get {
@@ -215,6 +221,8 @@ class CustomDirectivesSuite extends FunSuite with ScalatestRouteTest {
           assert("http://localhost" === v.toString)
         case `Access-Control-Allow-Methods`(vs) =>
           assert("GET,PATCH,POST,PUT,DELETE" === vs.map(_.name()).mkString(","))
+        case `Access-Control-Allow-Credentials`(v) =>
+          assert(v)
         case h if h.is("vary") =>
           assert(h.value === "Origin")
         case h =>
@@ -237,6 +245,8 @@ class CustomDirectivesSuite extends FunSuite with ScalatestRouteTest {
           assert("GET,PATCH,POST,PUT,DELETE" === vs.map(_.name()).mkString(","))
         case `Access-Control-Expose-Headers`(vs) =>
           assert("foo" === vs.mkString(","))
+        case `Access-Control-Allow-Credentials`(v) =>
+          assert(v)
         case h if h.is("vary") =>
           assert(h.value === "Origin")
         case h if h.lowercaseName == "foo" =>
@@ -262,6 +272,8 @@ class CustomDirectivesSuite extends FunSuite with ScalatestRouteTest {
           assert("GET,PATCH,POST,PUT,DELETE" === vs.map(_.name()).mkString(","))
         case `Access-Control-Allow-Headers`(vs) =>
           assert("foo" === vs.mkString(","))
+        case `Access-Control-Allow-Credentials`(v) =>
+          assert(v)
         case h if h.is("vary") =>
           assert(h.value === "Origin")
         case h =>
@@ -283,6 +295,8 @@ class CustomDirectivesSuite extends FunSuite with ScalatestRouteTest {
           assert("*" === v.toString)
         case `Access-Control-Allow-Methods`(vs) =>
           assert("GET,PATCH,POST,PUT,DELETE" === vs.map(_.name()).mkString(","))
+        case `Access-Control-Allow-Credentials`(v) =>
+          assert(v)
         case h if h.is("vary") =>
           assert(h.value === "Origin")
         case h =>
@@ -305,6 +319,8 @@ class CustomDirectivesSuite extends FunSuite with ScalatestRouteTest {
           assert("GET,PATCH,POST,PUT,DELETE" === vs.map(_.name()).mkString(","))
         case `Access-Control-Expose-Headers`(vs) =>
           assert("Vary" === vs.mkString(","))
+        case `Access-Control-Allow-Credentials`(v) =>
+          assert(v)
         case h if h.is("vary") =>
           assert(Set("Origin", "Host").contains(h.value))
         case h =>
@@ -325,6 +341,8 @@ class CustomDirectivesSuite extends FunSuite with ScalatestRouteTest {
           assert("http://localhost" === v.toString)
         case `Access-Control-Allow-Methods`(vs) =>
           assert("GET,PATCH,POST,PUT,DELETE" === vs.map(_.name()).mkString(","))
+        case `Access-Control-Allow-Credentials`(v) =>
+          assert(v)
         case h if h.is("vary") =>
           assert(h.value === "Origin")
         case h =>
@@ -344,6 +362,8 @@ class CustomDirectivesSuite extends FunSuite with ScalatestRouteTest {
           assert("http://localhost" === v.toString)
         case `Access-Control-Allow-Methods`(vs) =>
           assert("GET,PATCH,POST,PUT,DELETE" === vs.map(_.name()).mkString(","))
+        case `Access-Control-Allow-Credentials`(v) =>
+          assert(v)
         case h if h.is("vary") =>
           assert(h.value === "Origin")
         case h =>


### PR DESCRIPTION
Adds the `atlas.akka.cors-host-patterns` setting that can
be used to set an eplicit whitelist of origins that are
allowed to receive CORS headers.

Also adds `Access-Control-Allow-Credentials` for use-cases
that need to work with cookies.