### PR TITLE
add group by keys to time series message

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
@@ -38,6 +38,8 @@ sealed trait DataExpr extends TimeSeriesExpr {
     Some(TaggedItem.computeId(tags).toString)
   }
 
+  def finalGrouping: List[String] = Nil
+
   def exprString: String
 
   protected def consolidate(step: Long, ts: List[TimeSeries]): List[TimeSeries] = {
@@ -277,6 +279,8 @@ object DataExpr {
     def keyString(tags: Map[String, String]): String = DataExpr.keyString(keys, tags)
 
     override def groupByKey(tags: Map[String, String]): Option[String] = Option(keyString(tags))
+
+    override def finalGrouping: List[String] = keys
 
     override def exprString: String = s"$af,(,${keys.mkString(",")},),:by"
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterExpr.scala
@@ -31,6 +31,8 @@ object FilterExpr {
 
     def groupByKey(tags: Map[String, String]): Option[String] = expr.groupByKey(tags)
 
+    def finalGrouping: List[String] = expr.finalGrouping
+
     private def value(s: SummaryStats): Double = stat match {
       case "avg"   => s.avg
       case "max"   => s.max
@@ -61,6 +63,8 @@ object FilterExpr {
     def isGrouped: Boolean = false
 
     def groupByKey(tags: Map[String, String]): Option[String] = None
+
+    def finalGrouping: List[String] = Nil
 
     def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
       ResultSet(this, Nil, context.state)
@@ -103,6 +107,8 @@ object FilterExpr {
     def isGrouped: Boolean = expr1.isGrouped
 
     def groupByKey(tags: Map[String, String]): Option[String] = expr1.groupByKey(tags)
+
+    def finalGrouping: List[String] = expr1.finalGrouping
 
     def matches(context: EvalContext, ts: TimeSeries): Boolean = {
       var m = false

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -43,6 +43,8 @@ object MathExpr {
 
     def groupByKey(tags: Map[String, String]): Option[String] = None
 
+    def finalGrouping: List[String] = Nil
+
     def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
       val seq = new FunctionTimeSeq(DsType.Gauge, context.step, _ => v)
       val ts = TimeSeries(Map("name" -> v.toString), v.toString, seq)
@@ -59,6 +61,8 @@ object MathExpr {
     def isGrouped: Boolean = false
 
     def groupByKey(tags: Map[String, String]): Option[String] = None
+
+    def finalGrouping: List[String] = Nil
 
     def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
       val seq = new FunctionTimeSeq(DsType.Gauge, context.step, rand)
@@ -120,6 +124,8 @@ object MathExpr {
 
     def groupByKey(tags: Map[String, String]): Option[String] = None
 
+    def finalGrouping: List[String] = Nil
+
     def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
       val seq = new FunctionTimeSeq(DsType.Gauge, context.step, valueFunc)
       val ts = TimeSeries(Map("name" -> mode), mode, seq)
@@ -136,6 +142,8 @@ object MathExpr {
     def isGrouped: Boolean = false
 
     def groupByKey(tags: Map[String, String]): Option[String] = None
+
+    def finalGrouping: List[String] = Nil
 
     private def parseDate(
       gs: ZonedDateTime,
@@ -217,6 +225,8 @@ object MathExpr {
 
     def groupByKey(tags: Map[String, String]): Option[String] = expr.groupByKey(tags)
 
+    def finalGrouping: List[String] = expr.finalGrouping
+
     def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
       val rs = expr.eval(context, data)
       ResultSet(this, rs.data.map { t =>
@@ -238,6 +248,8 @@ object MathExpr {
     def isGrouped: Boolean = expr.isGrouped
 
     def groupByKey(tags: Map[String, String]): Option[String] = expr.groupByKey(tags)
+
+    def finalGrouping: List[String] = expr.finalGrouping
 
     def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
       val rs = expr.eval(context, data)
@@ -262,6 +274,8 @@ object MathExpr {
     def isGrouped: Boolean = expr.isGrouped
 
     def groupByKey(tags: Map[String, String]): Option[String] = expr.groupByKey(tags)
+
+    def finalGrouping: List[String] = expr.finalGrouping
 
     def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
       val rs = expr.eval(context, data)
@@ -328,6 +342,10 @@ object MathExpr {
 
     def groupByKey(tags: Map[String, String]): Option[String] = {
       expr1.groupByKey(tags).orElse(expr2.groupByKey(tags))
+    }
+
+    def finalGrouping: List[String] = {
+      if (expr1.isGrouped) expr1.finalGrouping else expr2.finalGrouping
     }
 
     def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
@@ -520,6 +538,8 @@ object MathExpr {
 
     def groupByKey(tags: Map[String, String]): Option[String] = None
 
+    def finalGrouping: List[String] = Nil
+
     def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
       val rs = expr.eval(context, data)
       val ts =
@@ -605,6 +625,8 @@ object MathExpr {
     def groupByKey(tags: Map[String, String]): Option[String] =
       Option(DataExpr.keyString(keys, tags))
 
+    def finalGrouping: List[String] = keys
+
     def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
       val inner = expr.expr.eval(context, data)
 
@@ -678,6 +700,8 @@ object MathExpr {
     override def isGrouped: Boolean = true
 
     override def groupByKey(tags: Map[String, String]): Option[String] = expr.groupByKey(tags)
+
+    def finalGrouping: List[String] = expr.finalGrouping
 
     override def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
       val inner = expr.eval(context, data)
@@ -859,6 +883,8 @@ object MathExpr {
     def isGrouped: Boolean = evalExpr.isGrouped
 
     def groupByKey(tags: Map[String, String]): Option[String] = evalExpr.groupByKey(tags)
+
+    def finalGrouping: List[String] = evalExpr.finalGrouping
 
     def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
       evalExpr.eval(context, data).copy(expr = this)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
@@ -40,6 +40,8 @@ object StatefulExpr {
 
     def groupByKey(tags: Map[String, String]): Option[String] = expr.groupByKey(tags)
 
+    def finalGrouping: List[String] = expr.finalGrouping
+
     private def eval(ts: ArrayTimeSeq, s: State): State = {
       val data = ts.data
       var pos = s.pos
@@ -107,6 +109,8 @@ object StatefulExpr {
 
     def groupByKey(tags: Map[String, String]): Option[String] = expr.groupByKey(tags)
 
+    def finalGrouping: List[String] = expr.finalGrouping
+
     private def eval(ts: ArrayTimeSeq, s: State): State = {
       val desF = OnlineDes(s.desState)
 
@@ -159,6 +163,8 @@ object StatefulExpr {
     def isGrouped: Boolean = expr.isGrouped
 
     def groupByKey(tags: Map[String, String]): Option[String] = expr.groupByKey(tags)
+
+    def finalGrouping: List[String] = expr.finalGrouping
 
     private def eval(ts: ArrayTimeSeq, s: State): State = {
       val desF = OnlineSlidingDes(s.desState)
@@ -224,6 +230,8 @@ object StatefulExpr {
     def isGrouped: Boolean = expr.isGrouped
 
     def groupByKey(tags: Map[String, String]): Option[String] = expr.groupByKey(tags)
+
+    def finalGrouping: List[String] = expr.finalGrouping
 
     private def eval(period: Int, ts: ArrayTimeSeq, s: State): State = {
       val data = ts.data
@@ -292,6 +300,8 @@ object StatefulExpr {
 
     def groupByKey(tags: Map[String, String]): Option[String] = expr.groupByKey(tags)
 
+    def finalGrouping: List[String] = expr.finalGrouping
+
     def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
       val rs = expr.eval(context, data)
       val state = rs.state.getOrElse(this, new StateMap).asInstanceOf[StateMap]
@@ -334,6 +344,8 @@ object StatefulExpr {
     def isGrouped: Boolean = expr.isGrouped
 
     def groupByKey(tags: Map[String, String]): Option[String] = expr.groupByKey(tags)
+
+    def finalGrouping: List[String] = expr.finalGrouping
 
     private def newState(): State = State(Double.NaN)
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/FinalGroupingSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/FinalGroupingSuite.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.atlas.core.stacklang.Interpreter
+import org.scalatest.FunSuite
+
+class FinalGroupingSuite extends FunSuite {
+
+  private val interpreter = Interpreter(StyleVocabulary.allWords)
+
+  private def eval(s: String): List[String] = {
+    val expr = interpreter.execute(s).stack match {
+      case ModelExtractors.PresentationType(t) :: Nil => t
+      case _                                          => throw new IllegalArgumentException(s)
+    }
+    expr.expr.finalGrouping
+  }
+
+  test("constant") {
+    assert(eval("42") === Nil)
+  }
+
+  test("aggregate") {
+    assert(eval("name,sps,:eq,:sum") === Nil)
+  }
+
+  test("data group by") {
+    assert(eval("name,sps,:eq,(,cluster,),:by") === List("cluster"))
+  }
+
+  test("data group by with multiple keys") {
+    assert(eval("name,sps,:eq,(,app,region,device,),:by") === List("app", "region", "device"))
+  }
+
+  test("data group by with math aggregate") {
+    val expr = "name,sps,:eq,(,app,region,device,),:by,:max"
+    val expected = Nil
+    assert(eval(expr) === expected)
+  }
+
+  test("data group by with math group by") {
+    val expr = "name,sps,:eq,(,app,region,device,),:by,:max,(,region,device,),:by"
+    val expected = List("region", "device")
+    assert(eval(expr) === expected)
+  }
+
+  test("aggregate with percentiles") {
+    val expr = "name,sps,:eq,(,50,),:percentiles"
+    val expected = List("percentile")
+    assert(eval(expr) === expected)
+  }
+
+  test("data group by with percentiles") {
+    val expr = "name,sps,:eq,(,app,),:by,(,50,),:percentiles"
+    val expected = List("percentile", "app")
+    assert(eval(expr) === expected)
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathGroupBySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathGroupBySuite.scala
@@ -54,7 +54,7 @@ class MathGroupBySuite extends FunSuite {
     assert(rs.size === 1)
 
     val expected = ts(6).withTags(Map("name" -> "test")).withLabel("(name=test)")
-    assert(rs(0) === expected)
+    assert(rs.head === expected)
   }
 
   test("(,name,),:by,(,foo,),:by") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/BaseExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/BaseExamplesSuite.scala
@@ -16,6 +16,7 @@
 package com.netflix.atlas.core.stacklang
 
 import com.netflix.atlas.core.model.ModelExtractors
+import com.netflix.atlas.core.model.StyleExpr
 import com.netflix.atlas.core.model.TimeSeriesExpr
 import org.scalatest.FunSuite
 
@@ -60,6 +61,14 @@ abstract class BaseExamplesSuite extends FunSuite {
           }
           val stack2 = interpreter.execute(Interpreter.toString(prg)).stack
           assert(stack2 === prg)
+        }
+      }
+
+      test(s"finalGrouping and isGrouped match -- $ex,:${w.name}") {
+        interpreter.execute(s"$ex,:${w.name}").stack.foreach {
+          case s: StyleExpr      => assert(s.expr.finalGrouping.nonEmpty === s.expr.isGrouped)
+          case t: TimeSeriesExpr => assert(t.finalGrouping.nonEmpty === t.isGrouped)
+          case _                 =>
         }
       }
 

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeSeriesMessage.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeSeriesMessage.scala
@@ -32,6 +32,10 @@ import com.netflix.atlas.core.util.SmallHashMap
   *     Expression for the time series. Note, the same expression can result in many time
   *     series when using group by. For matching the data for a particular time series the
   *     id field should be used.
+  * @param groupByKeys
+  *     The final keys used for grouping the result. The value will be an empty list if
+  *     the expression is not grouped. For multi-level group by this will be the final
+  *     grouping used for the result.
   * @param start
   *     Start time for the data.
   * @param end
@@ -50,6 +54,7 @@ import com.netflix.atlas.core.util.SmallHashMap
 case class TimeSeriesMessage(
   id: String,
   query: String,
+  groupByKeys: List[String],
   start: Long,
   end: Long,
   step: Long,
@@ -94,7 +99,7 @@ object TimeSeriesMessage {
   /**
     * Create a new time series message.
     *
-    * @param query
+    * @param expr
     *     Expression for the time series. Note, the same expression can result in many time
     *     series when using group by. For matching the data for a particular time series the
     *     id field should be used.
@@ -104,12 +109,14 @@ object TimeSeriesMessage {
     * @param ts
     *     Time series to use for the message.
     */
-  def apply(query: String, context: EvalContext, ts: TimeSeries): TimeSeriesMessage = {
+  def apply(expr: StyleExpr, context: EvalContext, ts: TimeSeries): TimeSeriesMessage = {
+    val query = expr.toString
     val id = TaggedItem.computeId(ts.tags + ("atlas.query" -> query)).toString
     val data = ts.data.bounded(context.start, context.end)
     TimeSeriesMessage(
       id,
       query,
+      expr.expr.finalGrouping,
       context.start,
       context.end,
       context.step,

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeSeriesMessage.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeSeriesMessage.scala
@@ -68,6 +68,11 @@ case class TimeSeriesMessage(
     gen.writeStringField("type", "timeseries")
     gen.writeStringField("id", id)
     gen.writeStringField("query", query)
+    if (groupByKeys.nonEmpty) {
+      gen.writeArrayFieldStart("groupByKeys")
+      groupByKeys.foreach(gen.writeString)
+      gen.writeEndArray()
+    }
     gen.writeStringField("label", label)
     encodeTags(gen, tags)
     gen.writeNumberField("start", start)

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
@@ -148,7 +148,7 @@ private[stream] class FinalExprEval(interpreter: ExprInterpreter, step: Long = 6
               val result = expr.expr.eval(context, expressionDatapoints)
               states(expr) = result.state
               val msgs = result.data.map { t =>
-                TimeSeriesMessage(expr.toString, context, t.withLabel(expr.legend(t)))
+                TimeSeriesMessage(expr, context, t.withLabel(expr.legend(t)))
               }
 
               val diagnostics = expr.expr.dataExprs.flatMap(expressionDiagnostics.get)

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/TimeSeriesMessageSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/TimeSeriesMessageSuite.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+import org.scalatest.FunSuite
+
+class TimeSeriesMessageSuite extends FunSuite {
+  private val baseMessage = TimeSeriesMessage(
+    id = "12345",
+    query = "name,sps,:eq,(,cluster,),:by",
+    groupByKeys = List("cluster"),
+    start = 0L,
+    end = 60000L,
+    step = 60000L,
+    label = "test",
+    tags = Map("name" -> "sps", "cluster" -> "www"),
+    data = ArrayData(Array(42.0))
+  )
+
+  test("json encoding with empty group by") {
+    val input = baseMessage.copy(groupByKeys = Nil)
+    assert(!input.toJson.contains("groupByKeys"))
+  }
+
+  test("json encoding with group by") {
+    val input = baseMessage
+    assert(input.toJson.contains(""""groupByKeys":["cluster"]"""))
+  }
+}

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/FetchRequestActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/FetchRequestActor.scala
@@ -116,7 +116,7 @@ class FetchRequestActor(request: GraphApi.Request)
         state = result.state
         result.data.foreach { ts =>
           if (!isAllNaN(ts.data, chunk.start, chunk.end, chunk.step))
-            queue.add(TimeSeriesMessage(s.toString, chunk, ts))
+            queue.add(TimeSeriesMessage(s, chunk, ts))
         }
       }
       chunk = null


### PR DESCRIPTION
Fixes #754. Exposes the set of keys that were used
explicitly as part of a group by in the time series
messages emitted by fetch and streaming evaluation.

This is useful for things like canary analysis that
generate a set of lines for multiple clusters and
need a reliable way to find the correlated entries
from the baseline and canary. Since the tags will
contain exact matches from the query as well as
keys used in the group by, this change will allow
the user to extract just the keys from the group by
and ignore other exact match tags coming from the
scope used on the query.