### PR TITLE
fix #763, custom consolidation with rewrites

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/NamedRewriteSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/NamedRewriteSuite.scala
@@ -214,4 +214,10 @@ class NamedRewriteSuite extends FunSuite {
     val expected = eval("name,a,:eq,(,b,),:by,10,:mul,:dup,:sum,:div,100,:mul,c,:has,:cq")
     assert(actual === expected)
   }
+
+  test("issue-763: avg with cf-max") {
+    val actual = eval("name,a,:eq,:avg,:cf-max")
+    val expected = eval("name,a,:eq,:sum,:cf-max,name,a,:eq,:count,:cf-max,:div")
+    assert(actual === expected)
+  }
 }


### PR DESCRIPTION
The rewrites that look like aggregation functions will now
work with custom consolidations. If used the rewrite will
not be preserved in the model. So the output of converting
the parsed expression model to a string will be the expanded
expression and not indicate the rewrite was used.