### PR TITLE
docs: fix end tag for example tables

### DIFF
--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Page.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/Page.scala
@@ -120,7 +120,7 @@ trait StackWordPage extends Page {
         buf
           .append(s"<tr>\n<td>$p</td>\n")
           .append(s"${renderCell(i, graph, params)}\n")
-          .append(s"${renderCell(o, graph, params)}\n<s/tr>")
+          .append(s"${renderCell(o, graph, params)}\n</tr>")
     }
     buf.append("</tbody></table>\n")
     buf.toString()


### PR DESCRIPTION
Change `<s/tr>` to `</tr>`.