### PR TITLE
reduce overhead for creating hash strings

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
@@ -566,4 +566,31 @@ object Strings {
 
   /** Convert BigInteger value to hex string and zero pad. */
   def zeroPad(v: BigInteger, width: Int): String = zeroPad(v.toString(16), width)
+
+  // Pre-computed set of hex strings for each byte value
+  private val byteHexStrings = {
+    (0 until 256).map(i => zeroPad(Integer.toHexString(i), 2)).toArray
+  }
+
+  /**
+    * Convert integer represented as a byte array to a hex string and zero pad. This can be
+    * used to avoid a conversion to BigInteger if the hex string is the only result needed.
+    * The minimum padding width is 2, smaller values will get ignored.
+    */
+  def zeroPad(v: Array[Byte], width: Int): String = {
+    val n = width - 2 * v.length
+    val builder = new StringBuilder(math.max(width, 2 * v.length))
+    var i = 0
+    while (i < n) {
+      builder.append('0')
+      i += 1
+    }
+    i = 0
+    while (i < v.length) {
+      val idx = java.lang.Byte.toUnsignedInt(v(i))
+      builder.append(byteHexStrings(idx))
+      i += 1
+    }
+    builder.toString()
+  }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/HashSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/HashSuite.scala
@@ -26,4 +26,10 @@ class HashSuite extends FunSuite {
   test("sha1") {
     assert(Hash.sha1("42").toString(10) == "838146913046966959093018715372872234545534447190")
   }
+
+  test("sha1bytes zeroPad") {
+    val expected = Strings.zeroPad(Hash.sha1("42"), 40)
+    val actual = Strings.zeroPad(Hash.sha1bytes("42"), 40)
+    assert(actual === expected)
+  }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
@@ -494,6 +494,38 @@ class StringsSuite extends FunSuite {
     assert(zeroPad(b, 8) === "0000002a")
   }
 
+  test("zeroPad byte array empty") {
+    val b = Array.empty[Byte]
+    assert(zeroPad(b, 1) === "0")
+    assert(zeroPad(b, 2) === "00")
+    assert(zeroPad(b, 3) === "000")
+    assert(zeroPad(b, 8) === "00000000")
+  }
+
+  test("zeroPad byte array unsigned conversion") {
+    val b = Array[Byte](-1)
+    assert(zeroPad(b, 1) === "ff")
+    assert(zeroPad(b, 2) === "ff")
+    assert(zeroPad(b, 3) === "0ff")
+    assert(zeroPad(b, 8) === "000000ff")
+  }
+
+  test("zeroPad byte array minimum padding of 2") {
+    val b = Array[Byte](1)
+    assert(zeroPad(b, 1) === "01")
+    assert(zeroPad(b, 2) === "01")
+    assert(zeroPad(b, 3) === "001")
+    assert(zeroPad(b, 8) === "00000001")
+  }
+
+  test("zeroPad byte array all values") {
+    (java.lang.Byte.MIN_VALUE until java.lang.Byte.MAX_VALUE).foreach { i =>
+      val s = zeroPad(Array(i.toByte), 1)
+      val v = Integer.parseInt(s, 16).byteValue()
+      assert(v === i)
+    }
+  }
+
   test("range: both absolute") {
     val (s, e) = timeRange("2018-07-24", "2018-07-24T00:05")
     assert(s === parseDate("2018-07-24").toInstant)

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GrapherSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GrapherSuite.scala
@@ -45,7 +45,7 @@ class GrapherSuite extends FunSuite with BeforeAndAfterAll {
 
   def imageTest(name: String)(uri: => String): Unit = {
     test(name) {
-      val fname = Strings.zeroPad(Hash.sha1(name), 40).substring(0, 8) + ".png"
+      val fname = Strings.zeroPad(Hash.sha1bytes(name), 40).substring(0, 8) + ".png"
       val result = grapher.evalAndRender(Uri(uri), db)
       val image = PngImage(result.data)
       graphAssertions.assertEquals(image, fname, bless)
@@ -363,7 +363,7 @@ class GrapherSuite extends FunSuite with BeforeAndAfterAll {
 
   def renderTest(name: String)(uri: => String): Unit = {
     test(name) {
-      val fname = Strings.zeroPad(Hash.sha1(name), 40).substring(0, 8) + ".png"
+      val fname = Strings.zeroPad(Hash.sha1bytes(name), 40).substring(0, 8) + ".png"
       val config = grapher.toGraphConfig(Uri(uri))
       val styleData = config.exprs.map { styleExpr =>
         val dataResults = styleExpr.expr.dataExprs.distinct.map { dataExpr =>

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionApi.scala
@@ -96,7 +96,7 @@ object ExpressionApi {
 
     // TODO: This should get refactored so we do not need to recompute each time
     val str = expressions.sorted.mkString(";")
-    val hash = Strings.zeroPad(Hash.sha1(str), 40).substring(20)
+    val hash = Strings.zeroPad(Hash.sha1bytes(str), 40).substring(20)
     '"' + hash + '"'
   }
 }

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionMetadata.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionMetadata.scala
@@ -46,6 +46,6 @@ object ExpressionMetadata {
   }
 
   def computeId(e: String, f: Long): String = {
-    Strings.zeroPad(Hash.sha1(s"$f~$e"), 40)
+    Strings.zeroPad(Hash.sha1bytes(s"$f~$e"), 40)
   }
 }

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiSuite.scala
@@ -85,7 +85,7 @@ class GraphApiSuite extends FunSuite with ScalatestRouteTest {
   }
 
   private def imageFileName(uri: String): String = {
-    s"${Strings.zeroPad(Hash.sha1(uri), 40).substring(0, 8)}.png"
+    s"${Strings.zeroPad(Hash.sha1bytes(uri), 40).substring(0, 8)}.png"
   }
 
 }

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/GraphHelper.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/GraphHelper.scala
@@ -119,7 +119,7 @@ class GraphHelper(db: Database, dir: File, path: String) extends StrictLogging {
   }
 
   private def imageFileName(uri: String): String = {
-    s"${Strings.zeroPad(Hash.sha1(uri), 40).substring(0, 8)}.png"
+    s"${Strings.zeroPad(Hash.sha1bytes(uri), 40).substring(0, 8)}.png"
   }
 
   def formatQuery(line: String): String = {


### PR DESCRIPTION
Avoids creating a BigInteger object from the hash array
just for the purposes of creating the hex string.