### PR TITLE
do not request gzip for /stream call

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/HostSource.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/HostSource.scala
@@ -65,8 +65,7 @@ private[stream] object HostSource extends StrictLogging {
 
   private def singleCall(client: SimpleClient)(uri: String): Source[ByteString, Any] = {
     logger.info(s"subscribing to $uri")
-    val headers =
-      List(Accept(MediaTypes.`text/event-stream`), `Accept-Encoding`(HttpEncodings.gzip))
+    val headers = List(Accept(MediaTypes.`text/event-stream`))
     val request = HttpRequest(HttpMethods.GET, uri, headers)
 
     Source


### PR DESCRIPTION
Current testing indicates the largest chunk of CPU time
server side is in the GZIP compression. The akka directive
doesn't easily allow for configuring it with `BEST_SPEED`
instead of `BEST_COMPRESSION`. Further on the client side,
the largest chunk of allocations is for the decompression.

Overall it seems preferable right now to use more bandwidth
and avoid the compression. Will revisit after web-socket
change and switching to binary encoding for stream.