### PR TITLE
add mapping for TrustedAdvisor metrics

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/reference.conf
@@ -63,6 +63,10 @@ atlas {
           alias = "nf.zone"
         },
         {
+          name = "Region"
+          alias = "aws.region"
+        },
+        {
           name = "LinkedAccount"
           alias = "aws.account"
         },
@@ -93,6 +97,10 @@ atlas {
         {
           name = "ServiceName"
           alias = "aws.service"
+        },
+        {
+          name = "ServiceLimit"
+          alias = "aws.limit"
         },
         {
           name = "BucketName"
@@ -226,6 +234,7 @@ atlas {
       "s3-request",
       "sns",
       "sqs",
+      "trustedadvisor",
       "workflow",
       "workflow-activity"
     ]
@@ -252,3 +261,4 @@ include "s3-request.conf"
 include "sns.conf"
 include "sqs.conf"
 include "swf.conf"
+include "trustedadvisor.conf"

--- a/atlas-poller-cloudwatch/src/main/resources/trustedadvisor.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/trustedadvisor.conf
@@ -1,0 +1,33 @@
+
+atlas {
+  cloudwatch {
+
+    // https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/trusted-advisor-metricscollected.html
+    // Mapping for service limit metrics only. It isn't clear the others are of any use to us
+    // at this time.
+    trustedadvisor = {
+      namespace = "AWS/TrustedAdvisor"
+
+      // Update frequency seems to be ~1h15m, but isn't as regular as most other cloudwatch
+      // data. Using 2h to provide some buffer.
+      period = 2h
+
+      // Note, TA data for all regions seems to show up in CloudWatch for us-east-1
+      dimensions = [
+        "Region",
+        "ServiceName",
+        "ServiceLimit"
+      ]
+
+      metrics = [
+        {
+          name = "ServiceLimitUsage"
+          alias = "aws.trustedadvisor.serviceLimitUsage"
+          // AWS documentation and unit indicate it is a percentage, but the actual values
+          // are from 0 to 1 instead of 0 to 100.
+          conversion = "max,percent"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/Conversions.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/Conversions.scala
@@ -44,14 +44,15 @@ object Conversions {
 
   private def from(name: String, conversions: List[String]): Conversion = {
     conversions match {
-      case "min" :: Nil   => min
-      case "max" :: Nil   => max
-      case "sum" :: Nil   => sum
-      case "count" :: Nil => count
-      case "avg" :: Nil   => avg
-      case "rate" :: cs   => rate(from(name, cs))
-      case v :: cs        => throw new IllegalArgumentException(s"unknown conversion '$v' ($name)")
-      case Nil            => throw new IllegalArgumentException(s"empty conversion list ($name)")
+      case "min" :: Nil    => min
+      case "max" :: Nil    => max
+      case "sum" :: Nil    => sum
+      case "count" :: Nil  => count
+      case "avg" :: Nil    => avg
+      case "rate" :: cs    => rate(from(name, cs))
+      case "percent" :: cs => multiply(from(name, cs), 100.0)
+      case v :: cs         => throw new IllegalArgumentException(s"unknown conversion '$v' ($name)")
+      case Nil             => throw new IllegalArgumentException(s"empty conversion list ($name)")
     }
   }
 

--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionsSuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionsSuite.scala
@@ -262,6 +262,12 @@ class ConversionsSuite extends FunSuite {
     assert(v === 42.0)
   }
 
+  test("ratio to percent") {
+    val cnv = Conversions.fromName("sum,percent")
+    val v = cnv(null, newDatapoint(0.42, StandardUnit.Percent))
+    assert(v === 42.0)
+  }
+
   test("unit none") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.None))


### PR DESCRIPTION
For now it is only the service limit usage metrics that
give us an idea of how close we are to limits. This can
be a simple alternative to many of the uses of howlermonkey.
The update frequency for the trusted advisor metrics is
fairly low so it will take an hour or so to detect a
problem. For slow growth it is adequate.