### PR TITLE
diagnostic messages from publisher to subscriber

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcDiagnosticMessage.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcDiagnosticMessage.scala
@@ -15,14 +15,17 @@
  */
 package com.netflix.atlas.eval.model
 
+import com.netflix.atlas.akka.DiagnosticMessage
+import com.netflix.atlas.json.JsonSupport
+
 /**
-  * Subscription message that is returned by the LWC service.
+  * Diagnostic message for a particular expression.
   *
-  * @param expression
-  *     Expression that was used for the initial subscription.
-  * @param metrics
-  *     Data expressions that result from the root expression.
+  * @param id
+  *     Identifies the expression that resulted in this message being generated.
+  * @param message
+  *     Actual message to pass through to the user.
   */
-case class LwcSubscription(expression: String, metrics: List[LwcDataExpr]) {
-  val `type`: String = "subscription"
+case class LwcDiagnosticMessage(id: String, message: DiagnosticMessage) extends JsonSupport {
+  val `type`: String = "diagnostic"
 }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcMessages.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcMessages.scala
@@ -33,6 +33,7 @@ object LwcMessages {
       case "expression"   => Json.decode[LwcExpression](data)
       case "subscription" => Json.decode[LwcSubscription](data)
       case "datapoint"    => Json.decode[LwcDatapoint](data)
+      case "diagnostic"   => Json.decode[LwcDiagnosticMessage](data)
       case _              => Json.decode[DiagnosticMessage](data)
     }
   }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -94,7 +94,7 @@ private[stream] class StreamContext(
 
   /**
     * Current set of data sources being processed by the stream. This may be updated while
-    * there is still some in-flight data for a given data source that was previously being
+    * there are still some in-flight data for a given data source that was previously being
     * processed.
     */
   @volatile var dataSources: DataSources = DataSources.empty()

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -32,6 +32,7 @@ import akka.util.ByteString
 import com.netflix.atlas.akka.AccessLogger
 import com.netflix.atlas.akka.DiagnosticMessage
 import com.netflix.atlas.akka.StreamOps
+import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.util.Streams
 import com.netflix.atlas.eval.stream.Evaluator.DataSource
 import com.netflix.atlas.eval.stream.Evaluator.DataSources
@@ -91,13 +92,24 @@ private[stream] class StreamContext(
     }
   }
 
+  /**
+    * Current set of data sources being processed by the stream. This may be updated while
+    * there is still some in-flight data for a given data source that was previously being
+    * processed.
+    */
+  @volatile var dataSources: DataSources = DataSources.empty()
+
+  /**
+    * Validate the input and return a new object with only the valid data sources. A diagnostic
+    * message will be written to the `dsLogger` for any failures.
+    */
   def validate(input: DataSources): DataSources = {
     import scala.collection.JavaConverters._
     val valid = input.getSources.asScala.flatMap(validateDataSource).asJava
     new DataSources(valid)
   }
 
-  def validateDataSource(ds: DataSource): Option[DataSource] = {
+  private def validateDataSource(ds: DataSource): Option[DataSource] = {
     try {
       val uri = Uri(ds.getUri)
 
@@ -113,6 +125,16 @@ private[stream] class StreamContext(
       case e: Exception =>
         dsLogger(ds, DiagnosticMessage.error(e))
         None
+    }
+  }
+
+  /**
+    * Send a diagnostic message to all data sources that use a particular data expression.
+    */
+  def log(expr: DataExpr, msg: DiagnosticMessage): Unit = {
+    val map = interpreter.dataExprMap(dataSources)
+    map.get(expr).foreach { ds =>
+      ds.foreach(s => dsLogger(s, msg))
     }
   }
 

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcMessagesSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcMessagesSuite.scala
@@ -51,4 +51,10 @@ class LwcMessagesSuite extends FunSuite {
     val actual = LwcMessages.parse(Json.encode(expected))
     assert(actual === expected)
   }
+
+  test("diagnostic message for a particular expression") {
+    val expected = LwcDiagnosticMessage("abc", DiagnosticMessage.error("something bad happened"))
+    val actual = LwcMessages.parse(Json.encode(expected))
+    assert(actual === expected)
+  }
 }

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/EvaluateApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/EvaluateApiSuite.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwcapi
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.testkit.RouteTestTimeout
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import com.netflix.atlas.akka.DiagnosticMessage
+import com.netflix.atlas.eval.model.LwcDiagnosticMessage
+import com.netflix.atlas.lwcapi.EvaluateApi._
+import com.netflix.spectator.api.NoopRegistry
+import org.scalatest.FunSuite
+
+class EvaluateApiSuite extends FunSuite with ScalatestRouteTest {
+  import scala.concurrent.duration._
+
+  private implicit val routeTestTimeout = RouteTestTimeout(5.second)
+
+  private val sm = new StreamSubscriptionManager
+  private val endpoint = new EvaluateApi(new NoopRegistry, sm)
+
+  test("post empty payload") {
+    val json = EvaluateRequest(1234L, Nil, Nil).toJson
+    Post("/lwc/api/v1/evaluate", json) ~> endpoint.routes ~> check {
+      assert(response.status === StatusCodes.OK)
+    }
+  }
+
+  test("post metrics") {
+    val metrics = List(Item("abc", Map("a" -> "1"), 42.0))
+    val json = EvaluateRequest(1234L, metrics, Nil).toJson
+    Post("/lwc/api/v1/evaluate", json) ~> endpoint.routes ~> check {
+      assert(response.status === StatusCodes.OK)
+    }
+  }
+
+  test("post diagnostic message") {
+    val msgs = List(LwcDiagnosticMessage("abc", DiagnosticMessage.error("bad expression")))
+    val json = EvaluateRequest(1234L, Nil, msgs).toJson
+    Post("/lwc/api/v1/evaluate", json) ~> endpoint.routes ~> check {
+      assert(response.status === StatusCodes.OK)
+    }
+  }
+
+  test("post missing messages field") {
+    val json = """{"timestamp":12345,"metrics":[]}"""
+    Post("/lwc/api/v1/evaluate", json) ~> endpoint.routes ~> check {
+      assert(response.status === StatusCodes.OK)
+    }
+  }
+
+  test("post missing metrics field") {
+    val json = """{"timestamp":12345,"messages":[]}"""
+    Post("/lwc/api/v1/evaluate", json) ~> endpoint.routes ~> check {
+      assert(response.status === StatusCodes.OK)
+    }
+  }
+}


### PR DESCRIPTION
Adds support for diagnostic messages to be sent to the
evaluate api along with the data values. This can be used
for the publisher to send diagnostic messages that will
be received by a particular subscriber. An example use-case
is to reject an expression due to the amount of load already
on the publisher.