### PR TITLE
fix behavior for aggregating count

### DIFF
--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
@@ -210,7 +210,7 @@ class TimeGroupedSuite extends FunSuite {
     val data = (0 until n).toList.map { i =>
       AggrDatapoint(10, 10, expr, "test", Map.empty, i)
     }
-    val expected = AggrDatapoint(10, 10, expr, "test", Map.empty, n)
+    val expected = AggrDatapoint(10, 10, expr, "test", Map.empty, n * (n - 1) / 2)
 
     val groups = run(data)
     assert(groups === List(TimeGroup(10, Map(expr -> List(expected)))))
@@ -271,16 +271,16 @@ class TimeGroupedSuite extends FunSuite {
   }
 
   test("group by aggregate: count") {
-    val n = 10000
+    val n = 5000
     val expr: DataExpr = DataExpr.GroupBy(DataExpr.Count(Query.True), List("category"))
-    val data = (0 until n).toList.map { i =>
+    val data = (0 until 2 * n).toList.map { i =>
       val category = if (i % 2 == 0) "even" else "odd"
       AggrDatapoint(10, 10, expr, "test", Map("category" -> category), i)
     }
     val expected = Map(
       expr -> List(
-        AggrDatapoint(10, 10, expr, "test", Map("category" -> "even"), n / 2),
-        AggrDatapoint(10, 10, expr, "test", Map("category" -> "odd"), n / 2)
+        AggrDatapoint(10, 10, expr, "test", Map("category" -> "even"), n * (n - 1)),
+        AggrDatapoint(10, 10, expr, "test", Map("category" -> "odd"), n * n)
       )
     )
 


### PR DESCRIPTION
The aggregate datapoint will already have been converted
from a raw value to a base count at the source. So when
it is received here it should behave just like a simple
sum. Before it was converting the datapoint to a 1 or 0
when aggregating as well which can lead to drastically
smaller count than expected if the source has many time
series for the query.