### PR TITLE
fix #733, add :freeze operator

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Context.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Context.scala
@@ -15,4 +15,40 @@
  */
 package com.netflix.atlas.core.stacklang
 
-case class Context(interpreter: Interpreter, stack: List[Any], variables: Map[String, Any])
+/**
+  * State related to the execution of a stack language expression.
+  *
+  * @param interpreter
+  *     Interpreter that is performing the execution.
+  * @param stack
+  *     Stack that maintains the state for the program.
+  * @param variables
+  *     Variables that can be set to keep state outside of the main stack. See the
+  *     `:get` and `:set` operators for more information.
+  * @param frozenStack
+  *     Separate stack that has been frozen to prevent further modification. See the
+  *     `:freeze` operator for more information.
+  */
+case class Context(
+  interpreter: Interpreter,
+  stack: List[Any],
+  variables: Map[String, Any],
+  frozenStack: List[Any] = Nil
+) {
+
+  /**
+    * Remove the contents of the stack and push them onto the frozen stack. The variable
+    * state will also be cleared.
+    */
+  def freeze: Context = {
+    copy(stack = Nil, variables = Map.empty[String, Any], frozenStack = stack ::: frozenStack)
+  }
+
+  /**
+    * Combine the stack and frozen stack to a final result stack. The frozen contents will
+    * be older entries on the final result stack.
+    */
+  def unfreeze: Context = {
+    copy(stack = stack ::: frozenStack, frozenStack = Nil)
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
@@ -100,7 +100,7 @@ case class Interpreter(vocabulary: List[Word]) {
   }
 
   final def execute(program: List[Any], context: Context): Context = {
-    execute(Step(program, context))
+    execute(Step(program, context)).unfreeze
   }
 
   final def execute(program: List[Any]): Context = {
@@ -118,7 +118,11 @@ case class Interpreter(vocabulary: List[Word]) {
   }
 
   final def debug(program: List[Any], context: Context): List[Step] = {
-    debugImpl(Nil, Step(program, context)).reverse
+    val result = debugImpl(Nil, Step(program, context)) match {
+      case s :: steps => s.copy(context = s.context.unfreeze) :: steps
+      case Nil        => Nil
+    }
+    result.reverse
   }
 
   final def debug(program: List[Any]): List[Step] = {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/FreezeSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/FreezeSuite.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.stacklang
+
+import org.scalatest.FunSuite
+
+class FreezeSuite extends FunSuite {
+
+  def interpreter: Interpreter = Interpreter(StandardVocabulary.allWords)
+
+  test("basic operation") {
+    val context = interpreter.execute("a,b,c,:freeze")
+    assert(context.stack === List("c", "b", "a"))
+    assert(context.frozenStack.isEmpty)
+  }
+
+  test("frozen stack is isolated") {
+    val context = interpreter.execute("a,b,c,:freeze,d,e,f,:clear")
+    assert(context.stack === List("c", "b", "a"))
+    assert(context.frozenStack.isEmpty)
+  }
+
+  test("variables are cleared") {
+    val e = intercept[NoSuchElementException] {
+      interpreter.execute("foo,1,:set,:freeze,foo,:get")
+    }
+    assert(e.getMessage === "key not found: foo")
+  }
+
+  test("multiple freeze operations") {
+    val context = interpreter.execute("a,b,c,:freeze,d,e,f,:freeze,g,h,i,:freeze,j,k,l,:clear")
+    assert(context.stack === List("i", "h", "g", "f", "e", "d", "c", "b", "a"))
+    assert(context.frozenStack.isEmpty)
+  }
+}

--- a/atlas-webapi/src/main/resources/reference.conf
+++ b/atlas-webapi/src/main/resources/reference.conf
@@ -154,6 +154,7 @@ atlas {
           "each",
           "fcall",
           "format",
+          "freeze",
           "get",
           "list",
           "map",


### PR DESCRIPTION
Adds `:freeze` operator to allow freezing a portion
of the stack so it is isolated from further modification.
This is useful for query overlay and some other use-cases
where we essentially need to combine multiple expressions
and still be able to use operations like `:clear` or `:list`
without worrying about exactly how far back to go on the
stack.