### PR TITLE
remove redis from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,3 @@ cache:
   directories:
   - $HOME/.sbt
   - $HOME/.ivy2
-services:
-  - redis-server


### PR DESCRIPTION
This is no longer needed for the Atlas build.