### PR TITLE
fix #746, avoid rounding for percentile labels

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -664,10 +664,10 @@ object MathExpr {
 
     override def toString: String = {
       val baseExpr =
-        if (evalGroupKeys.isEmpty) expr.af.query.toString
-        else {
+        if (evalGroupKeys.isEmpty)
+          expr.af.query.toString
+        else
           s"${expr.af.query},(,${evalGroupKeys.mkString(",")},),:by"
-        }
       s"$baseExpr,(,${pcts.mkString(",")},),:percentiles"
     }
 
@@ -779,10 +779,16 @@ object MathExpr {
           i += 1
         }
 
-        // Apply the tags and labels to the output
+        // Apply the tags and labels to the output. The percentile values are padded with a
+        // space so that the decimal place will line up vertically when using a monospace font
+        // for rendering.
         output.toList.zipWithIndex.map {
           case (seq, j) =>
-            val p = f"${pcts(j)}%5.1f"
+            val p = pcts(j) match {
+              case v if v < 10.0  => s"  $v"
+              case v if v < 100.0 => s" $v"
+              case v              => v.toString
+            }
             val tags = data.head.tags + (TagKey.percentile -> p)
             TimeSeries(tags, f"percentile($baseLabel, $p)", seq)
         }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/PercentilesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/PercentilesSuite.scala
@@ -165,6 +165,29 @@ class PercentilesSuite extends FunSuite {
     }
   }
 
+  private def checkPercentile(v: Double, s: String): Unit = {
+    val data = eval(s"name,test,:eq,(,$v,),:percentiles", inputSpectatorTimer)
+
+    assert(data.size === 1)
+    List(v).zip(data).foreach {
+      case (p, t) =>
+        assert(t.tags === Map("name" -> "test", "percentile" -> s))
+        assert(t.label === f"percentile(name=test, $s)")
+    }
+  }
+
+  test("9.99999999th percentile") {
+    checkPercentile(9.99999999, "  9.99999999")
+  }
+
+  test("99.99th percentile") {
+    checkPercentile(99.99, " 99.99")
+  }
+
+  test("99.999999th percentile") {
+    checkPercentile(99.999999, " 99.999999")
+  }
+
   test("distribution summary :max") {
     val data = eval("name,test,:eq,:max,(,25,50,90,),:percentiles", input100)
 


### PR DESCRIPTION
Use the default double to string conversion so the value
more closely reflects what the user entered. The previous
approach of using the formatter would cause rounding if
there were too many significant digits.