### PR TITLE
cache the split expressions

### DIFF
--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionSplitterSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionSplitterSuite.scala
@@ -29,24 +29,22 @@ class ExpressionSplitterSuite extends FunSuite {
   private val splitter = new ExpressionSplitter
 
   test("splits single expression into data expressions") {
-    val ret = splitter.split(query1, frequency1)
-    assert(
-      ret === List(
-        Subscription(matchList1, ExpressionMetadata(ds1a, frequency1)),
-        Subscription(matchList1, ExpressionMetadata(ds1b, frequency1))
-      ).reverse
-    )
+    val actual = splitter.split(query1, frequency1)
+    val expected = List(
+      Subscription(matchList1, ExpressionMetadata(ds1a, frequency1)),
+      Subscription(matchList1, ExpressionMetadata(ds1b, frequency1))
+    ).reverse
+    assert(actual === expected)
   }
 
   test("splits compound expression into data expressions") {
     val expr = query1 + "," + query1
-    val ret = splitter.split(expr, frequency1)
-    assert(
-      ret === List(
-        Subscription(matchList1, ExpressionMetadata(ds1a, frequency1)),
-        Subscription(matchList1, ExpressionMetadata(ds1b, frequency1))
-      ).reverse
-    )
+    val actual = splitter.split(expr, frequency1)
+    val expected = List(
+      Subscription(matchList1, ExpressionMetadata(ds1a, frequency1)),
+      Subscription(matchList1, ExpressionMetadata(ds1b, frequency1))
+    ).reverse
+    assert(actual === expected)
   }
 
   test("throws IAE for invalid expressions") {


### PR DESCRIPTION
A substantial chunk of the CPU usage (~40%) on the lwcapi
clusters is being spent processing the subscription updates.
In most cases these are the same expressions each time. This
changes the splitter to cache the processed result to eliminate
most of the overhead.

/cc @zimmermatt 