### PR TITLE
avoid config loading for demo dataset

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/DataSet.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/DataSet.scala
@@ -231,7 +231,9 @@ private[db] object DataSet {
     ds.withTags(tags)
   }
 
-  val step = DefaultSettings.stepSize
+  // For the sample data sets it doesn't matter much wath the step size is, just use
+  // a minute
+  val step = 60000
 
   def constant(v: Double): TimeSeries = {
     TimeSeries(Map("name" -> v.toString), new FunctionTimeSeq(DsType.Gauge, step, _ => v))


### PR DESCRIPTION
This is used for generating fake data for the purposes
of testing or creating documentation examples. The config
load is causing problems due to classloader issues when
running as part of build plugin. Not sure why, but for this
use-case it can be avoided.