### PR TITLE
use same hash for IntRefHashMap and IntIntMap

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntRefHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntRefHashMap.scala
@@ -15,10 +15,6 @@
  */
 package com.netflix.atlas.core.util
 
-import java.nio.ByteBuffer
-
-import scala.util.hashing.MurmurHash3
-
 /**
   * Mutable integer map based on open-addressing. Primary use-case is computing
   * a count for the number of times a particular value was encountered.
@@ -33,10 +29,6 @@ class IntRefHashMap[T <: AnyRef: Manifest](noData: Int, capacity: Int = 10) {
   private[this] var values = ArrayHelper.newInstance[T](keys.length)
   private[this] var used = 0
   private[this] var cutoff = computeCutoff(keys.length)
-
-  // Used for computing the hash code.
-  private[this] var buffer = ThreadLocal
-    .withInitial[ByteBuffer](() => ByteBuffer.allocate(Integer.BYTES))
 
   // Set at 50% capacity to get reasonable tradeoff between performance and
   // memory use. See IntIntMap benchmark.
@@ -66,12 +58,8 @@ class IntRefHashMap[T <: AnyRef: Manifest](noData: Int, capacity: Int = 10) {
     cutoff = computeCutoff(tmpKS.length)
   }
 
-  private def hash(v: Int, length: Int): Int = {
-    val buf = buffer.get()
-    buf.clear()
-    buf.putInt(v)
-    val h = MurmurHash3.bytesHash(buf.array())
-    Hash.absOrZero(h) % length
+  private def hash(k: Int, length: Int): Int = {
+    Hash.absOrZero(k) % length
   }
 
   private def put(ks: Array[Int], vs: Array[T], k: Int, v: T): Boolean = {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntRefHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntRefHashMapSuite.scala
@@ -83,7 +83,7 @@ class IntRefHashMapSuite extends FunSuite {
   test("memory per map") {
     // Sanity check to verify if some change introduces more overhead per set
     val bytes = ClassLayout.parseClass(classOf[IntRefHashMap[Integer]]).instanceSize()
-    assert(bytes === 40)
+    assert(bytes === 32)
   }
 
   test("memory - 5 items") {
@@ -101,7 +101,7 @@ class IntRefHashMapSuite extends FunSuite {
     //println(jgraph.toFootprint)
 
     // Integer class creates a bunch of objects
-    assert(igraph.totalCount() === 10)
+    assert(igraph.totalCount() === 8)
 
     // Sanity check size is < 340, mostly for Integer static fields
     assert(igraph.totalSize() <= 340)
@@ -122,7 +122,7 @@ class IntRefHashMapSuite extends FunSuite {
     //println(jgraph.toFootprint)
 
     // Around 10 or so for the Integer class + 10k for the values
-    assert(igraph.totalCount() === 10005)
+    assert(igraph.totalCount() === 10003)
 
     // Sanity check size is < 370kb
     assert(igraph.totalSize() <= 370e3)


### PR DESCRIPTION
Updates IntRefHashMap to just use the int value as the hash
code just like IntIntMap and Integer.hashCode. This makes them
more consistent. In tests on real data the overhead of computing
the murmur hash outweighs the benefits it provides.