### PR TITLE
remove stat vars from output tags

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
@@ -35,8 +35,12 @@ case class StyleExpr(expr: TimeSeriesExpr, settings: Map[String, String]) extend
   }
 
   def legend(t: TimeSeries): String = {
-    val fmt = settings.getOrElse("legend", t.label)
-    sed(Strings.substitute(fmt, t.tags))
+    legend(t.label, t.tags)
+  }
+
+  def legend(label: String, tags: Map[String, String]): String = {
+    val fmt = settings.getOrElse("legend", label)
+    sed(Strings.substitute(fmt, tags))
   }
 
   private def sed(str: String): String = {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
@@ -277,8 +277,12 @@ case class Grapher(settings: DefaultSettings) {
           val labelledTS = ts.map { t =>
             val stats = SummaryStats(t.data, start, end)
             val offset = Strings.toString(Duration.ofMillis(s.offset))
-            val newT = t.withTags(t.tags ++ stats.tags(statFormatter) + (TagKey.offset -> offset))
-            newT.withLabel(s.legend(newT)) -> stats
+            val outputTags = t.tags + (TagKey.offset -> offset)
+            // Additional stats can be used for substitutions, but should not be included
+            // as part of the output tag map
+            val legendTags = outputTags ++ stats.tags(statFormatter)
+            val newT = t.withTags(outputTags)
+            newT.withLabel(s.legend(newT.label, legendTags)) -> stats
           }
 
           val linePalette = s.palette.map(newPalette).getOrElse {


### PR DESCRIPTION
The stat vars are desired for substitutions (#878), but should
not be included in the tag maps for the output. The output tags
should be stable over time if evaluated incrementally. Including
the stats breaks this because the values are dependent on the
data for that time slice.