### PR TITLE
add dependency on jsr250

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ lazy val `atlas-akka` = project
     Dependencies.akkaSlf4j,
     Dependencies.akkaStream,
     Dependencies.iepService,
+    Dependencies.jsr250,
     Dependencies.spectatorSandbox,
     Dependencies.akkaHttp,
     Dependencies.typesafeConfig,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -49,6 +49,7 @@ object Dependencies {
   val jacksonSmile2   = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-smile" % jackson
   val jodaConvert     = "org.joda" % "joda-convert" % "1.8.3"
   val jol             = "org.openjdk.jol" % "jol-core" % "0.9"
+  val jsr250          = "javax.annotation" % "jsr250-api" % "1.0"
   val jsr305          = "com.google.code.findbugs" % "jsr305" % "3.0.2"
   val log4jApi        = "org.apache.logging.log4j" % "log4j-api" % log4j
   val log4jCore       = "org.apache.logging.log4j" % "log4j-core" % log4j


### PR DESCRIPTION
In jdk9 the PostConstruct and PreDestroy annotations have
been moved to a deprecated module that has to be explicitly
enabled. Adding explicit dependency so that those classes
can be found and the start/stop methods on services will
be called correctly.