### PR TITLE
use custom vocabulary from eval lib

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -67,7 +67,7 @@ private[stream] abstract class EvaluatorImpl(
 
   private def newStreamContext(dsLogger: DataSourceLogger = (_, _) => ()): StreamContext = {
     new StreamContext(
-      config.getConfig("atlas.eval.stream"),
+      config,
       Http().superPool(),
       materializer,
       registry,
@@ -190,7 +190,7 @@ private[stream] abstract class EvaluatorImpl(
     Flow[DataSources]
       .map(s => context.validate(s))
       .via(g)
-      .via(new FinalExprEval)
+      .via(new FinalExprEval(context.interpreter))
       .flatMapConcat(s => s)
       .via(context.countEvents("13_OutputMessages"))
       .via(new OnUpstreamFinish[MessageEnvelope](queue.complete()))

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
@@ -16,14 +16,15 @@
 package com.netflix.atlas.eval.stream
 
 import akka.http.scaladsl.model.Uri
+import com.netflix.atlas.core.model.CustomVocabulary
 import com.netflix.atlas.core.model.ModelExtractors
 import com.netflix.atlas.core.model.StyleExpr
-import com.netflix.atlas.core.model.StyleVocabulary
 import com.netflix.atlas.core.stacklang.Interpreter
+import com.typesafe.config.Config
 
-private[stream] object ExprInterpreter {
+private[stream] class ExprInterpreter(config: Config) {
 
-  private val interpreter = Interpreter(StyleVocabulary.allWords)
+  private val interpreter = Interpreter(new CustomVocabulary(config).allWords)
 
   def eval(expr: String): List[StyleExpr] = {
     interpreter.execute(expr).stack.map {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
@@ -45,10 +45,12 @@ import com.typesafe.scalalogging.StrictLogging
   * Takes the set of data sources and time grouped partial aggregates as input and performs
   * the final evaluation step.
   *
+  * @param interpreter
+  *     Used for evaluating the expressions.
   * @param step
   *     Step size for the input data.
   */
-private[stream] class FinalExprEval(step: Long = 60000L)
+private[stream] class FinalExprEval(interpreter: ExprInterpreter, step: Long = 60000L)
     extends GraphStage[FlowShape[AnyRef, Source[MessageEnvelope, NotUsed]]]
     with StrictLogging {
 
@@ -92,7 +94,7 @@ private[stream] class FinalExprEval(step: Long = 60000L)
         recipients = sources
           .flatMap { s =>
             try {
-              val exprs = ExprInterpreter.eval(Uri(s.getUri))
+              val exprs = interpreter.eval(Uri(s.getUri))
               exprs.map(e => e -> s.getId)
             } catch {
               case e: Exception =>

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/SubscriptionManager.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/SubscriptionManager.scala
@@ -115,7 +115,7 @@ private[stream] class SubscriptionManager(context: StreamContext)
 
       private def toSubscribeRequest(ds: List[DataSource]): String = {
         val exprs = ds.flatMap { d =>
-          ExprInterpreter.eval(Uri(d.getUri)).map { expr =>
+          context.interpreter.eval(Uri(d.getUri)).map { expr =>
             Expression(expr.toString)
           }
         }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
@@ -29,6 +29,7 @@ import com.netflix.atlas.eval.model.TimeSeriesMessage
 import com.netflix.atlas.eval.stream.Evaluator.DataSource
 import com.netflix.atlas.eval.stream.Evaluator.DataSources
 import com.netflix.atlas.eval.stream.Evaluator.MessageEnvelope
+import com.typesafe.config.ConfigFactory
 import org.scalatest.FunSuite
 
 import scala.concurrent.Await
@@ -39,9 +40,11 @@ class FinalExprEvalSuite extends FunSuite {
   private implicit val system = ActorSystem(getClass.getSimpleName)
   private implicit val mat = ActorMaterializer()
 
+  private val interpreter = new ExprInterpreter(ConfigFactory.load())
+
   private def run(input: List[AnyRef]): List[MessageEnvelope] = {
     val future = Source(input)
-      .via(new FinalExprEval)
+      .via(new FinalExprEval(interpreter))
       .flatMapConcat(s => s)
       .runWith(Sink.seq)
     Await.result(future, Duration.Inf).toList

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
@@ -32,18 +32,25 @@ object TestContext {
 
   private val config =
     ConfigFactory.parseString("""
-      |backends = [
-      |  {
-      |    host = "localhost"
-      |    eureka-uri = "http://localhost:7102/v2/vips/local-dev:7001"
-      |    instance-uri = "http://{host}:{port}"
-      |  },
-      |  {
-      |    host = "atlas"
-      |    eureka-uri = "http://eureka/v2/vips/atlas-lwcapi:7001"
-      |    instance-uri = "http://{host}:{port}"
-      |  }
-      |]
+      |atlas.core.vocabulary {
+      |  words = []
+      |  custom-averages = []
+      |}
+      |
+      |atlas.eval.stream {
+      |  backends = [
+      |    {
+      |      host = "localhost"
+      |      eureka-uri = "http://localhost:7102/v2/vips/local-dev:7001"
+      |      instance-uri = "http://{host}:{port}"
+      |    },
+      |    {
+      |      host = "atlas"
+      |      eureka-uri = "http://eureka/v2/vips/atlas-lwcapi:7001"
+      |      instance-uri = "http://{host}:{port}"
+      |    }
+      |  ]
+      |}
     """.stripMargin)
 
   def createContext(


### PR DESCRIPTION
Updates the eval lib to use the same vocabulary
that would get used with the graph api after #776.