### PR TITLE
avoid conversion if already a ConfigValue

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineAlgorithm.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineAlgorithm.scala
@@ -68,6 +68,7 @@ object OnlineAlgorithm {
       case vs: Iterable[_] => toConfigList(vs)
       case vs: Array[_]    => toConfigList(vs.toList)
       case c: Config       => c.root()
+      case c: ConfigValue  => c
       case v               => ConfigValueFactory.fromAnyRef(v)
     }
   }


### PR DESCRIPTION
In the docs site it is getting config 1.2 in the sbt
classpath. There isn't an obvious way to force it to
a newer version. The older version will fail if trying
to convert a ConfigValue to a ConfigValue. For now we
can workaround the problem by special casing that to
avoid the unnecessary conversion.