### PR TITLE
short circuit pattern matching with prefix check

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/StringMatcher.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/StringMatcher.scala
@@ -47,6 +47,19 @@ object StringMatcher {
   /** A regex that has a simple prefix along with some arbitrary pattern. */
   private val PrefixPattern = """^\^+([\-_a-zA-Z0-9]+).*$""".r
 
+  /**
+    * Convert the string pattern into a matcher object. If possible, it will use a simple
+    * string matcher and avoid expensive regex operations.
+    *
+    * @param pattern
+    *     Regular expression string to compile.
+    * @param caseSensitive
+    *     Whether or not the match should be case sensitive. The default is true. Case
+    *     insensitive matching is more expensive and breaks the ability to reliably match
+    *     the prefix of queries. Avoid if possible.
+    * @return
+    *     Matcher based on the provided pattern.
+    */
   def compile(pattern: String, caseSensitive: Boolean = true): StringMatcher = {
     pattern match {
       case EqualsPattern(p) if caseSensitive      => Equals(p)
@@ -59,18 +72,18 @@ object StringMatcher {
       case AnchoredOrPattern(s) if caseSensitive  => compileOr(s, v => s"^$v$$")
       case StartOrPattern(s) if caseSensitive     => compileOr(s, v => s"^$v")
       case FloatingOrPattern(s) if caseSensitive  => compileOr(s, v => s"$v")
-      case PrefixPattern(p) if caseSensitive      => Regex(Some(p), Pattern.compile(pattern))
+      case PrefixPattern(p) if caseSensitive      => PrefixedRegex(p, Pattern.compile(pattern))
       case _                                      => default(pattern, caseSensitive)
     }
   }
 
   private def compileOr(s: String, f: String => String): StringMatcher = {
-    Or(s.split("\\|").toList.map(v => compile(f(v), true)))
+    Or(s.split("\\|").toList.map(v => compile(f(v))))
   }
 
-  private def default(re: String, caseSensitive: Boolean): StringMatcher = {
+  private def default(re: String, caseSensitive: Boolean = true): StringMatcher = {
     val flags = if (caseSensitive) 0 else Pattern.CASE_INSENSITIVE
-    Regex(None, Pattern.compile(re, flags))
+    Regex(Pattern.compile(re, flags))
   }
 
   /** Match all strings. */
@@ -80,7 +93,41 @@ object StringMatcher {
     def matches(v: String): Boolean = true
   }
 
-  case class Regex(prefix: Option[String], pattern: Pattern) extends StringMatcher {
+  case class PrefixedRegex(prefixStr: String, pattern: Pattern) extends StringMatcher {
+
+    val prefix: Option[String] = Some(prefixStr)
+
+    // Reuse matcher to reduce allocations, keep in thread local in-case this Regex instance is
+    // shared across multiple threads.
+    private val matcher = new ThreadLocal[Matcher] {
+
+      override protected def initialValue: Matcher = pattern.matcher("")
+    }
+
+    private def reMatches(v: String): Boolean = {
+      val m = matcher.get
+      m.reset(v)
+      m.find
+    }
+
+    def matches(v: String): Boolean = {
+      // Check with startsWith first to avoid using regex as much as possible. When using
+      // for streaming evaluation, this is a big win. When used with the index, we already
+      // know the prefix matches so it is a bit of extra overhead, but not too bad.
+      v.startsWith(prefixStr) && reMatches(v)
+    }
+
+    override def equals(obj: Any): Boolean = {
+      obj match {
+        case PrefixedRegex(p, re) =>
+          prefixStr == p && pattern.pattern() == re.pattern() && pattern.flags() == re.flags()
+        case _ => false
+      }
+    }
+  }
+
+  case class Regex(pattern: Pattern) extends StringMatcher {
+    val prefix: Option[String] = None
 
     // Reuse matcher to reduce allocations, keep in thread local in-case this Regex instance is
     // shared across multiple threads.
@@ -97,8 +144,8 @@ object StringMatcher {
 
     override def equals(obj: Any): Boolean = {
       obj match {
-        case Regex(p, re) =>
-          prefix == p && pattern.pattern() == re.pattern() && pattern.flags() == re.flags()
+        case Regex(re) =>
+          pattern.pattern() == re.pattern() && pattern.flags() == re.flags()
         case _ => false
       }
     }
@@ -140,6 +187,12 @@ object StringMatcher {
       }
       false
     }
+  }
+
+  case class And(matchers: List[StringMatcher]) extends StringMatcher {
+    val prefix: Option[String] = matchers.head.prefix
+
+    def matches(v: String): Boolean = matchers.forall(_.matches(v))
   }
 
   case class Or(matchers: List[StringMatcher]) extends StringMatcher {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringMatcherSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringMatcherSuite.scala
@@ -55,19 +55,19 @@ class StringMatcherSuite extends FunSuite {
   }
 
   test("matches Regex") {
-    assert(Regex(None, re("^f")).matches("foo"))
-    assert(Regex(None, re("f")).matches("foo"))
-    assert(Regex(None, re("foo")).matches("foo"))
-    assert(Regex(None, re("oo")).matches("foo"))
-    assert(!Regex(None, re("Foo")).matches("foo"))
+    assert(Regex(re("^f")).matches("foo"))
+    assert(Regex(re("f")).matches("foo"))
+    assert(Regex(re("foo")).matches("foo"))
+    assert(Regex(re("oo")).matches("foo"))
+    assert(!Regex(re("Foo")).matches("foo"))
   }
 
   test("matches RegexIgnoreCase") {
-    assert(Regex(None, reic("^f")).matches("foo"))
-    assert(Regex(None, reic("f")).matches("foo"))
-    assert(Regex(None, reic("foo")).matches("foo"))
-    assert(Regex(None, reic("oo")).matches("foO"))
-    assert(Regex(None, reic("Foo")).matches("foo"))
+    assert(Regex(reic("^f")).matches("foo"))
+    assert(Regex(reic("f")).matches("foo"))
+    assert(Regex(reic("foo")).matches("foo"))
+    assert(Regex(reic("oo")).matches("foO"))
+    assert(Regex(reic("Foo")).matches("foo"))
   }
 
   test("matches Or") {
@@ -91,8 +91,12 @@ class StringMatcherSuite extends FunSuite {
     assert(compile("^foo.*") === StartsWith("foo"))
   }
 
+  test("compile StartsWith and dot") {
+    assert(compile("^foo.bar.*") === PrefixedRegex("foo", re("^foo.bar.*")))
+  }
+
   test("compile StartsWithIgnoreCase") {
-    assert(compile("^foo.*", false) === Regex(None, reic("^foo.*")))
+    assert(compile("^foo.*", false) === Regex(reic("^foo.*")))
   }
 
   test("compile Equals") {
@@ -106,7 +110,7 @@ class StringMatcherSuite extends FunSuite {
   test("compile starting glob") {
     // Make sure this doesn't get mapped to an index of query
     // https://github.com/Netflix/atlas/issues/841
-    assert(compile("^*foo*") === Regex(None, re("^*foo*")))
+    assert(compile("^*foo*") === Regex(re("^*foo*")))
   }
 
   test("compile IndexOf") {
@@ -122,36 +126,36 @@ class StringMatcherSuite extends FunSuite {
   }
 
   test("compile Prefix") {
-    val prefix = Some("foo")
-    assert(compile("^foo[bar]") === Regex(prefix, re("^foo[bar]")))
-    assert(compile("^foo[bar].*") === Regex(prefix, re("^foo[bar].*")))
-    assert(compile("^foo[bar].*$") === Regex(prefix, re("^foo[bar].*$")))
+    val prefix = "foo"
+    assert(compile("^foo[bar]") === PrefixedRegex(prefix, re("^foo[bar]")))
+    assert(compile("^foo[bar].*") === PrefixedRegex(prefix, re("^foo[bar].*")))
+    assert(compile("^foo[bar].*$") === PrefixedRegex(prefix, re("^foo[bar].*$")))
   }
 
   test("compile PrefixIgnoreCase") {
-    assert(compile("^foo[bar]", false) === Regex(None, reic("^foo[bar]")))
-    assert(compile("^foo[bar].*", false) === Regex(None, reic("^foo[bar].*")))
-    assert(compile("^foo[bar].*$", false) === Regex(None, reic("^foo[bar].*$")))
+    assert(compile("^foo[bar]", false) === Regex(reic("^foo[bar]")))
+    assert(compile("^foo[bar].*", false) === Regex(reic("^foo[bar].*")))
+    assert(compile("^foo[bar].*$", false) === Regex(reic("^foo[bar].*$")))
   }
 
   test("compile Regex") {
-    assert(compile("^.*foo[bar]") === Regex(None, re("^.*foo[bar]")))
-    assert(compile("^.*foo[bar].*") === Regex(None, re("^.*foo[bar].*")))
-    assert(compile("^.*foo[bar].*$") === Regex(None, re("^.*foo[bar].*$")))
+    assert(compile("^.*foo[bar]") === Regex(re("^.*foo[bar]")))
+    assert(compile("^.*foo[bar].*") === Regex(re("^.*foo[bar].*")))
+    assert(compile("^.*foo[bar].*$") === Regex(re("^.*foo[bar].*$")))
   }
 
   test("compile RegexIgnoreCase") {
-    assert(compile("^.*foo[bar]", false) === Regex(None, reic("^.*foo[bar]")))
-    assert(compile("^.*foo[bar].*", false) === Regex(None, reic("^.*foo[bar].*")))
-    assert(compile("^.*foo[bar].*$", false) === Regex(None, reic("^.*foo[bar].*$")))
+    assert(compile("^.*foo[bar]", false) === Regex(reic("^.*foo[bar]")))
+    assert(compile("^.*foo[bar].*", false) === Regex(reic("^.*foo[bar].*")))
+    assert(compile("^.*foo[bar].*$", false) === Regex(reic("^.*foo[bar].*$")))
   }
 
   test("compile Regex end anchor") {
-    assert(compile("^foo[1-3]$") === Regex(Some("foo"), re("^foo[1-3]$")))
+    assert(compile("^foo[1-3]$") === PrefixedRegex("foo", re("^foo[1-3]$")))
   }
 
   test("compile RegexIgnoreCase end anchor") {
-    assert(compile("^foo[1-3]$", false) === Regex(None, reic("^foo[1-3]$")))
+    assert(compile("^foo[1-3]$", false) === Regex(reic("^foo[1-3]$")))
   }
 
   test("compile Or anchored at start and end") {
@@ -165,7 +169,7 @@ class StringMatcherSuite extends FunSuite {
     assert(compile("^a|b|c", true) === Or(List(StartsWith("a"), IndexOf("b"), IndexOf("c"))))
     assert(
       compile("^.*a.*|.*b.*|c*)", true) === Or(
-        List(IndexOf("a"), IndexOf("b"), Regex(None, re("c*")))
+        List(IndexOf("a"), IndexOf("b"), Regex(re("c*")))
       )
     )
   }
@@ -174,13 +178,13 @@ class StringMatcherSuite extends FunSuite {
     assert(compile("(a|b|c)", true) === Or(List(IndexOf("a"), IndexOf("b"), IndexOf("c"))))
     assert(
       compile(".*a.*|.*b.*|c*)", true) === Or(
-        List(IndexOf("a"), IndexOf("b"), Regex(None, re("c*")))
+        List(IndexOf("a"), IndexOf("b"), Regex(re("c*")))
       )
     )
   }
 
   test("compile Or, too complex") {
-    assert(compile("(a(d|e)|b|c)", true) === Regex(None, re("(a(d|e)|b|c)")))
+    assert(compile("(a(d|e)|b|c)", true) === Regex(re("(a(d|e)|b|c)")))
   }
 
 }

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/StringMatching.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/StringMatching.scala
@@ -43,12 +43,12 @@ class StringMatching {
   private val startsWithMatcher = StringMatcher.StartsWith(prefix)
   private val ssIndexOfMatcher = StringMatcher.IndexOf(substr)
   private val icIndexOfMatcher = StringMatcher.IndexOfIgnoreCase(substr)
-  private val regexMatcher = StringMatcher.Regex(None, Pattern.compile(s"^$prefix"))
-  private val icRegexMatcher = StringMatcher.Regex(None, Pattern.compile(s"^$prefix", flags))
-  private val ssRegexMatcher = StringMatcher.Regex(None, Pattern.compile(s"^.*$substr"))
-  private val ssRegexMatcher2 = StringMatcher.Regex(None, Pattern.compile(substr))
-  private val ssICRegexMatcher = StringMatcher.Regex(None, Pattern.compile(s"^.*$substr", flags))
-  private val ssICRegexMatcher2 = StringMatcher.Regex(None, Pattern.compile(substr, flags))
+  private val regexMatcher = StringMatcher.Regex(Pattern.compile(s"^$prefix"))
+  private val icRegexMatcher = StringMatcher.Regex(Pattern.compile(s"^$prefix", flags))
+  private val ssRegexMatcher = StringMatcher.Regex(Pattern.compile(s"^.*$substr"))
+  private val ssRegexMatcher2 = StringMatcher.Regex(Pattern.compile(substr))
+  private val ssICRegexMatcher = StringMatcher.Regex(Pattern.compile(s"^.*$substr", flags))
+  private val ssICRegexMatcher2 = StringMatcher.Regex(Pattern.compile(substr, flags))
 
   @Threads(1)
   @Benchmark

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/StringMatchingOr.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/StringMatchingOr.scala
@@ -47,10 +47,10 @@ class StringMatchingOr {
   private val query8 = "adec123|abc|2|23|12345|abc34521|fedbca*.|98a2def.*"
   private val query32 = s"$query8|$query8|$query8|$query8"
 
-  private val regex8 = StringMatcher.Regex(None, Pattern.compile(query8))
+  private val regex8 = StringMatcher.Regex(Pattern.compile(query8))
   private val orMatcher8 = StringMatcher.compile(query8)
 
-  private val regex32 = StringMatcher.Regex(None, Pattern.compile(query32))
+  private val regex32 = StringMatcher.Regex(Pattern.compile(query32))
   private val orMatcher32 = StringMatcher.compile(query32)
 
   @Threads(1)

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/StringMatchingPrefix.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/StringMatchingPrefix.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import java.util.UUID
+import java.util.regex.Pattern
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Threads
+import org.openjdk.jmh.infra.Blackhole
+
+/**
+  * Sanity check prefix matching and the benefits of short ciruiting with a startsWith
+  * check before falling back to the regex matcher.
+  *
+  * ```
+  * > run -wi 10 -i 10 -f1 -t1 .*StringMatchingPrefix.*
+  * [info] Benchmark                      Mode  Cnt      Score     Error  Units
+  * [info] StringMatchingPrefix.matcher  thrpt   10  10314.028 ± 191.544  ops/s
+  * [info] StringMatchingPrefix.regex    thrpt   10   3431.614 ± 350.880  ops/s
+  * ```
+  */
+@State(Scope.Thread)
+class StringMatchingPrefix {
+
+  private val ids = (0 until 10000).map(_ => UUID.randomUUID().toString).toList
+
+  private val patternWithDot = "^disk.percentused."
+
+  private val regex = StringMatcher.Regex(Pattern.compile(patternWithDot))
+  private val matcher = StringMatcher.compile(patternWithDot)
+
+  @Threads(1)
+  @Benchmark
+  def regex(bh: Blackhole): Unit = {
+    bh.consume(ids.filter(id => regex.matches(id)))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def matcher(bh: Blackhole): Unit = {
+    bh.consume(ids.filter(id => matcher.matches(id)))
+  }
+
+}


### PR DESCRIPTION
In the streaming execution, up to 25% of the CPU usage is
checking regular expressions. This change improves the
chances that checks will be able to quickly fail without
needing regex by always checking the fixed prefix when
known in the matches function. This wasn't done before
because when evaluating with the index we already know
the prefix matches before checking.