### PR TITLE
add config setting for max tags permitted

### DIFF
--- a/atlas-webapi/src/main/resources/reference.conf
+++ b/atlas-webapi/src/main/resources/reference.conf
@@ -132,6 +132,10 @@ atlas {
         }
       ]
 
+      // Maximum number of tags permitted per datapoint. No testing has been done on this
+      // for numbers larger than 30.
+      max-permitted-tags = 30
+
       // Max age for a datapoint. By default it is one step interval. If the timestamps are
       // normalized locally on the client 2 times the step is likely more appropriate.
       max-age = ${atlas.core.model.step}

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
@@ -75,6 +75,8 @@ class ApiSettings(root: => Config) {
     }
   }
 
+  def maxPermittedTags: Int = config.getInt("publish.max-permitted-tags")
+
   def maxDatapointAge: Long = config.getDuration("publish.max-age", TimeUnit.MILLISECONDS)
 
   def validationRules: List[Rule] = Rule.load(config.getConfigList("publish.rules"))

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
@@ -111,7 +111,7 @@ object PublishApi {
 
   type TagMap = Map[String, String]
 
-  private final val maxPermittedTags = 30
+  private final val maxPermittedTags = ApiSettings.maxPermittedTags
 
   private def decodeTags(parser: JsonParser, commonTags: TagMap, intern: Boolean): TagMap = {
     val strInterner = Interner.forStrings


### PR DESCRIPTION
For general use it is not recommended to change this, but
making it configurable to facilitate experimentation and
testing.