### PR TITLE
use dedicated object for algo state

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/AlgoState.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/AlgoState.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+/**
+  * Represents the current state for an online algorithm. Can be used with `OnlineAlgorithm.apply`
+  * to create a new instance with the same state. This state object is reliably serializable with
+  * helpers such as the `atlas-json` library so state can be persisted.
+  */
+case class AlgoState(algorithm: String, settings: Map[String, Any]) {
+
+  private def get[T](key: String): T = settings(key).asInstanceOf[T]
+
+  /** Retrieve a boolean value for a given key. */
+  def getBoolean(key: String): Boolean = get[Boolean](key)
+
+  /** Retrieve a number value for a given key. */
+  def getNumber(key: String): Number = get[Number](key)
+
+  /** Retrieve an integer value for a given key. */
+  def getInt(key: String): Int = getNumber(key).intValue()
+
+  /** Retrieve a long value for a given key. */
+  def getLong(key: String): Long = getNumber(key).longValue()
+
+  /** Retrieve a double value for a given key. */
+  def getDouble(key: String): Double = getNumber(key).doubleValue()
+
+  /** Retrieve a string value for a given key. */
+  def getString(key: String): String = get[String](key)
+
+  /** Retrieve an array of double values for a given key. */
+  def getDoubleArray(key: String): Array[Double] = {
+    // When the state is from a de-serialized source the type may have changed to
+    // a Seq type such as List.
+    settings(key) match {
+      case vs: Seq[_]        => vs.map(_.asInstanceOf[Double]).toArray
+      case vs: Array[Double] => vs
+    }
+  }
+
+  /** Retrieve a sub-state object for a given key. */
+  def getState(key: String): AlgoState = AlgoState(settings(key))
+
+  /** Retrieve a list of sub-state objects for a given key. */
+  def getStateList(key: String): List[AlgoState] = get[List[Any]](key).map(AlgoState.apply)
+}
+
+/** Helper functions to make it easier to create state objects. */
+object AlgoState {
+
+  /** Create a new instance. */
+  def apply(algorithm: String, settings: (String, Any)*): AlgoState = {
+    apply(algorithm, settings.toMap)
+  }
+
+  private def apply(map: Map[_, _]): AlgoState = {
+    val m = map.asInstanceOf[Map[String, Any]]
+    apply(m("algorithm").asInstanceOf[String], m("settings").asInstanceOf[Map[String, Any]])
+  }
+
+  private def apply(value: Any): AlgoState = {
+    value match {
+      case s: AlgoState => s
+      case m: Map[_, _] => apply(m)
+    }
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineDelay.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineDelay.scala
@@ -15,8 +15,6 @@
  */
 package com.netflix.atlas.core.algorithm
 
-import com.typesafe.config.Config
-
 /**
   * Delays the values by the window size. This is similar to the `:offset` operator
   * except that it can be applied to any input line instead of just changing the time
@@ -29,8 +27,8 @@ case class OnlineDelay(buf: RollingBuffer) extends OnlineAlgorithm {
 
   override def reset(): Unit = buf.clear()
 
-  override def state: Config = {
-    OnlineAlgorithm.toConfig(Map("type" -> "delay", "buffer" -> buf.state))
+  override def state: AlgoState = {
+    AlgoState("delay", "buffer" -> buf.state)
   }
 }
 
@@ -38,7 +36,7 @@ object OnlineDelay {
 
   def apply(n: Int): OnlineDelay = new OnlineDelay(RollingBuffer(n))
 
-  def apply(config: Config): OnlineDelay = {
-    apply(RollingBuffer(config.getConfig("buffer")))
+  def apply(state: AlgoState): OnlineDelay = {
+    apply(RollingBuffer(state.getState("buffer")))
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineDes.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineDes.scala
@@ -15,8 +15,6 @@
  */
 package com.netflix.atlas.core.algorithm
 
-import com.typesafe.config.Config
-
 /**
   * Helper to compute DES value iteratively for a set of numbers.
   *
@@ -55,29 +53,28 @@ case class OnlineDes(training: Int, alpha: Double, beta: Double) extends OnlineA
     bp = Double.NaN
   }
 
-  override def state: Config = {
-    OnlineAlgorithm.toConfig(
-      Map(
-        "type"          -> "des",
-        "training"      -> training,
-        "alpha"         -> alpha,
-        "beta"          -> beta,
-        "currentSample" -> currentSample,
-        "sp"            -> sp,
-        "bp"            -> bp
-      )
+  override def state: AlgoState = {
+    AlgoState(
+      "des",
+      "type"          -> "des",
+      "training"      -> training,
+      "alpha"         -> alpha,
+      "beta"          -> beta,
+      "currentSample" -> currentSample,
+      "sp"            -> sp,
+      "bp"            -> bp
     )
   }
 }
 
 object OnlineDes {
 
-  def apply(config: Config): OnlineDes = {
+  def apply(state: AlgoState): OnlineDes = {
     val des =
-      new OnlineDes(config.getInt("training"), config.getDouble("alpha"), config.getDouble("beta"))
-    des.currentSample = config.getInt("currentSample")
-    des.sp = config.getDouble("sp")
-    des.bp = config.getDouble("bp")
+      new OnlineDes(state.getInt("training"), state.getDouble("alpha"), state.getDouble("beta"))
+    des.currentSample = state.getInt("currentSample")
+    des.sp = state.getDouble("sp")
+    des.bp = state.getDouble("bp")
     des
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineIgnoreN.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineIgnoreN.scala
@@ -15,8 +15,6 @@
  */
 package com.netflix.atlas.core.algorithm
 
-import com.typesafe.config.Config
-
 /**
   * Ignore the first N datapoints that are passed in. This is typically used to achieve an
   * initial alignment to step boundaries when using a deterministic sliding window approach
@@ -36,16 +34,16 @@ case class OnlineIgnoreN(n: Int) extends OnlineAlgorithm {
     pos = 0
   }
 
-  override def state: Config = {
-    OnlineAlgorithm.toConfig(Map("type" -> "ignore", "n" -> n, "pos" -> pos))
+  override def state: AlgoState = {
+    AlgoState("ignore", "n" -> n, "pos" -> pos)
   }
 }
 
 object OnlineIgnoreN {
 
-  def apply(config: Config): OnlineIgnoreN = {
-    val algo = apply(config.getInt("n"))
-    algo.pos = config.getInt("pos")
+  def apply(state: AlgoState): OnlineIgnoreN = {
+    val algo = apply(state.getInt("n"))
+    algo.pos = state.getInt("pos")
     algo
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingMax.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingMax.scala
@@ -15,8 +15,6 @@
  */
 package com.netflix.atlas.core.algorithm
 
-import com.typesafe.config.Config
-
 /**
   * Keeps track of the maximum value within a given window. This is typically used as a
   * way to get a smooth upper bound line that closely tracks a noisy input.
@@ -39,8 +37,8 @@ case class OnlineRollingMax(buf: RollingBuffer) extends OnlineAlgorithm {
     max = Double.NaN
   }
 
-  override def state: Config = {
-    OnlineAlgorithm.toConfig(Map("type" -> "rolling-max", "buffer" -> buf.state))
+  override def state: AlgoState = {
+    AlgoState("rolling-max", "buffer" -> buf.state)
   }
 }
 
@@ -48,7 +46,7 @@ object OnlineRollingMax {
 
   def apply(n: Int): OnlineRollingMax = apply(RollingBuffer(n))
 
-  def apply(config: Config): OnlineRollingMax = {
-    apply(RollingBuffer(config.getConfig("buffer")))
+  def apply(state: AlgoState): OnlineRollingMax = {
+    apply(RollingBuffer(state.getState("buffer")))
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingMin.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingMin.scala
@@ -15,8 +15,6 @@
  */
 package com.netflix.atlas.core.algorithm
 
-import com.typesafe.config.Config
-
 /**
   * Keeps track of the minimum value within a given window. This is typically used as a
   * way to get a smooth lower bound line that closely tracks a noisy input.
@@ -39,8 +37,8 @@ case class OnlineRollingMin(buf: RollingBuffer) extends OnlineAlgorithm {
     min = Double.NaN
   }
 
-  override def state: Config = {
-    OnlineAlgorithm.toConfig(Map("type" -> "rolling-min", "buffer" -> buf.state))
+  override def state: AlgoState = {
+    AlgoState("rolling-min", "buffer" -> buf.state)
   }
 }
 
@@ -48,7 +46,7 @@ object OnlineRollingMin {
 
   def apply(n: Int): OnlineRollingMin = apply(RollingBuffer(n))
 
-  def apply(config: Config): OnlineRollingMin = {
-    apply(RollingBuffer(config.getConfig("buffer")))
+  def apply(state: AlgoState): OnlineRollingMin = {
+    apply(RollingBuffer(state.getState("buffer")))
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineSlidingDes.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineSlidingDes.scala
@@ -15,8 +15,6 @@
  */
 package com.netflix.atlas.core.algorithm
 
-import com.typesafe.config.Config
-
 /**
   * Alternate between two DES functions after each training period. This provides a deterministic
   * estimate within a bounded amount of time.
@@ -58,36 +56,34 @@ case class OnlineSlidingDes(
     des2.reset()
   }
 
-  override def state: Config = {
-    OnlineAlgorithm.toConfig(
-      Map(
-        "type"          -> "sliding-des",
-        "training"      -> training,
-        "alpha"         -> alpha,
-        "beta"          -> beta,
-        "useOne"        -> useOne,
-        "currentSample" -> currentSample,
-        "des1"          -> des1.state,
-        "des2"          -> des2.state
-      )
+  override def state: AlgoState = {
+    AlgoState(
+      "sliding-des",
+      "training"      -> training,
+      "alpha"         -> alpha,
+      "beta"          -> beta,
+      "useOne"        -> useOne,
+      "currentSample" -> currentSample,
+      "des1"          -> des1.state,
+      "des2"          -> des2.state
     )
   }
 }
 
 object OnlineSlidingDes {
 
-  def apply(config: Config): OnlineSlidingDes = {
-    val des1 = OnlineDes(config.getConfig("des1"))
-    val des2 = OnlineDes(config.getConfig("des2"))
+  def apply(state: AlgoState): OnlineSlidingDes = {
+    val des1 = OnlineDes(state.getState("des1"))
+    val des2 = OnlineDes(state.getState("des2"))
     val sdes = new OnlineSlidingDes(
-      config.getInt("training"),
-      config.getDouble("alpha"),
-      config.getDouble("beta"),
+      state.getInt("training"),
+      state.getDouble("alpha"),
+      state.getDouble("beta"),
       des1,
       des2
     )
-    sdes.useOne = config.getBoolean("useOne")
-    sdes.currentSample = config.getInt("currentSample")
+    sdes.useOne = state.getBoolean("useOne")
+    sdes.currentSample = state.getInt("currentSample")
     sdes
   }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/Pipeline.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/Pipeline.scala
@@ -15,8 +15,6 @@
  */
 package com.netflix.atlas.core.algorithm
 
-import com.typesafe.config.Config
-
 /**
   * Push a value through a sequence of online algorithms and return the result.
   */
@@ -32,16 +30,15 @@ case class Pipeline(stages: List[OnlineAlgorithm]) extends OnlineAlgorithm {
     stages.foreach(_.reset())
   }
 
-  override def state: Config = {
-    OnlineAlgorithm.toConfig(Map("type" -> "pipeline", "stages" -> stages.map(_.state)))
+  override def state: AlgoState = {
+    AlgoState("pipeline", "stages" -> stages.map(_.state))
   }
 }
 
 object Pipeline {
 
-  def apply(config: Config): Pipeline = {
-    import scala.collection.JavaConverters._
-    apply(config.getConfigList("stages").asScala.map(OnlineAlgorithm.apply).toList)
+  def apply(state: AlgoState): Pipeline = {
+    apply(state.getStateList("stages").map(OnlineAlgorithm.apply))
   }
 
   def apply(stages: OnlineAlgorithm*): Pipeline = apply(stages.toList)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/RollingBuffer.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/RollingBuffer.scala
@@ -17,7 +17,6 @@ package com.netflix.atlas.core.algorithm
 
 import com.netflix.atlas.core.util.ArrayHelper
 import com.netflix.atlas.core.util.Math
-import com.typesafe.config.Config
 
 /**
   * Buffer for tracking the last N values of a time series.
@@ -83,8 +82,9 @@ class RollingBuffer(values: Array[Double], start: Int = 0) {
     size = 0
   }
 
-  def state: Config = {
-    OnlineAlgorithm.toConfig(Map("values" -> values, "pos" -> pos))
+  def state: AlgoState = {
+    val vs = java.util.Arrays.copyOf(values, values.length)
+    AlgoState("rolling-buffer", "values" -> vs, "pos" -> pos)
   }
 }
 
@@ -96,14 +96,9 @@ object RollingBuffer {
   }
 
   /** Create a new buffer based on previously captured state. */
-  def apply(config: Config): RollingBuffer = {
-    import scala.collection.JavaConverters._
-    val values = config
-      .getDoubleList("values")
-      .asScala
-      .map(_.doubleValue())
-      .toArray
-    val pos = config.getInt("pos")
+  def apply(state: AlgoState): RollingBuffer = {
+    val values = state.getDoubleArray("values")
+    val pos = state.getInt("pos")
     new RollingBuffer(values, pos)
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
@@ -25,8 +25,8 @@ import com.netflix.atlas.core.algorithm.OnlineRollingMax
 import com.netflix.atlas.core.algorithm.OnlineRollingMin
 import com.netflix.atlas.core.algorithm.OnlineSlidingDes
 import com.netflix.atlas.core.algorithm.Pipeline
+import com.netflix.atlas.core.algorithm.AlgoState
 import com.netflix.atlas.core.util.Math
-import com.typesafe.config.Config
 
 trait StatefulExpr extends TimeSeriesExpr {}
 
@@ -359,7 +359,7 @@ object StatefulExpr {
     * OnlineAlgorithm.
     */
   trait OnlineExpr extends StatefulExpr {
-    type StateMap = scala.collection.mutable.AnyRefMap[ItemId, Config]
+    type StateMap = scala.collection.mutable.AnyRefMap[ItemId, AlgoState]
 
     protected def name: String
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/AlgoStateSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/AlgoStateSuite.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+import com.netflix.atlas.json.Json
+import org.scalatest.FunSuite
+
+class AlgoStateSuite extends FunSuite {
+
+  private def serde(state: AlgoState): AlgoState = {
+    Json.decode[AlgoState](Json.encode(state))
+  }
+
+  private def assertEquals(state: AlgoState, get: AlgoState => Any, expected: Any): Unit = {
+    assert(get(state) === expected)
+    assert(get(serde(state)) === expected)
+  }
+
+  test("boolean") {
+    val s = AlgoState("foo", "test" -> true)
+    assertEquals(s, _.getBoolean("test"), true)
+  }
+
+  test("int") {
+    val s = AlgoState("foo", "test" -> 42)
+    assertEquals(s, _.getInt("test"), 42)
+  }
+
+  test("long") {
+    val s = AlgoState("foo", "test" -> 42L)
+    assertEquals(s, _.getLong("test"), 42L)
+  }
+
+  test("long as double") {
+    val s = AlgoState("foo", "test" -> 42L)
+    assertEquals(s, _.getDouble("test"), 42.0)
+  }
+
+  test("double") {
+    val s = AlgoState("foo", "test" -> 42.0)
+    assertEquals(s, _.getDouble("test"), 42.0)
+  }
+
+  test("double: NaN") {
+    val s = AlgoState("foo", "test" -> Double.NaN)
+    assert(s.getDouble("test").isNaN)
+    assert(serde(s).getDouble("test").isNaN)
+  }
+
+  test("double array") {
+    val s = AlgoState("foo", "test" -> Array(42.0, 1.0))
+    assertEquals(s, _.getDoubleArray("test"), Array(42.0, 1.0))
+  }
+
+  test("double array: NaN") {
+    val s = AlgoState("foo", "test" -> Array(42.0, Double.NaN))
+    val vs = s.getDoubleArray("test")
+    assert(vs(0) === 42.0)
+    assert(vs(1).isNaN)
+    assert(vs.count(!_.isNaN) === 1)
+  }
+
+  test("double array: NaN serde") {
+    val s = serde(AlgoState("foo", "test" -> Array(42.0, Double.NaN)))
+    val vs = s.getDoubleArray("test")
+    assert(vs(0) === 42.0)
+    assert(vs(1).isNaN)
+    assert(vs.count(!_.isNaN) === 1)
+  }
+
+  test("string") {
+    val s = AlgoState("foo", "test" -> "42.0")
+    assertEquals(s, _.getString("test"), "42.0")
+  }
+
+  test("sub-state") {
+    val expected = AlgoState("bar", "test" -> 42)
+    val s = AlgoState("foo", "test"        -> expected)
+    assertEquals(s, _.getState("test"), expected)
+  }
+
+  test("sub-state list") {
+    val expected = (0 until 10).toList.map { i =>
+      AlgoState("bar", "test" -> i)
+    }
+    val s = AlgoState("foo", "test" -> expected)
+    assertEquals(s, _.getStateList("test"), expected)
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineAlgorithmSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineAlgorithmSuite.scala
@@ -15,50 +15,13 @@
  */
 package com.netflix.atlas.core.algorithm
 
-import com.typesafe.config.ConfigException
 import org.scalatest.FunSuite
 
 class OnlineAlgorithmSuite extends FunSuite {
 
   test("restore unknown type") {
-    val cfg = OnlineAlgorithm.toConfig(Map("type" -> "foo"))
     intercept[IllegalArgumentException] {
-      OnlineAlgorithm(cfg)
+      OnlineAlgorithm(AlgoState("foo", Map.empty[String, Any]))
     }
-  }
-
-  test("no type specified") {
-    val cfg = OnlineAlgorithm.toConfig(Map("foo" -> "bar"))
-    intercept[ConfigException] {
-      OnlineAlgorithm(cfg)
-    }
-  }
-
-  test("toConfig: string field") {
-    val cfg = OnlineAlgorithm.toConfig(Map("value" -> "str"))
-    assert("str" === cfg.getString("value"))
-  }
-
-  test("toConfig: int field") {
-    val cfg = OnlineAlgorithm.toConfig(Map("value" -> 42))
-    assert(42 === cfg.getInt("value"))
-  }
-
-  test("toConfig: double field") {
-    val cfg = OnlineAlgorithm.toConfig(Map("value" -> 42.0))
-    assert(42.0 === cfg.getInt("value"))
-  }
-
-  test("toConfig: double array field") {
-    val cfg = OnlineAlgorithm.toConfig(Map("array" -> Array(1.0, 2.0)))
-    val vs = cfg.getDoubleList("array")
-    assert(vs.size() === 2)
-    assert(vs.get(1) === 2.0)
-  }
-
-  test("toConfig: config field") {
-    val subCfg = OnlineAlgorithm.toConfig(Map("foo" -> "bar"))
-    val cfg = OnlineAlgorithm.toConfig(Map("cfg"    -> subCfg))
-    assert(subCfg === cfg.getConfig("cfg"))
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/RollingBufferSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/RollingBufferSuite.scala
@@ -135,12 +135,11 @@ class RollingBufferSuite extends FunSuite {
   }
 
   test("n = 2, state") {
-    import scala.collection.JavaConverters._
     val buf = RollingBuffer(2)
     buf.add(0.0)
     val cfg = buf.state
     assert(cfg.getInt("pos") === 1)
-    val actual = cfg.getDoubleList("values").asScala.toList
+    val actual = cfg.getDoubleArray("values")
     val expected = List(0.0, Double.NaN)
     assert(actual.size === 2)
     actual.zip(expected).foreach {

--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ lazy val `atlas-config` = project
 
 lazy val `atlas-core` = project
   .configure(BuildSettings.profile)
-  .dependsOn(`atlas-config`)
+  .dependsOn(`atlas-config`, `atlas-json` % "test")
   .settings(libraryDependencies ++= Seq(
     Dependencies.caffeine,
     Dependencies.roaringBitmap,


### PR DESCRIPTION
Before it was using a Config object for convenience. This
switches it to a dedicated object that can be easily used
with `Json.encode/decode` or other similar tools. This should
also be more efficient for the more common use-cases because
we can avoid creation of the needless config objects.