### PR TITLE
set --release for javac

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -11,6 +11,8 @@ object BuildSettings {
     "-feature"
   )
 
+  private val isJdk11 = System.getProperty("java.specification.version") == "11"
+
   lazy val checkLicenseHeaders = taskKey[Unit]("Check the license headers for all source files.")
   lazy val formatLicenseHeaders = taskKey[Unit]("Fix the license headers for all source files.")
 
@@ -25,11 +27,16 @@ object BuildSettings {
     scalacOptions ++= {
       // -release option is not supported in scala 2.11
       val v = scalaVersion.value
-      val isJdk11 = System.getProperty("java.specification.version") == "11"
       CrossVersion.partialVersion(v).map(_._2.toInt) match {
         case Some(12) if isJdk11 => compilerFlags ++ Seq("-release", "8")
         case _                   => compilerFlags ++ Seq("-target:jvm-1.8")
       }
+    },
+    javacOptions ++= {
+      if (isJdk11)
+        Seq("--release", "8")
+      else
+        Seq("-source", "1.8", "-target", "1.8")
     },
     crossPaths := true,
     crossScalaVersions := Dependencies.Versions.crossScala,


### PR DESCRIPTION
After switching to use jdk11 for the build, the java classes
were getting compiled to class version 55 instead of 52.