### PR TITLE
optimize json encoding for lwc datapoint

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcDatapoint.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.eval.model
 
+import com.fasterxml.jackson.core.JsonGenerator
 import com.netflix.atlas.json.JsonSupport
 
 /**
@@ -34,4 +35,18 @@ import com.netflix.atlas.json.JsonSupport
 case class LwcDatapoint(timestamp: Long, id: String, tags: Map[String, String], value: Double)
     extends JsonSupport {
   val `type`: String = "datapoint"
+
+  override def encode(gen: JsonGenerator): Unit = {
+    gen.writeStartObject()
+    gen.writeStringField("type", `type`)
+    gen.writeNumberField("timestamp", timestamp)
+    gen.writeStringField("id", id)
+    gen.writeObjectFieldStart("tags")
+    tags.foreach { t =>
+      gen.writeStringField(t._1, t._2)
+    }
+    gen.writeEndObject()
+    gen.writeNumberField("value", value)
+    gen.writeEndObject()
+  }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcMessagesSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcMessagesSuite.scala
@@ -46,6 +46,12 @@ class LwcMessagesSuite extends FunSuite {
     assert(actual === expected)
   }
 
+  test("datapoint, custom encode") {
+    val expected = LwcDatapoint(step, "a", Map("foo" -> "bar"), 42.0)
+    val actual = LwcMessages.parse(expected.toJson)
+    assert(actual === expected)
+  }
+
   test("diagnostic message") {
     val expected = DiagnosticMessage.error("something bad happened")
     val actual = LwcMessages.parse(Json.encode(expected))

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/eval/model/LwcDatapointEncode.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/eval/model/LwcDatapointEncode.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+import java.io.StringWriter
+
+import com.netflix.atlas.json.Json
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.infra.Blackhole
+
+/**
+  * ```
+  * > jmh:run -prof gc -wi 10 -i 10 -f1 -t1 .*LwcDatapointEncode.*
+  * ```
+  *
+  * Throughput:
+  *
+  * ```
+  * Benchmark                          Mode  Cnt       Score       Error   Units
+  * customEncode                      thrpt   10  778092.834 ± 39878.875   ops/s
+  * defaultEncode                     thrpt   10  679355.101 ± 27340.720   ops/s
+  * ```
+  *
+  * Allocations:
+  *
+  * ```
+  * Benchmark                          Mode  Cnt       Score       Error   Units
+  * customEncode         gc.alloc.rate.norm   10    2136.000 ±     0.001    B/op
+  * defaultEncode        gc.alloc.rate.norm   10    3000.000 ±     0.001    B/op
+  * ```
+  **/
+@State(Scope.Thread)
+class LwcDatapointEncode {
+
+  private val tags = Map(
+    "nf.app"     -> "atlas_backend",
+    "nf.cluster" -> "atlas_backend-dev",
+    "nf.asg"     -> "atlas_backend-dev-v001",
+    "nf.stack"   -> "dev",
+    "nf.region"  -> "us-east-1",
+    "nf.zone"    -> "us-east-1e",
+    "nf.node"    -> "i-123456789",
+    "nf.ami"     -> "ami-987654321",
+    "nf.vmtype"  -> "r3.2xlarge",
+    "name"       -> "jvm.gc.pause",
+    "cause"      -> "Allocation_Failure",
+    "action"     -> "end_of_major_GC",
+    "statistic"  -> "totalTime"
+  )
+
+  private val datapoint = LwcDatapoint(1234567890L, "i-12345", tags, 42.0)
+
+  private def toJson(v: LwcDatapoint): String = {
+    val w = new StringWriter
+    val gen = Json.newJsonGenerator(w)
+    Json.encode(gen, v)
+    gen.close()
+    w.toString
+  }
+
+  @Benchmark
+  def defaultEncode(bh: Blackhole): Unit = {
+    bh.consume(toJson(datapoint))
+  }
+
+  @Benchmark
+  def customEncode(bh: Blackhole): Unit = {
+    bh.consume(datapoint.toJson)
+  }
+}


### PR DESCRIPTION
Avoid using databind to automatically encode as this is
a hot path that is called many times on lwcapi for sending
the datapoints to the user.