### PR TITLE
add Json.decode that takes a JsonNode object

### DIFF
--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
@@ -42,9 +42,11 @@ object Json {
 
     def decode(json: String): T = decode(factory.createParser(json))
 
+    def decode(input: Reader): T = decode(factory.createParser(input))
+
     def decode(input: InputStream): T = decode(factory.createParser(input))
 
-    def decode(input: Reader): T = decode(factory.createParser(input))
+    def decode(node: JsonNode): T = reader.readValue[T](node)
 
     def decode(parser: JsonParser): T = {
       try {
@@ -167,6 +169,8 @@ object Json {
   def decode[T: Manifest](reader: Reader): T = decoder[T].decode(reader)
 
   def decode[T: Manifest](stream: InputStream): T = decoder[T].decode(stream)
+
+  def decode[T: Manifest](node: JsonNode): T = decoder[T].decode(node)
 
   def decode[T: Manifest](parser: JsonParser): T = {
     val reader: ObjectReader =

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
@@ -22,6 +22,7 @@ import java.util.regex.Pattern
 
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.core.JsonToken
+import com.fasterxml.jackson.databind.JsonNode
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
 import org.joda.time.Duration
@@ -473,6 +474,19 @@ class JsonSuite extends FunSuite {
     val obj = Json.decode[JsonSuiteArrayString]("""{"name":"name", "values":[]}""")
     val json = Json.encode(obj)
     assert(json === """{"name":"name","values":[]}""")
+  }
+
+  test("decode from JsonData") {
+    def parse(json: String): List[JsonSuiteSimple] = {
+      val node = Json.decode[JsonNode](json)
+      if (node.isArray)
+        Json.decode[List[JsonSuiteSimple]](node)
+      else
+        List(Json.decode[JsonSuiteSimple](node))
+    }
+    val list = parse("""[{"foo":42,"bar":"abc"}]""")
+    val obj = parse("""{"foo":42,"bar":"abc"}""")
+    assert(list === obj)
   }
 }
 


### PR DESCRIPTION
Can be useful for cases where there is a need to do some
basic structural inspection before mapping into an internal
value type.