### PR TITLE
honor legend flag for v2.json format image

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonCodec.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonCodec.scala
@@ -92,7 +92,7 @@ private[chart] object JsonCodec {
     gen.writeEndArray()
   }
 
-  // Writes out a pre-rendered image for the chart without the legend. This can be used
+  // Writes out a pre-rendered image for the chart. This can be used
   // for partially dynamic views.
   private def writeGraphImage(gen: JsonGenerator, config: GraphDef): Unit = {
     gen.writeStartObject()
@@ -102,8 +102,7 @@ private[chart] object JsonCodec {
   }
 
   private def toDataUri(config: GraphDef): String = {
-    val gdef = config.copy(legendType = LegendType.OFF)
-    val image = PngImage(pngEngine.createImage(gdef)).toByteArray
+    val image = PngImage(pngEngine.createImage(config)).toByteArray
     val encoded = Base64.getEncoder.encodeToString(image)
     s"data:image/png;base64,$encoded"
   }


### PR DESCRIPTION
See #564 and #568 for more context. The included image would
suppress the image. For some use-cases it is desirable to
include it. The previous output can still be achieved by
explicitly using `no_legend=1`.

Main use-case right now is an explode view that shows the
images, but has some dynamic filtering for outliers or missing
data. This avoids the need to make multiple requests for the
same data if the user requests to see the legends.

/cc @nathfisher @tregoning 