### PR TITLE
fix hash code for LongIntHashMap

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Hash.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Hash.scala
@@ -16,11 +16,25 @@
 package com.netflix.atlas.core.util
 
 import java.math.BigInteger
+import java.nio.ByteBuffer
 import java.security.MessageDigest
 
 import scala.util.Try
+import scala.util.hashing.MurmurHash3
 
 object Hash {
+
+  // Used for computing the hash code for Long values.
+  private[this] val buffer = ThreadLocal
+    .withInitial[ByteBuffer](() => ByteBuffer.allocate(java.lang.Long.BYTES))
+
+  /** Compute MurmurHash3 for a java long value. */
+  def murmur3(v: Long): Int = {
+    val buf = buffer.get()
+    buf.clear()
+    buf.putLong(v)
+    MurmurHash3.bytesHash(buf.array())
+  }
 
   // Seeing contention on MessageDigest.getInstance, following pattern used by jruby:
   // https://github.com/jruby/jruby/commit/e840823c435393e8365be1bae93f646c1bb0043f

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongIntHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongIntHashMap.scala
@@ -15,9 +15,6 @@
  */
 package com.netflix.atlas.core.util
 
-import java.nio.ByteBuffer
-
-import scala.util.hashing.MurmurHash3
 
 /**
   * Mutable long to integer map based on open-addressing. Primary use-case is computing
@@ -36,10 +33,6 @@ class LongIntHashMap(noData: Long, capacity: Int = 10) {
   private[this] var values = new Array[Int](keys.length)
   private[this] var used = 0
   private[this] var cutoff = computeCutoff(keys.length)
-
-  // Used for computing the hash code.
-  private[this] val buffer = ThreadLocal
-    .withInitial[ByteBuffer](() => ByteBuffer.allocate(java.lang.Long.BYTES))
 
   // Set at 50% capacity to get reasonable tradeoff between performance and
   // memory use. See IntIntMap benchmark.
@@ -70,11 +63,7 @@ class LongIntHashMap(noData: Long, capacity: Int = 10) {
   }
 
   private def hash(ks: Array[Long], k: Long): Int = {
-    val buf = buffer.get()
-    buf.clear()
-    buf.putLong(k)
-    MurmurHash3.bytesHash(buf.array())
-    Hash.absOrZero(java.lang.Long.hashCode(k)) % ks.length
+    Hash.absOrZero(Hash.murmur3(k)) % ks.length
   }
 
   private def put(ks: Array[Long], vs: Array[Int], k: Long, v: Int): Boolean = {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongIntHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongIntHashMap.scala
@@ -15,7 +15,6 @@
  */
 package com.netflix.atlas.core.util
 
-
 /**
   * Mutable long to integer map based on open-addressing. Primary use-case is computing
   * a count for the number of times a particular value was encountered.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/DoubleIntHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/DoubleIntHashMapSuite.scala
@@ -110,8 +110,8 @@ class DoubleIntHashMapSuite extends FunSuite {
     //println(igraph.toFootprint)
     //println(jgraph.toFootprint)
 
-    // Only objects should be the key/value arrays, hash buffer, and the map itself
-    assert(igraph.totalCount() === 6)
+    // Only objects should be the key/value arrays and the map itself
+    assert(igraph.totalCount() === 4)
 
     // Sanity check size is < 300 bytes
     assert(igraph.totalSize() <= 300)
@@ -132,7 +132,7 @@ class DoubleIntHashMapSuite extends FunSuite {
     //println(jgraph.toFootprint)
 
     // Only objects should be the key/value arrays and the map itself
-    assert(igraph.totalCount() === 6)
+    assert(igraph.totalCount() === 4)
 
     // Sanity check size is < 320kb
     assert(igraph.totalSize() <= 320000)

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/LongHashSetSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/LongHashSetSuite.scala
@@ -80,7 +80,7 @@ class LongHashSetSuite extends FunSuite {
   test("memory per set") {
     // Sanity check to verify if some change introduces more overhead per set
     val bytes = ClassLayout.parseClass(classOf[LongHashSet]).instanceSize()
-    assert(bytes === 40)
+    assert(bytes === 32)
   }
 
   test("memory - 5 items") {
@@ -97,8 +97,8 @@ class LongHashSetSuite extends FunSuite {
     //println(igraph.toFootprint)
     //println(jgraph.toFootprint)
 
-    // Only objects should be the array, hash buffer, and the set itself
-    assert(igraph.totalCount() === 4)
+    // Only objects should be the array and the set itself
+    assert(igraph.totalCount() === 2)
 
     // Sanity check size is < 100 bytes
     assert(igraph.totalSize() <= 250)
@@ -118,8 +118,8 @@ class LongHashSetSuite extends FunSuite {
     //println(igraph.toFootprint)
     //println(jgraph.toFootprint)
 
-    // Only objects should be the array, hash buffer, and the set itself
-    assert(igraph.totalCount() === 4)
+    // Only objects should be the array and the set itself
+    assert(igraph.totalCount() === 2)
 
     // Sanity check size is < 220kb
     assert(igraph.totalSize() <= 220000)

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/LongIntHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/LongIntHashMapSuite.scala
@@ -136,8 +136,8 @@ class LongIntHashMapSuite extends FunSuite {
     //println(igraph.toFootprint)
     //println(jgraph.toFootprint)
 
-    // Only objects should be the key/value arrays, hash buffer, and the map itself
-    assert(igraph.totalCount() === 5)
+    // Only objects should be the key/value arrays and the map itself
+    assert(igraph.totalCount() === 3)
 
     // Sanity check size is < 300 bytes
     assert(igraph.totalSize() <= 300)
@@ -158,7 +158,7 @@ class LongIntHashMapSuite extends FunSuite {
     //println(jgraph.toFootprint)
 
     // Only objects should be the key/value arrays and the map itself
-    assert(igraph.totalCount() === 5)
+    assert(igraph.totalCount() === 3)
 
     // Sanity check size is < 320kb
     assert(igraph.totalSize() <= 320000)


### PR DESCRIPTION
Before it was computing the murmur3 hash and then ignoring
the result and using `Long.hashCode`. This change moves
the computation of the murmur3 hash to a helper function
and now LongIntHashMap uses that value.