### PR TITLE
improve performance of findValues for common tags

### DIFF
--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndexBench.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndexBench.scala
@@ -36,24 +36,15 @@ import org.openjdk.jmh.infra.Blackhole
   * > jmh:run -wi 10 -i 10 -f1 -t1 .*RoaringTagIndexBench.*
   * ```
   *
-  * Initial results:
+  * Results:
   *
   * ```
-  * Before
-  * [info] Benchmark                                Mode  Cnt     Score     Error  Units
-  * [info] RoaringTagIndexBench.create             thrpt   10    13.210 ±   1.041  ops/s
-  * [info] RoaringTagIndexBench.findKeysAll        thrpt   10  4646.344 ± 176.685  ops/s
-  * [info] RoaringTagIndexBench.findKeysQuery      thrpt   10   450.728 ±  39.296  ops/s
-  * [info] RoaringTagIndexBench.findValuesAllMany  thrpt   10   739.919 ±  41.530  ops/s
-  * [info] RoaringTagIndexBench.findValuesAllOne   thrpt   10  2194.050 ± 248.351  ops/s
-  *
-  * After
-  * [info] Benchmark                                Mode  Cnt        Score        Error  Units
-  * [info] RoaringTagIndexBench.create             thrpt   10       20.270 ±      0.798  ops/s
-  * [info] RoaringTagIndexBench.findKeysAll        thrpt   10  6382544.499 ± 353321.426  ops/s
-  * [info] RoaringTagIndexBench.findKeysQuery      thrpt   10     1118.262 ±    370.960  ops/s
-  * [info] RoaringTagIndexBench.findValuesAllMany  thrpt   10     3849.128 ±    416.156  ops/s
-  * [info] RoaringTagIndexBench.findValuesAllOne   thrpt   10     4485.419 ±    424.741  ops/s
+  * Benchmark                                Mode  Cnt         Score        Error  Units
+  * RoaringTagIndexBench.create             thrpt   10        22.204 ±      0.907  ops/s
+  * RoaringTagIndexBench.findKeysAll        thrpt   10  14053463.630 ± 656709.056  ops/s
+  * RoaringTagIndexBench.findKeysQuery      thrpt   10      1323.195 ±     81.122  ops/s
+  * RoaringTagIndexBench.findValuesAllMany  thrpt   10      4172.656 ±    305.764  ops/s
+  * RoaringTagIndexBench.findValuesAllOne   thrpt   10    357671.851 ±  17709.502  ops/s
   * ```
   */
 @State(Scope.Thread)


### PR DESCRIPTION
For tags that are repeated across many metrics, this change
prunes the item set by doing a lookup for that key value. The
`andNot` is quite a bit faster than iterating the matches.
It mostly impacts queries that are projecting all values for
a common tag without other restrictions.

For the sample benchmark, findValuesAllOne is the only one
to show a noticeable change as expected. Before it was about
4864.472 ops/s and after 357671.851 ops/s.

Trying it on real data, it is mostly faster, but there are a
handful of cases where it is a bit slower. The table below
shows mean time per operation in milliseconds for a handful
of common queries:

| *URI*                | *Before*  | *After*   |
|----------------------|-----------|-----------|
| `/nf.app`            | 115.5     | 26.9      |
| `/nf.cluster`        | 102.0     | 66.3      |
| `/nf.node`           | 156.4     | 196.9     |
| `/nf.account`        | 128.6     | 2.0       |
| `/nf.region`         | 97.1      | 2.3       |
| `/nf.zone`           | 90.5      | 5.5       |
| `/name`              | 122.5     | 111.0     |

Full URI is with prefix of `/api/v1/tags`.