### PR TITLE
empty filtered result should be transitive

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterExpr.scala
@@ -117,7 +117,7 @@ object FilterExpr {
       val rs2 = expr2.eval(context, data)
       val result = (expr1.isGrouped, expr2.isGrouped) match {
         case (_, false) =>
-          require(rs2.data.size == 1)
+          require(rs2.data.lengthCompare(1) == 0, "empty result for filter expression")
           if (matches(context, rs2.data.head)) rs1.data else Nil
         case (false, _) =>
           // Shouldn't be able to get here

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -334,12 +334,16 @@ object MathExpr {
       val rs1 = expr1.eval(context, data)
       val rs2 = expr2.eval(context, data)
       val result = (expr1.isGrouped, expr2.isGrouped) match {
+        case (_, false) if rs2.data.isEmpty =>
+          // Happens if the RHS is non-grouped but has had a filter applied that
+          // removes the single expected entry.
+          Nil
         case (_, false) =>
-          require(rs2.data.size == 1)
+          require(rs2.data.lengthCompare(1) == 0)
           val t2 = rs2.data.head
           rs1.data.map(_.binaryOp(t2, labelFmt, this))
         case (false, _) =>
-          require(rs1.data.size == 1)
+          require(rs1.data.lengthCompare(1) == 0)
           val t1 = rs1.data.head
           // Normally tags are kept for the lhs, in this case we want to prefer the tags from
           // the grouped expr on the rhs

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/FilterSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/FilterSuite.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import org.scalatest.FunSuite
+
+class FilterSuite extends FunSuite {
+
+  private val start = 0L
+  private val step = 60000L
+  private val context = EvalContext(start, start + step, step)
+
+  test("empty result from filtering constant expression") {
+    val expr = FilterExpr.Filter(
+      MathExpr.Constant(1),
+      MathExpr.GreaterThan(MathExpr.Constant(1), MathExpr.Constant(2))
+    )
+    assert(expr.eval(context, Nil).data.isEmpty)
+  }
+
+  test("empty filtered result with binary operation, lhs") {
+    val filteredExpr = FilterExpr.Filter(
+      MathExpr.Constant(1),
+      MathExpr.GreaterThan(MathExpr.Constant(1), MathExpr.Constant(2))
+    )
+    val expr = MathExpr.Add(filteredExpr, MathExpr.Constant(2))
+    assert(expr.eval(context, Nil).data.isEmpty)
+  }
+
+  test("empty filtered result with binary operation, rhs") {
+    val filteredExpr = FilterExpr.Filter(
+      MathExpr.Constant(1),
+      MathExpr.GreaterThan(MathExpr.Constant(1), MathExpr.Constant(2))
+    )
+    val expr = MathExpr.Add(MathExpr.Constant(2), filteredExpr)
+    assert(expr.eval(context, Nil).data.isEmpty)
+  }
+
+  test("empty filtered result with binary operation, both sides") {
+    val filteredExpr = FilterExpr.Filter(
+      MathExpr.Constant(1),
+      MathExpr.GreaterThan(MathExpr.Constant(1), MathExpr.Constant(2))
+    )
+    val expr = MathExpr.Add(filteredExpr, filteredExpr)
+    assert(expr.eval(context, Nil).data.isEmpty)
+  }
+}


### PR DESCRIPTION
Fixes #781. Before if a filter was applied to a non-grouped
expression, then it could result in a confusing error being
propagated to the user. The cause was that the binary
operations did not expect for an empty result set unless
the underlying expression was grouped.