### PR TITLE
disable scaladoc publishing

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -50,7 +50,11 @@ object BuildSettings {
       "Build-Date"   -> java.time.Instant.now().toString,
       "Build-Number" -> sys.env.getOrElse("TRAVIS_BUILD_NUMBER", "unknown"),
       "Commit"       -> sys.env.getOrElse("TRAVIS_COMMIT", "unknown")
-    )
+    ),
+    // scaladoc crashes on jdk11 using `-release 8` with assertion failure:
+    // type AnyRef in java.lang
+    // https://github.com/scala/community-builds/issues/796#issuecomment-423395500
+    publishArtifact in (Compile, packageDoc) := false
   )
 
   val commonDeps = Seq(


### PR DESCRIPTION
On JDK11 with `-release 8` it crashes with:

```
[error] java.lang.AssertionError: assertion failed:
[error]   type AnyRef in java.lang
[error]      while compiling: ...
[error]         during phase: globalPhase=terminal, enteringPhase=typer
[error]      library version: version 2.12.8
[error]     compiler version: version 2.12.8
```

This is a quick workaround as we do not rely on the published
scaladoc jars for anything.