### PR TITLE
reduce thread contention in SubscriptionManager

### DIFF
--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
@@ -15,6 +15,8 @@
  */
 package com.netflix.atlas.lwcapi
 
+import akka.actor.Actor
+import akka.actor.Props
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.testkit.RouteTestTimeout
@@ -26,6 +28,13 @@ class ExpressionApiSuite extends FunSuite with ScalatestRouteTest {
   import scala.concurrent.duration._
 
   private implicit val routeTestTimeout = RouteTestTimeout(5.second)
+
+  // Dummy actor ref used for handler
+  private val ref = system.actorOf(Props(new Actor {
+    override def receive: Receive = {
+      case _ =>
+    }
+  }))
 
   val splitter = new ExpressionSplitter()
 
@@ -67,7 +76,7 @@ class ExpressionApiSuite extends FunSuite with ScalatestRouteTest {
 
   test("has data") {
     val splits = splitter.split("nf.cluster,skan,:eq,:avg", 60000)
-    sm.register("a", null)
+    sm.register("a", ref)
     splits.foreach { s =>
       sm.subscribe("a", s)
     }
@@ -80,7 +89,7 @@ class ExpressionApiSuite extends FunSuite with ScalatestRouteTest {
 
   test("fetch all with data") {
     val splits = splitter.split("nf.cluster,skan,:eq,:avg,nf.app,brh,:eq,:max", 60000)
-    sm.register("a", null)
+    sm.register("a", ref)
     splits.foreach { s =>
       sm.subscribe("a", s)
     }


### PR DESCRIPTION
Refactors the subscription manager to make the updates
cheaper and minimize the synchronization that is needed.
Now the only synchronization is to ensure the that the
cleanup for the sub handlers map will not have a race
condition with adding new handlers.

This change also avoids the more costly computation of
the subscription handlers from the registration map. On
a test node with real traffic it significantly reduced
the CPU and thread contention observed.

/cc @ruchirj 