### PR TITLE
fix :cq with custom averages

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -865,7 +865,7 @@ object MathExpr {
     }
 
     override def rewrite(f: PartialFunction[Expr, Expr]): Expr = {
-      if (f.isDefinedAt(this) && !f.isDefinedAt(displayExpr) && !f.isDefinedAt(evalExpr)) {
+      if (f.isDefinedAt(this)) {
         // The partial function is defined for the rewrite itself, assume the caller
         // knows what to do
         super.rewrite(f)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.core.model
 
+import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZoneOffset
@@ -869,19 +870,11 @@ object MathExpr {
         // knows what to do
         super.rewrite(f)
       } else {
-        displayExpr match {
-          case q: Query =>
-            copy(
-              displayExpr = displayExpr.rewrite(f),
-              evalExpr = evalExpr.rewrite(f).asInstanceOf[TimeSeriesExpr]
-            )
-          case _ =>
-            val newDisplayExpr = displayExpr.rewrite(f)
-            val ctxt = context.interpreter.execute(toString(newDisplayExpr))
-            ctxt.stack match {
-              case (r: NamedRewrite) :: Nil => r
-              case _                        => throw new IllegalStateException(s"invalid stack for :$name")
-            }
+        val newDisplayExpr = displayExpr.rewrite(f)
+        val ctxt = context.interpreter.execute(toString(newDisplayExpr))
+        ctxt.stack match {
+          case (r: NamedRewrite) :: Nil => r
+          case _                        => throw new IllegalStateException(s"invalid stack for :$name")
         }
       }
     }
@@ -895,6 +888,10 @@ object MathExpr {
         f(displayExpr, keys)
       }
       copy(displayExpr = newDisplayExpr, evalExpr = newEvalExpr.asInstanceOf[TimeSeriesExpr])
+    }
+
+    override def withOffset(d: Duration): TimeSeriesExpr = {
+      copy(evalExpr = evalExpr.withOffset(d))
     }
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/CustomVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/CustomVocabularySuite.scala
@@ -76,6 +76,14 @@ class CustomVocabularySuite extends FunSuite {
     assert(expr === expected)
   }
 
+  test("expr with cq using non-infrastructure tags") {
+    val expr = eval(s"$cpuUser,:node-avg,core,1,:eq,:cq").rewrite {
+      case MathExpr.NamedRewrite("node-avg", _, e, _, _) => e
+    }
+    val expected = eval(s"$cpuUser,core,1,:eq,:and,:sum,$numInstances,:sum,:div")
+    assert(expr === expected)
+  }
+
   test("expr grouped by infrastructure tags") {
     val expr = eval(s"$cpuUser,cluster,foo,:eq,:and,:node-avg,(,zone,),:by").rewrite {
       case MathExpr.NamedRewrite("node-avg", _, e, _, _) => e

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/NamedRewriteSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/NamedRewriteSuite.scala
@@ -61,13 +61,17 @@ class NamedRewriteSuite extends FunSuite {
 
   test("dist-avg") {
     val actual = eval("name,a,:eq,:dist-avg")
-    val expected = eval("statistic,(,totalTime,totalAmount,),:in,:sum,statistic,count,:eq,:sum,:div,name,a,:eq,:cq")
+    val expected = eval(
+      "statistic,(,totalTime,totalAmount,),:in,:sum,statistic,count,:eq,:sum,:div,name,a,:eq,:cq"
+    )
     assert(actual === expected)
   }
 
   test("dist-avg with group by") {
     val actual = eval("name,a,:eq,:dist-avg,(,name,),:by")
-    val expected = eval("statistic,(,totalTime,totalAmount,),:in,:sum,statistic,count,:eq,:sum,:div,name,a,:eq,:cq,(,name,),:by")
+    val expected = eval(
+      "statistic,(,totalTime,totalAmount,),:in,:sum,statistic,count,:eq,:sum,:div,name,a,:eq,:cq,(,name,),:by"
+    )
     assert(actual === expected)
   }
 


### PR DESCRIPTION
If a `:cq` operation was used to restrict a query
by a tag that was not available on the denominator,
then it would result in a no data line because the
query would get applied to both sides. This change
simplifies the rewrite so it will always re-run
the operation after modifying the display expression.
In this case that means the `extractCommonQuery`
step will get executed on the new query formed by
applying the `:cq` operation.