### PR TITLE
fix #852, inconsistent group by behavior

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathGroupBySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathGroupBySuite.scala
@@ -204,4 +204,16 @@ class MathGroupBySuite extends FunSuite {
     val expr = eval(input)
     assert(expr.toString === input)
   }
+
+  test("issue-852: constant sum group by") {
+    val input = "0,:const,:sum,(,foo,),:by"
+    val expr = eval(input)
+    assert(expr.toString === "0.0,:const,:sum")
+  }
+
+  test("issue-852: constant group by") {
+    val input = "0,:const,(,foo,),:by"
+    val expr = eval(input)
+    assert(expr.toString === "0.0,:const")
+  }
 }


### PR DESCRIPTION
Before, attempting a group by on non-grouped expressions
without a math aggregate function would behave differently
than a non-grouped expression with a math aggregate. Now
they have the same behavior and the group by will be ignored
for expression trees that do not support it.