### PR TITLE
fix stop for Eureka refresh source

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookup.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookup.scala
@@ -60,7 +60,6 @@ private[stream] class EurekaGroupsLookup(context: StreamContext, frequency: Fini
         // If there is an existing source polling Eureka, then tell it to stop. Create a
         // new instance of the flag for the next source
         continue.set(false)
-        continue = new AtomicBoolean(true)
 
         val next = grab(in)
 
@@ -90,7 +89,8 @@ private[stream] class EurekaGroupsLookup(context: StreamContext, frequency: Fini
           .map(gs => next -> Groups(gs))
 
         // Regularly refresh the metadata until the returned continue flag is set to false
-        val src = EvaluationFlows.repeatWhile(NotUsed, frequency, continue.get())
+        val (src, hasNext) = EvaluationFlows.repeatWhile(NotUsed, frequency)
+        continue = hasNext
         push(out, src.flatMapConcat(_ => lookup))
       }
 

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluationFlows.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluationFlows.scala
@@ -15,6 +15,8 @@
  */
 package com.netflix.atlas.eval.stream
 
+import java.util.concurrent.atomic.AtomicBoolean
+
 import akka.Done
 import akka.NotUsed
 import akka.stream.ActorMaterializer
@@ -81,12 +83,14 @@ private[stream] object EvaluationFlows {
     * Source that will repeat the item with the specified delay in between while the
     * condition is still true.
     */
-  def repeatWhile[T](item: T, delay: FiniteDuration, condition: => Boolean): Source[T, NotUsed] = {
+  def repeatWhile[T](item: T, delay: FiniteDuration): (Source[T, NotUsed], AtomicBoolean) = {
+    val continue = new AtomicBoolean(true)
     val iterator = new Iterator[T] {
-      override def hasNext: Boolean = condition
+      override def hasNext: Boolean = continue.get()
       override def next(): T = item
     }
-    Source.fromIterator(() => iterator).throttle(1, delay, 1, ThrottleMode.Shaping)
+    val src = Source.fromIterator(() => iterator).throttle(1, delay, 1, ThrottleMode.Shaping)
+    src -> continue
   }
 
   /**

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -227,6 +227,7 @@ private[stream] abstract class EvaluatorImpl(
         .via(new EurekaGroupsLookup(context, 30.seconds))
         .via(context.countEvents("01_EurekaGroups"))
         .flatMapMerge(Int.MaxValue, s => s)
+        .via(context.countEvents("01_EurekaRefresh"))
       datasources.out(0).map(_.remoteOnly()) ~> eurekaLookup ~> eurekaGroups.in
       eurekaGroups.out(0) ~> new SubscriptionManager(context)
 


### PR DESCRIPTION
In #704, there was a change to fix how the Eureka refresh
source was stopped. That change has a bug in that the function
passed to `repeatWhile` has a reference to the member variable.
So it is almost always true, unless it happens to get checked
in the brief period between when the previous instance was set
to false and the new instance is created.

As a result, none of the sources are actually stopped and the
old DataSources instances get pushed out repeated. Depending
on how the expressions have changed, this can cause the
subscriptions for various expression to come and go.

This change avoids the problem on the actual instance. Still
need to come up with a way to test, but will do that as a new
PR so I can unblock some downstream users that need the fix.

/cc @zimmermatt 