### PR TITLE
fix offset for aggregate function rewrites

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TimeSeriesExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TimeSeriesExpr.scala
@@ -34,7 +34,8 @@ trait TimeSeriesExpr extends Expr {
     */
   def withOffset(d: Duration): TimeSeriesExpr = {
     val expr = rewrite {
-      case e: DataExpr => e.withOffset(d)
+      case e: DataExpr              => e.withOffset(d)
+      case e: MathExpr.NamedRewrite => e.withOffset(d)
     }
     expr.asInstanceOf[TimeSeriesExpr]
   }


### PR DESCRIPTION
Before if the display expression for a rewrite was a
Query type it would not correctly get the offset applied.

Fixes #788.