### PR TITLE
Add :pow operator

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -434,6 +434,21 @@ object MathExpr {
     }
   }
 
+  case class Power(expr1: TimeSeriesExpr, expr2: TimeSeriesExpr) extends BinaryMathExpr {
+
+    def name: String = "pow"
+
+    def labelFmt: String = "pow(%s, %s)"
+
+    def apply(v1: Double, v2: Double): Double = {
+      // we just use the behavior of math.pow, so expressions like math.pow(0, 0)
+      // or math.pow(Double.PositiveInfinity, 0) will return 1, not NaN (or an arithmetic exception)
+      // even though they're technically undefined.
+
+      math.pow(v1, v2)
+    }
+  }
+
   case class GreaterThan(expr1: TimeSeriesExpr, expr2: TimeSeriesExpr) extends BinaryMathExpr {
 
     def name: String = "gt"

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -54,6 +54,7 @@ object MathVocabulary extends Vocabulary {
     Subtract,
     Multiply,
     Divide,
+    Power,
     GreaterThan,
     GreaterThanEqual,
     LessThan,
@@ -727,6 +728,21 @@ object MathVocabulary extends Vocabulary {
         || Input 2 | 2.0 | 0.0 | 0.0 | NaN | NaN |
         |
         |Use the [fdiv](math-fdiv) operator to get strict floating point behavior.
+      """.stripMargin.trim
+  }
+
+  case object Power extends BinaryWord {
+
+    override def name: String = "pow"
+
+    def newInstance(t1: TimeSeriesExpr, t2: TimeSeriesExpr): TimeSeriesExpr = {
+      MathExpr.Power(t1, t2)
+    }
+
+    override def summary: String =
+      """
+        |Compute a new time series where each interval has the value `(a power b)` where `a`
+        | and `b` are the corresponding intervals in the input time series.
       """.stripMargin.trim
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
@@ -35,6 +35,6 @@ class ModelExtractorsSuite extends FunSuite {
   completionTest("name", 8)
   completionTest("name,sps", 19)
   completionTest("name,sps,:eq", 20)
-  completionTest("name,sps,:eq,app,foo,:eq", 40)
+  completionTest("name,sps,:eq,app,foo,:eq", 41)
   completionTest("name,sps,:eq,app,foo,:eq,:and,(,asg,)", 10)
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
@@ -66,6 +66,8 @@ class TimeSeriesExprSuite extends FunSuite {
     ":true,10,:sub"              -> const(ts(unknownTag, "(name=unknown - 10.0)", 55.0 - 10)),
     ":true,10,:mul"              -> const(ts(unknownTag, "(name=unknown * 10.0)", 55.0 * 10)),
     ":true,10,:div"              -> const(ts(unknownTag, "(name=unknown / 10.0)", 55.0 / 10)),
+    ":true,2,:pow"               -> const(ts(unknownTag, "pow(name=unknown, 2.0)", math.pow(55.0, 2.0))),
+    "2,:true,:pow"               -> const(ts(Map("name" -> "2.0"), "pow(2.0, name=unknown)", math.pow(2.0, 55.0))),
     ":true,0,:div"               -> const(ts(unknownTag, "(name=unknown / 0.0)", Double.NaN)),
     ":true,55,:gt"               -> const(ts(unknownTag, "(name=unknown > 55.0)", 0.0)),
     ":true,0,:gt"                -> const(ts(unknownTag, "(name=unknown > 0.0)", 1.0)),

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
@@ -67,25 +67,27 @@ class TimeSeriesExprSuite extends FunSuite {
     ":true,10,:mul"              -> const(ts(unknownTag, "(name=unknown * 10.0)", 55.0 * 10)),
     ":true,10,:div"              -> const(ts(unknownTag, "(name=unknown / 10.0)", 55.0 / 10)),
     ":true,2,:pow"               -> const(ts(unknownTag, "pow(name=unknown, 2.0)", math.pow(55.0, 2.0))),
-    "2,:true,:pow"               -> const(ts(Map("name" -> "2.0"), "pow(2.0, name=unknown)", math.pow(2.0, 55.0))),
-    ":true,0,:div"               -> const(ts(unknownTag, "(name=unknown / 0.0)", Double.NaN)),
-    ":true,55,:gt"               -> const(ts(unknownTag, "(name=unknown > 55.0)", 0.0)),
-    ":true,0,:gt"                -> const(ts(unknownTag, "(name=unknown > 0.0)", 1.0)),
-    ":true,55.1,:ge"             -> const(ts(unknownTag, "(name=unknown >= 55.1)", 0.0)),
-    ":true,55,:ge"               -> const(ts(unknownTag, "(name=unknown >= 55.0)", 1.0)),
-    ":true,0,:ge"                -> const(ts(unknownTag, "(name=unknown >= 0.0)", 1.0)),
-    ":true,55,:lt"               -> const(ts(unknownTag, "(name=unknown < 55.0)", 0.0)),
-    ":true,56,:lt"               -> const(ts(unknownTag, "(name=unknown < 56.0)", 1.0)),
-    ":true,55.1,:le"             -> const(ts(unknownTag, "(name=unknown <= 55.1)", 1.0)),
-    ":true,55,:le"               -> const(ts(unknownTag, "(name=unknown <= 55.0)", 1.0)),
-    ":true,0,:le"                -> const(ts(unknownTag, "(name=unknown <= 0.0)", 0.0)),
-    ":true,0,:and"               -> const(ts(unknownTag, "(name=unknown AND 0.0)", 0.0)),
-    ":true,1,:and"               -> const(ts(unknownTag, "(name=unknown AND 1.0)", 1.0)),
-    ":true,0,:or"                -> const(ts(unknownTag, "(name=unknown OR 0.0)", 1.0)),
-    ":true,1,:or"                -> const(ts(unknownTag, "(name=unknown OR 1.0)", 1.0)),
-    "0,0,:or"                    -> const(ts("name" -> "0.0", "(0.0 OR 0.0)", 0.0)),
-    "1,:per-step"                -> const(ts(Map("name" -> "1.0"), "per-step(1.0)", 60)),
-    "1,:integral"                -> const(integral(Map("name" -> "1.0"), "integral(1.0)", 1.0)),
+    "2,:true,:pow" -> const(
+      ts(Map("name" -> "2.0"), "pow(2.0, name=unknown)", math.pow(2.0, 55.0))
+    ),
+    ":true,0,:div"   -> const(ts(unknownTag, "(name=unknown / 0.0)", Double.NaN)),
+    ":true,55,:gt"   -> const(ts(unknownTag, "(name=unknown > 55.0)", 0.0)),
+    ":true,0,:gt"    -> const(ts(unknownTag, "(name=unknown > 0.0)", 1.0)),
+    ":true,55.1,:ge" -> const(ts(unknownTag, "(name=unknown >= 55.1)", 0.0)),
+    ":true,55,:ge"   -> const(ts(unknownTag, "(name=unknown >= 55.0)", 1.0)),
+    ":true,0,:ge"    -> const(ts(unknownTag, "(name=unknown >= 0.0)", 1.0)),
+    ":true,55,:lt"   -> const(ts(unknownTag, "(name=unknown < 55.0)", 0.0)),
+    ":true,56,:lt"   -> const(ts(unknownTag, "(name=unknown < 56.0)", 1.0)),
+    ":true,55.1,:le" -> const(ts(unknownTag, "(name=unknown <= 55.1)", 1.0)),
+    ":true,55,:le"   -> const(ts(unknownTag, "(name=unknown <= 55.0)", 1.0)),
+    ":true,0,:le"    -> const(ts(unknownTag, "(name=unknown <= 0.0)", 0.0)),
+    ":true,0,:and"   -> const(ts(unknownTag, "(name=unknown AND 0.0)", 0.0)),
+    ":true,1,:and"   -> const(ts(unknownTag, "(name=unknown AND 1.0)", 1.0)),
+    ":true,0,:or"    -> const(ts(unknownTag, "(name=unknown OR 0.0)", 1.0)),
+    ":true,1,:or"    -> const(ts(unknownTag, "(name=unknown OR 1.0)", 1.0)),
+    "0,0,:or"        -> const(ts("name" -> "0.0", "(0.0 OR 0.0)", 0.0)),
+    "1,:per-step"    -> const(ts(Map("name" -> "1.0"), "per-step(1.0)", 60)),
+    "1,:integral"    -> const(integral(Map("name" -> "1.0"), "integral(1.0)", 1.0)),
     "minuteOfDay,:time,1,:add" -> const(
       integral(Map("name" -> "minuteOfDay"), "(minuteOfDay + 1.0)", 1.0)
     ),
@@ -240,6 +242,7 @@ class TimeSeriesExprSuite extends FunSuite {
             val rs = expr.eval(p.ctxt, p.input)
             val ctxts = p.ctxt.partition(step, ChronoUnit.MINUTES)
             var state = Map.empty[StatefulExpr, Any]
+
             val incrResults = ctxts.map { ctxt =>
               val c = ctxt.copy(state = state)
               val results = expr.eval(c, bounded(p.input, ctxt))
@@ -247,6 +250,7 @@ class TimeSeriesExprSuite extends FunSuite {
               val boundedResults = results.data.map(_.mapTimeSeq(_.bounded(ctxt.start, ctxt.end)))
               boundedResults.groupBy(_.id)
             }
+
             val incrRS = ResultSet(
               expr,
               rs.data.map { t =>
@@ -354,6 +358,7 @@ class TimeSeriesExprSuite extends FunSuite {
   }
 
   def constants: List[TimeSeries] = {
+
     val ts = (0 to 10).map { i =>
       val seq = new FunctionTimeSeq(DsType.Gauge, 60000, _ => i)
       TimeSeries(Map("name" -> i.toString, "type" -> "constant"), seq)


### PR DESCRIPTION
Allows the user to use `math.pow` on time series expressions.

`a,b,:pow` will return a new time series where the values are `a` taken
to the power of `b`.