### PR TITLE
use the decoded name as field alias

### DIFF
--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Reflection.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Reflection.scala
@@ -86,8 +86,6 @@ private[json] object Reflection {
     // companion object.
     val params = ctor.paramLists.head.zipWithIndex.map {
       case (p, i) =>
-        val name = p.name.toString
-        val alias = getAlias(p.annotations)
         val dflt =
           if (!p.asTerm.isParamWithDefault) None
           else {
@@ -99,6 +97,12 @@ private[json] object Reflection {
               Some(instanceMirror.reflectMethod(dfltArg.asMethod).apply())
             }
           }
+        val name = p.name.toString
+
+        // If there isn't an explicit alias with the annotations, then use the decoded
+        // name for the symbol. This allows names with special characters like `.` to
+        // work correctly.
+        val alias = getAlias(p.annotations).orElse(Some(p.name.decodedName.toString))
         Param(name, alias, dflt)
     }
 

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
@@ -429,7 +429,14 @@ class JsonSuite extends FunSuite {
     val json = Json.encode(obj)
     assert(json === """{"foo":0}""")
   }
+
+  test("dots in field name") {
+    val obj = Json.decode[JsonKeyWithDot]("""{"a.b": "bar"}""")
+    assert(obj === JsonKeyWithDot("bar"))
+  }
 }
+
+case class JsonKeyWithDot(`a.b`: String)
 
 case object JsonSuiteObject
 


### PR DESCRIPTION
The name can have encoded characters such as `.`. For
example `a.b` will be encoded as `a$u002Eb`. The decoded
name is now used as an alias if there is not an explict
alias set with an annotation.