### PR TITLE
add ignore and pipeline helpers for step alignment

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineAlgorithm.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineAlgorithm.scala
@@ -49,6 +49,8 @@ object OnlineAlgorithm {
     config.getString("type") match {
       case "delay"       => OnlineDelay(config)
       case "des"         => OnlineDes(config)
+      case "ignore"      => OnlineIgnoreN(config)
+      case "pipeline"    => Pipeline(config)
       case "rolling-min" => OnlineRollingMin(config)
       case "rolling-max" => OnlineRollingMax(config)
       case "sliding-des" => OnlineSlidingDes(config)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineIgnoreN.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineIgnoreN.scala
@@ -43,8 +43,6 @@ case class OnlineIgnoreN(n: Int) extends OnlineAlgorithm {
 
 object OnlineIgnoreN {
 
-  def apply(n: Int): OnlineIgnoreN = new OnlineIgnoreN(n)
-
   def apply(config: Config): OnlineIgnoreN = {
     val algo = apply(config.getInt("n"))
     algo.pos = config.getInt("pos")

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineIgnoreN.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineIgnoreN.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+import com.typesafe.config.Config
+
+/**
+  * Ignore the first N datapoints that are passed in. This is typically used to achieve an
+  * initial alignment to step boundaries when using a deterministic sliding window approach
+  * like SDES.
+  */
+case class OnlineIgnoreN(n: Int) extends OnlineAlgorithm {
+
+  private var pos = 0
+
+  override def next(v: Double): Double = {
+    val i = pos
+    pos += 1
+    if (i >= n) v else Double.NaN
+  }
+
+  override def reset(): Unit = {
+    pos = 0
+  }
+
+  override def state: Config = {
+    OnlineAlgorithm.toConfig(Map("type" -> "ignore", "n" -> n, "pos" -> pos))
+  }
+}
+
+object OnlineIgnoreN {
+
+  def apply(n: Int): OnlineIgnoreN = new OnlineIgnoreN(n)
+
+  def apply(config: Config): OnlineIgnoreN = {
+    val algo = apply(config.getInt("n"))
+    algo.pos = config.getInt("pos")
+    algo
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/Pipeline.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/Pipeline.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+import com.typesafe.config.Config
+
+/**
+  * Push a value through a sequence of online algorithms and return the result.
+  */
+case class Pipeline(stages: List[OnlineAlgorithm]) extends OnlineAlgorithm {
+
+  override def next(v: Double): Double = {
+    stages.foldLeft(v) {
+      case (acc, stage) => stage.next(acc)
+    }
+  }
+
+  override def reset(): Unit = {
+    stages.foreach(_.reset())
+  }
+
+  override def state: Config = {
+    OnlineAlgorithm.toConfig(Map("type" -> "pipeline", "stages" -> stages.map(_.state)))
+  }
+}
+
+object Pipeline {
+
+  def apply(config: Config): Pipeline = {
+    import scala.collection.JavaConverters._
+    apply(config.getConfigList("stages").asScala.map(OnlineAlgorithm.apply).toList)
+  }
+
+  def apply(stages: OnlineAlgorithm*): Pipeline = apply(stages.toList)
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineIgnoreNSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineIgnoreNSuite.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+class OnlineIgnoreNSuite extends BaseOnlineAlgorithmSuite {
+
+  override def newInstance: OnlineAlgorithm = OnlineIgnoreN(10)
+
+  test("n = 1") {
+    val algo = OnlineIgnoreN(1)
+    assert(algo.next(0.0).isNaN)
+    assert(algo.next(1.0) === 1.0)
+    assert(algo.next(2.0) === 2.0)
+    assert(algo.next(Double.NaN).isNaN)
+  }
+
+  test("n = 1, reset") {
+    val algo = OnlineIgnoreN(1)
+    assert(algo.next(0.0).isNaN)
+    assert(algo.next(1.0) === 1.0)
+    algo.reset()
+    assert(algo.next(2.0).isNaN)
+    assert(algo.next(3.0) === 3.0)
+  }
+
+  test("n = 2") {
+    val algo = OnlineIgnoreN(2)
+    assert(algo.next(0.0).isNaN)
+    assert(algo.next(1.0).isNaN)
+    assert(algo.next(2.0) === 2.0)
+    assert(algo.next(Double.NaN).isNaN)
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/PipelineSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/PipelineSuite.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+class PipelineSuite extends BaseOnlineAlgorithmSuite {
+
+  def ignoreMax(n: Int): OnlineAlgorithm = {
+    Pipeline(OnlineIgnoreN(n), OnlineRollingMax(n))
+  }
+
+  override def newInstance: OnlineAlgorithm = ignoreMax(10)
+
+  test("n = 1") {
+    val algo = ignoreMax(1)
+    assert(algo.next(0.0).isNaN)
+    assert(algo.next(2.0) === 2.0)
+    assert(algo.next(1.0) === 1.0)
+    assert(algo.next(Double.NaN).isNaN)
+  }
+
+  test("n = 1, reset") {
+    val algo = ignoreMax(1)
+    assert(algo.next(0.0).isNaN)
+    assert(algo.next(1.0) === 1.0)
+    algo.reset()
+    assert(algo.next(2.0).isNaN)
+    assert(algo.next(3.0) === 3.0)
+  }
+
+  test("n = 2") {
+    val algo = ignoreMax(2)
+    assert(algo.next(0.0).isNaN)
+    assert(algo.next(1.0).isNaN)
+    assert(algo.next(2.0) === 2.0)
+    assert(algo.next(3.0) === 3.0)
+    assert(algo.next(0.0) === 3.0)
+    assert(algo.next(Double.NaN) === 0.0)
+    assert(algo.next(Double.NaN).isNaN)
+  }
+}


### PR DESCRIPTION
Adds an online algorithm to ignore the first N values. This
can be used with sliding DES to align to a step boundary
before starting the DES computation.

Also adds a pipeline that can be used to chain together a
sequence of online algorithms while conforming to the same
interface.