### PR TITLE
fix propagation of needsUnregister for shutdown

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SSEActor.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SSEActor.scala
@@ -94,6 +94,7 @@ class SSEActor(
       log.info(s"Closing SSE stream: ${msg.reason}")
       enqueue(msg, diagnosticMessages)
       shutdown = true
+      needsUnregister = msg.shouldUnregister
     case msg: SSEMessage =>
       enqueue(msg, messages)
   }


### PR DESCRIPTION
This needs a bit more work and consideration, but the
change here resolves the most common and easy to reproduce
problem. When a new connection comes in with an id that
is already in use, it will replace the previous connection
and that stream is unregistered before setting up the
registration for the new connection stream. This creates
a race condition:

1. GET /stream/id
    1. unregister(id), noop nothing present for id
    2. register(id)
2. GET /stream/id
    1. unregister(id), removes the previous and shutsdown
       the connection
    2. register(id), sets up new registration
    3. SSEActor.postStop -> unregister(id), unregisters the
       newly created actor

With this change the postStop method for SSEActor will not
attempt to unregister again because we know it has already
been unregistered.