### PR TITLE
add mapping for dynamo-db throttle events

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/dynamodb.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/dynamodb.conf
@@ -2,7 +2,7 @@
 atlas {
   cloudwatch {
 
-    // http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/MonitoringDynamoDB.html#dynamodb-metrics
+    // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/metrics-dimensions.html
     dynamodb-table-1m = {
       namespace = "AWS/DynamoDB"
       period = 1m
@@ -32,6 +32,28 @@ atlas {
           name = "ConsumedWriteCapacityUnits"
           alias = "aws.dynamodb.consumedCapacity"
           conversion = "dist-summary"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "ReadThrottleEvents"
+          alias = "aws.dynamodb.throttleEvents"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "WriteThrottleEvents"
+          alias = "aws.dynamodb.throttleEvents"
+          conversion = "sum,rate"
           tags = [
             {
               key = "id"


### PR DESCRIPTION
These appear to only be available at the table level. The
error for request throttled would be needed to see how it
impacts particular operations.