### PR TITLE
only use error images for browsers

### DIFF
--- a/atlas-eval/src/main/resources/reference.conf
+++ b/atlas-eval/src/main/resources/reference.conf
@@ -55,5 +55,8 @@ atlas.eval {
     // png image. This can be useful for debugging and possibly other tooling, but increases
     // the image sizes and may not be desirable if the image may be shared externally.
     png-metadata-enabled = false
+
+    // Pattern to use to detect that a user-agent is a web-browser
+    browser-agent-pattern = "mozilla|msie|gecko|chrome|opera|webkit"
   }
 }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/DefaultSettings.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/DefaultSettings.scala
@@ -16,6 +16,7 @@
 package com.netflix.atlas.eval.graph
 
 import java.util.concurrent.TimeUnit
+import java.util.regex.Pattern
 
 import akka.http.scaladsl.model.ContentType
 import com.netflix.atlas.chart.GraphEngine
@@ -65,6 +66,11 @@ case class DefaultSettings(root: Config, config: Config) {
 
   /** Should the uri and other graph metadata be encoded as text fields in the image? */
   val metadataEnabled: Boolean = config.getBoolean("png-metadata-enabled")
+
+  /** Pattern to use for detecting if a user-agent is a web-browser. */
+  val browserAgentPattern: Pattern = {
+    Pattern.compile(config.getString("browser-agent-pattern"), Pattern.CASE_INSENSITIVE)
+  }
 
   /** Maximum number of datapoints allowed for a line in a chart. */
   val maxDatapoints: Int = config.getInt("max-datapoints")

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
@@ -19,6 +19,7 @@ import java.awt.Color
 import java.io.ByteArrayOutputStream
 import java.time.Duration
 
+import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.Uri
 import com.netflix.atlas.chart.Colors
 import com.netflix.atlas.chart.model.GraphDef
@@ -47,6 +48,20 @@ import scala.util.Try
 case class Grapher(settings: DefaultSettings) {
 
   import Grapher._
+
+  /**
+    * Create a graph config from a request object. This will look at the URI and try to
+    * extract some context from the headers.
+    */
+  def toGraphConfig(request: HttpRequest): GraphConfig = {
+    val config = toGraphConfig(request.uri)
+    val agent = request.headers
+      .find(_.is("user-agent"))
+      .map(_.value())
+      .getOrElse("unknown")
+    val isBrowser = settings.browserAgentPattern.matcher(agent).find()
+    config.copy(isBrowser = isBrowser)
+  }
 
   /**
     * Create a graph config from an Atlas URI.

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
@@ -38,7 +38,7 @@ class GraphApi(config: Config, implicit val actorRefFactory: ActorRefFactory) ex
     endpointPath("api" / "v1" / "graph") {
       get { ctx =>
         val reqHandler = actorRefFactory.actorOf(Props(new GraphRequestActor(grapher, registry)))
-        val graphCfg = grapher.toGraphConfig(ctx.request.uri)
+        val graphCfg = grapher.toGraphConfig(ctx.request)
         val rc = ImperativeRequestContext(graphCfg, ctx)
         reqHandler ! rc
         rc.promise.future
@@ -47,7 +47,7 @@ class GraphApi(config: Config, implicit val actorRefFactory: ActorRefFactory) ex
     endpointPath("api" / "v2" / "fetch") {
       get {
         extractRequest { request =>
-          val graphCfg = grapher.toGraphConfig(request.uri)
+          val graphCfg = grapher.toGraphConfig(request)
           complete(FetchRequestActor.createResponse(actorRefFactory, graphCfg))
         }
       }

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphRequestActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphRequestActor.scala
@@ -47,7 +47,7 @@ class GraphRequestActor(grapher: Grapher, registry: Registry) extends Actor with
     case v =>
       try innerReceive(v)
       catch {
-        case t: Exception if request != null && request.shouldOutputImage =>
+        case t: Exception if request != null && request.isBrowser && request.shouldOutputImage =>
           // When viewing a page in a browser an error response is not rendered. To make it more
           // clear to the user we return a 200 with the error information encoded into an image.
           sendErrorImage(t, request.flags.width, request.flags.height)

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiSuite.scala
@@ -18,6 +18,7 @@ package com.netflix.atlas.webapi
 import akka.actor.Props
 import akka.http.scaladsl.model.MediaTypes
 import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.netflix.atlas.akka.RequestHandler
@@ -73,7 +74,8 @@ class GraphApiSuite extends FunSuite with ScalatestRouteTest {
   // the report: $ open ./atlas-webapi/target/GraphApiSuite/report.html
   all.filter(_.startsWith("/api/v1/graph")).foreach { uri =>
     test(uri) {
-      Get(uri) ~> routes ~> check {
+      val agent = `User-Agent`("Mozilla/5.0")
+      Get(uri).addHeader(agent) ~> routes ~> check {
         // Note: will fail prior to 8u20:
         // https://github.com/Netflix/atlas/issues/9
         assert(response.status === StatusCodes.OK)


### PR DESCRIPTION
There are some programmatic use-cases for accessing images
such as alerting emails and bots for including in chat apps.
The current behavior makes it hard to detect errors with the
images because it is embedded within the image text and has
a 200 response code. This changes the graph api behavior to
only use error images when the access appears to be coming
from a web browser.