### PR TITLE
fix name for AuroraBinlogReplicaLag

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/rds.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/rds.conf
@@ -55,7 +55,7 @@ atlas {
           ]
         },
         {
-          name = "AuroraBinLogReplicaLag"
+          name = "AuroraBinlogReplicaLag"
           alias = "aws.rds.binLogReplicaLag"
           conversion = "max"
         },


### PR DESCRIPTION
AWS is inconsistent in the casing for BinLog between the
disk usage and replica lag metrics.