### PR TITLE
fix #711, restrict limit when one list is empty

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/ListHelper.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/ListHelper.scala
@@ -48,9 +48,9 @@ object ListHelper {
     if (size == limit)
       acc.reverse
     else if (v1.isEmpty)
-      acc.reverse ++ v2
+      acc.reverse ++ v2.take(limit - size)
     else if (v2.isEmpty)
-      acc.reverse ++ v1
+      acc.reverse ++ v1.take(limit - size)
     else
       v1.head.compareTo(v2.head) match {
         case c if c < 0 =>

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/ListHelperSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/ListHelperSuite.scala
@@ -31,6 +31,30 @@ class ListHelperSuite extends FunSuite {
     assert(ListHelper.merge(2, v1, v2) === List("a", "b"))
   }
 
+  test("merge empty and sorted list") {
+    val v1 = List.empty[String]
+    val v2 = List("a", "b", "c")
+    assert(ListHelper.merge(2, v1, v2) === List("a", "b"))
+  }
+
+  test("merge empty and sorted list with size equal to limit") {
+    val v1 = List.empty[String]
+    val v2 = List("a", "b")
+    assert(ListHelper.merge(2, v1, v2) === List("a", "b"))
+  }
+
+  test("merge empty and sorted list with size less than limit") {
+    val v1 = List.empty[String]
+    val v2 = List("a")
+    assert(ListHelper.merge(2, v1, v2) === List("a"))
+  }
+
+  test("merge sorted and empty list") {
+    val v1 = List("a", "b", "c")
+    val v2 = List.empty[String]
+    assert(ListHelper.merge(2, v1, v2) === List("a", "b"))
+  }
+
   test("merge many sorted lists with limit") {
     val v1 = List("a", "c", "d")
     val v2 = List("b", "e")


### PR DESCRIPTION
Fixes the case when one of the lists is empty to check
the limit.