### PR TITLE
add helper function to validation a datasource

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/Evaluator.java
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/Evaluator.java
@@ -106,6 +106,17 @@ public final class Evaluator extends EvaluatorImpl {
   }
 
   /**
+   * Perform static analysis checks to ensure that the provided data source is supported
+   * by this evaluator instance.
+   *
+   * @param ds
+   *     Data source to validate.
+   */
+  public void validate(DataSource ds) {
+    validateImpl(ds);
+  }
+
+  /**
    * Immutable set of data sources that should be consumed.
    */
   public final static class DataSources {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -64,6 +64,9 @@ private[stream] abstract class EvaluatorImpl(
 
   private implicit val materializer = ActorMaterializer()
 
+  // Cached context instance used for things like expression validation.
+  private val validationStreamContext = newStreamContext()
+
   private def newStreamContext(dsLogger: DataSourceLogger = (_, _) => ()): StreamContext = {
     new StreamContext(
       config,
@@ -72,6 +75,10 @@ private[stream] abstract class EvaluatorImpl(
       registry,
       dsLogger
     )
+  }
+
+  protected def validateImpl(ds: DataSource): Unit = {
+    validationStreamContext.validateDataSource(ds).get
   }
 
   protected def writeInputToFileImpl(uri: String, file: Path, duration: Duration): Unit = {

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -370,7 +370,8 @@ class EvaluatorSuite extends FunSuite with BeforeAndAfter {
     val ds = new Evaluator.DataSource(
       "test",
       Duration.ofMinutes(1),
-      "resource:///gc-pause.dat?q=name,jvm.gc.pause,:eq,:dist-max,(,nf.asg,nf.node,),:by")
+      "resource:///gc-pause.dat?q=name,jvm.gc.pause,:eq,:dist-max,(,nf.asg,nf.node,),:by"
+    )
     evaluator.validate(ds)
   }
 
@@ -379,7 +380,8 @@ class EvaluatorSuite extends FunSuite with BeforeAndAfter {
     val ds = new Evaluator.DataSource(
       "test",
       Duration.ofMinutes(1),
-      "resource:///gc-pause.dat?q=name,jvm.gc.pause,:eq,:dist-max,(,nf.asg,nf.node,),:b")
+      "resource:///gc-pause.dat?q=name,jvm.gc.pause,:eq,:dist-max,(,nf.asg,nf.node,),:b"
+    )
     val e = intercept[IllegalStateException] {
       evaluator.validate(ds)
     }
@@ -391,7 +393,8 @@ class EvaluatorSuite extends FunSuite with BeforeAndAfter {
     val ds = new Evaluator.DataSource(
       "test",
       Duration.ofMinutes(1),
-      "resource:///gc-pause.dat?q=name,jvm.gc.pause,:eq,:sum,1w,:offset")
+      "resource:///gc-pause.dat?q=name,jvm.gc.pause,:eq,:sum,1w,:offset"
+    )
     val e = intercept[IllegalArgumentException] {
       evaluator.validate(ds)
     }
@@ -403,7 +406,8 @@ class EvaluatorSuite extends FunSuite with BeforeAndAfter {
     val ds = new Evaluator.DataSource(
       "test",
       Duration.ofMinutes(1),
-      "http://unknownhost.com?q=name,jvm.gc.pause,:eq,:sum")
+      "http://unknownhost.com?q=name,jvm.gc.pause,:eq,:sum"
+    )
     val e = intercept[NoSuchElementException] {
       evaluator.validate(ds)
     }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -364,4 +364,49 @@ class EvaluatorSuite extends FunSuite with BeforeAndAfter {
     val ds = newDataSource(Some("abc"))
     assert(ds.getStep === Duration.ofMinutes(1))
   }
+
+  test("validate: ok") {
+    val evaluator = new Evaluator(config, registry, system)
+    val ds = new Evaluator.DataSource(
+      "test",
+      Duration.ofMinutes(1),
+      "resource:///gc-pause.dat?q=name,jvm.gc.pause,:eq,:dist-max,(,nf.asg,nf.node,),:by")
+    evaluator.validate(ds)
+  }
+
+  test("validate: bad expression") {
+    val evaluator = new Evaluator(config, registry, system)
+    val ds = new Evaluator.DataSource(
+      "test",
+      Duration.ofMinutes(1),
+      "resource:///gc-pause.dat?q=name,jvm.gc.pause,:eq,:dist-max,(,nf.asg,nf.node,),:b")
+    val e = intercept[IllegalStateException] {
+      evaluator.validate(ds)
+    }
+    assert(e.getMessage === "unknown word ':b'")
+  }
+
+  test("validate: unsupported operation `:offset`") {
+    val evaluator = new Evaluator(config, registry, system)
+    val ds = new Evaluator.DataSource(
+      "test",
+      Duration.ofMinutes(1),
+      "resource:///gc-pause.dat?q=name,jvm.gc.pause,:eq,:sum,1w,:offset")
+    val e = intercept[IllegalArgumentException] {
+      evaluator.validate(ds)
+    }
+    assert(e.getMessage.startsWith(":offset not supported for streaming evaluation "))
+  }
+
+  test("validate: unknown backend") {
+    val evaluator = new Evaluator(config, registry, system)
+    val ds = new Evaluator.DataSource(
+      "test",
+      Duration.ofMinutes(1),
+      "http://unknownhost.com?q=name,jvm.gc.pause,:eq,:sum")
+    val e = intercept[NoSuchElementException] {
+      evaluator.validate(ds)
+    }
+    assert(e.getMessage === "unknownhost.com")
+  }
 }


### PR DESCRIPTION
This can be used as an upfront check to filter out bad
data sources rather than getting the failure via the
stream.