### PR TITLE
switch travis build to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
 script:
 - ./scripts/buildViaTravis.sh
 sudo: required
-dist: trusty
+dist: xenial
 env:
   global:
   - secure: EakB0ihwg817KJghs6NJ/C75H138DDDDY7jhnuph+2tbA65InChFEtPT6OBW6N/RWd1QOZRZ3UjUMMHoRshgKNMTeU6F6aZORRlJVbtCLDEyaelhfyjiNPkE6xPL1g/h2JqTv8Hv6eWLe8rbDqArSkefFbFXcvztmoKHbmaCkPg=

--- a/project/sbt
+++ b/project/sbt
@@ -8,8 +8,8 @@ OPTIONS=""
 
 java \
   -XX:+UseG1GC \
-  -Xms2g \
-  -Xmx2g \
+  -Xms3g \
+  -Xmx3g \
   -XX:ReservedCodeCacheSize=128m \
   -XX:+UseCodeCacheFlushing \
   -Dsbt.boot.directory=${WORKSPACE:-$HOME}/.sbt \


### PR DESCRIPTION
Also increase memory for build. There have been a few
sporadic build failures that may be resource related.
Xenial has fewer other services running by default.

https://blog.travis-ci.com/2018-11-08-xenial-release