### PR TITLE
preserve offset information for :percentiles

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -696,7 +696,10 @@ object MathExpr {
           expr.af.query.toString
         else
           s"${expr.af.query},(,${evalGroupKeys.mkString(",")},),:by"
-      s"$baseExpr,(,${pcts.mkString(",")},),:percentiles"
+      if (expr.offset.isZero)
+        s"$baseExpr,(,${pcts.mkString(",")},),:percentiles"
+      else
+        s"$baseExpr,(,${pcts.mkString(",")},),:percentiles,${expr.offset},:offset"
     }
 
     override def dataExprs: List[DataExpr] = List(expr)


### PR DESCRIPTION
Before it was getting lost if the percentile expression was
written back out to a string. Fixes #809.