### PR TITLE
extract the name portion of the target group dimension

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/reference.conf
@@ -54,7 +54,7 @@ atlas {
       // Only one capture group is supported, so only capture group 1 will
       // be used. If no match is found, the unaltered original value is
       // used.
-      extractors = [
+      extractors = ${?atlas.cloudwatch.tagger.extractors} [
         {
           name = "TargetGroup"
           pattern = "^targetgroup/([^/]+)/.*"

--- a/atlas-poller-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/reference.conf
@@ -50,6 +50,17 @@ atlas {
     tagger = {
       class = "com.netflix.atlas.cloudwatch.NetflixTagger"
 
+      // Enables extracting a substring of a dimension value using a regex.
+      // Only one capture group is supported, so only capture group 1 will
+      // be used. If no match is found, the unaltered original value is
+      // used.
+      extractors = [
+        {
+          name = "TargetGroup"
+          pattern = "^targetgroup/([^/]+)/.*"
+        }
+      ]
+
       // Allows the dimension names to be mapped to values that are more
       // familiar internally at Netflix. If no explicit mapping is found,
       // then the value from cloudwatch will be used as is.

--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/DefaultTaggerSuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/DefaultTaggerSuite.scala
@@ -15,6 +15,8 @@
  */
 package com.netflix.atlas.cloudwatch
 
+import java.util.regex.PatternSyntaxException
+
 import com.amazonaws.services.cloudwatch.model.Dimension
 import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
@@ -24,6 +26,8 @@ class DefaultTaggerSuite extends FunSuite {
 
   private val dimensions = List(
     new Dimension().withName("CloudWatch").withValue("abc"),
+    new Dimension().withName("ExtractDotDelimited").withValue("abc.def.captured-portion"),
+    new Dimension().withName("ExtractSlashDelimited").withValue("abc/captured-portion/42beef9876"),
     new Dimension().withName("NoMapping").withValue("def")
   )
 
@@ -36,6 +40,7 @@ class DefaultTaggerSuite extends FunSuite {
 
   test("add common tags") {
     val cfg = ConfigFactory.parseString("""
+        |extractors = []
         |mappings = []
         |common-tags = [
         |  {
@@ -46,9 +51,11 @@ class DefaultTaggerSuite extends FunSuite {
       """.stripMargin)
 
     val expected = Map(
-      "foo"        -> "bar",
-      "CloudWatch" -> "abc",
-      "NoMapping"  -> "def"
+      "foo"                   -> "bar",
+      "CloudWatch"            -> "abc",
+      "ExtractDotDelimited"   -> "abc.def.captured-portion",
+      "ExtractSlashDelimited" -> "abc/captured-portion/42beef9876",
+      "NoMapping"             -> "def"
     )
 
     val tagger = new DefaultTagger(cfg)
@@ -57,6 +64,7 @@ class DefaultTaggerSuite extends FunSuite {
 
   test("apply key mappings") {
     val cfg = ConfigFactory.parseString("""
+        |extractors = []
         |mappings = [
         |  {
         |    name = "CloudWatch"
@@ -67,8 +75,110 @@ class DefaultTaggerSuite extends FunSuite {
       """.stripMargin)
 
     val expected = Map(
-      "InternalAlias" -> "abc",
-      "NoMapping"     -> "def"
+      "ExtractDotDelimited"   -> "abc.def.captured-portion",
+      "ExtractSlashDelimited" -> "abc/captured-portion/42beef9876",
+      "InternalAlias"         -> "abc",
+      "NoMapping"             -> "def"
+    )
+
+    val tagger = new DefaultTagger(cfg)
+    assert(tagger(dimensions) === expected)
+  }
+
+  test("extract value for configured keys") {
+    val cfg = ConfigFactory.parseString("""
+        |extractors = [
+        |  {
+        |    name = "ExtractDotDelimited"
+        |    pattern = "[^.]+\\.[^.]+\\.(.*)"
+        |  },
+        |  {
+        |    name = "ExtractSlashDelimited"
+        |    pattern = "[^.]+/([^.]+)/.*"
+        |  }
+        |]
+        |mappings = []
+        |common-tags = []
+      """.stripMargin)
+
+    val expected = Map(
+      "ExtractDotDelimited"   -> "captured-portion",
+      "ExtractSlashDelimited" -> "captured-portion",
+      "CloudWatch"            -> "abc",
+      "NoMapping"             -> "def"
+    )
+
+    val tagger = new DefaultTagger(cfg)
+    assert(tagger(dimensions) === expected)
+  }
+
+  test("syntax error in extractor pattern throws") {
+    val cfg = ConfigFactory.parseString("""
+        |extractors = [
+        |  {
+        |    name = "ExtractDotDelimited"
+        |    pattern = "[^.]+\\.[^.]+\\.(.*"
+        |  }
+        |]
+        |mappings = []
+        |common-tags = []
+      """.stripMargin)
+
+    intercept[PatternSyntaxException] {
+      new DefaultTagger(cfg)
+    }
+
+  }
+
+  test("extractor without capture group returns raw value") {
+    val cfg = ConfigFactory.parseString("""
+        |extractors = [
+        |  {
+        |    name = "ExtractDotDelimited"
+        |    pattern = "[^.]+\\.[^.]+\\..*"
+        |  }
+        |]
+        |mappings = []
+        |common-tags = []
+      """.stripMargin)
+
+    val expected = Map(
+      "ExtractDotDelimited"   -> "abc.def.captured-portion",
+      "ExtractSlashDelimited" -> "abc/captured-portion/42beef9876",
+      "CloudWatch"            -> "abc",
+      "NoMapping"             -> "def"
+    )
+
+    val tagger = new DefaultTagger(cfg)
+    assert(tagger(dimensions) === expected)
+  }
+
+  test("apply key mappings and extract value for configured keys") {
+    val cfg = ConfigFactory.parseString("""
+        |extractors = [
+        |  {
+        |    name = "ExtractDotDelimited"
+        |    pattern = "[^.]+\\.[^.]+\\.(.*)"
+        |  },
+        |  {
+        |    name = "ExtractSlashDelimited"
+        |    pattern = "[^.]+/([^.]+)/.*"
+        |  }
+        |]
+        |mappings = [
+        |  {
+        |    name = "ExtractSlashDelimited"
+        |    alias = "extracted"
+        |  }
+        |]
+        |common-tags = []
+      """.stripMargin)
+
+    val expected = Map(
+      "ExtractDotDelimited" -> "captured-portion",
+      "extracted"           -> "captured-portion",
+      "CloudWatch"          -> "abc",
+      "NoMapping"           -> "def"
     )
 
     val tagger = new DefaultTagger(cfg)
@@ -77,6 +187,7 @@ class DefaultTaggerSuite extends FunSuite {
 
   test("dimensions override common tags") {
     val cfg = ConfigFactory.parseString("""
+        |extractors = []
         |mappings = [
         |  {
         |    name = "CloudWatch"
@@ -92,8 +203,10 @@ class DefaultTaggerSuite extends FunSuite {
       """.stripMargin)
 
     val expected = Map(
-      "foo"       -> "abc",
-      "NoMapping" -> "def"
+      "ExtractDotDelimited"   -> "abc.def.captured-portion",
+      "ExtractSlashDelimited" -> "abc/captured-portion/42beef9876",
+      "foo"                   -> "abc",
+      "NoMapping"             -> "def"
     )
 
     val tagger = new DefaultTagger(cfg)

--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/NetflixTaggerSuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/NetflixTaggerSuite.scala
@@ -36,6 +36,7 @@ class NetflixTaggerSuite extends FunSuite {
 
   test("extract tags using naming conventions") {
     val cfg = ConfigFactory.parseString("""
+        |extractors = []
         |mappings = [
         |  {
         |    name = "AutoScalingGroupName"


### PR DESCRIPTION
Some dimension values are decorated with information that reduces
readability without providing value (e.g., ALBs and NLBs). This commit
introduces a new `extractors` configuration within the `tagger` that
enables specifying a regex to capture the relevant portion of the name.