### PR TITLE
config setting for window of time grouping

### DIFF
--- a/atlas-eval/src/main/resources/reference.conf
+++ b/atlas-eval/src/main/resources/reference.conf
@@ -8,6 +8,11 @@ atlas.eval {
         instance-uri = "http://{local-ipv4}:{port}"
       }
     ]
+
+    // Number of buffers to use for the time grouping. More buffers means that data has
+    // more time to accumulate and there is less chance of data being dropped because it
+    // is too old
+    num-buffers = 1
   }
 
   graph {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -176,7 +176,7 @@ private[stream] abstract class EvaluatorImpl(
         .via(context.countEvents("10_InputLines"))
         .via(new LwcToAggrDatapoint)
         .via(context.countEvents("11_LwcDatapoints"))
-        .via(new TimeGrouped[AggrDatapoint](context, 1, 50, _.timestamp))
+        .via(new TimeGrouped[AggrDatapoint](context, 50, _.timestamp))
         .via(context.countEvents("12_GroupedDatapoints"))
 
       datasources.out(0) ~> intermediateEval ~> finalEvalInput.in(0)

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -65,6 +65,8 @@ private[stream] class StreamContext(
     }
   }
 
+  def numBuffers: Int = config.getInt("num-buffers")
+
   val interpreter = new ExprInterpreter(rootConfig)
 
   def findBackendForUri(uri: Uri): Backend = {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
@@ -32,10 +32,6 @@ import com.netflix.atlas.eval.model.TimeGroup
   *
   * @param context
   *     Shared context for the evaluation stream.
-  * @param numBuffers
-  *     Number of time buffers to maintain. The buffers are stored in a rolling array
-  *     and the data for a given buffer will be emitted when the first data comes in
-  *     for a new time that would evict the buffer with the minimum time.
   * @param max
   *     Maximum number of items that can be accumulated for a given time.
   * @param ts
@@ -45,10 +41,16 @@ import com.netflix.atlas.eval.model.TimeGroup
   */
 private[stream] class TimeGrouped[T](
   context: StreamContext,
-  numBuffers: Int,
   max: Int,
   ts: T => Long
 ) extends GraphStage[FlowShape[T, TimeGroup[T]]] {
+
+  /**
+   * Number of time buffers to maintain. The buffers are stored in a rolling array
+   * and the data for a given buffer will be emitted when the first data comes in
+   * for a new time that would evict the buffer with the minimum time.
+   */
+  private val numBuffers = context.numBuffers
 
   private val in = Inlet[T]("TimeGrouped.in")
   private val out = Outlet[TimeGroup[T]]("TimeGrouped.out")

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
@@ -50,6 +50,8 @@ object TestContext {
       |      instance-uri = "http://{host}:{port}"
       |    }
       |  ]
+      |
+      |  num-buffers = 2
       |}
     """.stripMargin)
 

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
@@ -46,7 +46,7 @@ class TimeGroupedSuite extends FunSuite {
 
   private def run(data: List[Event]): List[TimeGroup[Event]] = {
     val future = Source(data)
-      .via(new TimeGrouped[Event](context, 2, 10, _.timestamp))
+      .via(new TimeGrouped[Event](context, 10, _.timestamp))
       .runFold(List.empty[TimeGroup[Event]])((acc, g) => g :: acc)
     result(future)
   }


### PR DESCRIPTION
Adds a config setting that can be used to set the number
of buffers that will be maintained when grouping the
datapoints into time buckets. The default is 1 which will
flush the data as soon as data arrives for the next time
frame. More buffers allows more time for data to accumulate,
but means that it will take longer to emit data for a given
time.