### PR TITLE
iep 1.2.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val akka       = "2.5.11"
     val akkaHttpV  = "10.1.1"
     val aws        = "1.11.299"
-    val iep        = "1.2.1"
+    val iep        = "1.2.2"
     val guice      = "4.1.0"
     val jackson    = "2.9.5"
     val log4j      = "2.11.0"


### PR DESCRIPTION
This is mostly just to trigger a change to verify the
release. The previous attempt at 1.6.0-rc.10 failed
because it was still trying to publish 1.6.0-rc.9. The
theory is that this is because they were both tagging
the same commit.