### PR TITLE
conditionally apply an alias per pattern

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/reference.conf
@@ -57,7 +57,7 @@ atlas {
       extractors = ${?atlas.cloudwatch.tagger.extractors} [
         {
           name = "LoadBalancer"
-          patterns = [
+          directives = [
             {
               pattern = "^app/([^/]+)/.*"
               alias = "aws.alb"
@@ -70,7 +70,7 @@ atlas {
         },
         {
           name = "TargetGroup"
-          patterns = [
+          directives = [
             {
               pattern = "^targetgroup/([^/]+)/.*"
               alias = "aws.target"

--- a/atlas-poller-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/reference.conf
@@ -57,11 +57,25 @@ atlas {
       extractors = ${?atlas.cloudwatch.tagger.extractors} [
         {
           name = "LoadBalancer"
-          pattern = "^(?:app|net)/([^/]+)/.*"
+          patterns = [
+            {
+              pattern = "^app/([^/]+)/.*"
+              alias = "aws.alb"
+            },
+            {
+              pattern = "^net/([^/]+)/.*"
+              alias = "aws.nlb"
+            }
+          ]
         },
         {
           name = "TargetGroup"
-          pattern = "^targetgroup/([^/]+)/.*"
+          patterns = [
+            {
+              pattern = "^targetgroup/([^/]+)/.*"
+              alias = "aws.target"
+            }
+          ]
         }
       ]
 
@@ -92,14 +106,6 @@ atlas {
         {
           name = "LoadBalancerName"
           alias = "aws.elb"
-        },
-        {
-          name = "LoadBalancer"
-          alias = "aws.alb"
-        },
-        {
-          name = "TargetGroup"
-          alias = "aws.target"
         },
         {
           name = "TopicName"

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/DefaultTagger.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/DefaultTagger.scala
@@ -29,7 +29,7 @@ import scala.util.matching.Regex
 class DefaultTagger(config: Config) extends Tagger {
   import scala.collection.JavaConverters._
 
-  private val extractors: Map[String, Seq[(Regex, Option[String])]] = config
+  private val extractors: Map[String, Seq[(Regex, String)]] = config
     .getConfigList("extractors")
     .asScala
     .map { c =>
@@ -37,7 +37,7 @@ class DefaultTagger(config: Config) extends Tagger {
         .getConfigList("patterns")
         .asScala
         .map(cl => {
-          val alias = if (cl.hasPath("alias")) Some(cl.getString("alias")) else None
+          val alias = if (cl.hasPath("alias")) cl.getString("alias") else c.getString("name")
           cl.getString("pattern").r -> alias
         })
       c.getString("name") -> patterns
@@ -67,7 +67,7 @@ class DefaultTagger(config: Config) extends Tagger {
           val extractedValue = regex.findFirstMatchIn(cwValue).map { matches =>
             if (matches.groupCount > 0) matches.group(1) else cwValue
           }
-          extractedValue.map(v => alias.getOrElse(cwName) -> v)
+          extractedValue.map(v => alias -> v)
       }.headOption
     }
 

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/DefaultTagger.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/DefaultTagger.scala
@@ -34,7 +34,7 @@ class DefaultTagger(config: Config) extends Tagger {
     .asScala
     .map { c =>
       val patterns = c
-        .getConfigList("patterns")
+        .getConfigList("directives")
         .asScala
         .map(cl => {
           val alias = if (cl.hasPath("alias")) cl.getString("alias") else c.getString("name")

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/DefaultTagger.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/DefaultTagger.scala
@@ -65,7 +65,7 @@ class DefaultTagger(config: Config) extends Tagger {
       .get(cwName)
       .flatMap { directives =>
         directives.collectFirst {
-          case extractor(extracted) => extracted
+          case extractor(a, v) => a -> v
         }
       }
       .getOrElse(mappings.getOrElse(cwName, cwName) -> cwValue)

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/DefaultTagger.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/DefaultTagger.scala
@@ -36,10 +36,10 @@ class DefaultTagger(config: Config) extends Tagger {
       val directives = c
         .getConfigList("directives")
         .asScala
-        .map(cl => {
+        .map { cl =>
           val alias = if (cl.hasPath("alias")) cl.getString("alias") else c.getString("name")
           cl.getString("pattern").r -> alias
-        })
+        }
       c.getString("name") -> directives
     }
     .toMap

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/DefaultTagger.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/DefaultTagger.scala
@@ -32,7 +32,7 @@ class DefaultTagger(config: Config) extends Tagger {
   private val extractors: Map[String, Seq[(Regex, Option[String])]] = config
     .getConfigList("extractors")
     .asScala
-    .map(c => {
+    .map { c =>
       val patterns = c
         .getConfigList("patterns")
         .asScala
@@ -41,7 +41,7 @@ class DefaultTagger(config: Config) extends Tagger {
           cl.getString("pattern").r -> alias
         })
       c.getString("name") -> patterns
-    })
+    }
     .toMap
 
   private val mappings: Map[String, String] = config

--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/DefaultTaggerSuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/DefaultTaggerSuite.scala
@@ -90,7 +90,7 @@ class DefaultTaggerSuite extends FunSuite {
         |extractors = [
         |  {
         |    name = "ExtractDotDelimited"
-        |    patterns = [
+        |    directives = [
         |      {
         |        pattern = "[^.]+\\.[^.]+\\.(.*)"
         |      }
@@ -98,7 +98,7 @@ class DefaultTaggerSuite extends FunSuite {
         |  },
         |  {
         |    name = "ExtractSlashDelimited"
-        |    patterns = [
+        |    directives = [
         |      {
         |        pattern = "[^.]+/([^.]+)/.*"
         |      }
@@ -125,7 +125,7 @@ class DefaultTaggerSuite extends FunSuite {
         |extractors = [
         |  {
         |    name = "ExtractDotDelimited"
-        |    patterns = [
+        |    directives = [
         |      {
         |        pattern = "[^.]+\\.[^.]+\\.(.*"
         |      }
@@ -146,7 +146,7 @@ class DefaultTaggerSuite extends FunSuite {
         |extractors = [
         |  {
         |    name = "ExtractDotDelimited"
-        |    patterns = [
+        |    directives = [
         |      {
         |        alias = "new-name"
         |      }
@@ -167,7 +167,7 @@ class DefaultTaggerSuite extends FunSuite {
         |extractors = [
         |  {
         |    name = "ExtractDotDelimited"
-        |    patterns = [
+        |    directives = [
         |      {
         |        pattern = "[^.]+\\.[^.]+\\..*"
         |      }
@@ -194,7 +194,7 @@ class DefaultTaggerSuite extends FunSuite {
         |extractors = [
         |  {
         |    name = "ExtractDotDelimited"
-        |    patterns = [
+        |    directives = [
         |      {
         |        pattern = "[^.]+\\.[^.]+\\.(.*)"
         |      }
@@ -202,7 +202,7 @@ class DefaultTaggerSuite extends FunSuite {
         |  },
         |  {
         |    name = "ExtractSlashDelimited"
-        |    patterns = [
+        |    directives = [
         |      {
         |        pattern = "[^.]+/([^.]+)/.*"
         |        alias = "extracted"
@@ -230,7 +230,7 @@ class DefaultTaggerSuite extends FunSuite {
         |extractors = [
         |  {
         |    name = "ExtractSlashDelimited"
-        |    patterns = [
+        |    directives = [
         |      {
         |        pattern = "[^.]+/([^.]+)/.*"
         |        alias = "extracted"
@@ -263,7 +263,7 @@ class DefaultTaggerSuite extends FunSuite {
         |extractors = [
         |  {
         |    name = "ExtractSlashDelimited"
-        |    patterns = [
+        |    directives = [
         |      {
         |        pattern = "[^.]+/([^.]+)/.*"
         |        alias = "extracted"


### PR DESCRIPTION
CloudWatch uses the `LoadBalancer` dimension for both application and
network load balancers. This commit adds the ability to set an alias per
extractor pattern, enabling us to set it to `aws.alb` or `aws.nlb` as
appropriate depending on the context.