### PR TITLE
Provide a more useful description for `:dist-avg` and `:dist-max`.

### DIFF
--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Main.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Main.scala
@@ -111,6 +111,8 @@ object Main extends StrictLogging {
     SDesFast.word      -> SDesFast,
     SDesSlow.word      -> SDesSlow,
     SDesSlower.word    -> SDesSlower,
+    DistAvg.word       -> DistAvg,
+    DistMax.word       -> DistMax,
     DistStddev.word    -> DistStddev,
     Stddev.word        -> Stddev,
     Line.word          -> Line,

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/DistAvg.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/DistAvg.scala
@@ -28,7 +28,10 @@ case object DistAvg extends StackWordPage {
 
   override def summary: String =
     """
-      |Compute the average of the total time for [timers](http://netflix.github.io/spectator/en/latest/intro/timer/)
-      |and total count [distribution summaries](http://netflix.github.io/spectator/en/latest/intro/dist-summary/).
+      |Compute the average recorded value for [timers] and [distribution summaries]. This
+      |is calculated by dividing the total amount recorded by the number of recorded values.
+      |
+      |[timers]: http://netflix.github.io/spectator/en/latest/intro/timer/
+      |[distribution summaries]: http://netflix.github.io/spectator/en/latest/intro/dist-summary/
     """.stripMargin.trim
 }

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/DistAvg.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/DistAvg.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.wiki.pages
+
+import com.netflix.atlas.core.model.MathVocabulary
+import com.netflix.atlas.core.stacklang.Vocabulary
+import com.netflix.atlas.core.stacklang.Word
+import com.netflix.atlas.wiki.StackWordPage
+
+case object DistAvg extends StackWordPage {
+  val vocab: Vocabulary = MathVocabulary
+  val word: Word = vocab.words.find(_.name == "dist-avg").get
+
+  override def signature: String = s"`Query -- TimeSeriesExpr`"
+
+  override def summary: String =
+    """
+      |Compute the average of the total time for [timers](http://netflix.github.io/spectator/en/latest/intro/timer/)
+      |and total count [distribution summaries](http://netflix.github.io/spectator/en/latest/intro/dist-summary/).
+    """.stripMargin.trim
+}

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/DistMax.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/DistMax.scala
@@ -28,7 +28,10 @@ case object DistMax extends StackWordPage {
 
   override def summary: String =
     """
-      |Compute the maximum of the max statistic for [timers](http://netflix.github.io/spectator/en/latest/intro/timer/)
-      |and [distribution summaries](http://netflix.github.io/spectator/en/latest/intro/dist-summary/).
+      |Compute the maximum recorded value for [timers] and [distribution summaries]. This
+      |is a helper for selecting both the max aggregation and max statistic for the meter.
+      |
+      |[timers]: http://netflix.github.io/spectator/en/latest/intro/timer/
+      |[distribution summaries]: http://netflix.github.io/spectator/en/latest/intro/dist-summary/
     """.stripMargin.trim
 }

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/DistMax.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/DistMax.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.wiki.pages
+
+import com.netflix.atlas.core.model.MathVocabulary
+import com.netflix.atlas.core.stacklang.Vocabulary
+import com.netflix.atlas.core.stacklang.Word
+import com.netflix.atlas.wiki.StackWordPage
+
+case object DistMax extends StackWordPage {
+  val vocab: Vocabulary = MathVocabulary
+  val word: Word = vocab.words.find(_.name == "dist-max").get
+
+  override def signature: String = s"`Query -- TimeSeriesExpr`"
+
+  override def summary: String =
+    """
+      |Compute the maximum of the max statistic for [timers](http://netflix.github.io/spectator/en/latest/intro/timer/)
+      |and [distribution summaries](http://netflix.github.io/spectator/en/latest/intro/dist-summary/).
+    """.stripMargin.trim
+}

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/DistMax.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/DistMax.scala
@@ -29,7 +29,7 @@ case object DistMax extends StackWordPage {
   override def summary: String =
     """
       |Compute the maximum recorded value for [timers] and [distribution summaries]. This
-      |is a helper for selecting both the max aggregation and max statistic for the meter.
+      |is a helper for aggregating by the max of the max statistic for the meter.
       |
       |[timers]: http://netflix.github.io/spectator/en/latest/intro/timer/
       |[distribution summaries]: http://netflix.github.io/spectator/en/latest/intro/dist-summary/


### PR DESCRIPTION
The generated defaults are not very helpful to users since they just
output the expanded rewrite syntax.