### PR TITLE
fix additional case of losing offset

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/NamedRewriteSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/NamedRewriteSuite.scala
@@ -15,20 +15,42 @@
  */
 package com.netflix.atlas.core.model
 
+import java.time.Duration
+
 import com.netflix.atlas.core.stacklang.Interpreter
+import com.typesafe.config.ConfigFactory
 import org.scalatest.FunSuite
 
 class NamedRewriteSuite extends FunSuite {
 
-  private val interpreter = Interpreter(MathVocabulary.allWords)
+  private val config = ConfigFactory.parseString("""
+      |atlas.core.vocabulary {
+      |  words = []
+      |custom-averages = [
+      |  {
+      |    name = "node-avg"
+      |    base-query = "name,numNodes,:eq"
+      |    keys = ["app"]
+      |  }
+      |]
+      |}
+    """.stripMargin)
 
-  private def eval(program: String): List[TimeSeriesExpr] = {
-    interpreter.execute(program).stack.map {
-      case ModelExtractors.TimeSeriesType(t) =>
+  private val interpreter = Interpreter(new CustomVocabulary(config).allWords)
+
+  private def rawEval(program: String): List[StyleExpr] = {
+    interpreter.execute(program).stack.flatMap {
+      case ModelExtractors.PresentationType(t) => t.perOffset
+    }
+  }
+
+  private def eval(program: String): List[StyleExpr] = {
+    interpreter.execute(program).stack.flatMap {
+      case ModelExtractors.PresentationType(t) =>
         val expanded = t.rewrite {
           case nr: MathExpr.NamedRewrite => nr.evalExpr
         }
-        expanded.asInstanceOf[TimeSeriesExpr]
+        expanded.asInstanceOf[StyleExpr].perOffset
     }
   }
 
@@ -88,6 +110,44 @@ class NamedRewriteSuite extends FunSuite {
     val actual = eval("name,a,:eq,:avg,(,b,),:by,:max,1h,:offset")
     val expected = eval("name,a,:eq,:dup,:sum,:swap,:count,:div,1h,:offset,(,b,),:by,:max")
     assert(actual === expected)
+  }
+
+  test("node-avg, group by, max with offset") {
+    val actual = eval("name,a,:eq,:node-avg,(,app,),:by,:max,1h,:offset")
+    val expected = eval("name,a,:eq,name,numNodes,:eq,:div,1h,:offset,(,app,),:by,:max")
+    assert(actual === expected)
+  }
+
+  test("node-avg, offset maintained after query rewrite") {
+    val exprs = rawEval("name,a,:eq,:node-avg,1h,:offset").map { expr =>
+      expr.rewrite {
+        case q: Query => Query.And(q, Query.Equal("region", "east"))
+      }
+    }
+    val offsets = exprs
+      .collect {
+        case t: StyleExpr =>
+          t.expr.dataExprs.map(_.offset)
+      }
+      .flatten
+      .distinct
+    assert(offsets === List(Duration.ofHours(1)))
+  }
+
+  test("node-avg, group by, offset maintained after query rewrite") {
+    val exprs = rawEval("name,a,:eq,:node-avg,(,app,),:by,1h,:offset").map { expr =>
+      expr.rewrite {
+        case q: Query => Query.And(q, Query.Equal("region", "east"))
+      }
+    }
+    val offsets = exprs
+      .collect {
+        case t: StyleExpr =>
+          t.expr.dataExprs.map(_.offset)
+      }
+      .flatten
+      .distinct
+    assert(offsets === List(Duration.ofHours(1)))
   }
 
   test("freeze works with named rewrite, cq") {


### PR DESCRIPTION
The group by operation could lose the offset if it was
not encoded as part of the display expression.