### PR TITLE
add helpers for rolling min/max

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineAlgorithm.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineAlgorithm.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigList
+import com.typesafe.config.ConfigObject
+import com.typesafe.config.ConfigValue
+import com.typesafe.config.ConfigValueFactory
+
+/**
+  * Base trait for online algorithms used on time series.
+  */
+trait OnlineAlgorithm {
+
+  /** Apply the next value from the input and return the computed value. */
+  def next(v: Double): Double
+
+  /** Reset the state of the algorithm. */
+  def reset(): Unit
+
+  /**
+    * Capture the current state of the algorithm. It can be restored in a new instance
+    * with the [OnlineAlgorithm#apply] method.
+    */
+  def state: Config
+}
+
+object OnlineAlgorithm {
+
+  /**
+    * Create a new instance initialized with the captured state from a previous instance
+    * of an online algorithm.
+    */
+  def apply(config: Config): OnlineAlgorithm = {
+    config.getString("type") match {
+      case "rolling-min" => OnlineRollingMin(config)
+      case "rolling-max" => OnlineRollingMax(config)
+      case t             => throw new IllegalArgumentException(s"unknown type: '$t'")
+    }
+  }
+
+  private[algorithm] def toConfig(state: Map[String, _]): Config = {
+    toConfigObject(state).toConfig
+  }
+
+  private def toConfigValue(state: Any): ConfigValue = {
+    state match {
+      case m: Map[_, _]    => toConfigObject(m.asInstanceOf[Map[String, _]])
+      case vs: Iterable[_] => toConfigList(vs)
+      case vs: Array[_]    => toConfigList(vs.toList)
+      case c: Config       => c.root()
+      case v               => ConfigValueFactory.fromAnyRef(v)
+    }
+  }
+
+  private def toConfigObject(state: Map[String, _]): ConfigObject = {
+    import scala.collection.JavaConverters._
+    ConfigValueFactory.fromMap(state.mapValues(toConfigValue).asJava)
+  }
+
+  private def toConfigList(state: Iterable[_]): ConfigList = {
+    import scala.collection.JavaConverters._
+    ConfigValueFactory.fromIterable(state.map(toConfigValue).asJava)
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingMax.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingMax.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+import com.typesafe.config.Config
+
+/**
+  * Keeps track of the maximum value within a given window. This is typically used as a
+  * way to get a smooth upper bound line that closely tracks a noisy input.
+  */
+case class OnlineRollingMax(buf: RollingBuffer) extends OnlineAlgorithm {
+  private var max = buf.max
+
+  override def next(v: Double): Double = {
+    val removed = buf.add(v)
+    if (v >= max) { // Avoid doing linear computation of max value if possible
+      max = v
+    } else if (removed == max || (buf.size > 0 && max.isNaN)) {
+      max = buf.max
+    }
+    max
+  }
+
+  override def reset(): Unit = {
+    buf.clear()
+    max = Double.NaN
+  }
+
+  override def state: Config = {
+    OnlineAlgorithm.toConfig(Map("type" -> "rolling-max", "buffer" -> buf.state))
+  }
+}
+
+object OnlineRollingMax {
+
+  def apply(n: Int): OnlineRollingMax = apply(RollingBuffer(n))
+
+  def apply(config: Config): OnlineRollingMax = {
+    apply(RollingBuffer(config.getConfig("buffer")))
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingMin.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingMin.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+import com.typesafe.config.Config
+
+/**
+  * Keeps track of the minimum value within a given window. This is typically used as a
+  * way to get a smooth lower bound line that closely tracks a noisy input.
+  */
+case class OnlineRollingMin(buf: RollingBuffer) extends OnlineAlgorithm {
+  private var min = buf.min
+
+  override def next(v: Double): Double = {
+    val removed = buf.add(v)
+    if (v <= min) { // Avoid doing linear computation of min value if possible
+      min = v
+    } else if (removed == min || (buf.size > 0 && min.isNaN)) {
+      min = buf.min
+    }
+    min
+  }
+
+  override def reset(): Unit = {
+    buf.clear()
+    min = Double.NaN
+  }
+
+  override def state: Config = {
+    OnlineAlgorithm.toConfig(Map("type" -> "rolling-min", "buffer" -> buf.state))
+  }
+}
+
+object OnlineRollingMin {
+
+  def apply(n: Int): OnlineRollingMin = apply(RollingBuffer(n))
+
+  def apply(config: Config): OnlineRollingMin = {
+    apply(RollingBuffer(config.getConfig("buffer")))
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/RollingBuffer.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/RollingBuffer.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+import com.netflix.atlas.core.util.ArrayHelper
+import com.netflix.atlas.core.util.Math
+import com.typesafe.config.Config
+
+/**
+  * Buffer for tracking the last N values of a time series.
+  *
+  * @param values
+  *     Underlying array that is used to store the values. As new data is added it will roll
+  *     through the array and overwrite old values that are now out of the window. The window
+  *     size is the size of the array.
+  * @param start
+  *     Starting position within the array. This is typically only used when restoring from
+  *     state captured from another buffer.
+  */
+class RollingBuffer(values: Array[Double], start: Int = 0) {
+  require(values.length > 0, "values array cannot be empty")
+  require(start >= 0, s"starting position is out of bounds: $start < 0")
+  require(start < values.length, s"starting position is out of bounds: $start >= ${values.length}")
+
+  private[this] var pos = start
+
+  /** Returns the number of non-NaN values that are currently in the buffer. */
+  var size: Int = values.count(!_.isNaN)
+
+  private def next(): Unit = {
+    pos = (pos + 1) % values.length
+  }
+
+  def add(v: Double): Double = {
+    val previous = values(pos)
+    values(pos) = v
+    next()
+    if (!v.isNaN) size += 1
+    if (!previous.isNaN) size -= 1
+    previous
+  }
+
+  def min: Double = {
+    var result = Double.NaN
+    var i = 0
+    while (i < values.length) {
+      result = Math.minNaN(result, values(i))
+      i += 1
+    }
+    result
+  }
+
+  def max: Double = {
+    var result = Double.NaN
+    var i = 0
+    while (i < values.length) {
+      result = Math.maxNaN(result, values(i))
+      i += 1
+    }
+    result
+  }
+
+  def clear(): Unit = {
+    var i = 0
+    while (i < values.length) {
+      values(i) = Double.NaN
+      i += 1
+    }
+    pos = 0
+    size = 0
+  }
+
+  def state: Config = {
+    OnlineAlgorithm.toConfig(Map("values" -> values, "pos" -> pos))
+  }
+}
+
+object RollingBuffer {
+
+  /** Create a new buffer of size `n` initialized with NaN values. */
+  def apply(n: Int): RollingBuffer = {
+    new RollingBuffer(ArrayHelper.fill(n, Double.NaN))
+  }
+
+  /** Create a new buffer based on previously captured state. */
+  def apply(config: Config): RollingBuffer = {
+    import scala.collection.JavaConverters._
+    val values = config
+      .getDoubleList("values")
+      .asScala
+      .map(_.doubleValue())
+      .toArray
+    val pos = config.getInt("pos")
+    new RollingBuffer(values, pos)
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/BaseOnlineAlgorithmSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/BaseOnlineAlgorithmSuite.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+import org.scalatest.FunSuite
+
+abstract class BaseOnlineAlgorithmSuite extends FunSuite {
+
+  protected def newInstance: OnlineAlgorithm
+
+  test("restore from state") {
+    val algo = newInstance
+    var restoredAlgo = OnlineAlgorithm(algo.state)
+    val random = new java.util.Random()
+    val n = random.nextInt(200) + 50
+
+    (0 until 10000).foreach { i =>
+      val v = if (random.nextDouble() < 0.01) Double.NaN else random.nextDouble()
+      val expected = algo.next(v)
+      val actual = restoredAlgo.next(v)
+      assert(java.lang.Double.compare(actual, expected) === 0, s"$actual != $expected")
+      if (i % n == 0) {
+        restoredAlgo = OnlineAlgorithm(algo.state)
+      }
+    }
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineAlgorithmSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineAlgorithmSuite.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+import com.typesafe.config.ConfigException
+import org.scalatest.FunSuite
+
+class OnlineAlgorithmSuite extends FunSuite {
+
+  test("restore unknown type") {
+    val cfg = OnlineAlgorithm.toConfig(Map("type" -> "foo"))
+    intercept[IllegalArgumentException] {
+      OnlineAlgorithm(cfg)
+    }
+  }
+
+  test("no type specified") {
+    val cfg = OnlineAlgorithm.toConfig(Map("foo" -> "bar"))
+    intercept[ConfigException] {
+      OnlineAlgorithm(cfg)
+    }
+  }
+
+  test("toConfig: string field") {
+    val cfg = OnlineAlgorithm.toConfig(Map("value" -> "str"))
+    assert("str" === cfg.getString("value"))
+  }
+
+  test("toConfig: int field") {
+    val cfg = OnlineAlgorithm.toConfig(Map("value" -> 42))
+    assert(42 === cfg.getInt("value"))
+  }
+
+  test("toConfig: double field") {
+    val cfg = OnlineAlgorithm.toConfig(Map("value" -> 42.0))
+    assert(42.0 === cfg.getInt("value"))
+  }
+
+  test("toConfig: double array field") {
+    val cfg = OnlineAlgorithm.toConfig(Map("array" -> Array(1.0, 2.0)))
+    val vs = cfg.getDoubleList("array")
+    assert(vs.size() === 2)
+    assert(vs.get(1) === 2.0)
+  }
+
+  test("toConfig: config field") {
+    val subCfg = OnlineAlgorithm.toConfig(Map("foo" -> "bar"))
+    val cfg = OnlineAlgorithm.toConfig(Map("cfg"    -> subCfg))
+    assert(subCfg === cfg.getConfig("cfg"))
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMaxSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMaxSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+class OnlineRollingMaxSuite extends BaseOnlineAlgorithmSuite {
+
+  override def newInstance: OnlineAlgorithm = OnlineRollingMax(50)
+
+  test("n = 1") {
+    val algo = OnlineRollingMax(1)
+    assert(algo.next(0.0) === 0.0)
+    assert(algo.next(1.0) === 1.0)
+  }
+
+  test("n = 2") {
+    val algo = OnlineRollingMax(2)
+    assert(algo.next(0.0) === 0.0)
+    assert(algo.next(1.0) === 1.0)
+    assert(algo.next(2.0) === 2.0)
+  }
+
+  test("n = 2, decreasing") {
+    val algo = OnlineRollingMax(2)
+    assert(algo.next(2.0) === 2.0)
+    assert(algo.next(1.0) === 2.0)
+    assert(algo.next(0.0) === 1.0)
+  }
+
+  test("n = 2, NaNs") {
+    val algo = OnlineRollingMax(2)
+    assert(algo.next(0.0) === 0.0)
+    assert(algo.next(1.0) === 1.0)
+    assert(algo.next(2.0) === 2.0)
+    assert(algo.next(Double.NaN) === 2.0)
+    assert(algo.next(Double.NaN).isNaN)
+  }
+
+  test("n = 2, reset") {
+    val algo = OnlineRollingMax(2)
+    assert(algo.next(1.0) === 1.0)
+    algo.reset()
+    assert(algo.next(0.0) === 0.0)
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMinSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMinSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+class OnlineRollingMinSuite extends BaseOnlineAlgorithmSuite {
+
+  override def newInstance: OnlineAlgorithm = OnlineRollingMin(50)
+
+  test("n = 1") {
+    val algo = OnlineRollingMin(1)
+    assert(algo.next(0.0) === 0.0)
+    assert(algo.next(1.0) === 1.0)
+  }
+
+  test("n = 2") {
+    val algo = OnlineRollingMin(2)
+    assert(algo.next(0.0) === 0.0)
+    assert(algo.next(1.0) === 0.0)
+    assert(algo.next(2.0) === 1.0)
+  }
+
+  test("n = 2, decreasing") {
+    val algo = OnlineRollingMin(2)
+    assert(algo.next(2.0) === 2.0)
+    assert(algo.next(1.0) === 1.0)
+    assert(algo.next(0.0) === 0.0)
+  }
+
+  test("n = 2, NaNs") {
+    val algo = OnlineRollingMin(2)
+    assert(algo.next(0.0) === 0.0)
+    assert(algo.next(1.0) === 0.0)
+    assert(algo.next(2.0) === 1.0)
+    assert(algo.next(Double.NaN) === 2.0)
+    assert(algo.next(Double.NaN).isNaN)
+  }
+
+  test("n = 2, reset") {
+    val algo = OnlineRollingMin(2)
+    assert(algo.next(0.0) === 0.0)
+    algo.reset()
+    assert(algo.next(1.0) === 1.0)
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/RollingBufferSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/RollingBufferSuite.scala
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+import org.scalatest.FunSuite
+
+class RollingBufferSuite extends FunSuite {
+
+  test("n = 0") {
+    intercept[IllegalArgumentException] {
+      RollingBuffer(0)
+    }
+  }
+
+  test("n = 1, add") {
+    val buf = RollingBuffer(1)
+    assert(buf.add(0.0).isNaN)
+    assert(buf.add(1.0) === 0.0)
+    assert(buf.add(2.0) === 1.0)
+  }
+
+  test("n = 2, add") {
+    val buf = RollingBuffer(2)
+    assert(buf.add(0.0).isNaN)
+    assert(buf.add(1.0).isNaN)
+    assert(buf.add(2.0) === 0.0)
+    assert(buf.add(3.0) === 1.0)
+    assert(buf.add(4.0) === 2.0)
+    assert(buf.add(5.0) === 3.0)
+    assert(buf.add(6.0) === 4.0)
+  }
+
+  test("n = 2, add NaNs") {
+    val buf = RollingBuffer(2)
+    assert(buf.add(0.0).isNaN)
+    assert(buf.add(1.0).isNaN)
+    assert(buf.add(2.0) === 0.0)
+    assert(buf.add(3.0) === 1.0)
+    assert(buf.add(Double.NaN) === 2.0)
+    assert(buf.add(5.0) === 3.0)
+    assert(buf.add(6.0).isNaN)
+  }
+
+  test("n = 2, size") {
+    val buf = RollingBuffer(2)
+    assert(buf.size == 0)
+
+    buf.add(0.0)
+    assert(buf.size == 1)
+
+    buf.add(1.0)
+    assert(buf.size == 2)
+
+    buf.add(2.0)
+    assert(buf.size == 2)
+
+    buf.add(3.0)
+    assert(buf.size == 2)
+
+    buf.add(Double.NaN)
+    assert(buf.size == 1)
+
+    buf.add(Double.NaN)
+    assert(buf.size == 0)
+
+    buf.add(Double.NaN)
+    assert(buf.size == 0)
+  }
+
+  test("n = 2, min") {
+    val buf = RollingBuffer(2)
+    assert(buf.min.isNaN)
+
+    buf.add(0.0)
+    assert(buf.min == 0.0)
+
+    buf.add(1.0)
+    assert(buf.min == 0.0)
+
+    buf.add(2.0)
+    assert(buf.min == 1.0)
+
+    buf.add(3.0)
+    assert(buf.min == 2.0)
+
+    buf.add(Double.NaN)
+    assert(buf.min == 3.0)
+
+    buf.add(Double.NaN)
+    assert(buf.min.isNaN)
+  }
+
+  test("n = 2, max") {
+    val buf = RollingBuffer(2)
+    assert(buf.max.isNaN)
+
+    buf.add(0.0)
+    assert(buf.max == 0.0)
+
+    buf.add(1.0)
+    assert(buf.max == 1.0)
+
+    buf.add(2.0)
+    assert(buf.max == 2.0)
+
+    buf.add(3.0)
+    assert(buf.max == 3.0)
+
+    buf.add(Double.NaN)
+    assert(buf.max == 3.0)
+
+    buf.add(Double.NaN)
+    assert(buf.max.isNaN)
+  }
+
+  test("n = 2, clear") {
+    val buf = RollingBuffer(2)
+    buf.add(0.0)
+    buf.add(1.0)
+    buf.clear()
+    assert(buf.size == 0)
+  }
+
+  test("n = 2, state") {
+    import scala.collection.JavaConverters._
+    val buf = RollingBuffer(2)
+    buf.add(0.0)
+    val cfg = buf.state
+    assert(cfg.getInt("pos") === 1)
+    val actual = cfg.getDoubleList("values").asScala.toList
+    val expected = List(0.0, Double.NaN)
+    assert(actual.size === 2)
+    actual.zip(expected).foreach {
+      // Used Double.compare to handle NaN properly
+      case (v1, v2) => assert(java.lang.Double.compare(v1, v2) === 0, s"$v1 != $v2")
+    }
+  }
+
+  test("restore from state") {
+    val buf = RollingBuffer(50)
+    var restoredBuf = RollingBuffer(buf.state)
+    val random = new java.util.Random()
+    val n = random.nextInt(200) + 50
+
+    (0 until 10000).foreach { i =>
+      val v = if (random.nextDouble() < 0.01) Double.NaN else random.nextDouble()
+      val expected = buf.add(v)
+      val actual = restoredBuf.add(v)
+      assert(java.lang.Double.compare(actual, expected) === 0, s"$actual != $expected")
+      if (i % n == 0) {
+        restoredBuf = RollingBuffer(buf.state)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Also sets up a base OnlineAlgorithm trait that can be
used to get better reuse consuming the operations. The
state can be captured as a Config object to make it easy
to save the previous state and restore if needed.

Will refactor DES helpers to use the same pattern in a
follow up PR.