### PR TITLE
docs: update example for all to avoid limit

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataVocabulary.scala
@@ -71,6 +71,8 @@ object DataVocabulary extends Vocabulary {
         |> :warning: This operation is primarily intended for debugging and can have strange
         |behaviour when used with rollups. Most users should use [:by](data-by) instead.
       """.stripMargin.trim
+
+    override def examples: List[String] = List("name,sps,:eq,nf.cluster,nccp-ps3,:eq,:and")
   }
 
   case object Sum extends DataWord {


### PR DESCRIPTION
In #692, the simple static db was updated to check the
limits which resulted in the example for `:all` failing.
This changes the example to reduce the match set.