### PR TITLE
update travis to build on jdk10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ matrix:
   - jdk: oraclejdk10
     scala: 2.12.6
     env: BINTRAY_PUBLISH=false
-  - jdk: oraclejdk11
-    scala: 2.12.6
-    env: BINTRAY_PUBLISH=false
 script:
 - ./scripts/buildViaTravis.sh
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ matrix:
   - jdk: oraclejdk8
     scala: 2.12.6
     env: BINTRAY_PUBLISH=true
-  - jdk: oraclejdk9
+  - jdk: openjdk10
+    scala: 2.12.6
+    env: BINTRAY_PUBLISH=false
+  - jdk: openjdk11
     scala: 2.12.6
     env: BINTRAY_PUBLISH=false
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ matrix:
   - jdk: oraclejdk8
     scala: 2.12.6
     env: BINTRAY_PUBLISH=true
-  - jdk: openjdk10
+  - jdk: oraclejdk10
     scala: 2.12.6
     env: BINTRAY_PUBLISH=false
-  - jdk: openjdk11
+  - jdk: oraclejdk11
     scala: 2.12.6
     env: BINTRAY_PUBLISH=false
 script:

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/ConfigApiSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/ConfigApiSuite.scala
@@ -55,11 +55,11 @@ class ConfigApiSuite extends FunSuite with ScalatestRouteTest {
     }
   }
 
-  test("/config/java.version") {
+  test("/config/os.arch") {
     import scala.collection.JavaConverters._
-    Get("/api/v2/config/java.version") ~> endpoint.routes ~> check {
+    Get("/api/v2/config/os.arch") ~> endpoint.routes ~> check {
       val config = ConfigFactory.parseString(responseAs[String])
-      val v = sysConfig.getString("java.version")
+      val v = sysConfig.getString("os.arch")
       val expected = ConfigFactory.parseMap(Map("value" -> v).asJava)
       assert(expected === config)
     }


### PR DESCRIPTION
Dropping jdk9 as there is no reason to use it over
jdk10 at this point.