### PR TITLE
remove bad api from static config

### DIFF
--- a/atlas-standalone/src/main/resources/static.conf
+++ b/atlas-standalone/src/main/resources/static.conf
@@ -10,7 +10,6 @@ atlas {
 
     api-endpoints = ${?atlas.akka.api-endpoints} [
       "com.netflix.atlas.webapi.TagsApi",
-      "com.netflix.atlas.webapi.RenderApi",
       "com.netflix.atlas.webapi.GraphApi"
     ]
   }


### PR DESCRIPTION
The RenderApi never really worked and was removed as
part of #797.