### PR TITLE
fix use of :freeze with macros

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
@@ -99,8 +99,9 @@ case class Interpreter(vocabulary: List[Word]) {
     if (s.program.isEmpty) s.context else execute(nextStep(s))
   }
 
-  final def execute(program: List[Any], context: Context): Context = {
-    execute(Step(program, context)).unfreeze
+  final def execute(program: List[Any], context: Context, unfreeze: Boolean = true): Context = {
+    val result = execute(Step(program, context))
+    if (unfreeze) result.unfreeze else result
   }
 
   final def execute(program: List[Any]): Context = {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/StandardVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/StandardVocabulary.scala
@@ -57,7 +57,7 @@ object StandardVocabulary extends Vocabulary {
     override def matches(stack: List[Any]): Boolean = true
 
     override def execute(context: Context): Context = {
-      context.interpreter.execute(body, context)
+      context.interpreter.execute(body, context, unfreeze = false)
     }
 
     override def summary: String =

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/NamedRewriteSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/NamedRewriteSuite.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.atlas.core.stacklang.Interpreter
+import org.scalatest.FunSuite
+
+class NamedRewriteSuite extends FunSuite {
+
+  private val interpreter = Interpreter(MathVocabulary.allWords)
+
+  private def eval(program: String): List[TimeSeriesExpr] = {
+    interpreter.execute(program).stack.map {
+      case ModelExtractors.TimeSeriesType(t) => t
+    }
+  }
+
+  test("freeze works with named rewrite, cq") {
+    val actual = eval("name,a,:eq,:freeze,name,b,:eq,:avg,:list,(,app,foo,:eq,:cq,),:each")
+    val expected = eval("name,a,:eq,name,b,:eq,:avg,app,foo,:eq,:cq")
+    assert(actual === expected)
+  }
+
+  test("freeze works with named rewrite, add") {
+    val actual = eval("name,a,:eq,:freeze,name,b,:eq,:avg,:list,(,42,:add,),:each")
+    val expected = eval("name,a,:eq,name,b,:eq,:avg,42,:add")
+    assert(actual === expected)
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/FreezeSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/FreezeSuite.scala
@@ -45,4 +45,11 @@ class FreezeSuite extends FunSuite {
     assert(context.stack === List("i", "h", "g", "f", "e", "d", "c", "b", "a"))
     assert(context.frozenStack.isEmpty)
   }
+
+  test("freeze works with macros") {
+    // Before macros would force unfreeze after execution
+    val context = interpreter.execute("a,b,:freeze,d,e,:2over,:clear")
+    assert(context.stack === List("b", "a"))
+    assert(context.frozenStack.isEmpty)
+  }
 }


### PR DESCRIPTION
The macros like `:avg` on a graph are executed using the
same context as the overall expression. When completed they
were unfreezing the stack to get the final result stack. This
should not be done for internal executions, only once the
overall expression evaluation is completed.