### PR TITLE
improve performance for splitting expressions

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
@@ -108,7 +108,7 @@ case class Interpreter(vocabulary: List[Word]) {
   }
 
   final def execute(program: String): Context = {
-    execute(program.trim.split("\\s*,\\s*").filter(_.nonEmpty).toList)
+    execute(splitAndTrim(program))
   }
 
   @scala.annotation.tailrec
@@ -126,7 +126,7 @@ case class Interpreter(vocabulary: List[Word]) {
   }
 
   final def debug(program: String): List[Step] = {
-    debug(program.trim.split("\\s*,\\s*").filter(_.nonEmpty).toList)
+    debug(splitAndTrim(program))
   }
 
   /**
@@ -178,5 +178,24 @@ object Interpreter {
       case v: AnyRef   => v.toString
     }
     parts.mkString(",")
+  }
+
+  /**
+    * Helper for efficiently splitting the input string. See StringSplit benchmark for
+    * comparison with more naive approach. The string split method optimizes simple cases
+    * with a single character so that it does not require compiling the regex. This method
+    * uses a single character and does a simple `trim` operation to cleanup the whitespace.
+    */
+  private[stacklang] def splitAndTrim(str: String): List[String] = {
+    val parts = str.split(",")
+    val builder = List.newBuilder[String]
+    var i = 0
+    while (i < parts.length) {
+      val tmp = parts(i).trim
+      if (!tmp.isEmpty)
+        builder += tmp
+      i += 1
+    }
+    builder.result()
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/InterpreterSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/InterpreterSuite.scala
@@ -143,6 +143,25 @@ class InterpreterSuite extends FunSuite {
   test("typeSummary: a :: b :: Nil") {
     assert(Interpreter.typeSummary(List("a" :: "b" :: Nil)) === "[List]")
   }
+
+  //
+  // splitAndTrim
+  //
+
+  test("splitAndTrim should split by comma") {
+    val actual = Interpreter.splitAndTrim("a,b,c")
+    assert(actual === List("a", "b", "c"))
+  }
+
+  test("splitAndTrim should trim whitespace") {
+    val actual = Interpreter.splitAndTrim("  a\n,\t\nb ,c")
+    assert(actual === List("a", "b", "c"))
+  }
+
+  test("splitAndTrim should ignore empty strings") {
+    val actual = Interpreter.splitAndTrim(", ,\t,\n\n,")
+    assert(actual === Nil)
+  }
 }
 
 object InterpreterSuite {

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/stacklang/StringSplit.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/stacklang/StringSplit.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.stacklang
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.infra.Blackhole
+
+/**
+  * Simple test for splitting a stacklang expression by the `,`.
+  *
+  * ```
+  * > jmh:run -prof jmh.extras.JFR -wi 10 -i 10 -f1 -t1 .*StringSplit.*
+  * ...
+  * Benchmark                      Mode  Cnt       Score       Error  Units
+  * StringSplit.naive             thrpt   10  207502.367 ±  5054.394  ops/s
+  * StringSplit.splitAndTrim      thrpt   10  554580.700 ± 27627.109  ops/s
+  * ```
+  */
+@State(Scope.Thread)
+class StringSplit {
+
+  private val value = (0 until 50).mkString(",")
+
+  @Benchmark
+  def naive(bh: Blackhole): Unit = {
+    bh.consume(value.trim.split("\\s*,\\s*").filter(_.nonEmpty).toList)
+  }
+
+  @Benchmark
+  def splitAndTrim(bh: Blackhole): Unit = {
+    bh.consume(Interpreter.splitAndTrim(value))
+  }
+
+}


### PR DESCRIPTION
For some use-cases like lwcapi where many expressions
get processed a significant amount of time was being
spent compiling the regex used by `String.split`. This
change avoids the regex and significantly improves
the parsing performance.