### PR TITLE
add check for invalid messages in the stream

### DIFF
--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
@@ -130,4 +130,10 @@ class LwcToAggrDatapointSuite extends FunSuite {
     assert(d.timestamp === 1234567890)
     assert(d.step === 10)
   }
+
+  test("invalid message") {
+    val msg = """data: metric {"timestamp":20000,"id":"sum","tags":{"name":"cpu"},\u007F"value":3.0}"""
+    val results = eval(List(msg))
+    assert(results.size === 0)
+  }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
@@ -132,7 +132,8 @@ class LwcToAggrDatapointSuite extends FunSuite {
   }
 
   test("invalid message") {
-    val msg = """data: metric {"timestamp":20000,"id":"sum","tags":{"name":"cpu"},\u007F"value":3.0}"""
+    val msg =
+      """data: metric {"timestamp":20000,"id":"sum","tags":{"name":"cpu"},\u007F"value":3.0}"""
     val results = eval(List(msg))
     assert(results.size === 0)
   }


### PR DESCRIPTION
This will prevent the stream from failing and just log
the invalid message that was received to help with debugging.
If this does occur it isn't clear that the stream will
recover, but there is a metric to detect that bad messsages
were received.