### PR TITLE
simplify string mapping for NamedRewrite

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -878,12 +878,8 @@ object MathExpr {
           }
 
           buffer.toString()
-        case by: DataExpr.GroupBy if by.keys == evalExpr.finalGrouping =>
-          s"$by,:$name"
-        case by: MathExpr.GroupBy if by.keys == evalExpr.finalGrouping =>
-          s"$by,:$name"
-        case nr: NamedRewrite =>
-          s"$nr,:$name"
+        case t: TimeSeriesExpr if t.finalGrouping == evalExpr.finalGrouping =>
+          s"$t,:$name"
         case _ =>
           val grouping = evalExpr.finalGrouping
           val by = if (grouping.nonEmpty) grouping.mkString(",(,", ",", ",),:by") else ""

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathGroupBySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathGroupBySuite.scala
@@ -157,6 +157,12 @@ class MathGroupBySuite extends FunSuite {
     assert(expr.toString === input)
   }
 
+  test("multi-level group by with intermediate math and rewrites") {
+    val input = "name,sps,:eq,:sum,(,nf.cluster,nf.asg,),:by,:abs,:avg,(,nf.cluster,),:by"
+    val expr = eval(input)
+    assert(expr.toString === input)
+  }
+
   test("math group by and unary op") {
     val input = "name,sps,:eq,:sum,:abs,(,nf.cluster,),:by"
     val expr = eval(input)

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/NamedRewriteSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/NamedRewriteSuite.scala
@@ -101,4 +101,29 @@ class NamedRewriteSuite extends FunSuite {
     val expected = eval("name,a,:eq,name,b,:eq,:avg,42,:add")
     assert(actual === expected)
   }
+
+  test("pct rewrite") {
+    val actual = eval("name,a,:eq,(,b,),:by,:pct")
+    val expected = eval("name,a,:eq,(,b,),:by,:dup,:sum,:div,100,:mul")
+    assert(actual === expected)
+  }
+
+  test("pct rewrite with cq") {
+    val actual = eval("name,a,:eq,(,b,),:by,:pct,c,:has,:cq")
+    val expected = eval("name,a,:eq,(,b,),:by,:dup,:sum,:div,100,:mul,c,:has,:cq")
+    assert(actual === expected)
+  }
+
+  test("pct after binary op") {
+    val actual = eval("name,a,:eq,(,b,),:by,10,:mul,:pct")
+    val expected = eval("name,a,:eq,(,b,),:by,10,:mul,:dup,:sum,:div,100,:mul")
+    assert(actual === expected)
+  }
+
+  // https://github.com/Netflix/atlas/issues/791
+  test("pct after binary op with cq") {
+    val actual = eval("name,a,:eq,(,b,),:by,10,:mul,:pct,c,:has,:cq")
+    val expected = eval("name,a,:eq,(,b,),:by,10,:mul,:dup,:sum,:div,100,:mul,c,:has,:cq")
+    assert(actual === expected)
+  }
 }


### PR DESCRIPTION
If the final grouping for display varies from the final
grouping of the eval, then the rewrite is applying a
secondary grouping. Otherwise just apply the rewrite
operator.

Fixes #791.