### PR TITLE
jackson 2.9.4

### DIFF
--- a/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
@@ -434,6 +434,12 @@ class JsonSuite extends FunSuite {
     val obj = Json.decode[JsonKeyWithDot]("""{"a.b": "bar"}""")
     assert(obj === JsonKeyWithDot("bar"))
   }
+
+  test("object with empty array renders empty array") {
+    val obj = Json.decode[JsonSuiteArrayString]("""{"name":"name", "values":[]}""")
+    val json = Json.encode(obj)
+    assert(json === """{"name":"name","values":[]}""")
+  }
 }
 
 case class JsonKeyWithDot(`a.b`: String)
@@ -445,6 +451,8 @@ case class JsonSuiteSimple(foo: Int, bar: String)
 case class JsonSuiteNested(simple: Map[String, JsonSuiteSimple], bar: Option[String])
 
 case class JsonSuiteArrayDouble(name: String, values: Array[Double])
+
+case class JsonSuiteArrayString(name: String, values: Option[Array[String]])
 
 // https://github.com/FasterXML/jackson-module-scala/issues/62
 case class JsonSuiteOptionLong(foo: Option[Long])

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
     val aws        = "1.11.264"
     val iep        = "1.1.1"
     val guice      = "4.1.0"
-    val jackson    = "2.9.2"
+    val jackson    = "2.9.4"
     val log4j      = "2.10.0"
     val scala      = "2.12.4"
     val slf4j      = "1.7.25"


### PR DESCRIPTION
Fixes the issue for empty arrays brought up in #710.
The relevant jackson issue is FasterXML/jackson-module-scala#346.

/cc @skandragon 