### PR TITLE
set dstype for polled cloudwatch metrics

### DIFF
--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/Conversions.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/Conversions.scala
@@ -25,6 +25,14 @@ import com.amazonaws.services.cloudwatch.model.StandardUnit
 object Conversions {
 
   /**
+    * Determine the Atlas DS type based on the conversion. Anything that has a rate
+    * conversion will use a rate, otherwise it will be treated as a gauge.
+    */
+  def determineDsType(name: String): String = {
+    if (name.contains("rate")) "rate" else "gauge"
+  }
+
+  /**
     * Create a new conversion based on a simple comma separated list of known mappings.
     * The first element should be the statistic to extract. Allowed values are: `min`,
     * `max`, `sum`, `count`, and `avg`.

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricDefinition.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricDefinition.scala
@@ -17,6 +17,7 @@ package com.netflix.atlas.cloudwatch
 
 import com.amazonaws.services.cloudwatch.model.Datapoint
 import com.amazonaws.services.cloudwatch.model.StandardUnit
+import com.netflix.atlas.core.model.TagKey
 import com.typesafe.config.Config
 
 /**
@@ -103,13 +104,14 @@ object MetricDefinition {
   }
 
   private def newMetricDef(config: Config, cnv: String, tags: Tags): MetricDefinition = {
+    val dstype = Map(TagKey.dsType -> Conversions.determineDsType(cnv))
     val monotonic = config.hasPath("monotonic") && config.getBoolean("monotonic")
     MetricDefinition(
       name = config.getString("name"),
       alias = config.getString("alias"),
       conversion = Conversions.fromName(cnv),
       monotonicValue = monotonic,
-      tags = tags
+      tags = tags ++ dstype
     )
   }
 }

--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionsSuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionsSuite.scala
@@ -279,4 +279,24 @@ class ConversionsSuite extends FunSuite {
     val v = cnv(null, newDatapoint(42.0))
     assert(v === 4200.0)
   }
+
+  test("dstype for max") {
+    assert(Conversions.determineDsType("max") === "gauge")
+  }
+
+  test("dstype for sum") {
+    assert(Conversions.determineDsType("sum") === "gauge")
+  }
+
+  test("dstype for count") {
+    assert(Conversions.determineDsType("count") === "gauge")
+  }
+
+  test("dstype for sum,rate") {
+    assert(Conversions.determineDsType("sum,rate") === "rate")
+  }
+
+  test("dstype for count,rate") {
+    assert(Conversions.determineDsType("count,rate") === "rate")
+  }
 }

--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDefinitionSuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDefinitionSuite.scala
@@ -52,6 +52,30 @@ class MetricDefinitionSuite extends FunSuite {
     assert(definitions.head.alias === "aws.elb.requests")
   }
 
+  test("config with dsytpe rate") {
+    val cfg = ConfigFactory.parseString("""
+        |name = "RequestCount"
+        |alias = "aws.elb.requests"
+        |conversion = "sum,rate"
+      """.stripMargin)
+
+    val definitions = MetricDefinition.fromConfig(cfg)
+    assert(definitions.size === 1)
+    assert(definitions.head.tags === Map("atlas.dstype" -> "rate"))
+  }
+
+  test("config with dsytpe gauge") {
+    val cfg = ConfigFactory.parseString("""
+        |name = "RequestCount"
+        |alias = "aws.elb.requests"
+        |conversion = "sum"
+      """.stripMargin)
+
+    val definitions = MetricDefinition.fromConfig(cfg)
+    assert(definitions.size === 1)
+    assert(definitions.head.tags === Map("atlas.dstype" -> "gauge"))
+  }
+
   test("config for timer") {
     val cfg = ConfigFactory.parseString("""
         |name = "Latency"


### PR DESCRIPTION
It was not set before so all would get treated as rate.
This led to some confusion for some of the S3 metrics
where it appeared there was a massive drop in the amount
of data stored in s3 after a brief gap. This drop was
because the consolidation averaged with 0 for the NaN
values since the values were considered rates.