### PR TITLE
disable use of cache for ImageIO

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/PngImage.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/PngImage.scala
@@ -35,6 +35,9 @@ import com.sun.imageio.plugins.png.PNGMetadata
 
 object PngImage {
 
+  // Disable using on-disk cache for images. Avoids temp files on shared services.
+  ImageIO.setUseCache(false)
+
   def apply(bytes: Array[Byte]): PngImage = {
     val input = new ByteArrayInputStream(bytes)
     apply(input)


### PR DESCRIPTION
Should avoid tmp files that get created by default when
rendering images. Also helps avoid problems on shared
clusters when /tmp fills up.