### PR TITLE
switch to spectator-ext-ipc for request metrics

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/AccessLogger.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/AccessLogger.scala
@@ -54,8 +54,7 @@ class AccessLogger private (entry: IpcLogEntry, client: Boolean) {
     * This is currently ignored. The timing will always be for the arrival of the first
     * chunk.
     */
-  def chunkComplete(): Unit = {
-  }
+  def chunkComplete(): Unit = {}
 
   /** Complete the log entry and write out the result. */
   def complete(request: HttpRequest, result: Try[HttpResponse]): Unit = {

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/CustomDirectives.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/CustomDirectives.scala
@@ -37,7 +37,6 @@ import akka.http.scaladsl.server.directives.LoggingMagnet
 import akka.util.ByteString
 import com.fasterxml.jackson.core.JsonParser
 import com.netflix.atlas.json.Json
-import com.netflix.spectator.sandbox.HttpLogEntry
 
 import scala.util.Failure
 import scala.util.Success
@@ -322,7 +321,7 @@ object CustomDirectives {
   def accessLog: Directive0 = {
     extractClientIP.flatMap { ip =>
       val addr = ip.toOption.fold("unknown")(_.getHostAddress)
-      val entry = (new HttpLogEntry).withRemoteAddr(addr)
+      val entry = AccessLogger.ipcLogger.createServerEntry.withRemoteAddress(addr)
       val logger = AccessLogger.newServerLogger(entry)
       logRequestResult(LoggingMagnet(_ => log(logger)))
     }

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ lazy val `atlas-akka` = project
     Dependencies.akkaStream,
     Dependencies.iepService,
     Dependencies.jsr250,
-    Dependencies.spectatorSandbox,
+    Dependencies.spectatorIpc,
     Dependencies.akkaHttp,
     Dependencies.typesafeConfig,
     Dependencies.akkaHttpTestkit % "test",
@@ -186,7 +186,6 @@ lazy val `atlas-webapi` = project
     `atlas-json`,
     `atlas-test` % "test")
   .settings(libraryDependencies ++= Seq(
-    Dependencies.spectatorSandbox,
     Dependencies.akkaTestkit % "test",
     Dependencies.akkaHttpTestkit % "test"
   ))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
     val log4j      = "2.11.1"
     val scala      = "2.12.6"
     val slf4j      = "1.7.25"
-    val spectator  = "0.74.2"
+    val spectator  = "0.76.0"
 
     val crossScala = Seq(scala, "2.11.12")
   }
@@ -69,9 +69,9 @@ object Dependencies {
   val slf4jLog4j      = "org.slf4j" % "slf4j-log4j12" % slf4j
   val slf4jSimple     = "org.slf4j" % "slf4j-simple" % slf4j
   val spectatorApi    = "com.netflix.spectator" % "spectator-api" % spectator
+  val spectatorIpc    = "com.netflix.spectator" % "spectator-ext-ipc" % spectator
   val spectatorLog4j  = "com.netflix.spectator" % "spectator-ext-log4j2" % spectator
   val spectatorM2     = "com.netflix.spectator" % "spectator-reg-metrics2" % spectator
-  val spectatorSandbox= "com.netflix.spectator" % "spectator-ext-sandbox" % spectator
   val typesafeConfig  = "com.typesafe" % "config" % "1.3.3"
 }
 


### PR DESCRIPTION
Makes Atlas consistent with other Netflix apps following
the common-ipc pattern internally.