### PR TITLE
1.5.x backport: add dependency on jsr250 (#708)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ lazy val `atlas-akka` = project
     Dependencies.akkaActor,
     Dependencies.akkaSlf4j,
     Dependencies.iepService,
+    Dependencies.jsr250,
     Dependencies.spectatorSandbox,
     Dependencies.sprayCan,
     Dependencies.sprayRouting,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,6 +41,7 @@ object Dependencies {
   val jacksonSmile2   = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-smile" % jackson
   val jodaConvert     = "org.joda" % "joda-convert" % "1.8.1"
   val jol             = "org.openjdk.jol" % "jol-core" % "0.6"
+  val jsr250          = "javax.annotation" % "jsr250-api" % "1.0"
   val jsr305          = "com.google.code.findbugs" % "jsr305" % "3.0.1"
   val log4jApi        = "org.apache.logging.log4j" % "log4j-api" % log4j
   val log4jCore       = "org.apache.logging.log4j" % "log4j-core" % log4j


### PR DESCRIPTION
In jdk9 the PostConstruct and PreDestroy annotations have
been moved to a deprecated module that has to be explicitly
enabled. Adding explicit dependency so that those classes
can be found and the start/stop methods on services will
be called correctly.