### PR TITLE
 improve monitoring of eval flow

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/StreamOps.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/StreamOps.scala
@@ -1,0 +1,14 @@
+package com.netflix.atlas.akka
+
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.SourceQueueWithComplete
+import com.netflix.spectator.api.Registry
+
+class StreamOps {
+
+  def sourceQueue[T](registry: Registry, size: Int, strategy: OverflowStrategy): SourceQueueWithComplete[T] = {
+    Source.queue[T](size, strategy)
+  }
+
+}

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/StreamOps.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/StreamOps.scala
@@ -1,14 +1,173 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.atlas.akka
 
+import java.util.concurrent.TimeUnit
+
+import akka.Done
+import akka.NotUsed
+import akka.stream.Attributes
+import akka.stream.FlowShape
+import akka.stream.Inlet
+import akka.stream.Outlet
 import akka.stream.OverflowStrategy
+import akka.stream.QueueOfferResult
+import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
 import akka.stream.scaladsl.SourceQueueWithComplete
+import akka.stream.stage.GraphStage
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.InHandler
+import akka.stream.stage.OutHandler
 import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.Timer
 
-class StreamOps {
+import scala.concurrent.Future
+import scala.util.Failure
+import scala.util.Success
 
-  def sourceQueue[T](registry: Registry, size: Int, strategy: OverflowStrategy): SourceQueueWithComplete[T] = {
-    Source.queue[T](size, strategy)
+/**
+  * Utility functions for commonly used operations on Akka streams. Most of these are for
+  * the purpose of getting additional instrumentation into the behavior of the stream.
+  */
+object StreamOps {
+
+  /**
+    * Wraps a source queue and adds monitoring for the results of items offered to the queue.
+    * This can be used to detect if items are being dropped or offered after the associated
+    * stream has been closed.
+    *
+    * @param registry
+    *     Spectator registry to manage metrics for this queue.
+    * @param id
+    *     Dimension used to distinguish a particular queue usage.
+    * @param size
+    *     Number of enqueued items to allow before triggering the overflow strategy.
+    * @param strategy
+    *     How to handle items that come in while the queue is full.
+    */
+  def queue[T](
+    registry: Registry,
+    id: String,
+    size: Int,
+    strategy: OverflowStrategy
+  ): Source[T, SourceQueueWithComplete[T]] = {
+    Source
+      .queue[T](size, strategy)
+      .mapMaterializedValue(q => new WrappedSourceQueueWithComplete[T](registry, id, q))
   }
 
+  private final class WrappedSourceQueueWithComplete[T](
+    registry: Registry,
+    id: String,
+    queue: SourceQueueWithComplete[T]
+  ) extends SourceQueueWithComplete[T] {
+
+    private implicit val ec = scala.concurrent.ExecutionContext.Implicits.global
+
+    private val baseId = registry.createId("akka.stream.offeredToQueue", "id", id)
+    private val enqueued = registry.counter(baseId.withTag("result", "enqueued"))
+    private val dropped = registry.counter(baseId.withTag("result", "droppedQueueFull"))
+    private val closed = registry.counter(baseId.withTag("result", "droppedQueueClosed"))
+    private val failed = registry.counter(baseId.withTag("result", "droppedQueueFailure"))
+    private val completed = registry.counter(baseId.withTag("result", "droppedStreamCompleted"))
+
+    override def complete(): Unit = queue.complete()
+
+    override def fail(ex: Throwable): Unit = queue.fail(ex)
+
+    override def watchCompletion(): Future[Done] = queue.watchCompletion()
+
+    override def offer(elem: T): Future[QueueOfferResult] = {
+      queue.offer(elem).andThen {
+        case Success(QueueOfferResult.Enqueued)    => enqueued.increment()
+        case Success(QueueOfferResult.Dropped)     => dropped.increment()
+        case Success(QueueOfferResult.QueueClosed) => closed.increment()
+        case Success(QueueOfferResult.Failure(_))  => failed.increment()
+        case Failure(t)                            => completed.increment()
+      }
+    }
+  }
+
+  /**
+    * Stage that measures the flow of data through the stream. It will keep track of three
+    * meters:
+    *
+    * - `akka.stream.numEvents`: a simple counter indicating the number of events that flow
+    *   through the stream.
+    *
+    * - `akka.stream.downstreamDelay`: a timer measuring the delay for the downstream to
+    *   request a new element from the stream after an item is pushed. This can be used to
+    *   understand if the downstream cannot keep up and is introducing significant back
+    *   pressure delays.
+    *
+    * - `akka.stream.upstreamDelay`: a timer measuring the delay for the upstream to push
+    *   a new element after one has been requested.
+    *
+    * @param registry
+    *     Spectator registry to manage metrics.
+    * @param id
+    *     Dimension used to distinguish a particular usage.
+    */
+  def monitorFlow[T](registry: Registry, id: String): Flow[T, T, NotUsed] = {
+    Flow[T].via(new MonitorFlow[T](registry, id))
+  }
+
+  private final class MonitorFlow[T](registry: Registry, id: String)
+      extends GraphStage[FlowShape[T, T]] {
+
+    private val numEvents = registry.counter("akka.stream.numEvents", "id", id)
+    private val upstreamTimer = registry.timer("akka.stream.upstreamDelay", "id", id)
+    private val downstreamTimer = registry.timer("akka.stream.downstreamDelay", "id", id)
+
+    private val in = Inlet[T]("MonitorBackpressure.in")
+    private val out = Outlet[T]("MonitorBackpressure.out")
+
+    override val shape: FlowShape[T, T] = FlowShape(in, out)
+
+    override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
+
+      new GraphStageLogic(shape) with InHandler with OutHandler {
+
+        private var upstreamStart: Long = -1L
+        private var downstreamStart: Long = -1L
+
+        override def onPush(): Unit = {
+          upstreamStart = record(upstreamTimer, upstreamStart)
+          push(out, grab(in))
+          numEvents.increment()
+          downstreamStart = registry.clock().monotonicTime()
+        }
+
+        override def onPull(): Unit = {
+          downstreamStart = record(downstreamTimer, downstreamStart)
+          pull(in)
+          upstreamStart = registry.clock().monotonicTime()
+        }
+
+        private def record(timer: Timer, start: Long): Long = {
+          if (start > 0L) {
+            val delay = registry.clock().monotonicTime() - start
+            timer.record(delay, TimeUnit.NANOSECONDS)
+          }
+          -1L
+        }
+
+        setHandlers(in, out, this)
+      }
+    }
+  }
 }

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.akka
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.Keep
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.SourceQueueWithComplete
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.ManualClock
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.Utils
+import org.scalatest.FunSuite
+
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+import scala.util.Success
+
+class StreamOpsSuite extends FunSuite {
+
+  private implicit val ec = scala.concurrent.ExecutionContext.global
+
+  private implicit val system = ActorSystem(getClass.getSimpleName)
+  private implicit val materializer = ActorMaterializer()
+
+  private def runStream(
+    source: Source[Int, SourceQueueWithComplete[Int]],
+    values: Seq[Int]
+  ): Unit = {
+    val queue = source.toMat(Sink.ignore)(Keep.left).run()
+    values.foreach(queue.offer)
+    queue.complete()
+    Await.result(queue.watchCompletion(), Duration.Inf)
+  }
+
+  private def checkOfferedCounts(registry: Registry, expected: Map[String, Double]): Unit = {
+    import scala.collection.JavaConverters._
+    registry
+      .stream()
+      .iterator()
+      .asScala
+      .flatMap(_.measure().iterator().asScala)
+      .filter(m => m.id().name().equals("akka.stream.offeredToQueue"))
+      .foreach { m =>
+        val result = Utils.getTagValue(m.id(), "result")
+        assert(m.value() === expected.getOrElse(result, 0.0), result)
+      }
+  }
+
+  test("source queue, enqueued") {
+    val registry = new DefaultRegistry()
+    val source = StreamOps.queue[Int](registry, "test", 10, OverflowStrategy.dropNew)
+    runStream(source, Seq(1, 2, 3, 4))
+    checkOfferedCounts(registry, Map("enqueued" -> 4.0))
+  }
+
+  test("source queue, droppedQueueFull") {
+    val registry = new DefaultRegistry()
+    val source = StreamOps.queue[Future[Int]](registry, "test", 1, OverflowStrategy.dropNew)
+    val queue = source
+      .flatMapConcat(Source.fromFuture)
+      .toMat(Sink.ignore)(Keep.left)
+      .run()
+    val promise = Promise[Int]()
+    queue.offer(promise.future)
+    Await.result(Future.sequence(Seq(2, 3, 4, 5).map(i => queue.offer(Future(i)))), Duration.Inf)
+    promise.complete(Success(1))
+    queue.complete()
+    Await.result(queue.watchCompletion(), Duration.Inf)
+    checkOfferedCounts(registry, Map("enqueued" -> 2.0, "droppedQueueFull" -> 3.0))
+  }
+
+  private def checkCounts(registry: Registry, name: String, expected: Map[String, Double]): Unit = {
+    import scala.collection.JavaConverters._
+    registry
+      .stream()
+      .iterator()
+      .asScala
+      .flatMap(_.measure().iterator().asScala)
+      .filter(m => m.id().name().equals(s"akka.stream.$name"))
+      .foreach { m =>
+        val value = Utils.getTagValue(m.id(), "statistic")
+        val stat = if (value == null) "count" else value
+        assert(m.value() === expected.getOrElse(stat, 0.0), stat)
+      }
+  }
+
+  private def testMonitorFlow(name: String, expected: Map[String, Double]): Unit = {
+    val clock = new ManualClock()
+    val registry = new DefaultRegistry(clock)
+    val future = Source(0 until 10)
+      .via(StreamOps.monitorFlow(registry, "test"))
+      .map(i => clock.setMonotonicTime(i * 3))
+      .runWith(Sink.ignore)
+    Await.result(future, Duration.Inf)
+    checkCounts(registry, name, expected)
+  }
+
+  test("monitor flow: number of events") {
+    testMonitorFlow("numEvents", Map("count" -> 10.0))
+  }
+
+  test("monitor flow: downstream delay") {
+    testMonitorFlow("downstreamDelay", Map("count" -> 8.0, "totalTime" -> 24.0))
+  }
+
+  test("monitor flow: upstream delay") {
+    testMonitorFlow("upstreamDelay", Map("count" -> 8.0, "totalTime" -> 0.0))
+  }
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -31,6 +31,7 @@ import akka.stream.scaladsl.StreamConverters
 import akka.util.ByteString
 import com.netflix.atlas.akka.AccessLogger
 import com.netflix.atlas.akka.DiagnosticMessage
+import com.netflix.atlas.akka.StreamOps
 import com.netflix.atlas.core.util.Streams
 import com.netflix.atlas.eval.stream.Evaluator.DataSource
 import com.netflix.atlas.eval.stream.Evaluator.DataSources
@@ -129,12 +130,8 @@ private[stream] class StreamContext(
       }
   }
 
-  def countEvents[T](phase: String): Flow[T, T, NotUsed] = {
-    val counter = registry.counter("atlas.eval.numEvents", "id", phase)
-    Flow[T].map { value =>
-      counter.increment()
-      value
-    }
+  def monitorFlow[T](phase: String): Flow[T, T, NotUsed] = {
+    StreamOps.monitorFlow(registry, phase)
   }
 }
 


### PR DESCRIPTION
Adds a StreamOps helper class with utilities to monitor
source queue behavior and delays at a particular stage
in a flow. The flow monitoring can be used to understand
whether the producer or consumer is faster and where we
are getting backpressure delays.