### PR TITLE
support converting monotonic cw values to delta

### DIFF
--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/GetMetricActor.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/GetMetricActor.scala
@@ -30,7 +30,7 @@ class GetMetricActor(client: AmazonCloudWatch) extends Actor with StrictLogging 
   import CloudWatchPoller._
 
   def receive: Receive = {
-    case m: MetricMetadata => sender() ! MetricData(m, getMetric(m))
+    case m: MetricMetadata => sender() ! MetricData(m, None, getMetric(m))
   }
 
   /**

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricDefinition.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricDefinition.scala
@@ -29,6 +29,9 @@ import com.typesafe.config.Config
   * @param conversion
   *     Conversion to apply to the datapoint when extracting the value. See [[Conversions]]
   *     for more information.
+  * @param monotonicValue
+  *     Set to true if the value is monotonically increasing. These values will get converted
+  *     to a delta before passing into the conversion function.
   * @param tags
   *     Tags that should be applied to the metric.
   */
@@ -36,6 +39,7 @@ case class MetricDefinition(
   name: String,
   alias: String,
   conversion: (MetricMetadata, Datapoint) => Double,
+  monotonicValue: Boolean,
   tags: Map[String, String]
 )
 
@@ -99,10 +103,12 @@ object MetricDefinition {
   }
 
   private def newMetricDef(config: Config, cnv: String, tags: Tags): MetricDefinition = {
+    val monotonic = config.hasPath("monotonic") && config.getBoolean("monotonic")
     MetricDefinition(
       name = config.getString("name"),
       alias = config.getString("alias"),
       conversion = Conversions.fromName(cnv),
+      monotonicValue = monotonic,
       tags = tags
     )
   }

--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionsSuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionsSuite.scala
@@ -76,7 +76,7 @@ class ConversionsSuite extends FunSuite {
     val cnv = Conversions.fromName("sum,rate")
     val meta = MetricMetadata(
       MetricCategory("NFLX/Test", 300, Nil, Nil, Query.True),
-      MetricDefinition("test", "test-alias", cnv, Map.empty),
+      MetricDefinition("test", "test-alias", cnv, false, Map.empty),
       Nil
     )
     val v = cnv(meta, dp)
@@ -87,7 +87,7 @@ class ConversionsSuite extends FunSuite {
     val cnv = Conversions.fromName("sum,rate")
     val meta = MetricMetadata(
       MetricCategory("NFLX/Test", 300, Nil, Nil, Query.True),
-      MetricDefinition("test", "test-alias", cnv, Map.empty),
+      MetricDefinition("test", "test-alias", cnv, false, Map.empty),
       Nil
     )
     val v = cnv(meta, newDatapoint(6.0, StandardUnit.BytesSecond))

--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDataSuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDataSuite.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import java.util.Date
+
+import com.amazonaws.services.cloudwatch.model.Datapoint
+import com.amazonaws.services.cloudwatch.model.StandardUnit
+import com.netflix.atlas.cloudwatch.CloudWatchPoller.MetricData
+import com.netflix.atlas.core.model.Query
+import org.scalatest.FunSuite
+
+class MetricDataSuite extends FunSuite {
+
+  private val definition =
+    MetricDefinition("test", "alias", Conversions.fromName("sum"), false, Map.empty)
+  private val category =
+    MetricCategory("namespace", 60, List("dimension"), List(definition), Query.True)
+  private val metadata = MetricMetadata(category, definition, Nil)
+
+  private val monotonicMetadata = metadata.copy(definition = definition.copy(monotonicValue = true))
+
+  private def datapoint(v: Double): Option[Datapoint] = {
+    val d = new Datapoint()
+      .withMinimum(v)
+      .withMaximum(v)
+      .withSum(v)
+      .withSampleCount(1.0)
+      .withTimestamp(new Date())
+      .withUnit(StandardUnit.None)
+    Some(d)
+  }
+
+  test("access datapoint with no current value") {
+    val data = MetricData(metadata, None, None)
+    assert(data.datapoint.getSum === 0.0)
+  }
+
+  test("access datapoint with current value") {
+    val data = MetricData(metadata, None, datapoint(1.0))
+    assert(data.datapoint.getSum === 1.0)
+  }
+
+  test("access monotonic datapoint with no previous or current value") {
+    val data = MetricData(monotonicMetadata, None, None)
+    assert(data.datapoint.getSum.isNaN)
+  }
+
+  test("access monotonic datapoint with no current value") {
+    val data = MetricData(monotonicMetadata, datapoint(1.0), None)
+    assert(data.datapoint.getSum.isNaN)
+  }
+
+  test("access monotonic datapoint with no previous value") {
+    val data = MetricData(monotonicMetadata, None, datapoint(1.0))
+    assert(data.datapoint.getSum.isNaN)
+  }
+
+  test("access monotonic datapoint, current is larger") {
+    val data = MetricData(monotonicMetadata, datapoint(1.0), datapoint(2.0))
+    assert(data.datapoint.getSum === 1.0)
+  }
+
+  test("access monotonic datapoint, previous is larger") {
+    val data = MetricData(monotonicMetadata, datapoint(2.0), datapoint(1.0))
+    assert(data.datapoint.getSum === 0.0)
+  }
+
+  test("access monotonic datapoint, previous equals current") {
+    val data = MetricData(monotonicMetadata, datapoint(1.0), datapoint(1.0))
+    assert(data.datapoint.getSum === 0.0)
+  }
+}


### PR DESCRIPTION
Some values in cloudwatch may be reported as monotonic
counters. This change allows a `monotonic` flag to be
set on the metric definition to convert those to deltas
based on the previous value.