### PR TITLE
fix deprecation warnings for DataSource ctor

### DIFF
--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
@@ -21,7 +21,6 @@ import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
-import akka.stream.scaladsl.SourceQueueWithComplete
 import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spectator.api.ManualClock
 import com.netflix.spectator.api.Registry

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookupSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookupSuite.scala
@@ -65,7 +65,7 @@ class EurekaGroupsLookupSuite extends FunSuite {
   }
 
   private def ds(id: String, uri: String): DataSource = {
-    new DataSource(id, uri)
+    new DataSource(id, java.time.Duration.ofMinutes(1), uri)
   }
 
   private def run(input: List[DataSources], n: Int = 1): List[SourcesAndGroups] = {

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
@@ -57,7 +57,7 @@ class FinalExprEvalSuite extends FunSuite {
   }
 
   private def ds(id: String, uri: String): DataSource = {
-    new DataSource(id, uri)
+    new DataSource(id, java.time.Duration.ofMinutes(1), uri)
   }
 
   private def group(i: Long, vs: AggrDatapoint*): TimeGroup[AggrDatapoint] = {

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/SubscriptionManagerSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/SubscriptionManagerSuite.scala
@@ -74,7 +74,7 @@ class SubscriptionManagerSuite extends FunSuite with BeforeAndAfter {
   }
 
   private def ds(id: String, uri: String): DataSource = {
-    new DataSource(id, uri)
+    new DataSource(id, java.time.Duration.ofMinutes(1), uri)
   }
 
   private val requests = new ConcurrentLinkedQueue[HttpRequest]()


### PR DESCRIPTION
In #865, a new DataSource constructor was added to allow
the frequency to be specified and the previous constructor
was deprecated. The deprecated constructor was being used
in some of the test cases causing a lot of warnings.