### PR TITLE
fix #761, allow basic math ops on StyleExpr

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterVocabulary.scala
@@ -48,10 +48,13 @@ object FilterVocabulary extends Vocabulary {
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
       case (_: String) :: TimeSeriesType(_) :: _ => true
+      case (_: String) :: (_: StyleExpr) :: _    => true
     }
 
     protected def executor: PartialFunction[List[Any], List[Any]] = {
       case (s: String) :: TimeSeriesType(t) :: stack => FilterExpr.Stat(t, s) :: stack
+      case (s: String) :: (t: StyleExpr) :: stack =>
+        t.copy(expr = FilterExpr.Stat(t.expr, s)) :: stack
     }
 
     override def signature: String = "TimeSeriesExpr String -- FilterExpr"

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
@@ -60,10 +60,13 @@ object StatefulVocabulary extends Vocabulary {
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
       case IntType(_) :: TimeSeriesType(_) :: _ => true
+      case IntType(_) :: (_: StyleExpr) :: _    => true
     }
 
     protected def executor: PartialFunction[List[Any], List[Any]] = {
       case IntType(v) :: TimeSeriesType(t) :: s => StatefulExpr.RollingCount(t, v) :: s
+      case IntType(v) :: (t: StyleExpr) :: s =>
+        t.copy(expr = StatefulExpr.RollingCount(t.expr, v)) :: s
     }
 
     override def summary: String =
@@ -115,11 +118,14 @@ object StatefulVocabulary extends Vocabulary {
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
       case (_: String) :: (_: String) :: (_: String) :: TimeSeriesType(_) :: _ => true
+      case (_: String) :: (_: String) :: (_: String) :: (_: StyleExpr) :: _    => true
     }
 
     protected def executor: PartialFunction[List[Any], List[Any]] = {
       case DoubleType(b) :: DoubleType(a) :: IntType(n) :: TimeSeriesType(t) :: s =>
         StatefulExpr.Des(t, n, a, b) :: s
+      case DoubleType(b) :: DoubleType(a) :: IntType(n) :: (t: StyleExpr) :: s =>
+        t.copy(StatefulExpr.Des(t.expr, n, a, b)) :: s
     }
 
     override def summary: String =
@@ -140,11 +146,14 @@ object StatefulVocabulary extends Vocabulary {
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
       case (_: String) :: (_: String) :: (_: String) :: TimeSeriesType(_) :: _ => true
+      case (_: String) :: (_: String) :: (_: String) :: (_: StyleExpr) :: _    => true
     }
 
     protected def executor: PartialFunction[List[Any], List[Any]] = {
       case DoubleType(b) :: DoubleType(a) :: IntType(n) :: TimeSeriesType(t) :: s =>
         StatefulExpr.SlidingDes(t, n, a, b) :: s
+      case DoubleType(b) :: DoubleType(a) :: IntType(n) :: (t: StyleExpr) :: s =>
+        t.copy(expr = StatefulExpr.SlidingDes(t.expr, n, a, b)) :: s
     }
 
     override def summary: String =
@@ -203,11 +212,14 @@ object StatefulVocabulary extends Vocabulary {
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
       case (_: String) :: TimeSeriesType(_) :: _ => true
+      case (_: String) :: (_: StyleExpr) :: _    => true
     }
 
     protected def executor: PartialFunction[List[Any], List[Any]] = {
       case (v: String) :: TimeSeriesType(t) :: s =>
         StatefulExpr.Trend(t, Strings.parseDuration(v)) :: s
+      case (v: String) :: (t: StyleExpr) :: s =>
+        t.copy(expr = StatefulExpr.Trend(t.expr, Strings.parseDuration(v))) :: s
     }
 
     override def summary: String =
@@ -247,10 +259,12 @@ object StatefulVocabulary extends Vocabulary {
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
       case TimeSeriesType(_) :: _ => true
+      case (_: StyleExpr) :: _    => true
     }
 
     protected def executor: PartialFunction[List[Any], List[Any]] = {
       case TimeSeriesType(t) :: s => StatefulExpr.Integral(t) :: s
+      case (t: StyleExpr) :: s    => t.copy(expr = StatefulExpr.Integral(t.expr)) :: s
     }
 
     override def summary: String =
@@ -292,10 +306,12 @@ object StatefulVocabulary extends Vocabulary {
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
       case TimeSeriesType(_) :: _ => true
+      case (_: StyleExpr) :: _    => true
     }
 
     protected def executor: PartialFunction[List[Any], List[Any]] = {
       case TimeSeriesType(t) :: s => StatefulExpr.Derivative(t) :: s
+      case (t: StyleExpr) :: s    => t.copy(expr = StatefulExpr.Derivative(t.expr)) :: s
     }
 
     override def summary: String =

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathAcrossStyleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathAcrossStyleSuite.scala
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.atlas.core.stacklang.Interpreter
+import org.scalatest.FunSuite
+
+/**
+  * Verify that basic math operations can be applied to StyleExprs. For binary operators
+  * only one side can be a StyleExpr.
+  *
+  * https://github.com/Netflix/atlas/issues/761
+  */
+class MathAcrossStyleSuite extends FunSuite {
+
+  import ModelExtractors._
+
+  private val interpreter = Interpreter(StyleVocabulary.allWords)
+
+  private def eval(s: String): StyleExpr = {
+    val stack = interpreter.execute(s).stack
+    stack match {
+      case PresentationType(t) :: Nil => t
+      case _                          => fail(s"expected StyleExpr, found: $stack")
+    }
+  }
+
+  MathVocabulary.allWords
+    .filter(_.isInstanceOf[MathVocabulary.UnaryWord])
+    .foreach { w =>
+      test(s"${w.name}, StyleExpr op") {
+        val expected = eval(s"1,:${w.name},abc,:legend")
+        val actual = eval(s"1,abc,:legend,:${w.name}")
+        assert(actual === expected)
+      }
+    }
+
+  MathVocabulary.allWords
+    .filter(_.isInstanceOf[MathVocabulary.BinaryWord])
+    .foreach { w =>
+      val a = "a,:has,:sum"
+      val b = "b,:has,:sum"
+
+      test(s"${w.name}, TimeSeriesExpr op StyleExpr") {
+        val expected = eval(s"$a,$b,:${w.name},abc,:legend")
+        val actual = eval(s"$a,$b,abc,:legend,:${w.name}")
+        assert(actual === expected)
+      }
+
+      test(s"${w.name}, StyleExpr op TimeSeriesExpr") {
+        val expected = eval(s"$a,$b,:${w.name},abc,:legend")
+        val actual = eval(s"$a,abc,:legend,$b,:${w.name}")
+        assert(actual === expected)
+      }
+    }
+
+  test("clamp-min") {
+    val expected = eval("a,:has,1,:clamp-min,abc,:legend")
+    val actual = eval("a,:has,abc,:legend,1,:clamp-min")
+    assert(actual === expected)
+  }
+
+  test("clamp-max") {
+    val expected = eval("a,:has,1,:clamp-max,abc,:legend")
+    val actual = eval("a,:has,abc,:legend,1,:clamp-max")
+    assert(actual === expected)
+  }
+
+  test("rolling-count") {
+    val expected = eval("a,:has,1,:rolling-count,abc,:legend")
+    val actual = eval("a,:has,abc,:legend,1,:rolling-count")
+    assert(actual === expected)
+  }
+
+  test("des") {
+    val expected = eval("a,:has,1,0.1,0.2,:des,abc,:legend")
+    val actual = eval("a,:has,abc,:legend,1,0.1,0.2,:des")
+    assert(actual === expected)
+  }
+
+  test("sdes") {
+    val expected = eval("a,:has,1,0.1,0.2,:sdes,abc,:legend")
+    val actual = eval("a,:has,abc,:legend,1,0.1,0.2,:sdes")
+    assert(actual === expected)
+  }
+
+  test("trend") {
+    val expected = eval("a,:has,5m,:trend,abc,:legend")
+    val actual = eval("a,:has,abc,:legend,5m,:trend")
+    assert(actual === expected)
+  }
+
+  test("integral") {
+    val expected = eval("a,:has,:integral,abc,:legend")
+    val actual = eval("a,:has,abc,:legend,:integral")
+    assert(actual === expected)
+  }
+
+  test("derivative") {
+    val expected = eval("a,:has,:derivative,abc,:legend")
+    val actual = eval("a,:has,abc,:legend,:derivative")
+    assert(actual === expected)
+  }
+
+  test("stat") {
+    val expected = eval("a,:has,max,:stat,abc,:legend")
+    val actual = eval("a,:has,abc,:legend,max,:stat")
+    assert(actual === expected)
+  }
+
+  test("filter") {
+    val expected = eval("a,:has,:stat-max,1,:gt,:filter,abc,:legend")
+    val actual = eval("a,:has,abc,:legend,:stat-max,1,:gt,:filter")
+    assert(actual === expected)
+  }
+}


### PR DESCRIPTION
This change relaxes the language restrictions a bit
so that basic math operations can can be applied to
a time series expression after style attributes have
been applied. The main use-case is to allow for some
UI operations that need to perform operations on an
arbitrary graph in a similar manner to using `:cq`
to restrict the scope.

For binary operations, only one side can be a StyleExpr.
This prevents mutually exclusive presentation attributes
from the two sides.