### PR TITLE
fix #948, all zeros shown on y-axis

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/graphics/Ticks.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/graphics/Ticks.scala
@@ -124,7 +124,7 @@ object Ticks {
     */
   private def getPrefix(v: Double, major: Double): UnitPrefix = {
     val m = UnitPrefix.forRange(major, 3)
-    if (v < 10.0 * m.factor) m else UnitPrefix.forRange(v, 3)
+    if (v <= 10.0 * m.factor) m else UnitPrefix.forRange(v, 3)
   }
 
   /**

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/graphics/TicksSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/graphics/TicksSuite.scala
@@ -407,4 +407,14 @@ class TicksSuite extends FunSuite {
     val ticks = Ticks.time(s, e, ZoneOffset.UTC, 5)
     assert(ticks.size === 6)
   }
+
+  test("issue-948: [6.667e-3, 0.01]") {
+    val ticks = Ticks.value(6.667e-3, 0.01, 7)
+    sanityCheck(ticks)
+    assert(ticks.size === 34)
+    assert(ticks.count(_.major) === 7)
+    assert(ticks.head.offset === 0.0)
+    assert(ticks.head.label === "6.7m")
+    assert(ticks.last.label === "10.0m")
+  }
 }


### PR DESCRIPTION
If the upper bound exactly matched `10 * factor` for the
selected unit prefix, then it would use a different selection
to avoid large numbers for the tick labels. However, for an
exact match it is better to use the default prefix to avoid
getting zeros due to rounding with the larger prefix.