### PR TITLE
ensure subs are maintained for re-register check

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
@@ -101,7 +101,7 @@ class StreamApi @Inject()(
         // connection will then unregister the stream id. This is a short-term work around
         // to ensure running streams have a registered handler and track the number of
         // events that we see.
-        if (!sm.register(streamId, handler)) {
+        if (sm.register(streamId, handler)) {
           logger.debug(s"re-registered handler for stream $streamId")
           reRegistrations.increment()
         }

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
@@ -58,6 +58,18 @@ class SubscriptionManagerSuite extends FunSuite {
     assert(sm.register("a", 1))
   }
 
+  test("subs are maintained on attempted re-register") {
+    val sm = new SubscriptionManager[Integer]()
+    assert(sm.register("a", 1))
+
+    val exp1 = sub("name,exp1,:eq")
+    sm.subscribe("a", exp1)
+    assert(sm.subscriptions === List(exp1))
+
+    assert(!sm.register("a", 1))
+    assert(sm.subscriptions === List(exp1))
+  }
+
   test("multiple subscriptions for stream") {
     val sm = new SubscriptionManager[Integer]()
     sm.register("a", 1)


### PR DESCRIPTION
Helps to reduce the amount of churn we see for changes
when looking at the logs.