### PR TITLE
add test cases for Evaluator model objects

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/Evaluator.java
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/Evaluator.java
@@ -24,6 +24,7 @@ import akka.stream.javadsl.Source;
 import akka.stream.javadsl.StreamConverters;
 import akka.util.ByteString;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.atlas.json.JsonSupport;
 import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.spectator.api.Registry;
@@ -121,7 +122,7 @@ public final class Evaluator extends EvaluatorImpl {
 
     /** Create a new instance. */
     @JsonCreator
-    public DataSources(Set<DataSource> sources) {
+    public DataSources(@JsonProperty("sources") Set<DataSource> sources) {
       this.sources = Collections.unmodifiableSet(new HashSet<>(sources));
     }
 
@@ -185,7 +186,8 @@ public final class Evaluator extends EvaluatorImpl {
     private final String uri;
 
     /** Create a new instance. */
-    public DataSource(String id, String uri) {
+    @JsonCreator
+    public DataSource(@JsonProperty("id") String id, @JsonProperty("uri") String uri) {
       this.id = id;
       this.uri = uri;
     }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/Evaluator.java
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/Evaluator.java
@@ -23,6 +23,7 @@ import akka.stream.javadsl.Framing;
 import akka.stream.javadsl.Source;
 import akka.stream.javadsl.StreamConverters;
 import akka.util.ByteString;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.netflix.atlas.json.JsonSupport;
 import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.spectator.api.Registry;
@@ -119,6 +120,7 @@ public final class Evaluator extends EvaluatorImpl {
     }
 
     /** Create a new instance. */
+    @JsonCreator
     public DataSources(Set<DataSource> sources) {
       this.sources = Collections.unmodifiableSet(new HashSet<>(sources));
     }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -30,10 +30,13 @@ import akka.stream.scaladsl.Source
 import com.netflix.atlas.akka.DiagnosticMessage
 import com.netflix.atlas.core.util.Hash
 import com.netflix.atlas.eval.model.TimeSeriesMessage
+import com.netflix.atlas.json.Json
 import com.netflix.atlas.json.JsonSupport
 import com.netflix.atlas.test.SrcPath
 import com.netflix.spectator.api.DefaultRegistry
 import com.typesafe.config.ConfigFactory
+import nl.jqno.equalsverifier.EqualsVerifier
+import nl.jqno.equalsverifier.Warning
 import org.scalatest.BeforeAndAfter
 import org.scalatest.FunSuite
 
@@ -243,5 +246,41 @@ class EvaluatorSuite extends FunSuite with BeforeAndAfter {
           msg === s"IllegalArgumentException: :offset not supported for streaming evaluation [[$expr]]"
         )
     }
+  }
+
+  test("DataSource equals contract") {
+    EqualsVerifier
+      .forClass(classOf[Evaluator.DataSource])
+      .suppress(Warning.NULL_FIELDS)
+      .verify()
+  }
+
+  test("DataSources equals contract") {
+    EqualsVerifier
+      .forClass(classOf[Evaluator.DataSources])
+      .suppress(Warning.NULL_FIELDS)
+      .verify()
+  }
+
+  test("MessageEnvelope equals contract") {
+    EqualsVerifier
+      .forClass(classOf[Evaluator.MessageEnvelope])
+      .suppress(Warning.NULL_FIELDS)
+      .verify()
+  }
+
+  test("DataSource encode and decode") {
+    val expected = new Evaluator.DataSource("id", "uri")
+    val actual = Json.decode[Evaluator.DataSource](Json.encode(expected))
+    assert(actual === expected)
+  }
+
+  test("DataSources encode and decode") {
+    val expected = Evaluator.DataSources.of(
+      new Evaluator.DataSource("id1", "uri1"),
+      new Evaluator.DataSource("id2", "uri2")
+    )
+    val actual = Json.decode[Evaluator.DataSources](Json.encode(expected))
+    assert(actual === expected)
   }
 }


### PR DESCRIPTION
Verify the equals/hashCode contracts are satisfied. Also
check that DataSource and DataSources can be encoded and
decoded from JSON correctly. Needed to consume for replay
logging.