### PR TITLE
add timeRange helper function

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
@@ -493,4 +493,39 @@ class StringsSuite extends FunSuite {
     assert(zeroPad(b, 3) === "02a")
     assert(zeroPad(b, 8) === "0000002a")
   }
+
+  test("range: both absolute") {
+    val (s, e) = timeRange("2018-07-24", "2018-07-24T00:05")
+    assert(s === parseDate("2018-07-24").toInstant)
+    assert(e === parseDate("2018-07-24T00:05").toInstant)
+  }
+
+  test("range: end is before start") {
+    intercept[IllegalArgumentException] {
+      timeRange("2018-07-24T00:05", "2018-07-24")
+    }
+  }
+
+  test("range: start time is the same as end time") {
+    val (s, e) = timeRange("2018-07-24", "2018-07-24")
+    assert(s === e)
+  }
+
+  test("range: both relative") {
+    intercept[IllegalArgumentException] {
+      timeRange("e-5m", "s+5m")
+    }
+  }
+
+  test("range: start relative to end") {
+    val (s, e) = timeRange("e-5m", "2018-07-24T00:05")
+    assert(s === parseDate("2018-07-24").toInstant)
+    assert(e === parseDate("2018-07-24T00:05").toInstant)
+  }
+
+  test("range: end relative to start") {
+    val (s, e) = timeRange("2018-07-24", "s+5m")
+    assert(s === parseDate("2018-07-24").toInstant)
+    assert(e === parseDate("2018-07-24T00:05").toInstant)
+  }
 }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/GraphConfig.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/GraphConfig.scala
@@ -56,7 +56,7 @@ case class GraphConfig(
 
   // Resolved start and end time
   val (resStart, resEnd) =
-    timeRange(start.getOrElse(settings.startTime), end.getOrElse(settings.endTime), tz)
+    Strings.timeRange(start.getOrElse(settings.startTime), end.getOrElse(settings.endTime), tz)
 
   /** Input step size rounded if necessary to a supported step. */
   val roundedStepSize: Long = {
@@ -78,19 +78,6 @@ case class GraphConfig(
   def startMillis: Long = fstart.toEpochMilli + stepSize
 
   def endMillis: Long = fend.toEpochMilli + stepSize
-
-  private def timeRange(s: String, e: String, tz: ZoneId): (Instant, Instant) = {
-    if (Strings.isRelativeDate(s, true) || s == "e") {
-      require(!Strings.isRelativeDate(e, true), "start and end are both relative")
-      val end = Strings.parseDate(e, tz)
-      val start = Strings.parseDate(end, s, tz)
-      start.toInstant -> end.toInstant
-    } else {
-      val start = Strings.parseDate(s, tz)
-      val end = Strings.parseDate(start, e, tz)
-      start.toInstant -> end.toInstant
-    }
-  }
 
   private def roundToStep(s: Instant, e: Instant): (Instant, Instant) = {
     val rs = roundToStep(s)


### PR DESCRIPTION
There are a number of internal libs that have this same
logic of computing a time range based on parsed start and
end times that can be relative to each other. Move to a
helper function of Strings so it is easier to reuse.