### PR TITLE
add rolling-mean operator

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineAlgorithm.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineAlgorithm.scala
@@ -49,6 +49,7 @@ object OnlineAlgorithm {
       case "pipeline"      => Pipeline(state)
       case "rolling-count" => OnlineRollingCount(state)
       case "rolling-max"   => OnlineRollingMax(state)
+      case "rolling-mean"  => OnlineRollingMean(state)
       case "rolling-min"   => OnlineRollingMin(state)
       case "sliding-des"   => OnlineSlidingDes(state)
       case "trend"         => OnlineTrend(state)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingMean.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingMean.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+import com.netflix.atlas.core.util.Math
+
+/**
+  * Mean of the values within a moving window of the input. The denominator is the number
+  * of values (non-NaN entries) in the rolling buffer.
+  *
+  * @param buf
+  *     Rolling buffer to keep track of the input for a given window.
+  * @param minNumValues
+  *     Minimum number of values that must be present within the buffer for an average
+  *     to be emitted. If there are not enough non-NaN values, then NaN will be emitted.
+  */
+case class OnlineRollingMean(buf: RollingBuffer, minNumValues: Int) extends OnlineAlgorithm {
+
+  import java.lang.{Double => JDouble}
+
+  require(buf.values.length >= minNumValues, "minimum number of values must be <= window size")
+
+  private[this] val n = buf.values.length
+
+  private[this] var sum = Math.addNaN(0.0, buf.sum)
+  private[this] var count = buf.values.count(v => !JDouble.isNaN(v))
+
+  override def next(v: Double): Double = {
+    val removed = buf.add(v)
+
+    if (!JDouble.isNaN(removed)) {
+      sum -= removed
+      count -= 1
+    }
+
+    if (!JDouble.isNaN(v)) {
+      sum += v
+      count += 1
+    }
+
+    if (count >= minNumValues) sum / count else Double.NaN
+  }
+
+  override def reset(): Unit = {
+    buf.clear()
+    sum = 0.0
+    count = 0
+  }
+
+  override def state: AlgoState = {
+    AlgoState(
+      "rolling-mean",
+      "buffer"       -> buf.state,
+      "minNumValues" -> minNumValues
+    )
+  }
+}
+
+object OnlineRollingMean {
+
+  def apply(n: Int, minNumValues: Int): OnlineRollingMean = apply(RollingBuffer(n), minNumValues)
+
+  def apply(state: AlgoState): OnlineRollingMean = {
+    val minIntervals = state.getInt("minNumValues")
+    apply(RollingBuffer(state.getState("buffer")), minIntervals)
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
@@ -29,6 +29,7 @@ import com.netflix.atlas.core.algorithm.AlgoState
 import com.netflix.atlas.core.algorithm.OnlineDerivative
 import com.netflix.atlas.core.algorithm.OnlineIntegral
 import com.netflix.atlas.core.algorithm.OnlineRollingCount
+import com.netflix.atlas.core.algorithm.OnlineRollingMean
 import com.netflix.atlas.core.algorithm.OnlineTrend
 
 trait StatefulExpr extends TimeSeriesExpr {}
@@ -139,6 +140,20 @@ object StatefulExpr {
     }
 
     override def toString: String = s"$expr,$n,:rolling-max"
+  }
+
+  /**
+    * Computes the mean of the values over the last `n` intervals.
+    */
+  case class RollingMean(expr: TimeSeriesExpr, n: Int, minNumValues: Int) extends OnlineExpr {
+
+    override protected def name: String = "rolling-mean"
+
+    override protected def newAlgorithmInstance(context: EvalContext): OnlineAlgorithm = {
+      OnlineRollingMean(n, minNumValues)
+    }
+
+    override def toString: String = s"$expr,$n,$minNumValues,:rolling-mean"
   }
 
   /**

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMeanSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMeanSuite.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+class OnlineRollingMeanSuite extends BaseOnlineAlgorithmSuite {
+
+  override def newInstance: OnlineAlgorithm = OnlineRollingMean(50, 30)
+
+  test("n = 1, min = 1") {
+    val algo = OnlineRollingMean(1, 1)
+    assert(algo.next(0.0) === 0.0)
+    assert(algo.next(1.0) === 1.0)
+  }
+
+  test("n = 2, min = 1") {
+    val algo = OnlineRollingMean(2, 1)
+    assert(algo.next(0.0) === 0.0)
+    assert(algo.next(1.0) === 0.5)
+    assert(algo.next(2.0) === 1.5)
+  }
+
+  test("n = 2, min = 2") {
+    val algo = OnlineRollingMean(2, 2)
+    assert(algo.next(0.0).isNaN)
+    assert(algo.next(1.0) === 0.5)
+    assert(algo.next(2.0) === 1.5)
+  }
+
+  test("n = 2, min = 1, decreasing") {
+    val algo = OnlineRollingMean(2, 1)
+    assert(algo.next(2.0) === 2.0)
+    assert(algo.next(1.0) === 1.5)
+    assert(algo.next(0.0) === 0.5)
+  }
+
+  test("n = 2, min = 1, NaNs") {
+    val algo = OnlineRollingMean(2, 1)
+    assert(algo.next(0.0) === 0.0)
+    assert(algo.next(1.0) === 0.5)
+    assert(algo.next(2.0) === 1.5)
+    assert(algo.next(Double.NaN) === 2.0)
+    assert(algo.next(Double.NaN).isNaN)
+  }
+
+  test("n = 2, min = 1, reset") {
+    val algo = OnlineRollingMean(2, 1)
+    assert(algo.next(1.0) === 1.0)
+    algo.reset()
+    assert(algo.next(5.0) === 5.0)
+  }
+
+  test("min < n") {
+    intercept[IllegalArgumentException] {
+      OnlineRollingMean(1, 2)
+    }
+  }
+}


### PR DESCRIPTION
This is meant as an alternative to `:trend` that fixes a
number of issues with that operator. Specifically:

1. The denominator for the average is the number of actual
   values, that is non-NaN entries, within the rolling buffer.
   The `:trend` operator always uses the window size which
   can create confusing drops because `NaN` values are
   effectively 0.
2. The minimum number of values permitted before emitting
   a mean can be specified by the user.
3. It is more consistent with other stateful operators in
   that it works on a window size relative to the step
   interval rather than a fixed time duration.
4. It is more consistent with similar operators in other
   tools such as the `rolling_mean` function provided by
   Pandas.