### PR TITLE
add counters tracking the number of events

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapoint.scala
@@ -60,7 +60,7 @@ private[stream] class LwcToAggrDatapoint extends GraphStage[FlowShape[String, Ag
       private def updateState(msg: String): Unit = {
         val json = msg.substring(subscribePrefix.length)
         val sub = Json.decode[LwcSubscription](json)
-        state = sub.metrics.map(m => m.id -> m.expr).toMap
+        state ++= sub.metrics.map(m => m.id -> m.expr).toMap
         pull(in)
       }
 

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -33,7 +33,6 @@ import com.netflix.atlas.akka.DiagnosticMessage
 import com.netflix.atlas.core.util.Streams
 import com.netflix.atlas.eval.stream.Evaluator.DataSource
 import com.netflix.atlas.eval.stream.Evaluator.DataSources
-import com.netflix.spectator.api.Counter
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.api.Registry
 import com.typesafe.config.Config


### PR DESCRIPTION
Tracks the number of events seen during various phases
of the evaluation pipeline. The phase id is prefixed
so the group by will be ordered in the same manner as
they occur in the flow.