### PR TITLE
make tags parsing more lenient for publish api

### DIFF
--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
@@ -120,17 +120,12 @@ object PublishApi {
     foreachField(parser) {
       case key =>
         val value = parser.nextTextValue()
-        if (value == null || value.isEmpty) {
-          val loc = parser.getCurrentLocation
-          val line = loc.getLineNr
-          val col = loc.getColumnNr
-          val msg = s"tag value cannot be null or empty (key=$key, line=$line, col=$col)"
-          throw new IllegalArgumentException(msg)
+        if (value != null) {
+          if (intern)
+            b.add(strInterner.intern(key), strInterner.intern(value))
+          else
+            b.add(key, value)
         }
-        if (intern)
-          b.add(strInterner.intern(key), strInterner.intern(value))
-        else
-          b.add(key, value)
     }
     if (intern) TaggedItem.internTagsShallow(b.compact) else b.result
   }

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishApiJsonSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishApiJsonSuite.scala
@@ -118,6 +118,42 @@ class PublishApiJsonSuite extends FunSuite {
     assert(decoded.size === 1)
   }
 
+  test("decode legacy batch with empty name") {
+    val decoded = PublishApi.decodeBatch("""
+      {
+        "metrics": [
+          {
+            "tags": {"name": ""},
+            "start": 123456789,
+            "values": [1.0]
+          }
+        ]
+      }
+      """)
+    assert(decoded.size === 1)
+    decoded.foreach { d =>
+      assert(d.tags === Map("name" -> ""))
+    }
+  }
+
+  test("decode legacy batch with null name") {
+    val decoded = PublishApi.decodeBatch("""
+      {
+        "metrics": [
+          {
+            "tags": {"name": null},
+            "start": 123456789,
+            "values": [1.0]
+          }
+        ]
+      }
+      """)
+    assert(decoded.size === 1)
+    decoded.foreach { d =>
+      assert(d.tags === Map.empty)
+    }
+  }
+
   test("decode list empty") {
     val decoded = PublishApi.decodeList("""
       []


### PR DESCRIPTION
If an empty tag value was submitted it would cause the
entire payload to get rejected. With this change it will
go through and can then be caught by the validation checks
so that only the bad datapoints will get dropped.