### PR TITLE
fix possible contract error for IndexStats

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/IndexStats.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/IndexStats.scala
@@ -58,7 +58,7 @@ class IndexStats(registry: Registry = new NoopRegistry) {
 
     val now = registry.clock().wallTime()
     val n = 20
-    val sorted = stats.sortWith(_.numValues >= _.numValues)
+    val sorted = stats.sortWith(_.numValues > _.numValues)
 
     // Include the key for the top-N
     sorted.take(n).foreach { stat =>

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/IndexStatsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/IndexStatsSuite.scala
@@ -21,6 +21,8 @@ import com.netflix.spectator.api.patterns.PolledMeter
 import org.scalatest.BeforeAndAfter
 import org.scalatest.FunSuite
 
+import scala.util.Random
+
 class IndexStatsSuite extends FunSuite with BeforeAndAfter {
 
   private val clock = new ManualClock()
@@ -77,5 +79,15 @@ class IndexStatsSuite extends FunSuite with BeforeAndAfter {
     PolledMeter.update(registry)
     val numValues = registry.gauge("atlas.index.numberOfValues", "key", "42").value()
     assert(numValues.isNaN)
+  }
+
+  test("sort with duplicates") {
+    (0 until 100).foreach { i =>
+      clock.setWallTime(i)
+      val keyStats = (0 until 100).map { j =>
+        IndexStats.KeyStat(j.toString, i, Random.nextInt(10))
+      }
+      stats.updateKeyStats(keyStats.toList)
+    }
   }
 }


### PR DESCRIPTION
If there are duplicates for the number of distinct
values, then it is possible to get an error from the
sort:

```
java.lang.IllegalArgumentException: Comparison method violates its general contract!
	at java.util.TimSort.mergeHi(TimSort.java:899) ~[?:1.8.0_162]
	at java.util.TimSort.mergeAt(TimSort.java:516) ~[?:1.8.0_162]
	at java.util.TimSort.mergeCollapse(TimSort.java:441) ~[?:1.8.0_162]
	at java.util.TimSort.sort(TimSort.java:245) ~[?:1.8.0_162]
	at java.util.Arrays.sort(Arrays.java:1438) ~[?:1.8.0_162]
```

This adds a test and fixes the comparison operation.