### PR TITLE
Record the total number of unique metrics

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndex.scala
@@ -117,6 +117,7 @@ class RoaringTagIndex[T <: TaggedItem](items: Array[T], stats: IndexStats) exten
       i += 1
     }
     stats.updateKeyStats(builder.result())
+    stats.updateIndexStats(items.length)
   }
 
   private def createPositionMap(data: Array[String]): RefIntHashMap[String] = {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/IndexStatsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/IndexStatsSuite.scala
@@ -38,12 +38,15 @@ class IndexStatsSuite extends FunSuite with BeforeAndAfter {
       IndexStats.KeyStat(i.toString, 50 - i, i)
     }
     stats.updateKeyStats(keyStats.toList)
+    stats.updateIndexStats(100)
     PolledMeter.update(registry)
   }
 
   test("expected number of gauges present") {
-    // Should have 43 metrics, 1 num keys, 21 num values, 21 num items
-    assert(registry.gauges().count() === 43)
+    // Should have 44 metrics in total:
+    // 43 key metrics: 1 num keys, 21 num values, 21 num items
+    //  1  db metrics: 1 num metrics
+    assert(registry.gauges().count() === 44)
   }
 
   test("top-N value") {
@@ -89,5 +92,10 @@ class IndexStatsSuite extends FunSuite with BeforeAndAfter {
       }
       stats.updateKeyStats(keyStats.toList)
     }
+  }
+
+  test("db size is present") {
+    val numMetrics = registry.gauge("atlas.db.size").value()
+    assert(numMetrics === 100)
   }
 }


### PR DESCRIPTION
The total number of unique metrics is derived 
from the index size.  This is recorded as a gauge
by the memory database during a rebuild operation,
ensuring that Atomic variables are not read 
unnecessarily.


I initially attempted to record this within the memory
database itself, but the index stats seemed more appropriate.
See #848 