### PR TITLE
re-enable scala 2.11 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,14 @@ language: scala
 matrix:
   include:
   - jdk: oraclejdk8
+    scala: 2.11.12
+    env: BINTRAY_PUBLISH=true
+  - jdk: oraclejdk8
+    scala: 2.12.4
     env: BINTRAY_PUBLISH=true
   - jdk: oraclejdk9
+    scala: 2.12.4
     env: BINTRAY_PUBLISH=false
-scala:
-- 2.12.4
 script:
 - ./scripts/buildViaTravis.sh
 sudo: required

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookupSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookupSuite.scala
@@ -44,7 +44,7 @@ class EurekaGroupsLookupSuite extends FunSuite {
     applications = EurekaSource.Apps(
       List(
         EurekaSource.App("one", mkInstances("one", 5)),
-        EurekaSource.App("two", mkInstances("two", 3)),
+        EurekaSource.App("two", mkInstances("two", 3))
       )
     )
   )

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
@@ -113,7 +113,7 @@ class FinalExprEvalSuite extends FunSuite {
       group(0),
       group(1, AggrDatapoint(0, expr, "i-1", tags, 42.0)),
       group(2, AggrDatapoint(0, expr, "i-1", tags, 43.0)),
-      group(3, AggrDatapoint(0, expr, "i-1", tags, 44.0)),
+      group(3, AggrDatapoint(0, expr, "i-1", tags, 44.0))
     )
 
     val output = run(input)
@@ -158,7 +158,7 @@ class FinalExprEvalSuite extends FunSuite {
         3,
         AggrDatapoint(0, expr, "i-1", tags, 43.0),
         AggrDatapoint(0, expr, "i-2", tags, 44.0)
-      ),
+      )
     )
 
     val output = run(input)
@@ -194,7 +194,7 @@ class FinalExprEvalSuite extends FunSuite {
     val input = List(
       sources(
         ds("a", s"http://atlas/graph?q=$expr1"),
-        ds("b", s"http://atlas/graph?q=$expr2"),
+        ds("b", s"http://atlas/graph?q=$expr2")
       ),
       group(0, AggrDatapoint(0, expr1, "i-1", tags, 42.0)),
       group(
@@ -208,7 +208,7 @@ class FinalExprEvalSuite extends FunSuite {
         AggrDatapoint(0, expr2, "i-1", tags, 43.0),
         AggrDatapoint(0, expr2, "i-3", tags, 49.0),
         AggrDatapoint(0, expr1, "i-2", tags, 44.0)
-      ),
+      )
     )
 
     val output = run(input)
@@ -257,21 +257,21 @@ class FinalExprEvalSuite extends FunSuite {
         0, // Missing sum for i-2
         AggrDatapoint(0, expr1, "i-1", Map("node" -> "i-1"), 42.0),
         AggrDatapoint(0, expr2, "i-1", Map("node" -> "i-1"), 1.0),
-        AggrDatapoint(0, expr2, "i-2", Map("node" -> "i-2"), 1.0),
+        AggrDatapoint(0, expr2, "i-2", Map("node" -> "i-2"), 1.0)
       ),
       group(
         1,
         AggrDatapoint(0, expr1, "i-1", Map("node" -> "i-1"), 42.0),
         AggrDatapoint(0, expr1, "i-2", Map("node" -> "i-2"), 21.0),
         AggrDatapoint(0, expr2, "i-1", Map("node" -> "i-1"), 1.0),
-        AggrDatapoint(0, expr2, "i-2", Map("node" -> "i-2"), 1.0),
+        AggrDatapoint(0, expr2, "i-2", Map("node" -> "i-2"), 1.0)
       ),
       group(
         2, // Missing count for i-1
         AggrDatapoint(0, expr1, "i-1", Map("node" -> "i-1"), 42.0),
         AggrDatapoint(0, expr1, "i-2", Map("node" -> "i-2"), 21.0),
-        AggrDatapoint(0, expr2, "i-2", Map("node" -> "i-2"), 1.0),
-      ),
+        AggrDatapoint(0, expr2, "i-2", Map("node" -> "i-2"), 1.0)
+      )
     )
 
     val output = run(input)

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/SubscriptionManagerSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/SubscriptionManagerSuite.scala
@@ -48,7 +48,7 @@ class SubscriptionManagerSuite extends FunSuite with BeforeAndAfter {
     applications = EurekaSource.Apps(
       List(
         EurekaSource.App("one", mkInstances("one", 5)),
-        EurekaSource.App("two", mkInstances("two", 3)),
+        EurekaSource.App("two", mkInstances("two", 3))
       )
     )
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
     val slf4j      = "1.7.25"
     val spectator  = "0.61.0"
 
-    val crossScala = Seq(scala)
+    val crossScala = Seq(scala, "2.11.12")
   }
 
   import Versions._


### PR DESCRIPTION
It was dropped in #600. There are some use-cases
where it would be helpful to use the latest version
from Spark which does not yet support 2.12. We'll
revisit for Atlas 1.7.