### PR TITLE
add support for custom words

### DIFF
--- a/atlas-core/src/main/resources/reference.conf
+++ b/atlas-core/src/main/resources/reference.conf
@@ -24,5 +24,65 @@ atlas {
 
       max-datapoints = 500000
     }
+
+    vocabulary {
+      //
+      words = [
+        // Sample entry:
+        //{
+        //  // Name of the operator, users would call `:$name`
+        //  name = "square"
+        //
+        //  // Expression for this word
+        //  body = ":dup,:mul"
+        //
+        //  // Examples to demonstrate the use of this operator
+        //  examples = ["2"]
+        //}
+      ]
+
+      // Keys available on the custom averages used at netflix
+      nflx-keys = [
+        "nf.account",
+        "nf.app",
+        "nf.ami",
+        "nf.asg",
+        "nf.cluster",
+        "nf.stack",
+        "nf.zone",
+        "nf.region",
+        "nf.node",
+        "nf.vmtype"
+      ]
+
+      // Helpers to compute an average based on a specified denominator query
+      custom-averages = [
+        // Sample entry:
+        //{
+        //  // Name of the operator, users would call `:$name`
+        //  name = "node-avg"
+        //
+        //  // Query that is used for the denominator in the average
+        //  base-query = "name,numInstances,:eq"
+        //
+        //  // Set of tags that are available for use on the denominator. These
+        //  // will be used to extract common scope from the numerator query and
+        //  // validate the group by behavior.
+        //  keys = ["app", "cluster", "asg"]
+        //}
+
+        // Netflix averages:
+        {
+          name = "node-avg"
+          base-query = "name,poller.asg.instance,:eq"
+          keys = ${atlas.core.vocabulary.nflx-keys}
+        },
+        {
+          name = "eureka-avg"
+          base-query = "name,DiscoveryStatus_.*_UP,:re"
+          keys = ${atlas.core.vocabulary.nflx-keys}
+        }
+      ]
+    }
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/CustomVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/CustomVocabulary.scala
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.atlas.core.stacklang.Context
+import com.netflix.atlas.core.stacklang.Interpreter
+import com.netflix.atlas.core.stacklang.StandardVocabulary
+import com.netflix.atlas.core.stacklang.Vocabulary
+import com.netflix.atlas.core.stacklang.Word
+import com.typesafe.config.Config
+
+/**
+  * Vocabulary that allows custom extension operations to be loaded from the
+  * config.
+  *
+  * @param config
+  *     Config instance to use for loading the custom operations. The settings
+  *     will be loaded from the `atlas.core.vocabulary` block.
+  *
+  *     **Words**
+  *
+  *     Custom words can be defined using an expression. These are typically used
+  *     by the operators to provide common helper functions.
+  *
+  *     ```
+  *     words = [
+  *       {
+  *         name = "square"
+  *         body = ":dup,:mul"
+  *         examples = ["2"]
+  *       }
+  *     ]
+  *     ```
+  *
+  *     The supported fields are:
+  *
+  *     - `name`: operation name, when the user calls the operation they will use
+  *       `:$name`.
+  *     - `body`: expression that is executed for this operation.
+  *     - `examples`: set of example stacks that can be used as input to the operator
+  *       to show how it works.
+  *
+  *     **Averages**
+  *
+  *     The `custom-averages` list contains a set of rewrites for averaging based
+  *     on an arbitrary denominator query. This is typically used to make it easier
+  *     for performing an average based on a separate infrastructure metric. For
+  *     example, at Netflix there is a metric published for each instance that is
+  *     UP in Eureka. To compute an average per UP server we could define a custom
+  *     average like:
+  *
+  *     ```
+  *     custom-averages = [
+  *       {
+  *         name = "eureka-avg"
+  *         base-query = "name,eureka.state,:eq,status,UP,:eq,:and"
+  *         keys = ["nf.app", "nf.cluster", "nf.asg", "nf.node"]
+  *       }
+  *     ]
+  *     ```
+  *
+  *     The supported fields are:
+  *
+  *     - `name`: operation name, when the user calls the operation they will use
+  *       `:$name`.
+  *     - `base-query`: query for the denominator.
+  *     - `keys`: tag keys that are available for use on the denominator.
+  */
+class CustomVocabulary(config: Config) extends Vocabulary {
+  import CustomVocabulary._
+  import scala.collection.JavaConverters._
+
+  val name: String = "custom"
+
+  val dependsOn: List[Vocabulary] = List(StyleVocabulary)
+
+  val words: List[Word] = {
+    val vocab = config.getConfig("atlas.core.vocabulary")
+    val macros = loadCustomWords(vocab.getConfigList("words").asScala.toList)
+    val averages = loadCustomAverages(vocab.getConfigList("custom-averages").asScala.toList)
+    macros ::: averages
+  }
+
+  private def loadCustomWords(configs: List[Config]): List[Word] = {
+    configs.map { cfg =>
+      val name = cfg.getString("name")
+      val body = Interpreter.splitAndTrim(cfg.getString("body"))
+      val examples = cfg.getStringList("examples").asScala.toList
+      StandardVocabulary.Macro(name, body, examples)
+    }
+  }
+
+  private def loadCustomAverages(configs: List[Config]): List[Word] = {
+    configs.map { cfg =>
+      val name = cfg.getString("name")
+      val baseQuery = eval(cfg.getString("base-query"))
+      val keys = cfg.getStringList("keys").asScala.toSet
+      CustomAvg(name, baseQuery, keys)
+    }
+  }
+}
+
+object CustomVocabulary {
+
+  private val queryInterpreter = Interpreter(QueryVocabulary.allWords)
+
+  private def eval(s: String): Query = {
+    queryInterpreter.execute(s).stack match {
+      case (q: Query) :: Nil => q
+      case _                 => throw new IllegalArgumentException(s)
+    }
+  }
+
+  case class CustomAvg(name: String, baseQuery: Query, keys: Set[String]) extends Word {
+
+    def matches(stack: List[Any]): Boolean = {
+      if (matcher.isDefinedAt(stack)) matcher(stack) else false
+    }
+
+    def execute(context: Context): Context = {
+      val pf = executor(context)
+      if (pf.isDefinedAt(context.stack))
+        context.copy(stack = pf(context.stack))
+      else
+        invalidStack
+    }
+
+    protected def matcher: PartialFunction[List[Any], Boolean] = {
+      case (_: Query) :: _ => true
+    }
+
+    protected def executor(context: Context): PartialFunction[List[Any], List[Any]] = {
+      case (q: Query) :: s =>
+        val nq = extractCommonQuery(q)
+        val numerator = DataExpr.Sum(q)
+        val denominator = DataExpr.Sum(baseQuery.and(nq))
+        val avg = MathExpr.Divide(numerator, denominator)
+        val ctxt = Context(context.interpreter, Nil, Map.empty)
+        val rewrite = Some(groupByRewrite _)
+        MathExpr.NamedRewrite(name, q, avg, ctxt, rewrite) :: s
+    }
+
+    private def groupByRewrite(expr: Expr, ks: List[String]): Expr = {
+      val q = expr.asInstanceOf[Query]
+      val nq = extractCommonQuery(q)
+      val numerator = DataExpr.Sum(q)
+      val denominator = DataExpr.Sum(baseQuery.and(nq))
+      if (ks.forall(keys.contains)) {
+        // All keys in group by are shared by both sides
+        MathExpr.Divide(DataExpr.GroupBy(numerator, ks), DataExpr.GroupBy(denominator, ks))
+      } else if (ks.forall(k => !keys.contains(k))) {
+        // All keys in group by are only valid for the numerator
+        MathExpr.Divide(DataExpr.GroupBy(numerator, ks), denominator)
+      } else {
+        // Mix of keys that are common to both sides and keys that can only be
+        // applied to the numerator
+        throw new IllegalArgumentException(
+          s"invalid key list for grouping $name, mixes shared and non-shared tag keys"
+        )
+      }
+    }
+
+    /**
+      * Extract the portions of the user query that are also applicable to the
+      * denominator. This will be used to restrict the scope of `baseQuery` so
+      * that it will match that of the user query.
+      *
+      * As an example, suppose we want to compute an average per node for requests
+      * that have a 404 status code. The user query would be something like:
+      *
+      * ```
+      * name,http.requests,:eq,status,404,:eq,:and,nf.app,www,:eq,:and
+      * ```
+      *
+      * If we have a separate metric that indicates the number of instances and is
+      * only tagged with `nf.app`, then the common query we need to extract is:
+      *
+      * ```
+      * nf.app,www,:eq
+      * ```
+      */
+    private[model] def extractCommonQuery(query: Query): Query = {
+      val tmp = query.rewrite {
+        case kq: Query.KeyQuery if !keys.contains(kq.k) => Query.True
+      }
+      Query.simplify(tmp.asInstanceOf[Query], ignore = true)
+    }
+
+    override def summary: String =
+      s"""
+         |Compute the average using `$baseQuery` as the denominator. The following
+         |keys can be used to restrict the scope or as part of the group by:
+         |
+         |${keys.mkString("- ", "\n   |- ", "")}
+      """.stripMargin.trim
+
+    override def signature: String = "Query -- TimeSeriesExpr"
+
+    override def examples: List[String] = Nil
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -20,6 +20,7 @@ import java.time.ZoneOffset
 
 import com.netflix.atlas.core.model.DataExpr.AggregateFunction
 import com.netflix.atlas.core.model.MathExpr.AggrMathExpr
+import com.netflix.atlas.core.model.MathExpr.NamedRewrite
 import com.netflix.atlas.core.stacklang.Context
 import com.netflix.atlas.core.stacklang.SimpleWord
 import com.netflix.atlas.core.stacklang.StandardVocabulary.Macro
@@ -255,6 +256,7 @@ object MathVocabulary extends Vocabulary {
       case StringListType(keys) :: TimeSeriesType(t) :: stack =>
         // Default data group by applied across math operations
         val f = t.rewrite {
+          case nr: NamedRewrite      => nr.groupBy(keys)
           case af: AggregateFunction => DataExpr.GroupBy(af, keys)
         }
         f :: stack

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
@@ -195,7 +195,7 @@ object Interpreter {
     * with a single character so that it does not require compiling the regex. This method
     * uses a single character and does a simple `trim` operation to cleanup the whitespace.
     */
-  private[stacklang] def splitAndTrim(str: String): List[String] = {
+  def splitAndTrim(str: String): List[String] = {
     val parts = str.split(",")
     val builder = List.newBuilder[String]
     var i = 0

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/CustomVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/CustomVocabularySuite.scala
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.atlas.core.stacklang.Interpreter
+import com.typesafe.config.ConfigFactory
+import org.scalatest.FunSuite
+
+class CustomVocabularySuite extends FunSuite {
+
+  private val cpuUser = "name,cpuUser,:eq"
+  private val numInstances = "name,aws.numInstances,:eq"
+
+  private val config = ConfigFactory.parseString(s"""
+      |atlas.core.vocabulary {
+      |  words = [
+      |    {
+      |      name = "square"
+      |      body = ":dup,:mul"
+      |      examples = []
+      |    }
+      |  ]
+      |
+      |  custom-averages = [
+      |    {
+      |      name = "node-avg"
+      |      base-query = "$numInstances"
+      |      keys = ["app", "cluster", "asg", "node", "region", "zone"]
+      |    }
+      |  ]
+      |}
+    """.stripMargin)
+
+  private val vocab = new CustomVocabulary(config)
+  private val interpreter = Interpreter(vocab.allWords)
+
+  private def eval(program: String): TimeSeriesExpr = {
+    val result = interpreter.execute(program)
+    result.stack match {
+      case ModelExtractors.TimeSeriesType(v) :: Nil => v
+    }
+  }
+
+  test("custom word: square") {
+    val expr = eval("2,:square")
+    val expected = eval("2,2,:mul")
+    assert(expr === expected)
+  }
+
+  test("simple average") {
+    val expr = eval(s"$cpuUser,:node-avg").rewrite {
+      case MathExpr.NamedRewrite("node-avg", _, e, _, _) => e
+    }
+    val expected = eval(s"$cpuUser,:sum,$numInstances,:sum,:div")
+    assert(expr === expected)
+  }
+
+  test("expr with cluster") {
+    val expr = eval(s"$cpuUser,cluster,foo,:eq,:and,:node-avg").rewrite {
+      case MathExpr.NamedRewrite("node-avg", _, e, _, _) => e
+    }
+    val expected = eval(s"$cpuUser,:sum,$numInstances,:sum,:div,cluster,foo,:eq,:cq")
+    assert(expr === expected)
+  }
+
+  test("expr grouped by infrastructure tags") {
+    val expr = eval(s"$cpuUser,cluster,foo,:eq,:and,:node-avg,(,zone,),:by").rewrite {
+      case MathExpr.NamedRewrite("node-avg", _, e, _, _) => e
+    }
+    val expected =
+      eval(s"$cpuUser,:sum,(,zone,),:by,$numInstances,:sum,(,zone,),:by,:div,cluster,foo,:eq,:cq")
+    assert(expr === expected)
+  }
+
+  test("expr grouped by non-infrastructure tags") {
+    val expr = eval(s"$cpuUser,cluster,foo,:eq,:and,:node-avg,(,name,),:by").rewrite {
+      case MathExpr.NamedRewrite("node-avg", _, e, _, _) => e
+    }
+    val expected = eval(s"$cpuUser,:sum,(,name,),:by,$numInstances,:sum,:div,cluster,foo,:eq,:cq")
+    assert(expr === expected)
+  }
+
+  test("expr grouped by non-infrastructure tags with offset") {
+    val displayExpr = eval(s"$cpuUser,cluster,foo,:eq,:and,:node-avg,(,name,),:by,1h,:offset")
+    val evalExpr = displayExpr.rewrite {
+      case MathExpr.NamedRewrite("node-avg", _, e, _, _) => e
+    }
+    val expected = eval(
+      s"$cpuUser,:sum,(,name,),:by,PT1H,:offset,$numInstances,:sum,PT1H,:offset,:div,cluster,foo,:eq,:cq"
+    )
+    assert(evalExpr === expected)
+    assert(
+      displayExpr.toString === s"$cpuUser,cluster,foo,:eq,:and,:node-avg,PT1H,:offset,(,name,),:by"
+    )
+  }
+
+  private def ignoreRewrite(e: Expr): Expr = {
+    e.rewrite {
+      case nr: MathExpr.NamedRewrite => nr.copy(groupByRewrite = None)
+    }
+  }
+
+  test("expr with cq") {
+    val e1 = eval(s"$cpuUser,cluster,api,:eq,:and,:node-avg")
+    val e2 = eval(s"$cpuUser,:node-avg,:list,(,cluster,api,:eq,:cq,),:each")
+    assert(ignoreRewrite(e1) === ignoreRewrite(e2))
+  }
+
+  test("expr with group by") {
+    val e1 = eval("name,(,a,b,c,),:in,app,beacon,:eq,zone,1c,:eq,:and,:and,:node-avg,(,name,),:by")
+    val e2 = eval("name,(,a,b,c,),:in,:node-avg,(,name,),:by,app,beacon,:eq,zone,1c,:eq,:and,:cq")
+    assert(ignoreRewrite(e1) === ignoreRewrite(e2))
+  }
+
+  test("expr with not") {
+    val expr = eval(s"$cpuUser,foo,bar,:eq,:not,:and,cluster,foo,:eq,:and,:node-avg").rewrite {
+      case MathExpr.NamedRewrite("node-avg", _, e, _, _) => e
+    }
+    val expected =
+      eval(s"$cpuUser,foo,bar,:eq,:not,:and,:sum,$numInstances,:sum,:div,cluster,foo,:eq,:cq")
+    assert(expr === expected)
+  }
+
+  test("group by mixed keys") {
+    intercept[IllegalArgumentException] {
+      eval("name,(,a,b,c,),:in,app,beacon,:eq,:and,:node-avg,(,name,asg,),:by")
+    }
+  }
+}

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
@@ -20,8 +20,8 @@ import java.util.concurrent.TimeUnit
 import com.netflix.atlas.chart.GraphEngine
 import com.netflix.atlas.config.ConfigManager
 import com.netflix.atlas.core.db.Database
+import com.netflix.atlas.core.model.CustomVocabulary
 import com.netflix.atlas.core.model.DefaultSettings
-import com.netflix.atlas.core.model.StyleVocabulary
 import com.netflix.atlas.core.stacklang.Vocabulary
 import com.netflix.atlas.core.validation.Rule
 import com.typesafe.config.Config
@@ -71,7 +71,7 @@ class ApiSettings(root: => Config) {
 
   def graphVocabulary: Vocabulary = {
     config.getString("graph.vocabulary") match {
-      case "default" => StyleVocabulary
+      case "default" => new CustomVocabulary(root)
       case cls       => Class.forName(cls).newInstance().asInstanceOf[Vocabulary]
     }
   }

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
@@ -210,8 +210,10 @@ object ExprApi {
     import MathExpr.NamedRewrite
     val cleaned = exprs.map { e =>
       val clean = e.rewrite {
-        case r @ NamedRewrite(_, orig: Query, _, _)          => r.copy(evalExpr = DataExpr.Sum(orig))
-        case r @ NamedRewrite(_, orig: TimeSeriesExpr, _, _) => r.copy(evalExpr = orig)
+        case r @ NamedRewrite(_, orig: Query, _, _, _) =>
+          r.copy(evalExpr = DataExpr.Sum(orig))
+        case r @ NamedRewrite(_, orig: TimeSeriesExpr, _, _, _) =>
+          r.copy(evalExpr = orig)
       }
       clean.asInstanceOf[StyleExpr]
     }

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ApiSettingsSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ApiSettingsSuite.scala
@@ -15,7 +15,7 @@
  */
 package com.netflix.atlas.webapi
 
-import com.netflix.atlas.core.model.StyleVocabulary
+import com.netflix.atlas.core.model.CustomVocabulary
 import com.netflix.atlas.core.stacklang.Vocabulary
 import com.netflix.atlas.core.stacklang.Word
 import com.typesafe.config.ConfigFactory
@@ -24,8 +24,16 @@ import org.scalatest.FunSuite
 class ApiSettingsSuite extends FunSuite {
 
   test("graphVocabulary default") {
-    val cfg = new ApiSettings(ConfigFactory.parseString("atlas.webapi.graph.vocabulary=default"))
-    assert(cfg.graphVocabulary === StyleVocabulary)
+    val cfg = new ApiSettings(ConfigFactory.parseString("""
+        |atlas {
+        |  core.vocabulary {
+        |    words = []
+        |    custom-averages = []
+        |  }
+        |  webapi.graph.vocabulary=default
+        |}
+      """.stripMargin))
+    assert(cfg.graphVocabulary.isInstanceOf[CustomVocabulary])
   }
 
   test("graphVocabulary class") {


### PR DESCRIPTION
Merges internal vocabulary that allows us to specify
custom words or averages via the configuration. See
comments in `reference.conf` for more information about
how to set these up.

This will further reduce the difference between what
we run internally and OSS version. It should also make
it easier to keep LWC and backend operations consistent.