### PR TITLE
add hook to control startup delay for lwcapi

### DIFF
--- a/atlas-lwcapi/src/main/resources/reference.conf
+++ b/atlas-lwcapi/src/main/resources/reference.conf
@@ -3,6 +3,13 @@ atlas {
     register = {
       default-frequency = 60s
     }
+
+    # For an lwcapi instance to be ready to receive data, the consumer clients must have
+    # an opportunity to connect first. This delay is used to control the window of time
+    # they have to connnect and subscribe. The service will be marked as unhealthy until
+    # this time has passed so that data from the producers will not yet be pushed through
+    # the new instances.
+    startup-delay = 3m
   }
 
   akka {

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StartupDelayService.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StartupDelayService.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwcapi
+
+import com.netflix.iep.service.AbstractService
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+import javax.inject.Inject
+
+/**
+  * Service that will report as unhealthy for a configured window after startup. This is
+  * used to allow clients that will stream data time to connect before marking the instance
+  * as UP so that clients publishing data will send to the instance.
+  */
+class StartupDelayService @Inject()(registry: Registry, config: Config)
+    extends AbstractService
+    with StrictLogging {
+
+  private val clock = registry.clock()
+  private val delay = config.getDuration("atlas.lwcapi.startup-delay").toMillis
+
+  // Timestamp for when to switch to being healthy
+  @volatile private var switchTimestamp = -1L
+
+  override def isHealthy: Boolean = {
+    val timeRemaining = switchTimestamp - clock.wallTime()
+    if (switchTimestamp == -1L) {
+      logger.debug("service has not been started")
+    } else if (timeRemaining > 0L) {
+      logger.debug(s"waiting for another $timeRemaining milliseconds to report healthy")
+    }
+    switchTimestamp > 0L && timeRemaining <= 0L
+  }
+
+  override def startImpl(): Unit = {
+    switchTimestamp = clock.wallTime() + delay
+  }
+
+  override def stopImpl(): Unit = {}
+}

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/StartupDelayServiceSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/StartupDelayServiceSuite.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwcapi
+
+import java.time.Duration
+
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.ManualClock
+import com.typesafe.config.ConfigFactory
+import org.scalatest.FunSuite
+
+class StartupDelayServiceSuite extends FunSuite {
+
+  private def newInstance(delay: String): (StartupDelayService, ManualClock) = {
+    val config = ConfigFactory.parseString(s"atlas.lwcapi.startup-delay = $delay")
+    val clock = new ManualClock()
+    new StartupDelayService(new DefaultRegistry(clock), config) -> clock
+  }
+
+  test("not healthy until started") {
+    val (service, clock) = newInstance("3m")
+    clock.setWallTime(Duration.ofMinutes(3).toMillis)
+    assert(!service.isHealthy)
+  }
+
+  test("not healthy until after delay") {
+    val (service, clock) = newInstance("3m")
+    service.start()
+    assert(!service.isHealthy)
+    clock.setWallTime(Duration.ofMinutes(2).toMillis)
+    assert(!service.isHealthy)
+    clock.setWallTime(Duration.ofMinutes(3).toMillis)
+    assert(service.isHealthy)
+  }
+}

--- a/atlas-module-lwcapi/src/main/scala/com/netflix/atlas/guice/LwcApiModule.scala
+++ b/atlas-module-lwcapi/src/main/scala/com/netflix/atlas/guice/LwcApiModule.scala
@@ -16,13 +16,15 @@
 package com.netflix.atlas.guice
 
 import javax.inject.Singleton
-
 import com.google.inject.AbstractModule
 import com.google.inject.Provides
+import com.google.inject.multibindings.Multibinder
 import com.netflix.atlas.akka.AkkaModule
 import com.netflix.atlas.lwcapi.StreamSubscriptionManager
 import com.netflix.atlas.lwcapi.ExpressionSplitter
+import com.netflix.atlas.lwcapi.StartupDelayService
 import com.netflix.iep.guice.LifecycleModule
+import com.netflix.iep.service.Service
 import com.typesafe.config.Config
 
 final class LwcApiModule extends AbstractModule {
@@ -30,6 +32,9 @@ final class LwcApiModule extends AbstractModule {
   override def configure(): Unit = {
     install(new LifecycleModule)
     install(new AkkaModule)
+
+    val serviceBinder = Multibinder.newSetBinder(binder, classOf[Service])
+    serviceBinder.addBinding().to(classOf[StartupDelayService])
   }
 
   @Provides


### PR DESCRIPTION
This delay is used to keep the service in an unhealthy
state for a specified window. Clients that publish data
use the load balancer and will not start publishing until
it is healthy. The eval library that does the subscriptions
will attemtp to connect once it detects the new instance.
This delay means that subscriptions should be in place
before data starts flowing.