### PR TITLE
explicit error for unsupported expressions

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
@@ -35,6 +35,20 @@ private[stream] object ExprInterpreter {
     val expr = uri.query().get("q").getOrElse {
       throw new IllegalArgumentException(s"missing required URI parameter `q`: $uri")
     }
-    eval(expr)
+
+    // Check that data expressions are supported. The streaming path doesn't support
+    // time shifts.
+    val results = eval(expr)
+    results.foreach { result =>
+      result.expr.dataExprs.foreach { dataExpr =>
+        if (!dataExpr.offset.isZero) {
+          throw new IllegalArgumentException(
+            s":offset not supported for streaming evaluation [[$dataExpr]]"
+          )
+        }
+      }
+    }
+
+    results
   }
 }

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionSplitter.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionSplitter.scala
@@ -67,6 +67,16 @@ class ExpressionSplitter {
       case ModelExtractors.PresentationType(t) => t.expr.dataExprs
       case _                                   => throw new IllegalArgumentException("expression is invalid")
     }
+
+    // Offsets are not supported
+    dataExprs.foreach { dataExpr =>
+      if (!dataExpr.offset.isZero) {
+        throw new IllegalArgumentException(
+          s":offset not supported for streaming evaluation [[$dataExpr]]"
+        )
+      }
+    }
+
     dataExprs.distinct.map { e =>
       val q = intern(compress(e.dataExprs.head.query))
       Subscription(q, ExpressionMetadata(e.toString, frequency))

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionSplitterSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionSplitterSuite.scala
@@ -49,11 +49,19 @@ class ExpressionSplitterSuite extends FunSuite {
     )
   }
 
-  test("returns None for invalid expressions") {
+  test("throws IAE for invalid expressions") {
     val msg = intercept[IllegalArgumentException] {
       splitter.split("foo", frequency1)
     }
     assert(msg.getMessage === "expression is invalid")
+  }
+
+  test("throws IAE for expressions with offset") {
+    val expr = "name,foo,:eq,:sum,PT168H,:offset"
+    val msg = intercept[IllegalArgumentException] {
+      splitter.split(expr, frequency1)
+    }
+    assert(msg.getMessage === s":offset not supported for streaming evaluation [[$expr]]")
   }
 
   //


### PR DESCRIPTION
Some operations like `:offset` are not supported when
performing a streaming evaluaton. These will now result
in an error for that expression being propagated back
to the user.

/cc @ruchirj 