### PR TITLE
fix use of multi-level group by with rewrites

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -882,6 +882,8 @@ object MathExpr {
           s"$by,:$name"
         case by: MathExpr.GroupBy if by.keys == evalExpr.finalGrouping =>
           s"$by,:$name"
+        case nr: NamedRewrite =>
+          s"$nr,:$name"
         case _ =>
           val grouping = evalExpr.finalGrouping
           val by = if (grouping.nonEmpty) grouping.mkString(",(,", ",", ",),:by") else ""

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -242,8 +242,8 @@ object MathVocabulary extends Vocabulary {
         // Multi-level group by with an implicit aggregate of :sum
         true
       case StringListType(_) :: TimeSeriesType(t) :: _ =>
-        // Default data group by applied across math operations
-        t.dataExprs.forall(_.isInstanceOf[DataExpr.AggregateFunction])
+        // Default data or math aggregate group by applied across math operations
+        true
     }
 
     protected def executor: PartialFunction[List[Any], List[Any]] = {
@@ -258,6 +258,7 @@ object MathVocabulary extends Vocabulary {
         val f = t.rewrite {
           case nr: NamedRewrite      => nr.groupBy(keys)
           case af: AggregateFunction => DataExpr.GroupBy(af, keys)
+          case af: AggrMathExpr      => MathExpr.GroupBy(af, keys)
         }
         f :: stack
     }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathGroupBySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathGroupBySuite.scala
@@ -186,4 +186,16 @@ class MathGroupBySuite extends FunSuite {
     val expr = eval(input)
     assert(expr.toString === "name,sps,:eq,:sum,(,nf.cluster,nf.asg,),:by,:max,(,nf.asg,),:by,:pct")
   }
+
+  test("avg rewrite followed by pct rewrite") {
+    val input = "app,foo,:eq,:avg,:pct"
+    val expr = eval(input)
+    assert(expr.toString === input)
+  }
+
+  test("avg rewrite grouped followed by pct rewrite") {
+    val input = "app,foo,:eq,:avg,(,nf.cluster,),:by,:pct"
+    val expr = eval(input)
+    assert(expr.toString === input)
+  }
 }


### PR DESCRIPTION
Fixes #584. Before this would result in errors if the
rewrite resulted in a non-grouped time series expression.