### PR TITLE
lwc: server to client time notifications

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
@@ -20,6 +20,7 @@ import com.netflix.atlas.core.model.DataExpr.AggregateFunction
 import com.netflix.atlas.core.model.DataExpr.All
 import com.netflix.atlas.core.model.DataExpr.GroupBy
 import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.TimeSeries
 
 /**
@@ -62,9 +63,23 @@ case class AggrDatapoint(
     * phase.
     */
   def toTimeSeries: TimeSeries = Datapoint(tags, timestamp, value, step)
+
+  /** Check if it is a heartbeat datapoint. */
+  def isHeartbeat: Boolean = source == "heartbeat"
 }
 
 object AggrDatapoint {
+
+  /**
+    * Creates a dummy datapoint passed along when a heartbeat message is received from the
+    * lwcapi server. These are used to ensure regular messages are flowing into the time
+    * grouping stage so it will flush even if there is no matching data for any of the
+    * expressions being evaluated.
+    */
+  def heartbeat(timestamp: Long, step: Long): AggrDatapoint = {
+    val t = timestamp / step * step
+    AggrDatapoint(t, step, DataExpr.All(Query.False), "heartbeat", Map.empty, Double.NaN)
+  }
 
   /**
     * Base trait for an aggregator that can efficiently combine the datapoints as they

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcHeartbeat.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcHeartbeat.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+import com.netflix.atlas.json.JsonSupport
+
+/**
+  * Heartbeat message to indicate the time according to the server side. The eval client always
+  * adjusts to the timestamps of the data that is flowing through it. These messages can be used
+  * by the server side to ensure that there will always be at least one message for a given step
+  * size that is flowing through to the client so it will close out and evaluate a given time
+  * interval.
+  *
+  * @param timestamp
+  *     Current time aligned to the last completed step boundary.
+  * @param step
+  *     Step size for this heartbeat message. The server will typically send one heartbeat
+  *     foreach step size used in a subscription.
+  */
+case class LwcHeartbeat(timestamp: Long, step: Long) extends JsonSupport {
+  val `type`: String = "heartbeat"
+
+  require(timestamp % step == 0, s"timestamp ($timestamp) must be on boundary of step ($step)")
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcMessages.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcMessages.scala
@@ -34,6 +34,7 @@ object LwcMessages {
       case "subscription" => Json.decode[LwcSubscription](data)
       case "datapoint"    => Json.decode[LwcDatapoint](data)
       case "diagnostic"   => Json.decode[LwcDiagnosticMessage](data)
+      case "heartbeat"    => Json.decode[LwcHeartbeat](data)
       case _              => Json.decode[DiagnosticMessage](data)
     }
   }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcMessagesSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcMessagesSuite.scala
@@ -57,4 +57,16 @@ class LwcMessagesSuite extends FunSuite {
     val actual = LwcMessages.parse(Json.encode(expected))
     assert(actual === expected)
   }
+
+  test("heartbeat") {
+    val expected = LwcHeartbeat(1234567890L, 10L)
+    val actual = LwcMessages.parse(Json.encode(expected))
+    assert(actual === expected)
+  }
+
+  test("heartbeat not on step boundary") {
+    intercept[IllegalArgumentException] {
+      LwcHeartbeat(1234567891L, 10L)
+    }
+  }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
@@ -115,4 +115,17 @@ class LwcToAggrDatapointSuite extends FunSuite {
       }
     }
   }
+
+  test("heartbeat messages are passed through") {
+    val data = List(
+      """data: heartbeat {"type":"heartbeat","timestamp":1234567890,"step":10}"""
+    )
+    val results = eval(data)
+    assert(results.size === 1)
+
+    val d = results.head
+    assert(d.isHeartbeat)
+    assert(d.timestamp === 1234567890)
+    assert(d.step === 10)
+  }
 }

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
@@ -28,6 +28,7 @@ import com.netflix.atlas.akka.DiagnosticMessage
 import com.netflix.atlas.akka.RequestHandler
 import com.netflix.atlas.eval.model.LwcDatapoint
 import com.netflix.atlas.eval.model.LwcExpression
+import com.netflix.atlas.eval.model.LwcHeartbeat
 import com.netflix.atlas.eval.model.LwcMessages
 import com.netflix.atlas.eval.model.LwcSubscription
 import com.netflix.atlas.json.Json
@@ -85,6 +86,7 @@ class SubscribeApiSuite extends FunSuite with BeforeAndAfter with ScalatestRoute
         parse(client.expectMessage()) match {
           case msg: DiagnosticMessage =>
           case sub: LwcSubscription   => subscriptions = sub :: subscriptions
+          case h: LwcHeartbeat        => assert(h.step === 60000)
         }
       }
 


### PR DESCRIPTION
The eval client for consuming LWC data uses the timestamps
in the messages so it can be used to run on live or captured
data that may have old timestamps. If there is a subscription
to an expression that doesn't match any data, then no messages
will go through and thus the time grouping will not be flushed
for a given interval.

This change allows the server to send heartbeats with the
timestamp and step so it can ensure there will always be at
least one message coming though for a given stream. When
running on previously captured data it will also include the
heartbeat messages and exhibit the same behavior.