### PR TITLE
initial websocket support for lwcapi

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcDataExpr.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcDataExpr.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+import com.fasterxml.jackson.annotation.JsonAlias
+import com.netflix.atlas.core.model.DataExpr
+import com.netflix.atlas.core.model.DataVocabulary
+import com.netflix.atlas.core.stacklang.Interpreter
+
+/**
+  * Triple representing the id, data expression, and frequency for a given data
+  * flow. The id is needed to match [[LwcDatapoint]]s to the data expression they
+  * were generated for.
+  *
+  * @param id
+  *     Id used by LWC service for this expression. Data generated coming in will
+  *     be tagged with this id.
+  * @param expression
+  *     Data expression that was used to generate the intermediate result on each
+  *     client and that can be used for the final aggregation step during consumption.
+  * @param step
+  *     The step size used for this stream of data.
+  */
+case class LwcDataExpr(id: String, expression: String, @JsonAlias(Array("frequency")) step: Long) {
+  val expr: DataExpr = LwcDataExpr.parseExpr(expression)
+}
+
+object LwcDataExpr {
+
+  private val interpreter = Interpreter(DataVocabulary.allWords)
+
+  private def parseExpr(input: String): DataExpr = {
+    interpreter.execute(input).stack match {
+      case (expr: DataExpr) :: Nil => expr
+      case _                       => throw new IllegalArgumentException(s"invalid expr: $input")
+    }
+  }
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcDatapoint.scala
@@ -29,4 +29,6 @@ package com.netflix.atlas.eval.model
   * @param value
   *     Value for the datapoint.
   */
-case class LwcDatapoint(timestamp: Long, id: String, tags: Map[String, String], value: Double)
+case class LwcDatapoint(timestamp: Long, id: String, tags: Map[String, String], value: Double) {
+  val `type`: String = "datapoint"
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcExpression.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcExpression.scala
@@ -15,19 +15,16 @@
  */
 package com.netflix.atlas.eval.model
 
-import com.fasterxml.jackson.annotation.JsonAlias
-import com.netflix.atlas.core.model.DataExpr
-import com.netflix.atlas.core.model.DataVocabulary
-import com.netflix.atlas.core.stacklang.Interpreter
-
 /**
-  * Subscription message that is returned by the LWC service.
+  * Pair representing the expression and step size for data being requested from the LWCAPI
+  * service. A set of data expressions corresponding with this request will be returned as
+  * an [LwcSubscription] response message.
   *
   * @param expression
-  *     Expression that was used for the initial subscription.
-  * @param metrics
-  *     Data expressions that result from the root expression.
+  *     Expression to subscribe to from LWCAPI.
+  * @param step
+  *     The step size used for this stream of data.
   */
-case class LwcSubscription(expression: String, metrics: List[LwcDataExpr]) {
-  val `type`: String = "subscription"
+case class LwcExpression(expression: String, step: Long) {
+  val `type`: String = "expression"
 }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcMessages.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcMessages.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.netflix.atlas.akka.DiagnosticMessage
+import com.netflix.atlas.json.Json
+
+/**
+  * Helpers for working with messages coming back from the LWCAPI service.
+  */
+object LwcMessages {
+
+  /**
+    * Parse the message string into an internal model object based on the type.
+    */
+  def parse(msg: String): AnyRef = {
+    val data = Json.decode[JsonNode](msg)
+    data.get("type").asText() match {
+      case "expression"   => Json.decode[LwcExpression](data)
+      case "subscription" => Json.decode[LwcSubscription](data)
+      case "datapoint"    => Json.decode[LwcDatapoint](data)
+      case _              => Json.decode[DiagnosticMessage](data)
+    }
+  }
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapoint.scala
@@ -87,7 +87,7 @@ private[stream] class LwcToAggrDatapoint extends GraphStage[FlowShape[ByteString
             // TODO, put in source, for now make it random to avoid dedup
             nextSource += 1
             val expr = sub.expr
-            val step = sub.frequency
+            val step = sub.step
             push(out, AggrDatapoint(d.timestamp, step, expr, nextSource.toString, d.tags, d.value))
           case None =>
             pull(in)

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcMessagesSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcMessagesSuite.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+import com.netflix.atlas.akka.DiagnosticMessage
+import com.netflix.atlas.json.Json
+import org.scalatest.FunSuite
+
+class LwcMessagesSuite extends FunSuite {
+
+  private val step = 60000
+
+  test("data expr, decode with legacy frequency field") {
+    val json = """{"id":"1234","expression":"name,cpu,:eq,:sum","frequency":10}"""
+    val actual = Json.decode[LwcDataExpr](json)
+    val expected = LwcDataExpr("1234", "name,cpu,:eq,:sum", 10)
+    assert(actual === expected)
+  }
+
+  test("subscription info") {
+    val expr = "name,cpu,:eq,:avg"
+    val sum = "name,cpu,:eq,:sum"
+    val count = "name,cpu,:eq,:count"
+    val dataExprs = List(LwcDataExpr("a", sum, step), LwcDataExpr("b", count, step))
+    val expected = LwcSubscription(expr, dataExprs)
+    val actual = LwcMessages.parse(Json.encode(expected))
+    assert(actual === expected)
+  }
+
+  test("datapoint") {
+    val expected = LwcDatapoint(step, "a", Map("foo" -> "bar"), 42.0)
+    val actual = LwcMessages.parse(Json.encode(expected))
+    assert(actual === expected)
+  }
+
+  test("diagnostic message") {
+    val expected = DiagnosticMessage.error("something bad happened")
+    val actual = LwcMessages.parse(Json.encode(expected))
+    assert(actual === expected)
+  }
+}

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/HostSourceSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/HostSourceSuite.scala
@@ -167,5 +167,4 @@ class HostSourceSuite extends FunSuite {
     val result = Await.result(future, Duration.Inf).toList
     assert(result === (0 until 5).map(_ => "ok").toList)
   }
-
 }

--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ lazy val `atlas-json` = project
 
 lazy val `atlas-lwcapi` = project
   .configure(BuildSettings.profile)
-  .dependsOn(`atlas-akka`, `atlas-core`, `atlas-json`, `atlas-test` % "test")
+  .dependsOn(`atlas-akka`, `atlas-core`, `atlas-eval`, `atlas-json`, `atlas-test` % "test")
   .settings(libraryDependencies ++= Seq(
     Dependencies.iepNflxEnv,
     Dependencies.frigga,


### PR DESCRIPTION
Adds a websocket endpoint `/api/v1/subscribe` that can be
used for both updating the set of subscriptions and receiving
the stream of data. This also begins some changes to help
improve consistency with other Atlas APIs, namely the messages
rename `frequency` to `step` and the `/lwc` prefix is removed
from the endpoint path. For now there is an alias so the eval
client will still work with the messages coming from older
lwcapi services running.

This change also use the model objects from the eval client
on the server side for the websocket endpoint to help ensure
better consistency of the messages in the future. The old
endpoints have not been changed to preserve compatibility
during the transition.

Current plan:

1) Deploy updated lwcapi service with the new endpoint. The
   client will continue to work as before.
2) Update the eval client and get internal usages migrated.
3) Cleanup the lwcapi to remove the old subscribe/stream
   endpoints.

This should be the final big change before releasing 1.6.