### PR TITLE
handle monotonic values with multiple samples

### DIFF
--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDataSuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDataSuite.scala
@@ -33,12 +33,12 @@ class MetricDataSuite extends FunSuite {
 
   private val monotonicMetadata = metadata.copy(definition = definition.copy(monotonicValue = true))
 
-  private def datapoint(v: Double): Option[Datapoint] = {
+  private def datapoint(v: Double, c: Double = 1.0): Option[Datapoint] = {
     val d = new Datapoint()
       .withMinimum(v)
       .withMaximum(v)
-      .withSum(v)
-      .withSampleCount(1.0)
+      .withSum(v * c)
+      .withSampleCount(c)
       .withTimestamp(new Date())
       .withUnit(StandardUnit.None)
     Some(d)
@@ -82,5 +82,10 @@ class MetricDataSuite extends FunSuite {
   test("access monotonic datapoint, previous equals current") {
     val data = MetricData(monotonicMetadata, datapoint(1.0), datapoint(1.0))
     assert(data.datapoint.getSum === 0.0)
+  }
+
+  test("access monotonic datapoint, current is larger, previous dup") {
+    val data = MetricData(monotonicMetadata, datapoint(1.0, 3), datapoint(2.0))
+    assert(data.datapoint.getSum === 1.0)
   }
 }


### PR DESCRIPTION
For cloudwatch if a monotonic value gets multiple samples
within an interval it will cause a spike when looking at
the sum. Use the max to see the largest sample within a
given interval. Example metrics with this issue are the HSM
network stats (InterfaceEth2OctetsInput).

https://docs.aws.amazon.com/cloudhsm/latest/userguide/hsm-metrics-cw.html