### PR TITLE
store step size for TimeGroup

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeGroup.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeGroup.scala
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package com.netflix.atlas.eval.model
+
 import com.netflix.atlas.core.model.DataExpr
 
 /**
@@ -25,17 +26,9 @@ import com.netflix.atlas.core.model.DataExpr
   *
   * @param timestamp
   *     Timestamp that applies to all values within the group.
+  * @param step
+  *     Step size for the data within this group.
   * @param values
   *     Values associated with this time.
   */
-case class TimeGroup(timestamp: Long, values: Map[DataExpr, List[AggrDatapoint]]) {
-
-  /**
-    * Extract the step size from the time group. It is not explicitly checked on construction
-    * to avoid the overhead, but a group should always have a uniform step size for all
-    * datapoints.
-    */
-  def step: Long = {
-    values.values.find(_.nonEmpty).fold(-1L)(_.head.step)
-  }
-}
+case class TimeGroup(timestamp: Long, step: Long, values: Map[DataExpr, List[AggrDatapoint]])

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
@@ -65,7 +65,7 @@ class FinalExprEvalSuite extends FunSuite {
   private def group(i: Long, vs: AggrDatapoint*): TimeGroup = {
     val timestamp = i * step
     val values = vs.map(_.copy(timestamp = timestamp)).groupBy(_.expr).mapValues(_.toList)
-    TimeGroup(timestamp, values)
+    TimeGroup(timestamp, step, values)
   }
 
   test("exception while parsing exprs") {
@@ -86,7 +86,7 @@ class FinalExprEvalSuite extends FunSuite {
   test("division with no data should result in no data line") {
     val input = List(
       sources(ds("a", "http://atlas/graph?q=name,latency,:eq,:dist-avg")),
-      TimeGroup(0L, Map.empty)
+      TimeGroup(0L, step, Map.empty)
     )
     val output = run(input)
     assert(output.size === 1)

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
@@ -57,9 +57,9 @@ class TimeGroupedSuite extends FunSuite {
   private def timeGroup(t: Long, vs: List[AggrDatapoint]): TimeGroup = {
     val expr = DataExpr.All(Query.True)
     if (vs.isEmpty)
-      TimeGroup(t, Map.empty)
+      TimeGroup(t, step, Map.empty)
     else
-      TimeGroup(t, Map(expr -> vs))
+      TimeGroup(t, step, Map(expr -> vs))
   }
 
   private def datapoint(t: Long, v: Int): AggrDatapoint = {
@@ -204,7 +204,7 @@ class TimeGroupedSuite extends FunSuite {
     val expected = AggrDatapoint(10, 10, expr, "test", Map.empty, n * (n - 1) / 2)
 
     val groups = run(data)
-    assert(groups === List(TimeGroup(10, Map(expr -> List(expected)))))
+    assert(groups === List(TimeGroup(10, step, Map(expr -> List(expected)))))
   }
 
   test("simple aggregate: min") {
@@ -216,7 +216,7 @@ class TimeGroupedSuite extends FunSuite {
     val expected = AggrDatapoint(10, 10, expr, "test", Map.empty, 0)
 
     val groups = run(data)
-    assert(groups === List(TimeGroup(10, Map(expr -> List(expected)))))
+    assert(groups === List(TimeGroup(10, step, Map(expr -> List(expected)))))
   }
 
   test("simple aggregate: max") {
@@ -228,7 +228,7 @@ class TimeGroupedSuite extends FunSuite {
     val expected = AggrDatapoint(10, 10, expr, "test", Map.empty, n - 1)
 
     val groups = run(data)
-    assert(groups === List(TimeGroup(10, Map(expr -> List(expected)))))
+    assert(groups === List(TimeGroup(10, step, Map(expr -> List(expected)))))
   }
 
   test("simple aggregate: count") {
@@ -240,7 +240,7 @@ class TimeGroupedSuite extends FunSuite {
     val expected = AggrDatapoint(10, 10, expr, "test", Map.empty, n * (n - 1) / 2)
 
     val groups = run(data)
-    assert(groups === List(TimeGroup(10, Map(expr -> List(expected)))))
+    assert(groups === List(TimeGroup(10, step, Map(expr -> List(expected)))))
   }
 
   test("group by aggregate: sum") {
@@ -258,7 +258,7 @@ class TimeGroupedSuite extends FunSuite {
     )
 
     val groups = run(data)
-    assert(groups === List(TimeGroup(10, expected)))
+    assert(groups === List(TimeGroup(10, step, expected)))
   }
 
   test("group by aggregate: min") {
@@ -276,7 +276,7 @@ class TimeGroupedSuite extends FunSuite {
     )
 
     val groups = run(data)
-    assert(groups === List(TimeGroup(10, expected)))
+    assert(groups === List(TimeGroup(10, step, expected)))
   }
 
   test("group by aggregate: max") {
@@ -294,7 +294,7 @@ class TimeGroupedSuite extends FunSuite {
     )
 
     val groups = run(data)
-    assert(groups === List(TimeGroup(10, expected)))
+    assert(groups === List(TimeGroup(10, step, expected)))
   }
 
   test("group by aggregate: count") {
@@ -312,6 +312,6 @@ class TimeGroupedSuite extends FunSuite {
     )
 
     val groups = run(data)
-    assert(groups === List(TimeGroup(10, expected)))
+    assert(groups === List(TimeGroup(10, step, expected)))
   }
 }


### PR DESCRIPTION
If it is flushed via a heartbeat instead of data, then it
could be empty and the step size cannot be extracted from
the data.