### PR TITLE
add directives for setting Netflix-Endpoint header

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/ConfigApi.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/ConfigApi.scala
@@ -28,6 +28,7 @@ import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.RequestContext
 import akka.http.scaladsl.server.Route
+import com.netflix.atlas.akka.CustomDirectives._
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
@@ -49,7 +50,7 @@ class ConfigApi(config: Config, implicit val actorRefFactory: ActorRefFactory) e
   )
 
   def routes: Route = {
-    pathPrefix("api" / "v2" / "config") {
+    endpointPathPrefix("api" / "v2" / "config") {
       pathEndOrSingleSlash {
         get { ctx =>
           ctx.complete(doGet(ctx, None))

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/HealthcheckApi.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/HealthcheckApi.scala
@@ -23,6 +23,7 @@ import akka.http.scaladsl.model.MediaTypes
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import com.netflix.atlas.akka.CustomDirectives._
 import com.netflix.atlas.json.Json
 import com.netflix.iep.service.ServiceManager
 import com.typesafe.scalalogging.StrictLogging
@@ -35,7 +36,7 @@ class HealthcheckApi(serviceManagerProvider: Provider[ServiceManager])
     with StrictLogging {
 
   def routes: Route = {
-    path("healthcheck") {
+    endpointPath("healthcheck") {
       get {
         val status =
           if (serviceManager.isHealthy) StatusCodes.OK else StatusCodes.InternalServerError

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/EvaluateApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/EvaluateApi.scala
@@ -36,7 +36,7 @@ class EvaluateApi(registry: Registry, sm: StreamSubscriptionManager)
   private val ignoredCounter = registry.counter("atlas.lwcapi.ignoredItems")
 
   def routes: Route = {
-    path("lwc" / "api" / "v1" / "evaluate") {
+    endpointPath("lwc" / "api" / "v1" / "evaluate") {
       post {
         parseEntity(json[EvaluateRequest]) { req =>
           if (req.metrics.isEmpty) {

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionApi.scala
@@ -26,6 +26,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import com.netflix.atlas.akka.CustomDirectives._
 import com.netflix.atlas.akka.WebApi
 import com.netflix.atlas.core.util.Hash
 import com.netflix.atlas.core.util.Strings
@@ -46,7 +47,7 @@ case class ExpressionApi @Inject()(
   private val expressionCount = registry.distributionSummary("atlas.lwcapi.expressions.count")
 
   def routes: Route = {
-    pathPrefix("lwc" / "api" / "v1" / "expressions") {
+    endpointPathPrefix("lwc" / "api" / "v1" / "expressions") {
       optionalHeaderValueByName("If-None-Match") { etags =>
         get {
           pathEndOrSingleSlash {

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
@@ -31,6 +31,7 @@ import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
+import com.netflix.atlas.akka.CustomDirectives._
 import com.netflix.atlas.akka.StreamOps
 import com.netflix.atlas.akka.WebApi
 import com.netflix.atlas.json.Json
@@ -59,7 +60,7 @@ class StreamApi @Inject()(
   private val reRegistrations = registry.counter("atlas.lwcapi.reRegistrations")
 
   def routes: Route = {
-    path("lwc" / "api" / "v1" / "stream" / Segment) { streamId =>
+    endpointPath("lwc" / "api" / "v1" / "stream", Segment) { streamId =>
       get {
         complete(handleReq(streamId))
       }

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
@@ -46,7 +46,7 @@ class SubscribeApi @Inject()(
   private val itemsId = registry.createId("atlas.lwcapi.subscribe.itemCount")
 
   def routes: Route = {
-    path("lwc" / "api" / "v1" / "subscribe") {
+    endpointPath("lwc" / "api" / "v1" / "subscribe") {
       post {
         parseEntity(json[SubscribeRequest]) {
           case SubscribeRequest(_, Nil) =>

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
@@ -21,6 +21,7 @@ import akka.http.scaladsl.model.MediaTypes
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import com.netflix.atlas.akka.CustomDirectives._
 import com.netflix.atlas.akka.WebApi
 import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.Expr
@@ -52,20 +53,20 @@ class ExprApi extends WebApi {
   private val excludedWords = ApiSettings.excludedWords
 
   def routes: Route = parameters(('q, 'vocab ? vocabulary.name)) { (q, vocab) =>
-    path("api" / "v1" / "expr") {
+    endpointPath("api" / "v1" / "expr") {
       get { complete(processDebugRequest(q, vocab)) }
     } ~
     pathPrefix("api" / "v1" / "expr") {
-      path("debug") {
+      endpointPath("debug") {
         get { complete(processDebugRequest(q, vocab)) }
       } ~
-      path("normalize") {
+      endpointPath("normalize") {
         get { complete(processNormalizeRequest(q, vocab)) }
       } ~
-      path("complete") {
+      endpointPath("complete") {
         get { complete(processCompleteRequest(q, vocab)) }
       } ~
-      path("queries") {
+      endpointPath("queries") {
         get { complete(processQueriesRequest(q, vocab)) }
       }
     }

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
@@ -19,6 +19,7 @@ import akka.actor.ActorRefFactory
 import akka.actor.Props
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import com.netflix.atlas.akka.CustomDirectives._
 import com.netflix.atlas.akka.ImperativeRequestContext
 import com.netflix.atlas.akka.WebApi
 import com.netflix.atlas.core.model._
@@ -34,7 +35,7 @@ class GraphApi(config: Config, implicit val actorRefFactory: ActorRefFactory) ex
   private val registry = Spectator.globalRegistry()
 
   def routes: Route = {
-    path("api" / "v1" / "graph") {
+    endpointPath("api" / "v1" / "graph") {
       get { ctx =>
         val reqHandler = actorRefFactory.actorOf(Props(new GraphRequestActor(grapher, registry)))
         val graphCfg = grapher.toGraphConfig(ctx.request.uri)
@@ -43,7 +44,7 @@ class GraphApi(config: Config, implicit val actorRefFactory: ActorRefFactory) ex
         rc.promise.future
       }
     } ~
-    path("api" / "v2" / "fetch") {
+    endpointPath("api" / "v2" / "fetch") {
       get {
         extractRequest { request =>
           val graphCfg = grapher.toGraphConfig(request.uri)

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
@@ -54,10 +54,10 @@ class PublishApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi w
 
   def routes: Route = {
     post {
-      path("api" / "v1" / "publish") {
+      endpointPath("api" / "v1" / "publish") {
         handleReq
       } ~
-      path("api" / "v1" / "publish-fast") {
+      endpointPath("api" / "v1" / "publish-fast") {
         // Legacy path from when there was more than one publish mode
         handleReq
       }

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsApi.scala
@@ -27,6 +27,7 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.RequestContext
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.RouteResult
+import com.netflix.atlas.akka.CustomDirectives._
 import com.netflix.atlas.akka.WebApi
 import com.netflix.atlas.core.index.TagQuery
 import com.netflix.atlas.core.model.Query
@@ -46,7 +47,7 @@ class TagsApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi {
   private val dbRef = actorRefFactory.actorSelection("/user/db")
 
   def routes: Route = {
-    pathPrefix("api" / "v1" / "tags") {
+    endpointPathPrefix("api" / "v1" / "tags") {
       pathEndOrSingleSlash {
         handleReq(None)
       } ~


### PR DESCRIPTION
To improve the quality of metrics it is useful to be able
to see what path is being used. However, it shouldn't match
the full path that might have ids or other elements that
would make the cardinality explode. This change adds path
directives that will capture specified static portions and
map those to the `Netflix-Endpoint` header.

Note, when nested with other usages of the standard path
directives it will capture extracted portions from those
directives and include it in the header. While not ideal,
it isn't a common case and since the IPC logger has limiting
it will mostly impact the user with the broad matching.