### PR TITLE
fix #646, make compatible with jackson 2.9

### DIFF
--- a/atlas-json/src/main/scala/com/netflix/atlas/json/CaseClassDeserializer.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/CaseClassDeserializer.scala
@@ -71,7 +71,7 @@ class CaseClassDeserializer(
 
     val t = p.getCurrentToken
     if (t != JsonToken.START_OBJECT) {
-      ctxt.reportMappingException(s"found ${t.name()}, but START_OBJECT is required")
+      ctxt.handleUnexpectedToken(javaType.getRawClass, p)
     }
 
     p.nextToken()

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Reflection.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Reflection.scala
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.`type`.TypeReference
 import com.fasterxml.jackson.databind.BeanProperty
 import com.fasterxml.jackson.databind.JavaType
+import com.fasterxml.jackson.databind.PropertyMetadata
 import com.fasterxml.jackson.databind.PropertyName
 import com.fasterxml.jackson.databind.`type`.TypeFactory
 import com.fasterxml.jackson.databind.introspect.AnnotatedParameter
@@ -166,15 +167,14 @@ private[json] object Reflection {
           val am = new AnnotationMap
           annos(i).foreach(am.add)
           val fieldType = constructType(types(i))
-          val ap = new AnnotatedParameter(null, fieldType, am, i)
+          val ap = new AnnotatedParameter(null, fieldType, null, am, i)
           val prop = new BeanProperty.Std(
             new PropertyName(p.name),
             fieldType,
             null, // wrapperName
-            null, // contextAnnotations
             ap, // member
-            null
-          ) // metadata
+            PropertyMetadata.STD_REQUIRED_OR_OPTIONAL
+          )
           properties(i) = prop
       }
       properties

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
     val aws        = "1.11.185"
     val iep        = "1.0.4"
     val guice      = "4.1.0"
-    val jackson    = "2.8.9"
+    val jackson    = "2.9.1"
     val log4j      = "2.9.0"
     val scala      = "2.12.3"
     val slf4j      = "1.7.25"


### PR DESCRIPTION
The constructor for AnnotatedParameter now takes another
parameter. Also the PropertyMetadata for a BeanProperty
needs to be set or we get NPE in the test cases. A few
other changes were made to clear up deprecation warnings.