### PR TITLE
update to spectator 0.58.1

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/BlockStore.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/BlockStore.scala
@@ -21,15 +21,23 @@ import java.util.concurrent.atomic.AtomicLong
 import com.netflix.atlas.core.model._
 import com.netflix.atlas.core.util.ArrayHelper
 import com.netflix.spectator.api.Spectator
+import com.netflix.spectator.api.patterns.PolledMeter
 
 object BlockStats {
   private val registry = Spectator.globalRegistry
-  private val arrayCount = registry.gauge("atlas.block.arrayCount", new AtomicLong(0L))
-  private val constantCount = registry.gauge("atlas.block.constantCount", new AtomicLong(0L))
-  private val sparseCount = registry.gauge("atlas.block.sparseCount", new AtomicLong(0L))
-  private val arrayBytes = registry.gauge("atlas.block.arrayBytes", new AtomicLong(0L))
-  private val constantBytes = registry.gauge("atlas.block.constantBytes", new AtomicLong(0L))
-  private val sparseBytes = registry.gauge("atlas.block.sparseBytes", new AtomicLong(0L))
+  private val arrayCount = createGauge("atlas.block.arrayCount")
+  private val constantCount = createGauge("atlas.block.constantCount")
+  private val sparseCount = createGauge("atlas.block.sparseCount")
+  private val arrayBytes = createGauge("atlas.block.arrayBytes")
+  private val constantBytes = createGauge("atlas.block.constantBytes")
+  private val sparseBytes = createGauge("atlas.block.sparseBytes")
+
+  private def createGauge(name: String): AtomicLong = {
+    PolledMeter
+      .using(registry)
+      .withName(name)
+      .monitorValue(new AtomicLong(0L))
+  }
 
   private def inc(block: Block, count: AtomicLong, bytes: AtomicLong): Unit = {
     count.incrementAndGet

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SSEActor.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SSEActor.scala
@@ -26,6 +26,7 @@ import akka.stream.actor.ActorPublisher
 import akka.stream.actor.ActorPublisherMessage._
 import com.netflix.iep.NetflixEnvironment
 import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.patterns.PolledMeter
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -50,7 +51,10 @@ class SSEActor(
   private val droppedId = registry.createId("atlas.lwcapi.sse.droppedMessageCount")
 
   private val sseCountId = registry.createId("atlas.lwcapi.streams").withTag("streamType", "sse")
-  private val sseCount = registry.gauge(sseCountId, new AtomicInteger(1))
+  private val sseCount = PolledMeter
+    .using(registry)
+    .withId(sseCountId)
+    .monitorValue(new AtomicInteger(1))
 
   private var droppedMessageCount: Long = 0 // in messages
 

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalPublishActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalPublishActor.scala
@@ -35,6 +35,7 @@ import com.netflix.atlas.core.validation.ValidationResult
 import com.netflix.spectator.api.Registry
 import com.netflix.spectator.api.histogram.BucketCounter
 import com.netflix.spectator.api.histogram.BucketFunctions
+import com.netflix.spectator.api.patterns.PolledMeter
 
 class LocalPublishActor(registry: Registry, db: Database) extends Actor with ActorLogging {
 
@@ -116,7 +117,10 @@ object LocalPublishActor {
     }
 
     // Track the size of the message ids buffer
-    registry.mapSize("atlas.db.messageIdSetSize", messageIds)
+    PolledMeter
+      .using(registry)
+      .withName("atlas.db.messageIdSetSize")
+      .monitorSize(messageIds)
 
     // Number of datapoints that are deduped
     private val numDeduped = registry.counter("atlas.db.numDeduped")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,13 +7,13 @@ object Dependencies {
     val akka       = "2.5.6"
     val akkaHttpV  = "10.0.10"
     val aws        = "1.11.185"
-    val iep        = "1.0.4"
+    val iep        = "1.1.0"
     val guice      = "4.1.0"
     val jackson    = "2.9.1"
     val log4j      = "2.9.1"
     val scala      = "2.12.3"
     val slf4j      = "1.7.25"
-    val spectator  = "0.57.1"
+    val spectator  = "0.58.1"
 
     val crossScala = Seq(scala)
   }


### PR DESCRIPTION
Updates the version and fixes the new deprecation
warnings for gauges.