### PR TITLE
use standard IIOMetadata classes for PNG

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/util/PngImage.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/util/PngImage.scala
@@ -67,7 +67,8 @@ object PngImage {
   }
 
   private def extractTxtFields(m: IIOMetadata): Map[String, String] = {
-    val elements = m.getAsTree(IIOMetadataFormatImpl.standardMetadataFormatName)
+    val elements = m
+      .getAsTree(IIOMetadataFormatImpl.standardMetadataFormatName)
       .asInstanceOf[IIOMetadataNode]
       .getElementsByTagName("TextEntry")
     (0 until elements.getLength)

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/util/PngImageSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/util/PngImageSuite.scala
@@ -15,7 +15,6 @@
  */
 package com.netflix.atlas.chart.util
 
-import java.io.FileOutputStream
 import java.io.InputStream
 
 import com.netflix.atlas.core.util.Streams


### PR DESCRIPTION
When using the `-release 8` option the internal `PNGMetadata`
class is not found in the classpath. Update the usage to rely
on the public APIs.