### PR TITLE
maintain grouping by DataExpr

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
@@ -111,6 +111,8 @@ object AggrDatapoint {
       datapoint.expr match {
         case GroupBy(_: Count, _)              => newCountAggregator(datapoint)
         case GroupBy(af: AggregateFunction, _) => new SimpleAggregator(datapoint, af)
+        case _ =>
+          throw new IllegalArgumentException("datapoint is not for a grouped expression")
       }
     }
 

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeGroup.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeGroup.scala
@@ -14,14 +14,28 @@
  * limitations under the License.
  */
 package com.netflix.atlas.eval.model
+import com.netflix.atlas.core.model.DataExpr
 
 /**
   * A group of values for the same timestamp. This type is typically created as the result
   * of using the [[com.netflix.atlas.eval.stream.TimeGrouped]] operator on the stream.
+  *
+  * The values map should always be non-empty and have datapoints for all entries. Empty
+  * entries should be omitted.
   *
   * @param timestamp
   *     Timestamp that applies to all values within the group.
   * @param values
   *     Values associated with this time.
   */
-case class TimeGroup[T](timestamp: Long, values: List[T])
+case class TimeGroup(timestamp: Long, values: Map[DataExpr, List[AggrDatapoint]]) {
+
+  /**
+    * Extract the step size from the time group. It is not explicitly checked on construction
+    * to avoid the overhead, but a group should always have a uniform step size for all
+    * datapoints.
+    */
+  def step: Long = {
+    values.values.find(_.nonEmpty).fold(-1L)(_.head.step)
+  }
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -41,7 +41,6 @@ import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import com.netflix.atlas.akka.StreamOps
-import com.netflix.atlas.eval.model.AggrDatapoint
 import com.netflix.atlas.eval.model.TimeGroup
 import com.netflix.atlas.eval.stream.Evaluator.DataSource
 import com.netflix.atlas.eval.stream.Evaluator.DataSources
@@ -211,9 +210,9 @@ private[stream] abstract class EvaluatorImpl(
     * the objects so the FinalExprEval stage will only see a single step.
     */
   private def stepSize: PartialFunction[AnyRef, Long] = {
-    case ds: DataSources               => ds.stepSize()
-    case grp: TimeGroup[AggrDatapoint] => grp.values.head.step
-    case v                             => throw new IllegalArgumentException(s"unexpected value in stream: $v")
+    case ds: DataSources => ds.stepSize()
+    case grp: TimeGroup  => grp.step
+    case v               => throw new IllegalArgumentException(s"unexpected value in stream: $v")
   }
 
   /**

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
@@ -131,10 +131,10 @@ private[stream] class FinalExprEval(interpreter: ExprInterpreter)
 
       // Perform the final evaluation and create a source with the TimeSeriesMessages
       // addressed to each recipient
-      private def handleData(group: TimeGroup[AggrDatapoint]): Unit = {
+      private def handleData(group: TimeGroup): Unit = {
         // Finalize the DataExprs, needed as input for further evaluation
         val timestamp = group.timestamp
-        val groupedDatapoints = group.values.groupBy(_.expr)
+        val groupedDatapoints = group.values
 
         val expressionDatapoints = noData ++ groupedDatapoints.map {
           case (k, vs) =>
@@ -181,8 +181,8 @@ private[stream] class FinalExprEval(interpreter: ExprInterpreter)
 
       override def onPush(): Unit = {
         grab(in) match {
-          case ds: DataSources    => handleDataSources(ds)
-          case data: TimeGroup[_] => handleData(data.asInstanceOf[TimeGroup[AggrDatapoint]])
+          case ds: DataSources => handleDataSources(ds)
+          case data: TimeGroup => handleData(data)
         }
       }
 

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
@@ -62,9 +62,10 @@ class FinalExprEvalSuite extends FunSuite {
     new DataSource(id, java.time.Duration.ofMillis(step), uri)
   }
 
-  private def group(i: Long, vs: AggrDatapoint*): TimeGroup[AggrDatapoint] = {
+  private def group(i: Long, vs: AggrDatapoint*): TimeGroup = {
     val timestamp = i * step
-    TimeGroup(timestamp, vs.map(_.copy(timestamp = timestamp)).toList)
+    val values = vs.map(_.copy(timestamp = timestamp)).groupBy(_.expr).mapValues(_.toList)
+    TimeGroup(timestamp, values)
   }
 
   test("exception while parsing exprs") {
@@ -85,7 +86,7 @@ class FinalExprEvalSuite extends FunSuite {
   test("division with no data should result in no data line") {
     val input = List(
       sources(ds("a", "http://atlas/graph?q=name,latency,:eq,:dist-avg")),
-      TimeGroup(0L, List.empty[AggrDatapoint])
+      TimeGroup(0L, Map.empty)
     )
     val output = run(input)
     assert(output.size === 1)


### PR DESCRIPTION
The TimeGrouped stage needs to group by the DataExpr
to aggregate the values as they arrive. It was then
flattening these out to keep the stage output the
same. Since the only consumer is FinalExprEval and
it needs them grouped by DataExpr, this change
maintains the grouping and passes it along.