### PR TITLE
make queue size configurable

### DIFF
--- a/atlas-lwcapi/src/main/resources/reference.conf
+++ b/atlas-lwcapi/src/main/resources/reference.conf
@@ -10,6 +10,10 @@ atlas {
     # this time has passed so that data from the producers will not yet be pushed through
     # the new instances.
     startup-delay = 3m
+
+    # Size of the queue for each subscription stream. Data will be dropped if it is coming
+    # in faster than it can be written out.
+    queue-size = 100
   }
 
   akka {

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
@@ -52,10 +52,11 @@ class SubscribeApiSuite extends FunSuite with BeforeAndAfter with ScalatestRoute
       .run()
   )
 
+  private val config = ConfigFactory.load()
   private val sm = new StreamSubscriptionManager
-  private val splitter = new ExpressionSplitter(ConfigFactory.load())
+  private val splitter = new ExpressionSplitter(config)
 
-  private val api = new SubscribeApi(new NoopRegistry, sm, splitter, system)
+  private val api = new SubscribeApi(config, new NoopRegistry, sm, splitter, system)
 
   private val routes = RequestHandler.standardOptions(api.routes)
 


### PR DESCRIPTION
Add `atlas.lwcapi.queue-size` setting for controlling the
max number of items to queue up per stream before dropping.