### PR TITLE
use jdk8 for building the scala 2.11 artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: scala
-os: osx
 matrix:
   include:
   - jdk: openjdk8
     scala: 2.11.12
+    os: linux
+    dist: trusty
     env: BINTRAY_PUBLISH=true
   - jdk: openjdk11
     scala: 2.12.8
+    os: osx
     env: BINTRAY_PUBLISH=true
 script:
 - ./scripts/buildViaTravis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 os: osx
 matrix:
   include:
-  - jdk: openjdk11
+  - jdk: openjdk8
     scala: 2.11.12
     env: BINTRAY_PUBLISH=true
   - jdk: openjdk11


### PR DESCRIPTION
Since 2.11 doesn't support the `--release` option, building
on a newer version can lead to errors when running on jdk8.
Specifically the return type of some methods changed in jdk9+.

This should fix errors like:

```
Cause: java.lang.NoSuchMethodError: java.nio.CharBuffer.clear()Ljava/nio/CharBuffer;
  at com.netflix.atlas.core.model.TaggedItem$.writePair(TaggedItem.scala:59)
  at com.netflix.atlas.core.model.TaggedItem$.computeId(TaggedItem.scala:105)
```