### PR TITLE
fix possible buffer overflow for refreshing groups

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluationFlows.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluationFlows.scala
@@ -78,6 +78,18 @@ private[stream] object EvaluationFlows {
   }
 
   /**
+    * Source that will repeat the item with the specified delay in between while the
+    * condition is still true.
+    */
+  def repeatWhile[T](item: T, delay: FiniteDuration, condition: => Boolean): Source[T, NotUsed] = {
+    val iterator = new Iterator[T] {
+      override def hasNext: Boolean = condition
+      override def next(): T = item
+    }
+    Source.fromIterator(() => iterator).throttle(1, delay, 1, ThrottleMode.Shaping)
+  }
+
+  /**
     * Frames an SSE stream by new line. This is to ensure that a message is not broken
     * up in the middle. The LF is used instead of CRLF because some SSE sources are more
     * lax.

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -215,6 +215,8 @@ private[stream] abstract class EvaluatorImpl(
       // `POST /lwc/api/v1/subscribe` to update the set of subscriptions being sent
       // to each connection
       val eurekaLookup = Flow[DataSources]
+        .conflate((_, ds) => ds)
+        .throttle(1, 1.second, 1, ThrottleMode.Shaping)
         .via(context.countEvents("00_DataSourceUpdates"))
         .via(new EurekaGroupsLookup(context, 30.seconds))
         .via(context.countEvents("01_EurekaGroups"))


### PR DESCRIPTION
The EurekaGroupsLookup stage creates a source to regularly
refresh the set of Eureka vips that are needed based on the
requested data sources. When a new set of data sources comes
in, it will stop the old source and create a new one.

The problem is when a new set of data sources comes in quickly
it could stop the source refreshing Eureka groups after the
request was made and before the response was processed. In
this scenario the `max-open-requests` limit would eventually
be reached and all subsequent requests would fail.

There are two changes included here:

1. Before the source was stopped using a `takeWhile` operator
   at a later stage. Now it is stopped by changing the source
   to indicate it is done and no longer has data. This means
   that the subsequent stages of the flow should go ahead and
   run and so the response body of any outstanding requests will
   get processed. The BufferOverflowException is still possible
   with just this change if too many changes occur in a short
   period, however, they will eventually clear up if the rate
   goes down.
2. The input is now throttled and conflated so that if many
   changes to the set of data sources come in a short window
   all but the last will get ignored.