### PR TITLE
extract the step size from the uri

### DIFF
--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -344,4 +344,24 @@ class EvaluatorSuite extends FunSuite with BeforeAndAfter {
     val actual = Json.decode[Evaluator.DataSources](Json.encode(expected))
     assert(actual === expected)
   }
+
+  private def newDataSource(stepParam: Option[String]): Evaluator.DataSource = {
+    val uri = "/api/v1/graph?q=a,b,:eq" + stepParam.map(s => s"&step=$s").getOrElse("")
+    new Evaluator.DataSource("_", uri)
+  }
+
+  test("extractStepFromUri, step param not set") {
+    val ds = newDataSource(None)
+    assert(ds.getStep === Duration.ofMinutes(1))
+  }
+
+  test("extractStepFromUri, 5s step") {
+    val ds = newDataSource(Some("5s"))
+    assert(ds.getStep === Duration.ofSeconds(5))
+  }
+
+  test("extractStepFromUri, invalid step") {
+    val ds = newDataSource(Some("abc"))
+    assert(ds.getStep === Duration.ofMinutes(1))
+  }
 }


### PR DESCRIPTION
If a step size is not explicitly supplied as part of the
data source, then try to extract it based on the step param
of the uri before falling back to the default of 1m. This
allows `Evaluator.createPublisher` to work with a custom
step size.