### PR TITLE
Fix reporting of AWS/NetworkELB ConsumedLCUs

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/nlb.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/nlb.conf
@@ -7,6 +7,23 @@ atlas {
     // Note that the dimensions available per metric is ambiguous in the docs (as of 2018/09/12).
     // Though it may appear that AvailabilityZone, LoadBalancer, and TargetGroup are available on
     // all metrics, they are not. All three are available only on Healthy/UnHealthyHostCount.
+    nlb = {
+      namespace = "AWS/NetworkELB"
+      period = 1m
+
+      dimensions = [
+        "LoadBalancer"
+      ]
+
+      metrics = [
+        {
+          name = "ConsumedLCUs"
+          alias = "aws.nlb.consumedLCUs"
+          conversion = "sum"
+        },
+      ]
+    }
+
     nlb-zone = {
       namespace = "AWS/NetworkELB"
       period = 1m
@@ -21,11 +38,6 @@ atlas {
           name = "ActiveFlowCount"
           alias = "aws.nlb.activeFlowCount"
           conversion = "max"
-        },
-        {
-          name = "ConsumedLCUs"
-          alias = "aws.nlb.consumedLCUs"
-          conversion = "sum"
         },
         {
           name = "NewFlowCount"

--- a/atlas-poller-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/reference.conf
@@ -249,6 +249,7 @@ atlas {
       "events",
       "kinesis",
       "lambda",
+      "nlb",
       "nlb-zone",
       "nlb-tg-zone",
       "rds",


### PR DESCRIPTION
`ConsumedLCUs` is available only on the `LoadBalancer` dimension, not
`LoadBalancer` and `AvailabilityZone`.