### PR TITLE
add RollingInterval utility

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/RollingInterval.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/RollingInterval.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import java.time.Duration
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+/**
+  * Interval that moves over time in increments of a given unit. When in the middle of
+  * a unit it will round to the next even boundary. For example, if the unit is HOURS
+  * and it is 10:37, then it will round too 11:00.
+  *
+  * The offset and duration must be an even multiple of the unit.
+  *
+  * @param offset
+  *     Offset subtracted from the current time, `now - offset` is used as the end
+  *     time for this interval.
+  * @param duration
+  *     The length of the interval. The start time is `now - offset - duration`.
+  * @param unit
+  *     The unit to use when moving along. This is typically HOURS or DAYS.
+  */
+case class RollingInterval(offset: Duration, duration: Duration, unit: ChronoUnit) {
+
+  import RollingInterval._
+
+  checkParams(offset, duration, unit)
+
+  /** Current end time for this interval. */
+  def end: Instant = ceil(Instant.now(), unit).minus(offset)
+
+  /** Current start time for this interval. */
+  def start: Instant = end.minus(duration)
+
+  private def currentRange: (Long, Long) = {
+    val e = end
+    val s = e.minus(duration)
+    s.toEpochMilli -> e.toEpochMilli
+  }
+
+  /** Returns true if the instant is currently within this interval. */
+  def contains(instant: Instant): Boolean = {
+    val t = instant.toEpochMilli
+    val (s, e) = currentRange
+    s <= t && t <= e
+  }
+
+  private def isContainedBy(s: Instant, e: Instant): Boolean = {
+    val s1 = s.toEpochMilli
+    val e1 = e.toEpochMilli
+    val (s2, e2) = currentRange
+    s1 < s2 && e1 > e2
+  }
+
+  /** Returns true if the interval [s, e] overlaps with this interval. */
+  def overlaps(s: Instant, e: Instant): Boolean = {
+    contains(s) || contains(e) || isContainedBy(s, e)
+  }
+}
+
+object RollingInterval {
+
+  /**
+    * Create a new interval from a string representation. The string value should have the
+    * format: `offset,duration,unit`. Offset and duration will be parsed by using the
+    * Strings.parseDuration helper. Unit should be `HOURS` or `DAYS`.
+    */
+  def apply(interval: String): RollingInterval = {
+    val parts = interval.split("\\s*,\\s*")
+    require(parts.length == 3, s"invalid rolling interval: $interval")
+    val s = Strings.parseDuration(parts(0))
+    val e = Strings.parseDuration(parts(1))
+    val unit = ChronoUnit.valueOf(parts(2))
+    RollingInterval(s, e, unit)
+  }
+
+  private def checkParams(offset: Duration, duration: Duration, unit: ChronoUnit): Unit = {
+    val unitDuration = Duration.of(1, unit)
+    require(duration.toMillis >= unitDuration.toMillis, s"duration $duration <= $unitDuration")
+
+    require(offset.toMillis % unitDuration.toMillis == 0, s"offset must be multiple of $unit")
+    require(duration.toMillis % unitDuration.toMillis == 0, s"duration must be multiple of $unit")
+  }
+
+  private[util] def ceil(t: Instant, unit: ChronoUnit): Instant = {
+    val truncated = t.truncatedTo(unit)
+    if (truncated == t) t else truncated.plus(1, unit)
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/RollingIntervalSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/RollingIntervalSuite.scala
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import java.time.Duration
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+import org.scalatest.FunSuite
+
+class RollingIntervalSuite extends FunSuite {
+
+  test("ceil should not round up if on exact boundary") {
+    val expected = Instant.parse("2007-12-03T10:00:00.00Z")
+    val t = Instant.parse("2007-12-03T10:00:00.00Z")
+    assert(RollingInterval.ceil(t, ChronoUnit.HOURS) === expected)
+  }
+
+  test("ceil should round up to next boundary MINUTES") {
+    val expected = Instant.parse("2007-12-03T10:16:00.00Z")
+    val t = Instant.parse("2007-12-03T10:15:30.00Z")
+    assert(RollingInterval.ceil(t, ChronoUnit.MINUTES) === expected)
+  }
+
+  test("ceil should round up to next boundary HOURS") {
+    val expected = Instant.parse("2007-12-03T11:00:00.00Z")
+    val t = Instant.parse("2007-12-03T10:15:30.00Z")
+    assert(RollingInterval.ceil(t, ChronoUnit.HOURS) === expected)
+  }
+
+  test("ceil should round up to next boundary DAYS") {
+    val expected = Instant.parse("2007-12-04T00:00:00.00Z")
+    val t = Instant.parse("2007-12-03T10:15:30.00Z")
+    assert(RollingInterval.ceil(t, ChronoUnit.DAYS) === expected)
+  }
+
+  test("from string") {
+    val expected = RollingInterval(Duration.ZERO, Duration.ofDays(4), ChronoUnit.HOURS)
+    val actual = RollingInterval("0h,4d,HOURS")
+    assert(actual === expected)
+  }
+
+  test("from string, missing unit") {
+    val e = intercept[IllegalArgumentException] {
+      RollingInterval("0h,4d")
+    }
+    assert(e.getMessage.contains("invalid rolling interval: 0h,4d"))
+  }
+
+  test("from string, invalid unit") {
+    val e = intercept[IllegalArgumentException] {
+      RollingInterval("0h,4d,foo")
+    }
+    assert(e.getMessage.contains("No enum constant"))
+  }
+
+  test("from string, invalid duration") {
+    val e = intercept[IllegalArgumentException] {
+      RollingInterval("foo,4d,HOURS")
+    }
+    assert(e.getMessage.contains("invalid period foo"))
+  }
+
+  test("duration is less than 1 unit") {
+    val e = intercept[IllegalArgumentException] {
+      RollingInterval(Duration.ZERO, Duration.ZERO, ChronoUnit.DAYS)
+    }
+    assert(e.getMessage.contains("duration PT0S <= PT24H"))
+  }
+
+  test("offset is not multiple of unit") {
+    val e = intercept[IllegalArgumentException] {
+      RollingInterval(Duration.ofHours(3), Duration.ofDays(4), ChronoUnit.DAYS)
+    }
+    assert(e.getMessage.contains("offset must be multiple of Days"))
+  }
+
+  test("duration is not multiple of unit") {
+    val e = intercept[IllegalArgumentException] {
+      RollingInterval(Duration.ZERO, Duration.ofHours(47), ChronoUnit.DAYS)
+    }
+    assert(e.getMessage.contains("duration must be multiple of Days"))
+  }
+
+  test("contains start") {
+    val interval = RollingInterval(Duration.ofDays(3), Duration.ofDays(1), ChronoUnit.DAYS)
+    assert(interval.contains(interval.start))
+  }
+
+  test("contains end") {
+    val interval = RollingInterval(Duration.ofDays(3), Duration.ofDays(1), ChronoUnit.DAYS)
+    assert(interval.contains(interval.end))
+  }
+
+  test("contains times between start and end") {
+    val interval = RollingInterval(Duration.ofDays(3), Duration.ofDays(1), ChronoUnit.DAYS)
+    assert(interval.contains(interval.start.plusMillis(1)))
+  }
+
+  test("does not contain times before start") {
+    val interval = RollingInterval(Duration.ofDays(3), Duration.ofDays(1), ChronoUnit.DAYS)
+    assert(!interval.contains(interval.start.minusMillis(1)))
+  }
+
+  test("does not contain times after end") {
+    val interval = RollingInterval(Duration.ofDays(3), Duration.ofDays(1), ChronoUnit.DAYS)
+    assert(!interval.contains(interval.end.plusMillis(1)))
+  }
+
+  test("overlaps start") {
+    val s = Instant.now().minus(4, ChronoUnit.DAYS)
+    val interval = RollingInterval(Duration.ofDays(3), Duration.ofDays(2), ChronoUnit.DAYS)
+    assert(interval.overlaps(s, s.plus(2, ChronoUnit.DAYS)))
+  }
+
+  test("overlaps start exact") {
+    val interval = RollingInterval(Duration.ofDays(3), Duration.ofDays(2), ChronoUnit.DAYS)
+    val s = interval.start
+    assert(interval.overlaps(s, s.plus(2, ChronoUnit.DAYS)))
+  }
+
+  test("overlaps end") {
+    val e = Instant.now().minus(4, ChronoUnit.DAYS)
+    val interval = RollingInterval(Duration.ofDays(3), Duration.ofDays(2), ChronoUnit.DAYS)
+    assert(interval.overlaps(e.minus(2, ChronoUnit.DAYS), e))
+  }
+
+  test("overlaps end exact") {
+    val interval = RollingInterval(Duration.ofDays(3), Duration.ofDays(2), ChronoUnit.DAYS)
+    val e = interval.end
+    assert(interval.overlaps(e.minus(2, ChronoUnit.DAYS), e))
+  }
+
+  test("overlaps start and end") {
+    val s = Instant.now().minus(4, ChronoUnit.DAYS)
+    val interval = RollingInterval(Duration.ofDays(3), Duration.ofDays(2), ChronoUnit.DAYS)
+    assert(interval.overlaps(s, s.plus(2, ChronoUnit.HOURS)))
+  }
+
+  test("overlaps start and end exact") {
+    val interval = RollingInterval(Duration.ofDays(3), Duration.ofDays(2), ChronoUnit.DAYS)
+    assert(interval.overlaps(interval.start, interval.end))
+  }
+
+  test("overlaps when contained by interval") {
+    val interval = RollingInterval(Duration.ofDays(3), Duration.ofDays(2), ChronoUnit.DAYS)
+    assert(interval.overlaps(interval.start.minusSeconds(1), interval.end.plusSeconds(1)))
+  }
+
+  test("does not overlap when start is after end") {
+    val interval = RollingInterval(Duration.ofDays(3), Duration.ofDays(2), ChronoUnit.DAYS)
+    val e = interval.end
+    assert(!interval.overlaps(e.plus(1, ChronoUnit.DAYS), e.plus(2, ChronoUnit.DAYS)))
+  }
+
+  test("does not overlap when end is before start") {
+    val interval = RollingInterval(Duration.ofDays(3), Duration.ofDays(2), ChronoUnit.DAYS)
+    val s = interval.start
+    assert(!interval.overlaps(s.minus(2, ChronoUnit.DAYS), s.minus(1, ChronoUnit.DAYS)))
+  }
+}


### PR DESCRIPTION
This is being moved over from internal use. It is used for
keeping track of the set of data that should be loaded on
the historical clusters that read from s3.