### PR TITLE
 extract the name from the load balancer dimension

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/reference.conf
@@ -56,6 +56,10 @@ atlas {
       // used.
       extractors = ${?atlas.cloudwatch.tagger.extractors} [
         {
+          name = "LoadBalancer"
+          pattern = "^app/([^/]+)/.*"
+        },
+        {
           name = "TargetGroup"
           pattern = "^targetgroup/([^/]+)/.*"
         }


### PR DESCRIPTION
The `LoadBalancer` dimension is specified as the final portion of the
load balancer ARN. For example:
  `app/load-balancer-name/1234567890123456`