### PR TITLE
improve performance for bulk subscribe

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
@@ -77,8 +77,9 @@ class SubscribeApi @Inject()(
         val splits = splitter.split(expr.expression, expr.frequency)
 
         // Add any new expressions
+        val ref = sm.subscribe(streamId, splits)
         splits.foreach { sub =>
-          sm.subscribe(streamId, sub) ! SSESubscribe(expr.expression, List(sub.metadata))
+          ref ! SSESubscribe(expr.expression, List(sub.metadata))
         }
 
         // Add expression ids in use by this split

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
@@ -124,8 +124,17 @@ class SubscriptionManager[T] {
     * Start sending data for the subscription to the given stream id.
     */
   def subscribe(streamId: String, sub: Subscription): T = synchronized {
+    subscribe(streamId, List(sub))
+  }
+
+  /**
+    * Start sending data for the subscription to the given stream id.
+    */
+  def subscribe(streamId: String, subs: List[Subscription]): T = synchronized {
     val info = getInfo(streamId)
-    info.subs.put(sub.metadata.id, sub)
+    subs.foreach { sub =>
+      info.subs.put(sub.metadata.id, sub)
+    }
     updateSubHandlers()
     info.handler
   }


### PR DESCRIPTION
When creating a subscription with many expressions, the
`updateSubHandlers()` method in the subscription manager
is quite expensive. Before, the subscribe api would end
up calling this once per expression, now it will only
call it once.

/cc @ruchirj 