### PR TITLE
make random operator deterministic

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -40,6 +40,7 @@ object MathVocabulary extends Vocabulary {
     GroupBy,
     Const,
     Random,
+    SeededRandom,
     Time,
     TimeSpan,
     CommonQuery,
@@ -308,12 +309,41 @@ object MathVocabulary extends Vocabulary {
 
     override def summary: String =
       """
-        |Generates a line where each datapoint is a random value between 0.0 and 1.0.
+        |Generate a time series that appears to be random noise for the purposes of
+        |experimentation and generating sample data. To ensure that the line is deterministic
+        |and reproducible it actually is based on a hash of the timestamp. Each datapoint is a
+        |value between 0.0 and 1.0.
       """.stripMargin.trim
 
     override def signature: String = " -- TimeSeriesExpr"
 
     override def examples: List[String] = List("")
+  }
+
+  case object SeededRandom extends SimpleWord {
+
+    override def name: String = "srandom"
+
+    protected def matcher: PartialFunction[List[Any], Boolean] = {
+      case IntType(_) :: _ => true
+    }
+
+    protected def executor: PartialFunction[List[Any], List[Any]] = {
+      case IntType(seed) :: s => MathExpr.SeededRandom(seed) :: s
+    }
+
+    override def summary: String =
+      """
+        |Generate a time series that appears to be random noise for the purposes of
+        |experimentation and generating sample data. To ensure that the line is deterministic
+        |and reproducible it actually is based on a hash of the timestamp. The seed value is
+        |used to vary the values for the purposes of creating mulitple different sample lines.
+        |Each datapoint is a value between 0.0 and 1.0.
+      """.stripMargin.trim
+
+    override def signature: String = "seed:Int -- TimeSeriesExpr"
+
+    override def examples: List[String] = List("42")
   }
 
   case object Time extends SimpleWord {


### PR DESCRIPTION
The `:random` operator is mostly used for generating sample
data that has some noise. However, in its current form the
values will change every time it runs. When experimenting with
expressions this makes it hard to reason about because the
input is always changing.

Now it will be based on a hash of the timestamp so it is
reproducible. There is also now a seeded variant, `:srandom`
that can be used if multiple sample lines are needed with
different noise.

Fixes #847.