### PR TITLE
copy context in :set

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/StandardVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/StandardVocabulary.scala
@@ -534,7 +534,7 @@ object StandardVocabulary extends Vocabulary {
     override def execute(context: Context): Context = {
       context.stack match {
         case (v: Any) :: (k: String) :: vs =>
-          Context(context.interpreter, vs, context.variables + (k -> v))
+          context.copy(stack = vs, variables = context.variables + (k -> v))
         case _ => invalidStack
       }
     }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/FreezeSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/FreezeSuite.scala
@@ -70,4 +70,10 @@ class FreezeSuite extends FunSuite {
     assert(context.stack === List("b", "a"))
     assert(context.frozenStack.isEmpty)
   }
+
+  test("freeze works with :get/:set") {
+    val context = interpreter.execute("a,b,:freeze,d,e,:set,d,:get,:clear")
+    assert(context.stack === List("b", "a"))
+    assert(context.frozenStack.isEmpty)
+  }
 }


### PR DESCRIPTION
Before the `:set` operation was creating a new context
which is losing other information such as the frozen
stack. This changes it to copy and just update the
parts that are being modified by the operator.