### PR TITLE
only send LwcSubscription for new subscriptions

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
@@ -179,8 +179,8 @@ class SubscribeApi @Inject()(
         val splits = splitter.split(expr.expression, expr.frequency)
 
         // Add any new expressions
-        val queue = sm.subscribe(streamId, splits)
-        splits.foreach { sub =>
+        val (queue, addedSubs) = sm.subscribe(streamId, splits)
+        addedSubs.foreach { sub =>
           queue.offer(SSESubscribe(expr.expression, List(sub.metadata)))
         }
 

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
@@ -156,11 +156,11 @@ class SubscriptionManager[T] extends StrictLogging {
     val info = getInfo(streamId)
     val addedSubs = List.newBuilder[Subscription]
     subs.foreach { sub =>
-        if (info.subs.putIfAbsent(sub.metadata.id, sub) == null) {
-          logger.debug(s"subscribed $streamId to $sub")
-          addedSubs += sub
-        }
-        queryListChanged |= addHandler(sub.metadata.id, info.handler)
+      if (info.subs.putIfAbsent(sub.metadata.id, sub) == null) {
+        logger.debug(s"subscribed $streamId to $sub")
+        addedSubs += sub
+      }
+      queryListChanged |= addHandler(sub.metadata.id, info.handler)
     }
     info.handler -> addedSubs.result()
   }

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
@@ -143,24 +143,26 @@ class SubscriptionManager[T] extends StrictLogging {
   /**
     * Start sending data for the subscription to the given stream id.
     */
-  def subscribe(streamId: String, sub: Subscription): T = {
-    subscribe(streamId, List(sub))
+  private[lwcapi] def subscribe(streamId: String, sub: Subscription): T = {
+    subscribe(streamId, List(sub))._1
   }
 
   /**
-    * Start sending data for the subscription to the given stream id.
+    * Start sending data for the subscription to the given stream id. Returns the handler
+    * along with a list of newly added subscriptions.
     */
-  def subscribe(streamId: String, subs: List[Subscription]): T = {
+  def subscribe(streamId: String, subs: List[Subscription]): (T, List[Subscription]) = {
     logger.debug(s"updating subscriptions for $streamId")
     val info = getInfo(streamId)
-    queryListChanged = subs.foldLeft(queryListChanged) {
-      case (acc, sub) =>
+    val addedSubs = List.newBuilder[Subscription]
+    subs.foreach { sub =>
         if (info.subs.putIfAbsent(sub.metadata.id, sub) == null) {
           logger.debug(s"subscribed $streamId to $sub")
+          addedSubs += sub
         }
-        addHandler(sub.metadata.id, info.handler) || acc
+        queryListChanged |= addHandler(sub.metadata.id, info.handler)
     }
-    info.handler
+    info.handler -> addedSubs.result()
   }
 
   /**

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
@@ -20,8 +20,10 @@ import org.scalatest.FunSuite
 
 class SubscriptionManagerSuite extends FunSuite {
 
+  private val config = ConfigFactory.load()
+
   private def sub(expr: String): Subscription = {
-    val splitter = new ExpressionSplitter(ConfigFactory.load())
+    val splitter = new ExpressionSplitter(config)
     splitter.split(expr, 60).head
   }
 
@@ -170,5 +172,21 @@ class SubscriptionManagerSuite extends FunSuite {
 
     sm.unregister("a")
     assert(sm.handlersForSubscription(s.metadata.id) === Nil)
+  }
+
+  test("subscribe returns added expressions") {
+    val sm = new SubscriptionManager[Integer]()
+    assert(sm.register("a", 1))
+    assert(sm.register("b", 2))
+
+    val s1 = sub("name,exp1,:eq")
+    val s2 = sub("name,exp2,:eq")
+    val s3 = sub("name,exp3,:eq")
+
+    assert(sm.subscribe("a", List(s1, s2)) === 1 -> List(s1, s2))
+    assert(sm.subscribe("a", List(s1, s2)) === 1 -> Nil)
+    assert(sm.subscribe("b", List(s1, s2)) === 2 -> List(s1, s2))
+    assert(sm.subscribe("b", List(s1, s2, s3)) === 2 -> List(s3))
+    assert(sm.subscribe("a", List(s1, s3)) === 1 -> List(s3))
   }
 }

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
@@ -183,10 +183,10 @@ class SubscriptionManagerSuite extends FunSuite {
     val s2 = sub("name,exp2,:eq")
     val s3 = sub("name,exp3,:eq")
 
-    assert(sm.subscribe("a", List(s1, s2)) === 1 -> List(s1, s2))
-    assert(sm.subscribe("a", List(s1, s2)) === 1 -> Nil)
-    assert(sm.subscribe("b", List(s1, s2)) === 2 -> List(s1, s2))
+    assert(sm.subscribe("a", List(s1, s2)) === 1     -> List(s1, s2))
+    assert(sm.subscribe("a", List(s1, s2)) === 1     -> Nil)
+    assert(sm.subscribe("b", List(s1, s2)) === 2     -> List(s1, s2))
     assert(sm.subscribe("b", List(s1, s2, s3)) === 2 -> List(s3))
-    assert(sm.subscribe("a", List(s1, s3)) === 1 -> List(s3))
+    assert(sm.subscribe("a", List(s1, s3)) === 1     -> List(s3))
   }
 }


### PR DESCRIPTION
When running for a lot of expressions this can be a
significant number of messages. In most cases the set
of subscriptions do not change that often.