### PR TITLE
add test case for `^*` behavior with matcher

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringMatcherSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringMatcherSuite.scala
@@ -103,6 +103,12 @@ class StringMatcherSuite extends FunSuite {
     assert(compile("^foo$", false) === EqualsIgnoreCase("foo"))
   }
 
+  test("compile starting glob") {
+    // Make sure this doesn't get mapped to an index of query
+    // https://github.com/Netflix/atlas/issues/841
+    assert(compile("^*foo*") === Regex(None, re("^*foo*")))
+  }
+
   test("compile IndexOf") {
     assert(compile("foo") === IndexOf("foo"))
     assert(compile(".*foo.*") === IndexOf("foo"))


### PR DESCRIPTION
There was some inconsistency between the UI validation
which uses the javascript regex library and the backend.
Originally we suspected this was a bug and it was getting
mapped to an IndexOf query, but that is not the case. The
java regex engine has a slightly different interpretation.

Fixes #841