### PR TITLE
refactor to avoid AssignOrNamedArg

### DIFF
--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Reflection.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Reflection.scala
@@ -112,8 +112,10 @@ private[json] object Reflection {
 
   private def getAlias(annotations: List[Annotation]): Option[String] = {
     annotations.find(_.tree.tpe =:= typeOf[JsonProperty]).flatMap { anno =>
-      val constants = anno.tree.children.tail.collect {
-        case AssignOrNamedArg(_, Literal(Constant(v: String))) => v
+      val constants = anno.tree.children.flatMap { c =>
+        c.collect {
+          case Literal(Constant(v: String)) => v
+        }
       }
       constants.headOption
     }


### PR DESCRIPTION
This class was renamed in scala 2.13 (scala/scala@870131b).