### PR TITLE
Add optional CloudWatch metric timeout

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/rds.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/rds.conf
@@ -6,6 +6,7 @@ atlas {
     rds = {
       namespace = "AWS/RDS"
       period = 1m
+      timeout = 15m
 
       dimensions = [
         "DBInstanceIdentifier"

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
@@ -15,6 +15,8 @@
  */
 package com.netflix.atlas.cloudwatch
 
+import java.time.Duration
+import java.time.Instant
 import java.util.Date
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
@@ -61,8 +63,9 @@ class CloudWatchPoller(config: Config, registry: Registry, client: AmazonCloudWa
     extends Actor
     with StrictLogging {
 
-  import scala.concurrent.ExecutionContext.Implicits.global
   import CloudWatchPoller._
+
+  import scala.concurrent.ExecutionContext.Implicits.global
   import scala.concurrent.duration._
 
   // Load the categories and tagger based on the config settings
@@ -190,17 +193,23 @@ class CloudWatchPoller(config: Config, registry: Registry, client: AmazonCloudWa
   /** Add a datapoint to the cache. */
   private def processMetricData(data: MetricData): Unit = {
     pendingGets.decrementAndGet()
-    val prev = Option(metricCache.getIfPresent(data.meta)).flatMap(_.current)
-    metricCache.put(data.meta, data.copy(previous = prev))
+    val maybeMetricData = Option(metricCache.getIfPresent(data.meta))
+    val prev = maybeMetricData.flatMap(_.current)
+    val timestamp =
+      if (data.lastReportedTimestamp.isDefined)
+        data.lastReportedTimestamp
+      else
+        maybeMetricData.flatMap(_.lastReportedTimestamp)
+    metricCache.put(data.meta, data.copy(previous = prev, lastReportedTimestamp = timestamp))
   }
 
   /** Send all metrics that are currently in the cache. */
   private def sendMetricData(): Unit = {
     metricCache.asMap().forEach { (meta, data) =>
-      val d = data.datapoint
+      val now = registry.clock().wallTime()
+      val d = data.datapoint(Instant.ofEpochMilli(now))
       if (!d.getSum.isNaN) {
         val ts = tagger(meta.dimensions) ++ meta.definition.tags + ("name" -> meta.definition.alias)
-        val now = registry.clock().wallTime()
         val newValue = meta.convert(d)
         metricBatch += new AtlasDatapoint(ts, now, newValue)
         flush()
@@ -270,10 +279,11 @@ object CloudWatchPoller {
   case class MetricData(
     meta: MetricMetadata,
     previous: Option[Datapoint],
-    current: Option[Datapoint]
+    current: Option[Datapoint],
+    lastReportedTimestamp: Option[Instant]
   ) {
 
-    def datapoint: Datapoint = {
+    def datapoint(now: Instant = Instant.now): Datapoint = {
       if (meta.definition.monotonicValue) {
         previous.fold(DatapointNaN) { p =>
           // For a monotonic counter, use the max statistic. These will typically have a
@@ -292,7 +302,15 @@ object CloudWatchPoller {
             .withUnit(c.getUnit)
         }
       } else {
-        current.getOrElse(Zero)
+        current.getOrElse {
+          val timedOut = meta.category.timeout.exists { timeout =>
+            lastReportedTimestamp.exists { timestamp =>
+              Duration.between(timestamp, now).compareTo(timeout) > 0
+            }
+          }
+
+          if (timedOut) DatapointNaN else Zero
+        }
       }
     }
   }

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
@@ -195,11 +195,9 @@ class CloudWatchPoller(config: Config, registry: Registry, client: AmazonCloudWa
     pendingGets.decrementAndGet()
     val maybeMetricData = Option(metricCache.getIfPresent(data.meta))
     val prev = maybeMetricData.flatMap(_.current)
-    val timestamp =
-      if (data.lastReportedTimestamp.isDefined)
-        data.lastReportedTimestamp
-      else
-        maybeMetricData.flatMap(_.lastReportedTimestamp)
+    val timestamp = data.lastReportedTimestamp.orElse {
+      maybeMetricData.flatMap(_.lastReportedTimestamp)
+    }
     metricCache.put(data.meta, data.copy(previous = prev, lastReportedTimestamp = timestamp))
   }
 

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/GetMetricActor.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/GetMetricActor.scala
@@ -30,7 +30,10 @@ class GetMetricActor(client: AmazonCloudWatch) extends Actor with StrictLogging 
   import CloudWatchPoller._
 
   def receive: Receive = {
-    case m: MetricMetadata => sender() ! MetricData(m, None, getMetric(m))
+    case m: MetricMetadata =>
+      val metric = getMetric(m)
+      val timestamp = metric.map(m => m.getTimestamp.toInstant)
+      sender() ! MetricData(m, None, metric, timestamp)
   }
 
   /**

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricCategory.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricCategory.scala
@@ -43,8 +43,8 @@ import com.typesafe.scalalogging.StrictLogging
   * @param timeout
   *     How long the system should smooth out unreported CloudWatch metrics before
   *     ceasing to send them. CloudWatch will return 0 metrics in at least two cases:
-  *     1. No metrics were recorded.
-  *     1. The resource has been removed, but metrics for it still fall within
+  *     - No metrics were recorded.
+  *     - The resource has been removed, but metrics for it still fall within
   *        the retention window.
   * @param dimensions
   *     The dimensions to query for when getting data from CloudWatch. For the

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricCategory.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricCategory.scala
@@ -41,8 +41,9 @@ import com.typesafe.scalalogging.StrictLogging
   *     is within one period from the polling time. The period is also needed for
   *     performing rate conversions on some metrics.
   * @param timeout
-  *     How long the system should smooth out unreported CloudWatch metrics before
-  *     ceasing to send them. CloudWatch will return 0 metrics in at least two cases:
+  *     How long the system should interpolate a base value for unreported CloudWatch
+  *     metrics before ceasing to send them. CloudWatch will return 0 metrics for at
+  *     least two cases:
   *     - No metrics were recorded.
   *     - The resource has been removed, but metrics for it still fall within
   *        the retention window.

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricCategory.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricCategory.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.cloudwatch
 
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 import com.amazonaws.services.cloudwatch.model.DimensionFilter
@@ -26,7 +27,7 @@ import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
 
 /**
-  * Category of metrics to fetch from cloudwatch. This will typically correspond with
+  * Category of metrics to fetch from CloudWatch. This will typically correspond with
   * a CloudWatch namespace, though there may be multiple categories per namespace if
   * there is some variation in the behavior. For example, some namespaces will use a
   * different period for some metrics.
@@ -36,11 +37,17 @@ import com.typesafe.scalalogging.StrictLogging
   * @param period
   *     How frequently data in this category is updated. Atlas is meant for data that
   *     is continuously reported and requires a consistent step. To minimize confusion
-  *     for cloudwatch data we use the last reported value in cloudwatch as long as it
+  *     for CloudWatch data we use the last reported value in CloudWatch as long as it
   *     is within one period from the polling time. The period is also needed for
   *     performing rate conversions on some metrics.
+  * @param timeout
+  *     How long the system should smooth out unreported CloudWatch metrics before
+  *     ceasing to send them. CloudWatch will return 0 metrics in at least two cases:
+  *     1. No metrics were recorded.
+  *     1. The resource has been removed, but metrics for it still fall within
+  *        the retention window.
   * @param dimensions
-  *     The dimensions to query for when getting data from cloudwatch. For the
+  *     The dimensions to query for when getting data from CloudWatch. For the
   *     GetMetricData calls we have to explicitly specify all of the dimensions. In some
   *     cases CloudWatch has duplicate data for pre-computed aggregates. For example,
   *     ELB data is reported overall for the load balancer and by zone. For Atlas it
@@ -56,6 +63,7 @@ import com.typesafe.scalalogging.StrictLogging
 case class MetricCategory(
   namespace: String,
   period: Int,
+  timeout: Option[Duration],
   dimensions: List[String],
   metrics: List[MetricDefinition],
   filter: Query
@@ -63,7 +71,7 @@ case class MetricCategory(
 
   /**
     * Returns a set of list requests to fetch the metadata for the metrics matching
-    * this category. As there may be a lot of data in cloudwatch that we are not
+    * this category. As there may be a lot of data in CloudWatch that we are not
     * interested in, the list is used to restrict to the subset we actually care
     * about rather than a single request fetching everything for the namespace.
     */
@@ -99,9 +107,12 @@ object MetricCategory extends StrictLogging {
       else {
         parseQuery(config.getString("filter"))
       }
+    val timeout = if (config.hasPath("timeout")) Some(config.getDuration("timeout")) else None
+
     apply(
       namespace = config.getString("namespace"),
       period = config.getDuration("period", TimeUnit.SECONDS).toInt,
+      timeout = timeout,
       dimensions = config.getStringList("dimensions").asScala.toList,
       metrics = metrics.flatMap(MetricDefinition.fromConfig),
       filter = filter

--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionsSuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionsSuite.scala
@@ -75,7 +75,7 @@ class ConversionsSuite extends FunSuite {
   test("rate") {
     val cnv = Conversions.fromName("sum,rate")
     val meta = MetricMetadata(
-      MetricCategory("NFLX/Test", 300, Nil, Nil, Query.True),
+      MetricCategory("NFLX/Test", 300, None, Nil, Nil, Query.True),
       MetricDefinition("test", "test-alias", cnv, false, Map.empty),
       Nil
     )
@@ -86,7 +86,7 @@ class ConversionsSuite extends FunSuite {
   test("rate already") {
     val cnv = Conversions.fromName("sum,rate")
     val meta = MetricMetadata(
-      MetricCategory("NFLX/Test", 300, Nil, Nil, Query.True),
+      MetricCategory("NFLX/Test", 300, None, Nil, Nil, Query.True),
       MetricDefinition("test", "test-alias", cnv, false, Map.empty),
       Nil
     )

--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricCategorySuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricCategorySuite.scala
@@ -15,6 +15,8 @@
  */
 package com.netflix.atlas.cloudwatch
 
+import java.time.Duration
+
 import com.netflix.atlas.core.model.Query
 import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
@@ -58,6 +60,32 @@ class MetricCategorySuite extends FunSuite {
     assert(category.period === 60)
     assert(category.toListRequests.size === 2)
     assert(category.filter === Query.True)
+  }
+
+  test("category without timeout") {
+    val cfg = ConfigFactory.parseString("""
+        |namespace = "AWS/ELB"
+        |period = 1 m
+        |dimensions = ["LoadBalancerName"]
+        |metrics = []
+      """.stripMargin)
+
+    val category = MetricCategory.fromConfig(cfg)
+    assert(category.timeout.isEmpty)
+  }
+
+  test("category with timeout") {
+    val cfg = ConfigFactory.parseString("""
+        |namespace = "AWS/ELB"
+        |period = 1 m
+        |timeout = 1d
+        |dimensions = ["LoadBalancerName"]
+        |metrics = []
+      """.stripMargin)
+
+    val category = MetricCategory.fromConfig(cfg)
+    assert(category.timeout.nonEmpty)
+    assert(category.timeout.get === Duration.ofDays(1))
   }
 
   test("config with filter") {

--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDefinitionSuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDefinitionSuite.scala
@@ -27,7 +27,7 @@ import org.scalatest.FunSuite
 class MetricDefinitionSuite extends FunSuite {
 
   private val meta = MetricMetadata(
-    MetricCategory("AWS/ELB", 60, Nil, Nil, Query.True),
+    MetricCategory("AWS/ELB", 60, None, Nil, Nil, Query.True),
     null,
     Nil
   )


### PR DESCRIPTION
This commit adds a mechanism to specify how long the system should
smooth out unreported CloudWatch metrics before ceasing to send them.

CloudWatch will return 0 metrics in at least two cases:
  1. No metrics were recorded.
  2. The resource has been removed, but metrics for it still fall within
     the retention window.

I've made this optional and configurable at the metric category level to
tactically address the issue for RDS reported by a user and to minimize
visual clutter in the config. Depending on usage in practice, we may
want to require it to be specified for every category or lift the scope
to make it consistent at the global level.