### PR TITLE
fix state isolation for streaming execution

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/EvalContext.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/EvalContext.scala
@@ -19,11 +19,13 @@ import java.time.Duration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
+import com.netflix.atlas.core.util.IdentityMap
+
 case class EvalContext(
   start: Long,
   end: Long,
   step: Long,
-  state: Map[StatefulExpr, Any] = Map.empty
+  state: Map[StatefulExpr, Any] = IdentityMap.empty
 ) {
   require(start < end, s"start time must be less than end time ($start >= $end)")
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/ResultSet.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/ResultSet.scala
@@ -15,9 +15,11 @@
  */
 package com.netflix.atlas.core.model
 
+import com.netflix.atlas.core.util.IdentityMap
+
 case class ResultSet(
   expr: TimeSeriesExpr,
   data: List[TimeSeries] = Nil,
-  state: Map[StatefulExpr, Any] = Map.empty,
+  state: Map[StatefulExpr, Any] = IdentityMap.empty,
   messages: List[String] = Nil
 )

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/IdentityMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/IdentityMap.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+/**
+  * Wraps the java IdentityHashMap as an immutable scala Map. Modifications will result
+  * in a copy of the wrapped map being created and used with the new instance.
+  */
+class IdentityMap[K <: AnyRef, V] private (jmap: java.util.IdentityHashMap[K, V])
+    extends scala.collection.immutable.Map[K, V] {
+
+  override def +[V1 >: V](kv: (K, V1)): IdentityMap[K, V1] = {
+    val copy = new java.util.IdentityHashMap[K, V1](jmap)
+    copy.put(kv._1, kv._2)
+    new IdentityMap(copy)
+  }
+
+  override def get(key: K): Option[V] = Option(jmap.get(key))
+
+  override def iterator: Iterator[(K, V)] = {
+    val iter = jmap.entrySet().iterator()
+    new Iterator[(K, V)] {
+      override def hasNext: Boolean = iter.hasNext
+      override def next(): (K, V) = {
+        val entry = iter.next()
+        entry.getKey -> entry.getValue
+      }
+    }
+  }
+
+  override def -(key: K): IdentityMap[K, V] = {
+    val copy = new java.util.IdentityHashMap[K, V](jmap)
+    copy.remove(key)
+    new IdentityMap(copy)
+  }
+
+  override def toString: String = {
+    iterator.mkString("IdentityMap(", ", ", ")")
+  }
+}
+
+object IdentityMap {
+
+  private lazy val emptyMap = {
+    new IdentityMap[AnyRef, Any](new java.util.IdentityHashMap[AnyRef, Any]())
+  }
+
+  def empty[K <: AnyRef, V]: IdentityMap[K, V] = emptyMap.asInstanceOf[IdentityMap[K, V]]
+
+  def apply[K <: AnyRef, V](jmap: java.util.IdentityHashMap[K, V]): IdentityMap[K, V] = {
+    val copy = new java.util.IdentityHashMap[K, V](jmap)
+    new IdentityMap[K, V](copy)
+  }
+
+  def apply[K <: AnyRef, V](map: Map[K, V]): IdentityMap[K, V] = {
+    val copy = new java.util.IdentityHashMap[K, V]()
+    map.foreach { t =>
+      copy.put(t._1, t._2)
+    }
+    new IdentityMap[K, V](copy)
+  }
+
+  def apply[K <: AnyRef, V](vs: (K, V)*): IdentityMap[K, V] = {
+    val copy = new java.util.IdentityHashMap[K, V]()
+    vs.foreach { t =>
+      copy.put(t._1, t._2)
+    }
+    new IdentityMap[K, V](copy)
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/IdentityMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/IdentityMapSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import org.scalatest.FunSuite
+
+class IdentityMapSuite extends FunSuite {
+
+  test("add") {
+    val m = IdentityMap.empty[String, Int] + ("a" -> 42)
+    assert(m.get("a") === Some(42))
+  }
+
+  test("remove") {
+    val m = IdentityMap(Map("a" -> 42)) - "a"
+    assert(m.get("a") === None)
+  }
+
+  test("overwrite") {
+    val m = IdentityMap(Map("a" -> 42)) + ("a" -> 2)
+    assert(m.get("a") === Some(2))
+  }
+
+  test("iterate") {
+    val m = IdentityMap(new String("a") -> 2, new String("a") -> 1, "b" -> 3)
+    val values = m.iterator.map(_._2).toSet
+    assert(values === Set(1, 2, 3))
+  }
+
+  test("toString") {
+    val m = IdentityMap(new String("a") -> 2, new String("a") -> 1, "b" -> 3)
+
+    // order is not deterministic
+    val s = m.toString
+    assert(s.contains("(a,1)"))
+    assert(s.contains("(a,2)"))
+    assert(s.contains("(b,3)"))
+  }
+
+  test("uses reference equality") {
+    val m = IdentityMap.empty[String, Int] + ("a" -> 42)
+    assert(m.get(new String("a")) === None)
+  }
+}


### PR DESCRIPTION
If an expression has multiple equivalent stateful
sub-expressions, then the they would store the state
to the same place since the key is the stateful expr
instance. This changes the map used to look at the
identity when performing the state lookup, so separate
instances will have isolated state.

We'll probably need to refactor this more thoroughly
long term and either memoize equivalent sub-expressions
during the evaluation or lookup based on position.