### PR TITLE
re-register handler if needed on heartbeat

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
@@ -57,6 +57,8 @@ class StreamApi @Inject()(
   private implicit val ec = scala.concurrent.ExecutionContext.global
   private implicit val materializer = ActorMaterializer()
 
+  private val reRegistrations = registry.counter("atlas.lwcapi.reRegistrations")
+
   def routes: Route = {
     path("lwc" / "api" / "v1" / "stream" / Segment) { streamId =>
       parameters(('name.?, 'expression.?, 'frequency.?)) { (name, expr, frequency) =>
@@ -126,8 +128,9 @@ class StreamApi @Inject()(
       .run()
 
     // Send initial setup messages
+    val handler = new QueueHandler(streamId, queue)
     queue.offer(SSEHello(streamId, instanceId))
-    sm.register(streamId, new QueueHandler(streamId, queue))
+    sm.register(streamId, handler)
     splits.foreach {
       case (exprMeta, subscriptions) =>
         subscriptions.foreach(s => sm.subscribe(streamId, s))
@@ -138,6 +141,18 @@ class StreamApi @Inject()(
     val heartbeatSrc = Source
       .repeat(heartbeat)
       .throttle(1, 5.seconds, 1, ThrottleMode.Shaping)
+      .map { value =>
+        // There is a race condition on reconnects where the new connection can come in
+        // before the stream for the old connection is closed. The cleanup for the old
+        // connection will then unregister the stream id. This is a short-term work around
+        // to ensure running streams have a registered handler and track the number of
+        // events that we see.
+        if (!sm.register(streamId, handler)) {
+          logger.debug(s"re-registered handler for stream $streamId")
+          reRegistrations.increment()
+        }
+        value
+      }
 
     val source = Source
       .fromPublisher(pub)

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
@@ -104,11 +104,12 @@ class SubscriptionManager[T] extends StrictLogging {
     * Register a new stream with the provided id. The `handler` is used by the caller to
     * interact with the stream. The caller can use [[handlersForSubscription()]] to get a
     * list of handlers that should be called for a given subscription.
+    *
+    * Returns true if it is a new registration.
     */
-  def register(streamId: String, handler: T): Unit = {
+  def register(streamId: String, handler: T): Boolean = {
     logger.debug(s"registering $streamId")
-    registrations.put(streamId, new StreamInfo[T](handler))
-    queryListChanged = true
+    registrations.put(streamId, new StreamInfo[T](handler)) == null
   }
 
   /**

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
@@ -50,6 +50,14 @@ class SubscriptionManagerSuite extends FunSuite {
     assert(sm.unregister(sse1) === None)
   }
 
+  test("multiple registrations") {
+    val sm = new SubscriptionManager[Integer]()
+    assert(sm.register("a", 1))
+    assert(!sm.register("a", 1))
+    assert(sm.unregister("a") === Some(1))
+    assert(sm.register("a", 1))
+  }
+
   test("multiple subscriptions for stream") {
     val sm = new SubscriptionManager[Integer]()
     sm.register("a", 1)


### PR DESCRIPTION
There is a race condition on reconnects where the new
connection can come in before the stream for the old
connection is closed. The cleanup for the old connection
will then unregister the stream id. This is a short-term
work around to ensure running streams have a registered
handler and track the number of events that we see.