### PR TITLE
limit size of in clause for expansion

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/QueryIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/QueryIndex.scala
@@ -190,12 +190,15 @@ object QueryIndex {
   }
 
   /**
-    * Split :in queries into a list of queries using :eq.
+    * Split :in queries into a list of queries using :eq. In order to avoid a massive
+    * combinatorial explosion clauses that have more than 5 expressions will not be
+    * expanded. The number is somewhat arbitrary, but seems to work well in practice
+    * for the current query data sets at Netflix.
     */
   private def split(query: Query): List[Query] = {
     query match {
       case Query.And(q1, q2) => for (a <- split(q1); b <- split(q2)) yield { Query.And(a, b) }
-      case Query.In(k, vs) =>
+      case Query.In(k, vs) if vs.lengthCompare(5) < 0 =>
         vs.map { v =>
           Query.Equal(k, v)
         }


### PR DESCRIPTION
When building the query index we expand `:in` clauses
so we get a set of simpler queries with `:eq` clauses.
This allows us to greatly reduce the number of queries
that wind up in the fallback set that have to be checked
linearly.

However, if there are many `:in` clauses and some of them
match a large set, then there is a combinatorial explosion
and the number of queries we need to index becomes too
large. This changes restricts the expansion to `:in` clauses
with 5 or less values.