### PR TITLE
add helper function for simplifying a query

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
@@ -172,17 +172,17 @@ object Query {
       case Query.And(q, Query.False) => Query.False
       case Query.And(q1, q2)         => Query.And(simplify(q1, ignore), simplify(q2, ignore))
 
-      case Query.Or(Query.True, _)   => Query.True
-      case Query.Or(_, Query.True)   => Query.True
-      case Query.Or(Query.False, q)  => simplify(q)
-      case Query.Or(q, Query.False)  => simplify(q)
-      case Query.Or(q1, q2)          => Query.Or(simplify(q1, ignore), simplify(q2, ignore))
+      case Query.Or(Query.True, _)  => Query.True
+      case Query.Or(_, Query.True)  => Query.True
+      case Query.Or(Query.False, q) => simplify(q)
+      case Query.Or(q, Query.False) => simplify(q)
+      case Query.Or(q1, q2)         => Query.Or(simplify(q1, ignore), simplify(q2, ignore))
 
-      case Query.Not(Query.True)     => if (ignore) Query.True else Query.False
-      case Query.Not(Query.False)    => Query.True
-      case Query.Not(q)              => Query.Not(simplify(q, ignore))
+      case Query.Not(Query.True)  => if (ignore) Query.True else Query.False
+      case Query.Not(Query.False) => Query.True
+      case Query.Not(q)           => Query.Not(simplify(q, ignore))
 
-      case q                         => q
+      case q => q
     }
 
     if (newQuery != query) simplify(newQuery, ignore) else newQuery

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
@@ -168,8 +168,8 @@ object Query {
     val newQuery = query match {
       case Query.And(Query.True, q)  => simplify(q, ignore)
       case Query.And(q, Query.True)  => simplify(q, ignore)
-      case Query.And(Query.False, q) => Query.False
-      case Query.And(q, Query.False) => Query.False
+      case Query.And(Query.False, _) => Query.False
+      case Query.And(_, Query.False) => Query.False
       case Query.And(q1, q2)         => Query.And(simplify(q1, ignore), simplify(q2, ignore))
 
       case Query.Or(Query.True, _)  => Query.True

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
@@ -446,4 +446,89 @@ class QuerySuite extends FunSuite {
     assert(Query.dnfList(q) === List(Not(a), Not(b)))
     assert(Query.dnf(q) === Or(Not(a), Not(b)))
   }
+
+  test("simplify and(true, eq)") {
+    val q = And(True, Equal("a", "b"))
+    assert(Query.simplify(q) === Equal("a", "b"))
+  }
+
+  test("simplify and(eq, true)") {
+    val q = And(Equal("a", "b"), True)
+    assert(Query.simplify(q) === Equal("a", "b"))
+  }
+
+  test("simplify and(false, eq)") {
+    val q = And(False, Equal("a", "b"))
+    assert(Query.simplify(q) === False)
+  }
+
+  test("simplify and(eq, false)") {
+    val q = And(Equal("a", "b"), False)
+    assert(Query.simplify(q) === False)
+  }
+
+  test("simplify and(eq, eq)") {
+    val q = And(Equal("a", "b"), Equal("c", "d"))
+    assert(Query.simplify(q) === q)
+  }
+
+  test("simplify and recursive") {
+    val q = And(And(True, Equal("a", "b")), And(Equal("c", "d"), False))
+    assert(Query.simplify(q) === False)
+  }
+
+  test("simplify or(true, eq)") {
+    val q = Or(True, Equal("a", "b"))
+    assert(Query.simplify(q) === True)
+  }
+
+  test("simplify or(eq, true)") {
+    val q = Or(Equal("a", "b"), True)
+    assert(Query.simplify(q) === True)
+  }
+
+  test("simplify or(false, eq)") {
+    val q = Or(False, Equal("a", "b"))
+    assert(Query.simplify(q) === Equal("a", "b"))
+  }
+
+  test("simplify or(eq, false)") {
+    val q = Or(Equal("a", "b"), False)
+    assert(Query.simplify(q) === Equal("a", "b"))
+  }
+
+  test("simplify or(eq, eq)") {
+    val q = Or(Equal("a", "b"), Equal("c", "d"))
+    assert(Query.simplify(q) === q)
+  }
+
+  test("simplify or recursive") {
+    val q = Or(Or(True, Equal("a", "b")), Or(Equal("c", "d"), False))
+    assert(Query.simplify(q) === True)
+  }
+
+  test("simplify not(true)") {
+    val q = Not(True)
+    assert(Query.simplify(q) === False)
+  }
+
+  test("simplify not(true), ignore") {
+    val q = Not(True)
+    assert(Query.simplify(q, ignore = true) === True)
+  }
+
+  test("simplify not(false)") {
+    val q = Not(False)
+    assert(Query.simplify(q) === True)
+  }
+
+  test("simplify not recursive") {
+    val q = Not(And(Not(False), Equal("a", "b")))
+    assert(Query.simplify(q) === Not(Equal("a", "b")))
+  }
+
+  test("simplify not recursive ignore") {
+    val q = Not(And(Not(True), Equal("a", "b")))
+    assert(Query.simplify(q, ignore = true) === Not(Equal("a", "b")))
+  }
 }


### PR DESCRIPTION
A number of internal libraries have the use-case to
perform rewrites and then simplify the query expression.
This change adds it as a common helper function to the
Query object. In the case of rewrites it is often useful
to ignore terms so it has the option to use special
handling of the not true case so it will get elided rather
than making the overall expression false.