### PR TITLE
reduce allocations for merging many sorted lists

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/ListHelper.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/ListHelper.scala
@@ -73,9 +73,10 @@ object ListHelper {
     * @return
     *     Sorted list with a max size of `limit`.
     */
-  def merge[T <: Comparable[T]](limit: Int, vs: List[List[T]]): List[T] = {
-    vs.foldLeft(List.empty[T]) { (v1, v2) =>
-      merge(limit, v1, v2)
+  def merge[T <: Comparable[T]: Manifest](limit: Int, vs: List[List[T]]): List[T] = {
+    val merged = vs.foldLeft(ArrayHelper.merger[T](limit)) { (m, vs) =>
+      m.merge(vs)
     }
+    merged.toList
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/ArrayHelperSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/ArrayHelperSuite.scala
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import org.scalatest.FunSuite
+
+class ArrayHelperSuite extends FunSuite {
+
+  test("merge arrays, limit 1: empty, one") {
+    val v1 = Array.empty[String]
+    val v2 = Array("a")
+    val actual = ArrayHelper.merger[String](1).merge(v1).merge(v2).toArray
+    assert(actual === Array("a"))
+  }
+
+  test("merge arrays, limit 1: empty, abcde") {
+    val v1 = Array.empty[String]
+    val v2 = Array("a", "b", "c", "d", "e")
+    val actual = ArrayHelper.merger[String](1).merge(v1).merge(v2).toArray
+    assert(actual === Array("a"))
+  }
+
+  test("merge arrays, limit 1: abcde, empty") {
+    val v1 = Array("a", "b", "c", "d", "e")
+    val v2 = Array.empty[String]
+    val actual = ArrayHelper.merger[String](1).merge(v1).merge(v2).toArray
+    assert(actual === Array("a"))
+  }
+
+  test("merge arrays, limit 1: b, a") {
+    val v1 = Array("b")
+    val v2 = Array("a")
+    val actual = ArrayHelper.merger[String](1).merge(v1).merge(v2).toArray
+    assert(actual === Array("a"))
+  }
+
+  test("merge arrays, limit 1: a, b") {
+    val v1 = Array("a")
+    val v2 = Array("b")
+    val actual = ArrayHelper.merger[String](1).merge(v1).merge(v2).toArray
+    assert(actual === Array("a"))
+  }
+
+  test("merge arrays, limit 2: b, a") {
+    val v1 = Array("b")
+    val v2 = Array("a")
+    val actual = ArrayHelper.merger[String](2).merge(v1).merge(v2).toArray
+    assert(actual === Array("a", "b"))
+  }
+
+  test("merge arrays, limit 2: ab, a") {
+    val v1 = Array("a", "b")
+    val v2 = Array("a")
+    val actual = ArrayHelper.merger[String](2).merge(v1).merge(v2).toArray
+    assert(actual === Array("a", "b"))
+  }
+
+  test("merge arrays, limit 2: bc, ad") {
+    val v1 = Array("b", "c")
+    val v2 = Array("a", "d")
+    val actual = ArrayHelper.merger[String](2).merge(v1).merge(v2).toArray
+    assert(actual === Array("a", "b"))
+  }
+
+  test("merge list, limit 1: empty, one") {
+    val v1 = List.empty[String]
+    val v2 = List("a")
+    val actual = ArrayHelper.merger[String](1).merge(v1).merge(v2).toList
+    assert(actual === List("a"))
+  }
+
+  test("merge list, limit 1: empty, abcde") {
+    val v1 = List.empty[String]
+    val v2 = List("a", "b", "c", "d", "e")
+    val actual = ArrayHelper.merger[String](1).merge(v1).merge(v2).toList
+    assert(actual === List("a"))
+  }
+
+  test("merge list, limit 1: abcde, empty") {
+    val v1 = List("a", "b", "c", "d", "e")
+    val v2 = List.empty[String]
+    val actual = ArrayHelper.merger[String](1).merge(v1).merge(v2).toList
+    assert(actual === List("a"))
+  }
+
+  test("merge list, limit 1: b, a") {
+    val v1 = List("b")
+    val v2 = List("a")
+    val actual = ArrayHelper.merger[String](1).merge(v1).merge(v2).toList
+    assert(actual === List("a"))
+  }
+
+  test("merge list, limit 1: a, b") {
+    val v1 = List("a")
+    val v2 = List("b")
+    val actual = ArrayHelper.merger[String](1).merge(v1).merge(v2).toList
+    assert(actual === List("a"))
+  }
+
+  test("merge list, limit 2: b, a") {
+    val v1 = List("b")
+    val v2 = List("a")
+    val actual = ArrayHelper.merger[String](2).merge(v1).merge(v2).toList
+    assert(actual === List("a", "b"))
+  }
+
+  test("merge list, limit 2: ab, a") {
+    val v1 = List("a", "b")
+    val v2 = List("a")
+    val actual = ArrayHelper.merger[String](2).merge(v1).merge(v2).toList
+    assert(actual === List("a", "b"))
+  }
+
+  test("merge list, limit 2: bc, ad") {
+    val v1 = List("b", "c")
+    val v2 = List("a", "d")
+    val actual = ArrayHelper.merger[String](2).merge(v1).merge(v2).toList
+    assert(actual === List("a", "b"))
+  }
+}

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/ListMerge.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/ListMerge.scala
@@ -30,11 +30,11 @@ import scala.collection.SortedSet
   * ```
   * > jmh:run -wi 10 -i 10 -f1 -t1 .*ListMerge.*
   * ...
-  * [info] Benchmark             Mode  Cnt   Score   Error  Units
-  * [info] ListMerge.hashSet    thrpt   10   0.361 ± 0.038  ops/s
-  * [info] ListMerge.merge      thrpt   10  23.064 ± 5.711  ops/s
-  * [info] ListMerge.sortedSet  thrpt   10   0.239 ± 0.019  ops/s
-  * [info] ListMerge.treeSet    thrpt   10   0.267 ± 0.047  ops/s
+  * Benchmark                         Mode  Cnt   Score   Error  Units
+  * ListMerge.hashSet                thrpt   10   0.386 ± 0.021  ops/s
+  * ListMerge.merge                  thrpt   10  42.918 ± 2.044  ops/s
+  * ListMerge.sortedSet              thrpt   10   0.238 ± 0.007  ops/s
+  * ListMerge.treeSet                thrpt   10   0.316 ± 0.016  ops/s
   * ```
   */
 @State(Scope.Thread)

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/ListMergeCommonPrefix.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/ListMergeCommonPrefix.scala
@@ -26,8 +26,8 @@ import org.openjdk.jmh.infra.Blackhole
   * ```
   * > jmh:run -prof jmh.extras.JFR -wi 10 -i 10 -f1 -t1 .*ListMergeCommonPrefix.*
   * ...
-  * Benchmark                         Mode  Cnt  Score   Error  Units
-  * ListMergeCommonPrefix.merge      thrpt   10  6.606 ± 0.534  ops/s
+  * Benchmark                         Mode  Cnt   Score   Error  Units
+  * ListMergeCommonPrefix.merge      thrpt   10   8.700 ± 0.160  ops/s
   * ```
   */
 @State(Scope.Thread)


### PR DESCRIPTION
Changes the implementation of merging many sorted lists
to use arrays internally to store the intermediate results.
This eliminates the allocations when performing a merge
operation. Before it was construction many `::` objects
to create the merged list. This shows a nice improvement
on the JMH benchmarks as well.

**Before**

```
ListMerge.merge                thrpt   10  23.064 ± 5.711  ops/s
ListMergeCommonPrefix.merge    thrpt   10   6.606 ± 0.534  ops/s
```

**After**

```
ListMerge.merge                thrpt   10  42.918 ± 2.044  ops/s
ListMergeCommonPrefix.merge    thrpt   10   8.700 ± 0.160  ops/s
```