### PR TITLE
add helper for tracking index stats

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit
 
 import com.netflix.atlas.core.index.BatchUpdateTagIndex
 import com.netflix.atlas.core.index.CachingTagIndex
+import com.netflix.atlas.core.index.IndexStats
 import com.netflix.atlas.core.index.RoaringTagIndex
 import com.netflix.atlas.core.index.TagQuery
 import com.netflix.atlas.core.model.Block
@@ -60,8 +61,10 @@ class MemoryDatabase(registry: Registry, config: Config) extends Database {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  val index = new BatchUpdateTagIndex[BlockStoreItem]({ items =>
-    new CachingTagIndex(new RoaringTagIndex(items))
+  private val stats = new IndexStats(registry)
+
+  val index = new BatchUpdateTagIndex[BlockStoreItem](registry, { items =>
+    new CachingTagIndex(new RoaringTagIndex(items, stats))
   })
 
   // If the last update time for the index is older than the rebuild age force an update

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/SimpleStaticDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/SimpleStaticDatabase.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.core.db
 
+import com.netflix.atlas.core.index.IndexStats
 import com.netflix.atlas.core.index.RoaringTagIndex
 import com.netflix.atlas.core.index.TagIndex
 import com.netflix.atlas.core.index.TagQuery
@@ -28,7 +29,7 @@ class SimpleStaticDatabase(data: List[TimeSeries], config: Config) extends Datab
   private val maxLines = config.getInt("max-lines")
   private val maxDatapoints = config.getInt("max-datapoints")
 
-  val index: TagIndex[TimeSeries] = new RoaringTagIndex(data.toArray)
+  val index: TagIndex[TimeSeries] = new RoaringTagIndex(data.toArray, new IndexStats())
 
   def execute(context: EvalContext, expr: DataExpr): List[TimeSeries] = {
     val q = TagQuery(Some(expr.query))

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/IndexStats.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/IndexStats.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.index
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.patterns.PolledMeter
+
+/**
+  * Helper for reporting basic stats about the index. The three stats collected
+  * are:
+  *
+  * 1. Number of key strings
+  * 2. Number of value strings
+  * 3. Number of items
+  *
+  * The number of strings help to determine how close we are to the size of the
+  * string table used for interning. Items is mostly provided as a cross reference
+  * to get a rough idea of the impact for rolling up a given key. Since the overlap
+  * with other dimensions is not known, it will only be a rough estimate.
+  *
+  * @param registry
+  *     Spectator registry to use for reporting the stats.
+  */
+class IndexStats(registry: Registry = new NoopRegistry) {
+
+  import IndexStats._
+
+  private val numberOfKeys = PolledMeter
+    .using(registry)
+    .withName("atlas.index.numberOfKeys")
+    .monitorValue(new AtomicLong())
+
+  private val numberOfValues = new ConcurrentHashMap[Id, ValueEntry]()
+
+  /**
+    * Update the stats based on the latest build of the index.
+    */
+  def updateKeyStats(stats: List[KeyStat]): Unit = {
+    numberOfKeys.set(stats.length)
+
+    val now = registry.clock().wallTime()
+    val n = 20
+    val sorted = stats.sortWith(_.numValues >= _.numValues)
+
+    // Include the key for the top-N
+    sorted.take(n).foreach { stat =>
+      updateKeyStat("atlas.index.numberOfValues", stat.key, stat.numValues)
+      updateKeyStat("atlas.index.numberOfItems", stat.key, stat.numItems)
+    }
+
+    // All others get aggregated
+    var numValues = 0L
+    var numItems = 0L
+    sorted.drop(n).foreach { stat =>
+      numValues += stat.numValues
+      numItems += stat.numItems
+    }
+    updateKeyStat("atlas.index.numberOfValues", "-others-", numValues)
+    updateKeyStat("atlas.index.numberOfItems", "-others-", numItems)
+
+    // Remove older keys that have not been updated
+    val iter = numberOfValues.entrySet().iterator()
+    while (iter.hasNext) {
+      val entry = iter.next()
+      if (entry.getValue.timestamp.get() < now) {
+        PolledMeter.remove(registry, entry.getKey)
+        registry.gauge(entry.getKey).set(Double.NaN)
+        iter.remove()
+      }
+    }
+  }
+
+  private def updateKeyStat(name: String, key: String, count: Long): Unit = {
+    val valueId = registry.createId(name, "key", key)
+    val entry = numberOfValues.computeIfAbsent(
+      valueId,
+      id => {
+        val gauge = PolledMeter
+          .using(registry)
+          .withId(id)
+          .monitorValue(new AtomicLong())
+        ValueEntry(new AtomicLong(registry.clock().wallTime()), gauge)
+      }
+    )
+    entry.timestamp.set(registry.clock().wallTime())
+    entry.count.set(count)
+  }
+}
+
+object IndexStats {
+  case class KeyStat(key: String, numItems: Long, numValues: Long)
+  private case class ValueEntry(timestamp: AtomicLong, count: AtomicLong)
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/BatchUpdateTagIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/BatchUpdateTagIndexSuite.scala
@@ -16,14 +16,19 @@
 package com.netflix.atlas.core.index
 
 import com.netflix.atlas.core.model.LazyTaggedItem
+import com.netflix.spectator.api.NoopRegistry
 import org.scalatest.FunSuite
 
 class BatchUpdateTagIndexSuite extends FunSuite {
 
   case class Item(tags: Map[String, String], version: Int) extends LazyTaggedItem
 
+  private def newIndex: BatchUpdateTagIndex[Item] = {
+    BatchUpdateTagIndex.newRoaringIndex(new NoopRegistry)
+  }
+
   test("update") {
-    val idx = BatchUpdateTagIndex.newRoaringIndex[Item]
+    val idx = newIndex
     assert(idx.size === 0)
 
     val updates = List(Item(Map("a" -> "b"), 0))
@@ -35,7 +40,7 @@ class BatchUpdateTagIndexSuite extends FunSuite {
   }
 
   test("update, new items") {
-    val idx = BatchUpdateTagIndex.newRoaringIndex[Item]
+    val idx = newIndex
     assert(idx.size === 0)
 
     val updates1 = List(Item(Map("a" -> "b"), 0))
@@ -54,7 +59,7 @@ class BatchUpdateTagIndexSuite extends FunSuite {
   }
 
   test("update, prefer older item") {
-    val idx = BatchUpdateTagIndex.newRoaringIndex[Item]
+    val idx = newIndex
     assert(idx.size === 0)
 
     val updates1 = List(Item(Map("a" -> "b"), 0))

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/IndexStatsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/IndexStatsSuite.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.index
+
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.ManualClock
+import com.netflix.spectator.api.patterns.PolledMeter
+import org.scalatest.BeforeAndAfter
+import org.scalatest.FunSuite
+
+class IndexStatsSuite extends FunSuite with BeforeAndAfter {
+
+  private val clock = new ManualClock()
+  private var registry = new DefaultRegistry(clock)
+  private var stats = new IndexStats(registry)
+
+  before {
+    clock.setWallTime(0)
+    registry = new DefaultRegistry(clock)
+    stats = new IndexStats(registry)
+
+    val keyStats = (0 until 50).map { i =>
+      IndexStats.KeyStat(i.toString, 50 - i, i)
+    }
+    stats.updateKeyStats(keyStats.toList)
+    PolledMeter.update(registry)
+  }
+
+  test("expected number of gauges present") {
+    // Should have 43 metrics, 1 num keys, 21 num values, 21 num items
+    assert(registry.gauges().count() === 43)
+  }
+
+  test("top-N value") {
+    val numValues = registry.gauge("atlas.index.numberOfValues", "key", "42").value()
+    assert(numValues === 42)
+  }
+
+  test("top-N item") {
+    val numItems = registry.gauge("atlas.index.numberOfItems", "key", "42").value()
+    assert(numItems === 8)
+  }
+
+  test("aggregation of other values") {
+    // Top 20 are selected, others is N * (N - 1) / 2
+    val numValues = registry.gauge("atlas.index.numberOfValues", "key", "-others-").value()
+    assert(numValues === 30 * 29 / 2)
+  }
+
+  test("aggregation of other items") {
+    // Top 20 by value are selected, items were given reverse counts
+    val numItems = registry.gauge("atlas.index.numberOfItems", "key", "-others-").value()
+    val overall = 50 * 51 / 2
+    val top20 = 20 * 21 / 2
+    assert(numItems === overall - top20)
+  }
+
+  test("cleanup") {
+    clock.setWallTime(60)
+    val keyStats = (0 until 50).map { i =>
+      IndexStats.KeyStat(i.toString, 50 - i, if (i == 42) 2 else i)
+    }
+    stats.updateKeyStats(keyStats.toList)
+    PolledMeter.update(registry)
+    val numValues = registry.gauge("atlas.index.numberOfValues", "key", "42").value()
+    assert(numValues.isNaN)
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/RoaringTagIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/RoaringTagIndexSuite.scala
@@ -20,6 +20,6 @@ import com.netflix.atlas.core.model.TimeSeries
 class RoaringTagIndexSuite extends TagIndexSuite {
 
   val index: TagIndex[TimeSeries] = {
-    new RoaringTagIndex(TagIndexSuite.dataset.toArray)
+    new RoaringTagIndex(TagIndexSuite.dataset.toArray, new IndexStats())
   }
 }

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndexBench.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndexBench.scala
@@ -80,11 +80,11 @@ class RoaringTagIndexBench {
     BasicTaggedItem(SmallHashMap(baseId ++ Map("nf.node" -> id))) //, i.toString -> id))
   }
 
-  private val index = new RoaringTagIndex[BasicTaggedItem](items.toArray)
+  private val index = new RoaringTagIndex[BasicTaggedItem](items.toArray, new IndexStats())
 
   @Benchmark
   def create(bh: Blackhole): Unit = {
-    bh.consume(new RoaringTagIndex[BasicTaggedItem](items.toArray))
+    bh.consume(new RoaringTagIndex[BasicTaggedItem](items.toArray, new IndexStats()))
   }
 
   @Benchmark


### PR DESCRIPTION
This provides a quick summary of some key stats for
the index to see what is contributing the most to the
number of distinct strings. In most cases we just use
hive queries for digging into this, but these stats
can be used before data is in hive and are always scoped
to the specific index. In some cases where we already
have rollup policies the hive data is raw from before
the additional policies are enabled.