### PR TITLE
fix compiler warnings

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/StringMatcher.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/StringMatcher.scala
@@ -81,7 +81,7 @@ object StringMatcher {
     Or(s.split("\\|").toList.map(v => compile(f(v))))
   }
 
-  private def default(re: String, caseSensitive: Boolean = true): StringMatcher = {
+  private def default(re: String, caseSensitive: Boolean): StringMatcher = {
     val flags = if (caseSensitive) 0 else Pattern.CASE_INSENSITIVE
     Regex(Pattern.compile(re, flags))
   }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/Evaluator.java
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/Evaluator.java
@@ -32,7 +32,6 @@ import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.concurrent.duration.FiniteDuration;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -43,7 +42,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -304,7 +302,7 @@ public final class Evaluator extends EvaluatorImpl {
         .map(DataSources::new)
         .flatMapConcat(Source::repeat)                     // Repeat so stream doesn't shutdown
         .throttle(                                         // Throttle to avoid wasting CPU
-            1, FiniteDuration.apply(1, TimeUnit.MINUTES),
+            1, Duration.ofMinutes(1),
             1, ThrottleMode.shaping()
         )
         .via(Flow.fromProcessor(evaluator::createStreamsProcessor))


### PR DESCRIPTION
Fixes two compiler warnings:

```
Warning:(84, 35) private default argument in object
StringMatcher is never used
  private def default(re: String, caseSensitive: Boolean = true): StringMatcher = {

Warning:(306, 9) java: throttle(int,scala.concurrent.duration.FiniteDuration,int,akka.stream.ThrottleMode)
in akka.stream.javadsl.Source has been deprecated
```