### PR TITLE
fix shutdown for ActorSystem

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/ActorService.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/ActorService.scala
@@ -27,9 +27,6 @@ import com.netflix.iep.service.ClassFactory
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
 
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
-
 /**
   * Exposes actor system as service for healthcheck and proper shutdown. Additional
   * actors to start up can be specified using the `atlas.akka.actors` property.
@@ -55,7 +52,5 @@ class ActorService @Inject()(system: ActorSystem, config: Config, classFactory: 
     if (config.hasPath(routerCfgPath)) FromConfig.props(props) else props
   }
 
-  override def stopImpl(): Unit = {
-    Await.ready(system.terminate(), Duration.Inf)
-  }
+  override def stopImpl(): Unit = {}
 }

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/WebServer.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/WebServer.scala
@@ -17,7 +17,6 @@ package com.netflix.atlas.akka
 
 import javax.inject.Inject
 import javax.inject.Singleton
-
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.Http.ServerBinding
@@ -29,7 +28,9 @@ import com.netflix.spectator.api.Registry
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
 
+import scala.concurrent.Await
 import scala.concurrent.Future
+import scala.concurrent.duration.Duration
 
 /**
   * Web server instance.
@@ -68,7 +69,9 @@ class WebServer @Inject()(
   }
 
   protected def stopImpl(): Unit = {
-    bindingFuture.flatMap(_.unbind())
+    if (bindingFuture != null) {
+      Await.ready(bindingFuture.flatMap(_.unbind()), Duration.Inf)
+    }
   }
 
   def actorSystem: ActorSystem = system

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/WebServer.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/WebServer.scala
@@ -68,7 +68,7 @@ class WebServer @Inject()(
   }
 
   protected def stopImpl(): Unit = {
-    bindingFuture.flatMap(_.unbind()).onComplete(_ => system.terminate())
+    bindingFuture.flatMap(_.unbind())
   }
 
   def actorSystem: ActorSystem = system


### PR DESCRIPTION
It was being shutdown by ActorService and WebServer. Also
since it could be used by other classes that do not inject
those, the ActorSystem could be shutdown in the wrong order.
This change moves it to a dedicated provider so it will be
shutdown in the correct order.