### PR TITLE
fix subscribe for streams with multiple subs

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
@@ -149,10 +149,11 @@ class SubscriptionManager[T] extends StrictLogging {
   def subscribe(streamId: String, subs: List[Subscription]): T = {
     logger.debug(s"updating subscriptions for $streamId")
     val info = getInfo(streamId)
-    queryListChanged = subs.foldLeft(queryListChanged) { case (acc, sub) =>
-      logger.debug(s"subscribing $streamId to $sub")
-      info.subs.put(sub.metadata.id, sub)
-      addHandler(sub.metadata.id, info.handler) || acc
+    queryListChanged = subs.foldLeft(queryListChanged) {
+      case (acc, sub) =>
+        logger.debug(s"subscribing $streamId to $sub")
+        info.subs.put(sub.metadata.id, sub)
+        addHandler(sub.metadata.id, info.handler) || acc
     }
     info.handler
   }

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
@@ -149,10 +149,10 @@ class SubscriptionManager[T] extends StrictLogging {
   def subscribe(streamId: String, subs: List[Subscription]): T = {
     logger.debug(s"updating subscriptions for $streamId")
     val info = getInfo(streamId)
-    queryListChanged = subs.exists { sub =>
+    queryListChanged = subs.foldLeft(queryListChanged) { case (acc, sub) =>
       logger.debug(s"subscribing $streamId to $sub")
       info.subs.put(sub.metadata.id, sub)
-      addHandler(sub.metadata.id, info.handler)
+      addHandler(sub.metadata.id, info.handler) || acc
     }
     info.handler
   }

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
@@ -50,6 +50,16 @@ class SubscriptionManagerSuite extends FunSuite {
     assert(sm.unregister(sse1) === None)
   }
 
+  test("multiple subscriptions for stream") {
+    val sm = new SubscriptionManager[Integer]()
+    sm.register("a", 1)
+
+    val subs = List(sub("name,exp1,:eq"), sub("name,exp2,:eq"))
+    sm.subscribe("a", subs)
+
+    assert(sm.subscriptions.toSet === subs.toSet)
+  }
+
   test("duplicate subscriptions") {
     val sm = new SubscriptionManager[Integer]()
     sm.register("a", 1)


### PR DESCRIPTION
Before the short circuit behavior meant that only the first
new handler would get added.