### PR TITLE
switch to source based on BlockingQueue

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/StreamOps.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/StreamOps.scala
@@ -15,6 +15,8 @@
  */
 package com.netflix.atlas.akka
 
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.BlockingQueue
 import java.util.concurrent.TimeUnit
 
 import akka.Done
@@ -25,11 +27,13 @@ import akka.stream.Inlet
 import akka.stream.Outlet
 import akka.stream.OverflowStrategy
 import akka.stream.QueueOfferResult
+import akka.stream.SourceShape
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
 import akka.stream.scaladsl.SourceQueueWithComplete
 import akka.stream.stage.GraphStage
 import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.GraphStageWithMaterializedValue
 import akka.stream.stage.InHandler
 import akka.stream.stage.OutHandler
 import com.netflix.spectator.api.Registry
@@ -49,6 +53,9 @@ object StreamOps {
     * Wraps a source queue and adds monitoring for the results of items offered to the queue.
     * This can be used to detect if items are being dropped or offered after the associated
     * stream has been closed.
+    *
+    * **Warning:** can have high memory use if the incoming data rate for the queue is not
+    * limited based on the future returned from `SourceQueueWithComplete.offer`.
     *
     * @param registry
     *     Spectator registry to manage metrics for this queue.
@@ -76,7 +83,7 @@ object StreamOps {
     queue: SourceQueueWithComplete[T]
   ) extends SourceQueueWithComplete[T] {
 
-    private implicit val ec = scala.concurrent.ExecutionContext.Implicits.global
+    private implicit val ec = scala.concurrent.ExecutionContext.global
 
     private val baseId = registry.createId("akka.stream.offeredToQueue", "id", id)
     private val enqueued = registry.counter(baseId.withTag("result", "enqueued"))
@@ -99,6 +106,117 @@ object StreamOps {
         case Success(QueueOfferResult.Failure(_))  => failed.increment()
         case Failure(t)                            => completed.increment()
       }
+    }
+  }
+
+  /**
+    * Creates a queue source based on an `ArrayBlockingQueue`. Values offered to the queue
+    * will be emitted by the source. This can be used as an alternative to `Source.queue`
+    * or `Source.actorRef` that can have unbounded memory use if the consumer cannot keep
+    * up with the rate of data being offered ([#25798]).
+    *
+    * [#25798]: https://github.com/akka/akka/issues/25798
+    *
+    * @param registry
+    *     Spectator registry to manage metrics for this queue.
+    * @param id
+    *     Dimension used to distinguish a particular queue usage.
+    * @param size
+    *     Number of enqueued items to allow before triggering the overflow strategy.
+    * @return
+    *     Source that emits values offered to the queue.
+    */
+  def blockingQueue[T](registry: Registry, id: String, size: Int): Source[T, SourceQueue[T]] = {
+    val sourceQueue = new SourceQueue[T](registry, id, new ArrayBlockingQueue[T](size))
+    Source.fromGraph(new QueueSource[T](sourceQueue))
+  }
+
+  /** Bounded queue for submitting elements to a stream. */
+  class SourceQueue[T] private[akka] (registry: Registry, id: String, queue: BlockingQueue[T]) {
+
+    private val baseId = registry.createId("akka.stream.offeredToQueue", "id", id)
+    private val enqueued = registry.counter(baseId.withTag("result", "enqueued"))
+    private val dropped = registry.counter(baseId.withTag("result", "droppedQueueFull"))
+    private val closed = registry.counter(baseId.withTag("result", "droppedQueueClosed"))
+
+    private[akka] var push: T => Unit = _
+
+    @volatile private var pushImmediately: Boolean = false
+
+    @volatile private var completed: Boolean = false
+
+    private def increment(result: Boolean): Boolean = {
+      (if (result) enqueued else dropped).increment()
+      result
+    }
+
+    /**
+      * Add the value into the queue if there is room. Returns true if the value was successfully
+      * enqueued.
+      */
+    def offer(value: T): Boolean = {
+      if (completed) {
+        closed.increment()
+        false
+      } else {
+        if (pushImmediately) {
+          synchronized {
+            if (pushImmediately) {
+              pushImmediately = false
+              push(value)
+              increment(true)
+            } else {
+              increment(queue.offer(value))
+            }
+          }
+        } else {
+          increment(queue.offer(value))
+        }
+      }
+    }
+
+    private[akka] def pull(): Unit = {
+      if (queue.isEmpty)
+        pushImmediately = true
+      else
+        push(queue.poll())
+    }
+
+    /**
+      * Indicate that the use of the queue is complete. This will allow the associated stream
+      * to finish processing elements and then shutdown. Any new elements offered to the queue
+      * will be dropped.
+      */
+    def complete(): Unit = {
+      completed = true
+    }
+
+    /** Check if the queue is done, i.e., it has been completed and the queue is empty. */
+    def isDone: Boolean = completed && queue.isEmpty
+  }
+
+  private class QueueSource[T](queue: SourceQueue[T])
+      extends GraphStageWithMaterializedValue[SourceShape[T], SourceQueue[T]] {
+
+    private val out = Outlet[T]("QueueSource")
+
+    override val shape: SourceShape[T] = SourceShape(out)
+
+    override def createLogicAndMaterializedValue(
+      attrs: Attributes
+    ): (GraphStageLogic, SourceQueue[T]) = {
+      val logic = new GraphStageLogic(shape) with OutHandler {
+        override def onPull(): Unit = {
+          if (queue.isDone)
+            complete(out)
+          else
+            queue.pull()
+        }
+
+        setHandler(out, this)
+        queue.push = v => push(out, v)
+      }
+      logic -> queue
     }
   }
 

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
@@ -80,6 +80,43 @@ class StreamOpsSuite extends FunSuite {
     checkOfferedCounts(registry, Map("enqueued" -> 2.0, "droppedQueueFull" -> 3.0))
   }
 
+  test("blocking queue, enqueued") {
+    val registry = new DefaultRegistry()
+    val source = StreamOps.blockingQueue[Int](registry, "test", 10)
+    val queue = source.toMat(Sink.ignore)(Keep.left).run()
+    Seq(1, 2, 3, 4).foreach(queue.offer)
+    queue.complete()
+    checkOfferedCounts(registry, Map("enqueued" -> 4.0))
+  }
+
+  test("blocking queue, droppedQueueFull") {
+    val registry = new DefaultRegistry()
+    val source = StreamOps.blockingQueue[Future[Int]](registry, "test", 1)
+    val queue = source
+      .flatMapConcat(Source.fromFuture)
+      .toMat(Sink.ignore)(Keep.left)
+      .run()
+    val promise = Promise[Int]()
+    queue.offer(promise.future) // will pass through without going to the queue
+    queue.offer(promise.future) // fills the 1 slot in the queue
+    Seq(2, 3, 4, 5).foreach(i => queue.offer(Future(i)))
+    promise.complete(Success(1))
+    queue.complete()
+    checkOfferedCounts(registry, Map("enqueued" -> 2.0, "droppedQueueFull" -> 4.0))
+  }
+
+  test("blocking queue, droppedQueueClosed") {
+    val registry = new DefaultRegistry()
+    val source = StreamOps.blockingQueue[Int](registry, "test", 1)
+    val queue = source
+      .toMat(Sink.ignore)(Keep.left)
+      .run()
+    queue.offer(1)
+    queue.complete()
+    Seq(2, 3, 4, 5).foreach(i => queue.offer(i))
+    checkOfferedCounts(registry, Map("enqueued" -> 1.0, "droppedQueueClosed" -> 4.0))
+  }
+
   private def checkCounts(registry: Registry, name: String, expected: Map[String, Double]): Unit = {
     import scala.collection.JavaConverters._
     registry

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -28,7 +28,6 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.Uri
 import akka.stream.ActorMaterializer
 import akka.stream.FlowShape
-import akka.stream.OverflowStrategy
 import akka.stream.ThrottleMode
 import akka.stream.scaladsl.Broadcast
 import akka.stream.scaladsl.FileIO
@@ -150,7 +149,7 @@ private[stream] abstract class EvaluatorImpl(
 
     // Flow used for logging diagnostic messages
     val (queue, logSrc) = StreamOps
-      .queue[MessageEnvelope](registry, "DataSourceLogger", 10, OverflowStrategy.dropNew)
+      .blockingQueue[MessageEnvelope](registry, "DataSourceLogger", 10)
       .toMat(Sink.asPublisher(true))(Keep.both)
       .run()
     val dsLogger: DataSourceLogger = { (ds, msg) =>

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/akka/SourceQueueBench.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/akka/SourceQueueBench.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.akka
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.Keep
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import com.netflix.spectator.api.NoopRegistry
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+/**
+  * Double check performance of blocking queue.
+  *
+  * For more information about problems with Source.queue and Source.actorRef see:
+  * https://github.com/akka/akka/issues/25798
+  *
+  * Custom blocking queue source has much lower overhead in terms of worst-case memory
+  * use, number of allocations, and peak throughput. Note though, that if the higher rate
+  * is actually hit in practice then most likely a large fraction of the incoming data is
+  * going to be dropped.
+  *
+  * ```
+  * > jmh:run -prof stack -wi 10 -i 10 -f1 -t4 .*SourceQueueBench.*
+  * ...
+  * Benchmark                            Mode  Cnt         Score       Error   Units
+  * sourceActorRef                      thrpt   10     76267.028 ± 17961.096   ops/s
+  * sourceBlockingQueue                 thrpt   10  21011710.919 ± 25699.817   ops/s
+  * sourceQueue                         thrpt   10    230878.311 ±  5346.921   ops/s
+  *
+  * Benchmark                            Mode  Cnt         Score       Error   Units
+  * sourceActorRef         gc.alloc.rate.norm   10        48.063 ±     0.024    B/op
+  * sourceBlockingQueue    gc.alloc.rate.norm   10         0.252 ±     0.002    B/op
+  * sourceQueue            gc.alloc.rate.norm   10       593.506 ±   107.083    B/op
+  *
+  * Benchmark                            Mode  Cnt         Score       Error   Units
+  * sourceActorRef                   gc.count   10        13.000              counts
+  * sourceBlockingQueue              gc.count   10         4.000              counts
+  * sourceQueue                      gc.count   10       397.000              counts
+  *
+  * Benchmark                            Mode  Cnt         Score       Error   Units
+  * sourceActorRef                    gc.time   10    165589.000                  ms
+  * sourceBlockingQueue               gc.time   10         3.000                  ms
+  * sourceQueue                       gc.time   10       314.000                  ms
+  * ```
+  */
+@State(Scope.Benchmark)
+class SourceQueueBench {
+
+  private implicit val system = ActorSystem()
+  private implicit val materializer = ActorMaterializer()
+
+  private val queue = Source
+    .queue[NotUsed](10, OverflowStrategy.dropNew)
+    .toMat(Sink.ignore)(Keep.left)
+    .run()
+
+  private val actorRef = Source
+    .actorRef[NotUsed](10, OverflowStrategy.dropNew)
+    .toMat(Sink.ignore)(Keep.left)
+    .run()
+
+  private val blockingQueue = StreamOps
+    .blockingQueue[NotUsed](new NoopRegistry, "test", 10)
+    .toMat(Sink.ignore)(Keep.left)
+    .run()
+
+  @TearDown
+  def tearDown(): Unit = {
+    Await.ready(system.terminate(), Duration.Inf)
+  }
+
+  @Benchmark
+  def sourceQueue(bh: Blackhole): Unit = {
+    val result = Await.ready(queue.offer(NotUsed), Duration.Inf)
+    bh.consume(result)
+  }
+
+  @Benchmark
+  def sourceActorRef(): Unit = {
+    actorRef ! NotUsed
+  }
+
+  @Benchmark
+  def sourceBlockingQueue(bh: Blackhole): Unit = {
+    bh.consume(blockingQueue.offer(NotUsed))
+  }
+
+}

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/QueueHandler.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/QueueHandler.scala
@@ -15,12 +15,9 @@
  */
 package com.netflix.atlas.lwcapi
 
-import akka.stream.QueueOfferResult
-import akka.stream.scaladsl.SourceQueueWithComplete
+import com.netflix.atlas.akka.StreamOps
 import com.netflix.atlas.json.JsonSupport
 import com.typesafe.scalalogging.StrictLogging
-
-import scala.concurrent.Future
 
 /**
   * Message handler for use with the [SubscriptionManager].
@@ -31,9 +28,9 @@ import scala.concurrent.Future
   * @param queue
   *     Underlying queue that will receive the messsages.
   */
-class QueueHandler(id: String, queue: SourceQueueWithComplete[JsonSupport]) extends StrictLogging {
+class QueueHandler(id: String, queue: StreamOps.SourceQueue[JsonSupport]) extends StrictLogging {
 
-  def offer(msg: JsonSupport): Future[QueueOfferResult] = {
+  def offer(msg: JsonSupport): Boolean = {
     logger.trace(s"enqueuing message for $id: ${msg.toJson}")
     queue.offer(msg)
   }

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
@@ -26,7 +26,6 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.stream.ActorMaterializer
-import akka.stream.OverflowStrategy
 import akka.stream.ThrottleMode
 import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Sink
@@ -88,7 +87,7 @@ class StreamApi @Inject()(
 
     // Create queue to allow messages coming into /evaluate to be passed to this stream
     val (queue, pub) = StreamOps
-      .queue[JsonSupport](registry, "StreamApi", queueSize, OverflowStrategy.dropHead)
+      .blockingQueue[JsonSupport](registry, "StreamApi", queueSize)
       .toMat(Sink.asPublisher[JsonSupport](true))(Keep.both)
       .run()
 

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
@@ -31,7 +31,6 @@ import akka.http.scaladsl.model.ws.TextMessage
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.stream.ActorMaterializer
-import akka.stream.OverflowStrategy
 import akka.stream.ThrottleMode
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Keep
@@ -130,7 +129,7 @@ class SubscribeApi @Inject()(
 
     // Create queue to allow messages coming into /evaluate to be passed to this stream
     val (queue, pub) = StreamOps
-      .queue[JsonSupport](registry, "SubscribeApi", queueSize, OverflowStrategy.dropHead)
+      .blockingQueue[JsonSupport](registry, "SubscribeApi", queueSize)
       .map(msg => TextMessage(msg.toJson))
       .toMat(Sink.asPublisher[Message](true))(Keep.both)
       .run()

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
@@ -19,10 +19,9 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Sink
-import akka.stream.scaladsl.Source
+import com.netflix.atlas.akka.StreamOps
 import com.netflix.atlas.json.JsonSupport
 import com.netflix.spectator.api.NoopRegistry
 import com.typesafe.config.ConfigFactory
@@ -38,8 +37,8 @@ class ExpressionApiSuite extends FunSuite with ScalatestRouteTest {
   // Dummy queue used for handler
   private val queue = new QueueHandler(
     "test",
-    Source
-      .queue[JsonSupport](1, OverflowStrategy.dropHead)
+    StreamOps
+      .blockingQueue[JsonSupport](new NoopRegistry, "test", 1)
       .toMat(Sink.ignore)(Keep.left)
       .run()
   )

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
@@ -20,12 +20,11 @@ import akka.http.scaladsl.model.ws.Message
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.http.scaladsl.testkit.WSProbe
-import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Sink
-import akka.stream.scaladsl.Source
 import com.netflix.atlas.akka.DiagnosticMessage
 import com.netflix.atlas.akka.RequestHandler
+import com.netflix.atlas.akka.StreamOps
 import com.netflix.atlas.eval.model.LwcDatapoint
 import com.netflix.atlas.eval.model.LwcExpression
 import com.netflix.atlas.eval.model.LwcHeartbeat
@@ -47,8 +46,8 @@ class SubscribeApiSuite extends FunSuite with BeforeAndAfter with ScalatestRoute
   // Dummy queue used for handler
   private val queue = new QueueHandler(
     "test",
-    Source
-      .queue[JsonSupport](1, OverflowStrategy.dropHead)
+    StreamOps
+      .blockingQueue[JsonSupport](new NoopRegistry, "test", 1)
       .toMat(Sink.ignore)(Keep.left)
       .run()
   )


### PR DESCRIPTION
The default `Source.queue` has quite a bit of overhead and
the input must be throttled based on the future to bound the
memory use. `Source.actorRef` has a bit less overhead, but
has the same unbounded memory use if it cannot keep up and
does not provide a reasonable way to throttle the input.

This change uses a custom source stage based on the java
ArrayBlockingQueue. There is significantly less overhead and
the memory usage is bounded even with an offer and forget
usage style.