### PR TITLE
fix removal of key that is not in SmallHashMap

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
@@ -278,11 +278,15 @@ final class SmallHashMap[K <: Any, V <: Any] private (val data: Array[Any], data
   }
 
   def -(key: K): collection.immutable.Map[K, V] = {
-    val b = new SmallHashMap.Builder[K, V](size - 1)
-    foreachItem { (k, v) =>
-      if (key != k) b.add(k, v)
+    if (contains(key)) {
+      val b = new SmallHashMap.Builder[K, V](size - 1)
+      foreachItem { (k, v) =>
+        if (key != k) b.add(k, v)
+      }
+      b.result
+    } else {
+      this
     }
-    b.result
   }
 
   def ++(m: Map[K, V]): collection.immutable.Map[K, V] = {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/SmallHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/SmallHashMapSuite.scala
@@ -232,6 +232,12 @@ class SmallHashMapSuite extends FunSuite {
     assert((m2 - "k2").isInstanceOf[SmallHashMap[_, _]])
   }
 
+  test("remove key not in map") {
+    val m1 = SmallHashMap("k1" -> "v1", "k2" -> "v2")
+    assert(m1 === m1 - "k3")
+    assert((m1 - "k3").isInstanceOf[SmallHashMap[_, _]])
+  }
+
   test("retains type after adding pair") {
     val m1 = SmallHashMap("k1" -> "v1")
     val m2 = SmallHashMap("k1" -> "v1", "k2" -> "v2")


### PR DESCRIPTION
Before it would fail with:

```
requirement failed: data array is full
```