### PR TITLE
add support for configurable diagnostic headers

### DIFF
--- a/atlas-akka/src/main/resources/reference.conf
+++ b/atlas-akka/src/main/resources/reference.conf
@@ -30,6 +30,14 @@ atlas.akka {
   # An empty list means that CORS headers will not be added.
   cors-host-patterns = ["*"]
 
+  # Headers added to all responses for diagnostic and logging purposes.
+  diagnostic-headers = [
+    #{
+    #  name = "Netflix-ASG"
+    #  value = ${NETFLIX_AUTO_SCALE_GROUP}
+    #}
+  ]
+
   # Settings for the StaticPages API
   static {
     # Default page to redirect to when hitting /

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/CustomDirectivesSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/CustomDirectivesSuite.scala
@@ -34,6 +34,7 @@ import com.netflix.atlas.json.Json
 import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spectator.api.Spectator
 import com.netflix.spectator.ipc.IpcMetric
+import com.netflix.spectator.ipc.NetflixHeader
 import org.scalatest.BeforeAndAfter
 import org.scalatest.FunSuite
 
@@ -49,8 +50,10 @@ class CustomDirectivesSuite extends FunSuite with ScalatestRouteTest with Before
 
   class TestService(val actorRefFactory: ActorRefFactory) {
 
+    private val zone = RawHeader(NetflixHeader.Zone.headerName(), "us-east-1e")
+
     def routes: Route = {
-      accessLog {
+      accessLog(List(zone)) {
         respondWithCorsHeaders(List("*")) {
           jsonpFilter {
             path("text") {
@@ -432,6 +435,13 @@ class CustomDirectivesSuite extends FunSuite with ScalatestRouteTest with Before
       // Ideally it wouldn't match the 404 value that was extracted, but since this sort
       // of nesting is not common for our use-cases, that is left for later refinement
       assert(getEndpoint(response) === "/endpoint/v1/foo/404/bar")
+    }
+  }
+
+  test("diagnostic headers are added to response") {
+    Get("/text") ~> endpoint.routes ~> check {
+      val zone = response.headers.find(_.is("netflix-zone"))
+      assert(zone === Some(RawHeader("Netflix-Zone", "us-east-1e")))
     }
   }
 }

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/CustomDirectivesSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/CustomDirectivesSuite.scala
@@ -258,6 +258,8 @@ class CustomDirectivesSuite extends FunSuite with ScalatestRouteTest with Before
           assert("GET,PATCH,POST,PUT,DELETE" === vs.map(_.name()).mkString(","))
         case `Access-Control-Allow-Credentials`(v) =>
           assert(v)
+        case h if h.is("netflix-zone") =>
+          assert(h.value === "us-east-1e")
         case h if h.is("vary") =>
           assert(h.value === "Origin")
         case h =>
@@ -282,6 +284,8 @@ class CustomDirectivesSuite extends FunSuite with ScalatestRouteTest with Before
           assert("foo" === vs.mkString(","))
         case `Access-Control-Allow-Credentials`(v) =>
           assert(v)
+        case h if h.is("netflix-zone") =>
+          assert(h.value === "us-east-1e")
         case h if h.is("vary") =>
           assert(h.value === "Origin")
         case h if h.lowercaseName == "foo" =>
@@ -309,6 +313,8 @@ class CustomDirectivesSuite extends FunSuite with ScalatestRouteTest with Before
           assert("foo" === vs.mkString(","))
         case `Access-Control-Allow-Credentials`(v) =>
           assert(v)
+        case h if h.is("netflix-zone") =>
+          assert(h.value === "us-east-1e")
         case h if h.is("vary") =>
           assert(h.value === "Origin")
         case h =>
@@ -332,6 +338,8 @@ class CustomDirectivesSuite extends FunSuite with ScalatestRouteTest with Before
           assert("GET,PATCH,POST,PUT,DELETE" === vs.map(_.name()).mkString(","))
         case `Access-Control-Allow-Credentials`(v) =>
           assert(v)
+        case h if h.is("netflix-zone") =>
+          assert(h.value === "us-east-1e")
         case h if h.is("vary") =>
           assert(h.value === "Origin")
         case h =>
@@ -356,6 +364,8 @@ class CustomDirectivesSuite extends FunSuite with ScalatestRouteTest with Before
           assert("Vary" === vs.mkString(","))
         case `Access-Control-Allow-Credentials`(v) =>
           assert(v)
+        case h if h.is("netflix-zone") =>
+          assert(h.value === "us-east-1e")
         case h if h.is("vary") =>
           assert(Set("Origin", "Host").contains(h.value))
         case h =>
@@ -378,6 +388,8 @@ class CustomDirectivesSuite extends FunSuite with ScalatestRouteTest with Before
           assert("GET,PATCH,POST,PUT,DELETE" === vs.map(_.name()).mkString(","))
         case `Access-Control-Allow-Credentials`(v) =>
           assert(v)
+        case h if h.is("netflix-zone") =>
+          assert(h.value === "us-east-1e")
         case h if h.is("vary") =>
           assert(h.value === "Origin")
         case h =>
@@ -399,6 +411,8 @@ class CustomDirectivesSuite extends FunSuite with ScalatestRouteTest with Before
           assert("GET,PATCH,POST,PUT,DELETE" === vs.map(_.name()).mkString(","))
         case `Access-Control-Allow-Credentials`(v) =>
           assert(v)
+        case h if h.is("netflix-zone") =>
+          assert(h.value === "us-east-1e")
         case h if h.is("vary") =>
           assert(h.value === "Origin")
         case h =>

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerSuite.scala
@@ -39,6 +39,12 @@ class RequestHandlerSuite extends FunSuite with ScalatestRouteTest {
       |  "com.netflix.atlas.akka.TestApi"
       |]
       |atlas.akka.cors-host-patterns = [".suffix.com", "www.exact-match.com", "localhost"]
+      |atlas.akka.diagnostic-headers = [
+      |  {
+      |    name = "test"
+      |    value = "12345"
+      |  }
+      |]
     """.stripMargin
   )
 
@@ -79,6 +85,8 @@ class RequestHandlerSuite extends FunSuite with ScalatestRouteTest {
           assert(v)
         case h if h.is("vary") =>
           assert(h.value === "Origin")
+        case h if h.is("test") =>
+          assert(h.value === "12345")
         case h =>
           fail(s"unexpected header: $h")
       }
@@ -112,7 +120,7 @@ class RequestHandlerSuite extends FunSuite with ScalatestRouteTest {
     val header = RawHeader("Origin", origin)
     Get("/ok").addHeader(header) ~> routes ~> check {
       assert(response.status === StatusCodes.OK)
-      assert(response.headers.isEmpty)
+      assert(response.headers === List(RawHeader("test", "12345")))
     }
   }
 

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/TestApi.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/TestApi.scala
@@ -54,7 +54,7 @@ class TestApi(val actorRefFactory: ActorRefFactory) extends WebApi {
         }
       }
     } ~
-    accessLog {
+    accessLog(Nil) {
       path("chunked") {
         get {
           val source = Source


### PR DESCRIPTION
This can be used to add headers such as `Netflix-ASG`
or `Netflix-Zone` that are used by common IPC to provide
additional context.