### PR TITLE
additional logging for SubscriptionManager

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/QueueHandler.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/QueueHandler.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwcapi
+
+import akka.stream.QueueOfferResult
+import akka.stream.scaladsl.SourceQueueWithComplete
+import com.typesafe.scalalogging.StrictLogging
+
+import scala.concurrent.Future
+
+/**
+  * Message handler for use with the [SubscriptionManager].
+  *
+  * @param id
+  *     Stream id for this handler. Used to provide context in the log messages and easily
+  *     be able to grep for a given id.
+  * @param queue
+  *     Underlying queue that will receive the messsages.
+  */
+class QueueHandler(id: String, queue: SourceQueueWithComplete[SSERenderable])
+    extends StrictLogging {
+
+  def offer(msg: SSERenderable): Future[QueueOfferResult] = {
+    logger.trace(s"enqueuing message for $id: ${msg.toSSE}")
+    queue.offer(msg)
+  }
+
+  def complete(): Unit = {
+    logger.debug(s"queue complete for $id")
+    queue.complete()
+  }
+
+  override def toString: String = s"QueueHandler($id)"
+}

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
@@ -124,7 +124,7 @@ class StreamApi @Inject()(
 
     // Send initial setup messages
     queue.offer(SSEHello(streamId, instanceId))
-    sm.register(streamId, queue)
+    sm.register(streamId, new QueueHandler(streamId, queue))
     splits.foreach {
       case (exprMeta, subscriptions) =>
         subscriptions.foreach(s => sm.subscribe(streamId, s))

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamSubscriptionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamSubscriptionManager.scala
@@ -23,4 +23,4 @@ import akka.stream.scaladsl.SourceQueueWithComplete
   * is just to avoid those issues for the main use-cases where we need to inject a version
   * that needs a source queue.
   */
-class StreamSubscriptionManager extends SubscriptionManager[SourceQueueWithComplete[SSERenderable]]
+class StreamSubscriptionManager extends SubscriptionManager[QueueHandler]

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamSubscriptionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamSubscriptionManager.scala
@@ -15,8 +15,6 @@
  */
 package com.netflix.atlas.lwcapi
 
-import akka.stream.scaladsl.SourceQueueWithComplete
-
 /**
   * Subclass of [[SubscriptionManager]] that uses a source queue for the handler. In some cases
   * with dependency injection erasure can cause problems with generic types. This class

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit
 
 import com.netflix.atlas.core.index.QueryIndex
 import com.netflix.frigga.Names
+import com.typesafe.scalalogging.StrictLogging
 
 import scala.collection.JavaConverters._
 
@@ -34,7 +35,7 @@ import scala.collection.JavaConverters._
   * - subscribe/unsubscribe: informs the manager that a given stream should receive or stop
   *   receiving data for a given expression.
   */
-class SubscriptionManager[T] {
+class SubscriptionManager[T] extends StrictLogging {
 
   import SubscriptionManager._
 
@@ -67,6 +68,7 @@ class SubscriptionManager[T] {
     * access the concurrent map without synchronization.
     */
   private def addHandler(subId: String, handler: T): Unit = {
+    logger.debug(s"adding handler for $subId: $handler")
     subHandlers.synchronized {
       val handlers = subHandlers.computeIfAbsent(subId, _ => new ConcurrentSet[T])
       handlers.add(handler)
@@ -79,6 +81,7 @@ class SubscriptionManager[T] {
     * new handlers to the set.
     */
   private def removeHandler(subId: String, handler: T): Unit = {
+    logger.debug(s"removing handler for $subId: $handler")
     val handlers = subHandlers.get(subId)
     if (handlers != null) {
       handlers.remove(handler)
@@ -94,6 +97,7 @@ class SubscriptionManager[T] {
     * list of handlers that should be called for a given subscription.
     */
   def register(streamId: String, handler: T): Unit = {
+    logger.debug(s"registering $streamId")
     registrations.put(streamId, new StreamInfo[T](handler))
     queryListChanged = true
   }
@@ -104,6 +108,7 @@ class SubscriptionManager[T] {
     * removed.
     */
   def unregister(streamId: String): Option[T] = {
+    logger.debug(s"unregistering $streamId")
     val result = Option(registrations.remove(streamId)).map { info =>
       info.subscriptions.foreach { sub =>
         removeHandler(sub.metadata.id, info.handler)
@@ -133,8 +138,10 @@ class SubscriptionManager[T] {
     * Start sending data for the subscription to the given stream id.
     */
   def subscribe(streamId: String, subs: List[Subscription]): T = {
+    logger.debug(s"updating subscriptions for $streamId")
     val info = getInfo(streamId)
     subs.foreach { sub =>
+      logger.debug(s"subscribing $streamId to $sub")
       info.subs.put(sub.metadata.id, sub)
       addHandler(sub.metadata.id, info.handler)
     }
@@ -146,6 +153,7 @@ class SubscriptionManager[T] {
     * Stop sending data for the subscription to the given stream id.
     */
   def unsubscribe(streamId: String, subId: String): Unit = {
+    logger.debug(s"unsubscribing $streamId from $subId")
     val info = getInfo(streamId)
     info.subs.remove(subId)
     removeHandler(subId, info.handler)
@@ -198,6 +206,7 @@ class SubscriptionManager[T] {
   }
 
   def clear(): Unit = {
+    logger.debug("clearing all subscriptions")
     registrations.clear()
     queryListChanged = true
     regenerateQueryIndex()

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
@@ -35,10 +35,13 @@ class ExpressionApiSuite extends FunSuite with ScalatestRouteTest {
   private val splitter = new ExpressionSplitter(ConfigFactory.load())
 
   // Dummy queue used for handler
-  private val queue = Source
-    .queue[SSERenderable](1, OverflowStrategy.dropHead)
-    .toMat(Sink.ignore)(Keep.left)
-    .run()
+  private val queue = new QueueHandler(
+    "test",
+    Source
+      .queue[SSERenderable](1, OverflowStrategy.dropHead)
+      .toMat(Sink.ignore)(Keep.left)
+      .run()
+  )
 
   private val sm = new StreamSubscriptionManager
   private val endpoint = ExpressionApi(sm, new NoopRegistry, system)

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
@@ -35,10 +35,13 @@ class SubscribeApiSuite extends FunSuite with BeforeAndAfter with ScalatestRoute
   private implicit val routeTestTimeout = RouteTestTimeout(5.second)
 
   // Dummy queue used for handler
-  private val queue = Source
-    .queue[SSERenderable](1, OverflowStrategy.dropHead)
-    .toMat(Sink.ignore)(Keep.left)
-    .run()
+  private val queue = new QueueHandler(
+    "test",
+    Source
+      .queue[SSERenderable](1, OverflowStrategy.dropHead)
+      .toMat(Sink.ignore)(Keep.left)
+      .run()
+  )
 
   private val sm = new StreamSubscriptionManager
   private val splitter = new ExpressionSplitter(ConfigFactory.load())


### PR DESCRIPTION
Adds some debug logging for all of the modification
operations on the subscription manager. Also enables
trace logging for the messages going to each stream.