### PR TITLE
avoid unnecessary string allocations

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -15,7 +15,6 @@
  */
 package com.netflix.atlas.eval.stream
 
-import java.nio.charset.StandardCharsets
 import java.nio.file.OpenOption
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
@@ -173,7 +172,6 @@ private[stream] abstract class EvaluatorImpl(
       val finalEvalInput = builder.add(Merge[AnyRef](2))
 
       val intermediateEval = createInputFlow(context)
-        .map(_.decodeString(StandardCharsets.UTF_8))
         .map(ReplayLogging.log)
         .via(context.monitorFlow("10_InputLines"))
         .via(new LwcToAggrDatapoint)

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ReplayLogging.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ReplayLogging.scala
@@ -15,6 +15,9 @@
  */
 package com.netflix.atlas.eval.stream
 
+import java.nio.charset.StandardCharsets
+
+import akka.util.ByteString
 import com.netflix.atlas.eval.stream.Evaluator.DataSources
 import com.netflix.atlas.json.Json
 import com.typesafe.scalalogging.StrictLogging
@@ -28,6 +31,13 @@ import com.typesafe.scalalogging.StrictLogging
   * level is set to trace.
   */
 private[stream] object ReplayLogging extends StrictLogging {
+
+  def log(msg: ByteString): ByteString = {
+    if (msg.nonEmpty) {
+      logger.trace(msg.decodeString(StandardCharsets.UTF_8))
+    }
+    msg
+  }
 
   def log(msg: String): String = {
     val trimmed = msg.trim

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
@@ -19,6 +19,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
+import akka.util.ByteString
 import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.eval.model.AggrDatapoint
@@ -57,6 +58,7 @@ class LwcToAggrDatapointSuite extends FunSuite {
 
   private def eval(data: List[String]): List[AggrDatapoint] = {
     val future = Source(data)
+      .map(ByteString.apply)
       .via(new LwcToAggrDatapoint)
       .runWith(Sink.seq[AggrDatapoint])
     Await.result(future, Duration.Inf).toList

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/eval/stream/ByteStringDecode.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/eval/stream/ByteStringDecode.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import java.nio.charset.StandardCharsets
+
+import akka.util.ByteString
+import com.netflix.atlas.eval.model.LwcDatapoint
+import com.netflix.atlas.json.Json
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.infra.Blackhole
+
+/**
+  * Compare decoding a ByteString to JSON:
+  *
+  * 1. ByteString > String > Json.decode
+  * 2. ByteString > Array[Byte] (reused) > Json.decode
+  *
+  * ```
+  * > jmh:run -prof gc -wi 10 -i 10 -f1 -t1 .*ByteStringDecode.*
+  * ```
+  *
+  * Initial results:
+  *
+  * ```
+  * Throughput:
+  *
+  * Benchmark                   Mode  Cnt       Score       Error   Units
+  * decodeFromByteString       thrpt   10  344793.104 ± 11891.506   ops/s
+  * decodeFromString           thrpt   10  299394.816 ±  9240.783   ops/s
+  *
+  *
+  * Allocation rate per operation:
+  *
+  * Benchmark                   Mode  Cnt       Score       Error   Units
+  * decodeFromByteString       thrpt   10    3928.000 ±     0.002    B/op
+  * decodeFromString           thrpt   10    4680.001 ±     0.002    B/op
+  * ```
+  */
+@State(Scope.Thread)
+class ByteStringDecode {
+
+  private val tags = Map(
+    "nf.app"     -> "atlas_backend",
+    "nf.cluster" -> "atlas_backend-dev",
+    "nf.asg"     -> "atlas_backend-dev-v001",
+    "nf.stack"   -> "dev",
+    "nf.region"  -> "us-east-1",
+    "nf.zone"    -> "us-east-1e",
+    "nf.node"    -> "i-123456789",
+    "nf.ami"     -> "ami-987654321",
+    "nf.vmtype"  -> "r3.2xlarge",
+    "name"       -> "jvm.gc.pause",
+    "cause"      -> "Allocation_Failure",
+    "action"     -> "end_of_major_GC",
+    "statistic"  -> "totalTime"
+  )
+
+  private val datapoint = LwcDatapoint(1234567890L, "i-12345", tags, 42.0)
+  private val datapointJson = Json.encode(datapoint)
+  private val datapointBytes = ByteString(datapointJson)
+
+  private val buffer = new Array[Byte](16384)
+
+  @Benchmark
+  def decodeFromString(bh: Blackhole): Unit = {
+    val str = datapointBytes.decodeString(StandardCharsets.UTF_8)
+    val obj = Json.decode[LwcDatapoint](str)
+    bh.consume(obj)
+  }
+
+  @Benchmark
+  def decodeFromByteString(bh: Blackhole): Unit = {
+    val length = datapointBytes.length
+    datapointBytes.copyToArray(buffer, 0, length)
+    val obj = Json.decode[LwcDatapoint](buffer, 0, length)
+    bh.consume(obj)
+  }
+}


### PR DESCRIPTION
Refactor stream to avoid decoding into a String as an
intermediate step before parsing the JSON payloads. This
yields about a 16% reduction in bytes allocated per message
for the sample data tested.