### PR TITLE
remove handlers when a stream is unregistered

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SSEActor.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SSEActor.scala
@@ -24,7 +24,6 @@ import akka.actor.Cancellable
 import akka.http.scaladsl.model.HttpEntity.ChunkStreamPart
 import akka.stream.actor.ActorPublisher
 import akka.stream.actor.ActorPublisherMessage._
-import com.netflix.atlas.lwcapi.StreamApi.SSESubscribe
 import com.netflix.iep.NetflixEnvironment
 import com.netflix.spectator.api.Registry
 

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
@@ -104,7 +104,12 @@ class SubscriptionManager[T] {
     * removed.
     */
   def unregister(streamId: String): Option[T] = {
-    val result = Option(registrations.remove(streamId)).map(_.handler)
+    val result = Option(registrations.remove(streamId)).map { info =>
+      info.subscriptions.foreach { sub =>
+        removeHandler(sub.metadata.id, info.handler)
+      }
+      info.handler
+    }
     queryListChanged = true
     result
   }

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
@@ -135,9 +135,9 @@ class SubscriptionManagerSuite extends FunSuite {
 
     val s = sub("name,exp1,:eq")
     sm.subscribe("a", s)
-    assert(sm.handlersForSubscription(s.metadata.id).sorted === List(1))
+    assert(sm.handlersForSubscription(s.metadata.id) === List(1))
 
     sm.unregister("a")
-    assert(sm.handlersForSubscription(s.metadata.id).sorted === Nil)
+    assert(sm.handlersForSubscription(s.metadata.id) === Nil)
   }
 }

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
@@ -118,7 +118,7 @@ class SubscriptionManagerSuite extends FunSuite {
     }
   }
 
-  test("unsubscript for unknown expression does not cause any exceptions") {
+  test("unsubscribe for unknown expression does not cause any exceptions") {
     val sm = new SubscriptionManager[Integer]()
     sm.register("a", 42)
     sm.unsubscribe("a", "d")
@@ -127,5 +127,17 @@ class SubscriptionManagerSuite extends FunSuite {
   test("unregister for unknown stream does not cause any exceptions") {
     val sm = new SubscriptionManager[Integer]()
     assert(sm.unregister("a") === None)
+  }
+
+  test("unregister should remove handlers") {
+    val sm = new SubscriptionManager[Integer]()
+    sm.register("a", 1)
+
+    val s = sub("name,exp1,:eq")
+    sm.subscribe("a", s)
+    assert(sm.handlersForSubscription(s.metadata.id).sorted === List(1))
+
+    sm.unregister("a")
+    assert(sm.handlersForSubscription(s.metadata.id).sorted === Nil)
   }
 }


### PR DESCRIPTION
Before when the stream went away the map for the subscription
to the handler was not getting cleaned up.