### PR TITLE
fix #762, use proper legend in streaming eval

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
@@ -146,7 +146,7 @@ private[stream] class FinalExprEval(step: Long = 60000L)
               val result = expr.expr.eval(context, expressionDatapoints)
               states(expr) = result.state
               val msgs = result.data.map { t =>
-                TimeSeriesMessage(expr.toString, context, t)
+                TimeSeriesMessage(expr.toString, context, t.withLabel(expr.legend(t)))
               }
 
               val diagnostics = expr.expr.dataExprs.flatMap(expressionDiagnostics.get)


### PR DESCRIPTION
Before it was ignoring the pattern specified using
`:legend` and always using the default.