### PR TITLE
use custom vocabulary from lwcapi

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionSplitter.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionSplitter.scala
@@ -19,13 +19,14 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
 import com.github.benmanes.caffeine.cache.Caffeine
+import com.netflix.atlas.core.model.CustomVocabulary
 import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.ModelExtractors
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.Query.KeyQuery
-import com.netflix.atlas.core.model.StyleVocabulary
 import com.netflix.atlas.core.stacklang.Interpreter
 import com.netflix.spectator.api.Utils
+import com.typesafe.config.Config
 
 import scala.util.Failure
 import scala.util.Success
@@ -36,13 +37,13 @@ import scala.util.Try
   * subscription is based on the underlying data expressions (DataExpr) that get pushed back
   * to the systems supplying data to LWCAPI.
   */
-class ExpressionSplitter {
+class ExpressionSplitter(config: Config) {
 
   import ExpressionSplitter._
 
   private val keepKeys = Set("nf.app", "nf.stack", "nf.cluster")
 
-  private val interpreter = Interpreter(StyleVocabulary.allWords)
+  private val interpreter = Interpreter(new CustomVocabulary(config).allWords)
 
   /**
     * Processing the expressions can be quite expensive. In particular compiling regular

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
@@ -22,6 +22,7 @@ import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.netflix.spectator.api.NoopRegistry
+import com.typesafe.config.ConfigFactory
 import org.scalatest.FunSuite
 
 class ExpressionApiSuite extends FunSuite with ScalatestRouteTest {
@@ -36,7 +37,7 @@ class ExpressionApiSuite extends FunSuite with ScalatestRouteTest {
     }
   }))
 
-  val splitter = new ExpressionSplitter()
+  val splitter = new ExpressionSplitter(ConfigFactory.load())
 
   val sm = new ActorSubscriptionManager
   val endpoint = ExpressionApi(sm, new NoopRegistry, system)

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionSplitterSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionSplitterSuite.scala
@@ -16,6 +16,7 @@
 package com.netflix.atlas.lwcapi
 
 import com.netflix.atlas.core.model.Query
+import com.typesafe.config.ConfigFactory
 import org.scalatest.FunSuite
 
 class ExpressionSplitterSuite extends FunSuite {
@@ -26,7 +27,7 @@ class ExpressionSplitterSuite extends FunSuite {
   private val ds1b = "nf.cluster,skan-test,:eq,name,memUsed,:eq,:and,:sum,(,nf.node,),:by"
   private val matchList1 = Query.Equal("nf.cluster", "skan-test")
 
-  private val splitter = new ExpressionSplitter
+  private val splitter = new ExpressionSplitter(ConfigFactory.load())
 
   test("splits single expression into data expressions") {
     val actual = splitter.split(query1, frequency1)

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
@@ -22,6 +22,7 @@ import akka.http.scaladsl.testkit.RouteTestTimeout
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.netflix.atlas.akka.RequestHandler
 import com.netflix.spectator.api.NoopRegistry
+import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfter
 import org.scalatest.FunSuite
 
@@ -33,7 +34,7 @@ class SubscribeApiSuite extends FunSuite with BeforeAndAfter with ScalatestRoute
   private implicit val routeTestTimeout = RouteTestTimeout(5.second)
 
   private val sm = new ActorSubscriptionManager
-  private val splitter = new ExpressionSplitter
+  private val splitter = new ExpressionSplitter(ConfigFactory.load())
 
   private val api = new SubscribeApi(new NoopRegistry, sm, splitter)
 

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
@@ -15,12 +15,13 @@
  */
 package com.netflix.atlas.lwcapi
 
+import com.typesafe.config.ConfigFactory
 import org.scalatest.FunSuite
 
 class SubscriptionManagerSuite extends FunSuite {
 
   private def sub(expr: String): Subscription = {
-    val splitter = new ExpressionSplitter
+    val splitter = new ExpressionSplitter(ConfigFactory.load())
     splitter.split(expr, 60).head
   }
 

--- a/atlas-module-lwcapi/src/main/scala/com/netflix/atlas/guice/LwcApiModule.scala
+++ b/atlas-module-lwcapi/src/main/scala/com/netflix/atlas/guice/LwcApiModule.scala
@@ -23,6 +23,7 @@ import com.netflix.atlas.akka.AkkaModule
 import com.netflix.atlas.lwcapi.ActorSubscriptionManager
 import com.netflix.atlas.lwcapi.ExpressionSplitter
 import com.netflix.iep.guice.LifecycleModule
+import com.typesafe.config.Config
 
 final class LwcApiModule extends AbstractModule {
 
@@ -33,8 +34,8 @@ final class LwcApiModule extends AbstractModule {
 
   @Provides
   @Singleton
-  protected def providesExpressionSplitter(): ExpressionSplitter = {
-    new ExpressionSplitter()
+  protected def providesExpressionSplitter(config: Config): ExpressionSplitter = {
+    new ExpressionSplitter(config)
   }
 
   @Provides


### PR DESCRIPTION
Updates the lwcapi expression splitter to use the
same vocabulary that would get used with the graph
api after #776.