### PR TITLE
fix `LoadBalancer` extractor pattern

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/reference.conf
@@ -57,7 +57,7 @@ atlas {
       extractors = ${?atlas.cloudwatch.tagger.extractors} [
         {
           name = "LoadBalancer"
-          pattern = "^(app|net)/([^/]+)/.*"
+          pattern = "^(?:app|net)/([^/]+)/.*"
         },
         {
           name = "TargetGroup"

--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/DefaultTaggerSuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/DefaultTaggerSuite.scala
@@ -212,4 +212,20 @@ class DefaultTaggerSuite extends FunSuite {
     val tagger = new DefaultTagger(cfg)
     assert(tagger(dimensions) === expected)
   }
+
+  test("aws.alb is assigned to LoadBalancer names starting with app with main config") {
+    val cfg = ConfigFactory.parseResources("reference.conf").resolve()
+    val tagger = new DefaultTagger(cfg.getConfig("atlas.cloudwatch.tagger"))
+
+    val expected = Map(
+      "aws.alb"   -> "captured-portion",
+      "nf.region" -> "us-west-2"
+    )
+
+    val actual = tagger(
+      List(new Dimension().withName("LoadBalancer").withValue("app/captured-portion/42beef9876"))
+    )
+
+    assert(actual === expected)
+  }
 }


### PR DESCRIPTION
Configure the app|net matching as a non-capturing group, so the correct
portion is extracted.

As I was thinking about the addition of NLB metrics, I realized the
previous commits don't handle conditional mapping of `LoadBalancer`
which will need to set `aws.alb` or `aws.nlb` depending on the context.
In the course of writing a passing case for `aws.alb` and a failing one
for `aws.nlb`, this bug was uncovered. I'll fix the ALB vs NLB handling
in a separate commit.