### PR TITLE
switch to `skip in publish := true`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val root = project.in(file("."))
     `atlas-test`,
     `atlas-webapi`,
     `atlas-wiki`)
-  .settings(BuildSettings.noPackaging: _*)
+  .settings(skip in publish := true)
 
 lazy val `atlas-akka` = project
   .configure(BuildSettings.profile)

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -62,14 +62,6 @@ object BuildSettings {
     "jfrog".at("http://oss.jfrog.org/oss-snapshot-local")
   )
 
-  // Don't create root.jar, from:
-  // http://stackoverflow.com/questions/20747296/producing-no-artifact-for-root-project-with-package-under-multi-project-build-in
-  lazy val noPackaging = Seq(
-    Keys.`package` := file(""),
-    packageBin in Global := file(""),
-    packagedArtifacts := Map()
-  )
-
   def profile: Project => Project = p => {
     bintrayProfile(p)
       .settings(buildSettings: _*)


### PR DESCRIPTION
The old no packaging hack is no longer needed on recent
versions of sbt and sbt-bintray.