### PR TITLE
add heartbeat messages back to StreamApi

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
@@ -132,7 +132,8 @@ class StreamApi @Inject()(
     }
 
     // Heartbeat messages to ensure that the socket is never idle
-    val heartbeatSrc = Source.repeat(heartbeat)
+    val heartbeatSrc = Source
+      .repeat(heartbeat)
       .throttle(1, 5.seconds, 1, ThrottleMode.Shaping)
 
     val source = Source

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/StreamApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/StreamApiSuite.scala
@@ -32,10 +32,6 @@ class StreamApiSuite extends FunSuite with ScalatestRouteTest {
     assert(ret.contains(""""instanceId":"""))
   }
 
-  test("SSEStatistics renders") {
-    assert(SSEStatistics(1).toSSE === """info: statistics {"outputFullFailures":1}""")
-  }
-
   test("SSEShutdown renders") {
     assert(SSEShutdown("foo").toSSE === """info: shutdown {"reason":"foo"}""")
   }


### PR DESCRIPTION
The old mechanism of pushing the stats messages was lost
inadvertantly as part of #871. Changed to a simple heartbeat
message since the stats are now checked as part of the queue
for the stream.