### PR TITLE
pre-compute data expr map

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -193,7 +193,7 @@ private[stream] abstract class EvaluatorImpl(
       .map(ReplayLogging.log)
       .map { s =>
         val validated = context.validate(s)
-        context.dataSources = validated
+        context.setDataSources(validated)
         validated
       }
       .via(g)

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
@@ -74,8 +74,10 @@ class LwcToAggrDatapointSuite extends FunSuite {
     dsLogger = (ds, msg) => logMessages.add(ds -> msg)
   )
 
-  context.dataSources = DataSources.of(
-    new DataSource("abc", java.time.Duration.ofMinutes(1), "/api/v1/graph?q=name,cpu,:eq,:avg")
+  context.setDataSources(
+    DataSources.of(
+      new DataSource("abc", java.time.Duration.ofMinutes(1), "/api/v1/graph?q=name,cpu,:eq,:avg")
+    )
   )
 
   private def eval(data: List[String]): List[AggrDatapoint] = {


### PR DESCRIPTION
Computes the data expr map when the data sources are updated
instead of when doing a lookup for logging. Reduces the
overhead later in the stream if there are a lot of diagnostic
messages.