### PR TITLE
add datapoint counters for TimeGrouped operator

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -176,7 +176,7 @@ private[stream] abstract class EvaluatorImpl(
         .via(context.countEvents("10_InputLines"))
         .via(new LwcToAggrDatapoint)
         .via(context.countEvents("11_LwcDatapoints"))
-        .via(new TimeGrouped[AggrDatapoint](1, 50, _.timestamp))
+        .via(new TimeGrouped[AggrDatapoint](context, 1, 50, _.timestamp))
         .via(context.countEvents("12_GroupedDatapoints"))
 
       datasources.out(0) ~> intermediateEval ~> finalEvalInput.in(0)

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaSourceSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaSourceSuite.scala
@@ -37,7 +37,6 @@ import akka.util.ByteString
 import com.netflix.atlas.akka.AccessLogger
 import com.netflix.atlas.core.util.Streams
 import com.netflix.atlas.eval.stream.EurekaSource.GroupResponse
-import com.typesafe.config.ConfigFactory
 import org.scalatest.FunSuite
 
 import scala.concurrent.Await
@@ -98,13 +97,11 @@ class EurekaSourceSuite extends FunSuite {
   private implicit val system = ActorSystem(getClass.getSimpleName)
   private implicit val mat = ActorMaterializer()
 
-  private val config = ConfigFactory.parseString("backends = []")
-
   private def run(uri: String, response: Try[HttpResponse]): GroupResponse = {
     val client = Flow[(HttpRequest, AccessLogger)].map {
       case (_, logger) => response -> logger
     }
-    val context = new StreamContext(config, client, mat)
+    val context = TestContext.createContext(mat, client)
     val future = EurekaSource(uri, context).runWith(Sink.head)
     Await.result(future, Duration.Inf)
   }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/SubscriptionManagerSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/SubscriptionManagerSuite.scala
@@ -27,7 +27,6 @@ import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import com.netflix.atlas.akka.AccessLogger
-import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfter
 import org.scalatest.FunSuite
 
@@ -43,22 +42,6 @@ class SubscriptionManagerSuite extends FunSuite with BeforeAndAfter {
 
   private implicit val system = ActorSystem(getClass.getSimpleName)
   private implicit val mat = ActorMaterializer()
-
-  private val config =
-    ConfigFactory.parseString("""
-      |backends = [
-      |  {
-      |    host = "localhost"
-      |    eureka-uri = "http://localhost:7102/v2/vips/local-dev:7001"
-      |    instance-uri = "http://{host}:{port}"
-      |  },
-      |  {
-      |    host = "atlas"
-      |    eureka-uri = "http://eureka/v2/vips/atlas-lwcapi:7001"
-      |    instance-uri = "http://{host}:{port}"
-      |  }
-      |]
-    """.stripMargin)
 
   private val group1 = EurekaSource.VipResponse(
     uri = "http://eureka/v2/vips/atlas-lwcapi:7001",
@@ -103,7 +86,7 @@ class SubscriptionManagerSuite extends FunSuite with BeforeAndAfter {
           requests.add(req)
           Success(HttpResponse(StatusCodes.OK)) -> v
       }
-    val context = new StreamContext(config, client, mat)
+    val context = TestContext.createContext(mat, client)
     val sink = new SubscriptionManager(context)
     val future = Source(input).runWith(sink)
     Await.result(future, Duration.Inf)

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.StatusCodes
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Flow
+import com.netflix.atlas.akka.AccessLogger
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.ConfigFactory
+
+import scala.util.Success
+import scala.util.Try
+
+object TestContext {
+
+  private val config =
+    ConfigFactory.parseString("""
+      |backends = [
+      |  {
+      |    host = "localhost"
+      |    eureka-uri = "http://localhost:7102/v2/vips/local-dev:7001"
+      |    instance-uri = "http://{host}:{port}"
+      |  },
+      |  {
+      |    host = "atlas"
+      |    eureka-uri = "http://eureka/v2/vips/atlas-lwcapi:7001"
+      |    instance-uri = "http://{host}:{port}"
+      |  }
+      |]
+    """.stripMargin)
+
+  def createContext(
+    mat: ActorMaterializer,
+    client: Client = defaultClient,
+    registry: Registry = new NoopRegistry
+  ): StreamContext = {
+    new StreamContext(config, client, mat, registry)
+  }
+
+  def defaultClient: Client = client(HttpResponse(StatusCodes.OK))
+
+  def client(response: HttpResponse): Client = client(Success(response))
+
+  def client(result: Try[HttpResponse]): Client = {
+    Flow[(HttpRequest, AccessLogger)].map { case (_, v) => result -> v }
+  }
+}


### PR DESCRIPTION
Add counters to track how many datapoints are getting
dropped and buffered when going through the time grouped
stage.