### PR TITLE
move metered queue config out of reference.conf

### DIFF
--- a/atlas-akka/src/main/resources/metered-mailbox.conf
+++ b/atlas-akka/src/main/resources/metered-mailbox.conf
@@ -1,0 +1,6 @@
+akka.actor {
+  default-mailbox {
+    mailbox-type = "com.netflix.atlas.akka.UnboundedMeteredMailbox"
+    path-pattern = ${atlas.akka.path-pattern}
+  }
+}

--- a/atlas-akka/src/main/resources/reference.conf
+++ b/atlas-akka/src/main/resources/reference.conf
@@ -68,10 +68,6 @@ akka {
       autoreceive = on
       lifecycle = on
     }
-    default-mailbox {
-      mailbox-type = "com.netflix.atlas.akka.UnboundedMeteredMailbox"
-      path-pattern = ${atlas.akka.path-pattern}
-    }
 
     default-dispatcher {
       fork-join-executor {


### PR DESCRIPTION
Makes it easier for us to do comparison performance tests
with other implementations. It can be included with the
application config when needed.