### PR TITLE
fix procedure syntax warnings

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/GraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/GraphEngine.scala
@@ -30,5 +30,5 @@ trait GraphEngine {
 
   def contentType: String
 
-  def write(config: GraphDef, output: OutputStream)
+  def write(config: GraphDef, output: OutputStream): Unit
 }

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/StatsJsonGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/StatsJsonGraphEngine.scala
@@ -42,7 +42,7 @@ class StatsJsonGraphEngine extends GraphEngine {
     numberFmt.format(v)
   }
 
-  def write(config: GraphDef, output: OutputStream) {
+  def write(config: GraphDef, output: OutputStream): Unit = {
     val writer = new OutputStreamWriter(output, "UTF-8")
     val seriesList = config.plots.flatMap(_.lines)
     val count = seriesList.size

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/graphics/Element.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/graphics/Element.scala
@@ -22,7 +22,7 @@ import java.awt.Graphics2D
   */
 trait Element {
 
-  def draw(g: Graphics2D, x1: Int, y1: Int, x2: Int, y2: Int)
+  def draw(g: Graphics2D, x1: Int, y1: Int, x2: Int, y2: Int): Unit
 
   /** Compute the width for the element if restricted to the specified height. */
   def getWidth(g: Graphics2D, height: Int): Int = {

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/util/GraphAssertions.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/util/GraphAssertions.scala
@@ -45,7 +45,7 @@ class GraphAssertions(goldenDir: String, targetDir: String, assert: (Any, Any) =
     }
   }
 
-  def generateReport(clazz: Class[_], diffsOnly: Boolean = true) {
+  def generateReport(clazz: Class[_], diffsOnly: Boolean = true): Unit = {
     val report = s"""<html>
       <head><title>${clazz.getSimpleName}</title></head>
       <body><h1>${clazz.getSimpleName}</h1><hr/> ${
@@ -83,31 +83,31 @@ class GraphAssertions(goldenDir: String, targetDir: String, assert: (Any, Any) =
     }
   }
 
-  def assertEquals(v1: Double, v2: Double, delta: Double) {
+  def assertEquals(v1: Double, v2: Double, delta: Double): Unit = {
     val diff = scala.math.abs(v1 - v2)
     if (diff > delta) {
       throw new AssertionError("%f != %f".format(v1, v2))
     }
   }
 
-  def assertEquals(v1: Double, v2: Double, delta: Double, msg: String) {
+  def assertEquals(v1: Double, v2: Double, delta: Double, msg: String): Unit = {
     val diff = scala.math.abs(v1 - v2)
     if (diff > delta) {
       throw new AssertionError("%f != %f, %s".format(v1, v2, msg))
     }
   }
 
-  def assertEquals(i1: RenderedImage, i2: RenderedImage) {
+  def assertEquals(i1: RenderedImage, i2: RenderedImage): Unit = {
     val diff = PngImage.diff(i1, i2)
     assert(diff.metadata("identical"), "true")
   }
 
-  def assertEquals(i1: PngImage, i2: PngImage) {
+  def assertEquals(i1: PngImage, i2: PngImage): Unit = {
     assertEquals(i1.data, i2.data)
     assert(i1.metadata, i2.metadata)
   }
 
-  def assertEquals(i1: PngImage, f: String, bless: Boolean = false) {
+  def assertEquals(i1: PngImage, f: String, bless: Boolean = false): Unit = {
     // Skip on systems with incompatible font rendering
     if (!Fonts.shouldRunTests) return
 
@@ -130,28 +130,28 @@ class GraphAssertions(goldenDir: String, targetDir: String, assert: (Any, Any) =
     assertEquals(i1, i2)
   }
 
-  private def blessImage(img: PngImage, f: String) {
+  private def blessImage(img: PngImage, f: String): Unit = {
     writeImage(img, goldenDir, f)
   }
 
-  private def writeImage(img: PngImage, dir: String, f: String) {
+  private def writeImage(img: PngImage, dir: String, f: String): Unit = {
     val file = new File(new File(dir), f)
     file.getParentFile.mkdirs()
     val stream = new FileOutputStream(file)
     img.write(stream)
   }
 
-  def assertEquals(s1: String, f: String, bless: Boolean) {
+  def assertEquals(s1: String, f: String, bless: Boolean): Unit = {
     if (bless) blessString(s1, f)
     val s2 = getString(f)
     assert(s1, s2)
   }
 
-  private def blessString(s: String, f: String) {
+  private def blessString(s: String, f: String): Unit = {
     writeString(s, goldenDir, f)
   }
 
-  private def writeString(s: String, dir: String, f: String) {
+  private def writeString(s: String, dir: String, f: String): Unit = {
     val file = new File(new File(dir), f)
     file.getParentFile.mkdirs()
     val stream = new FileOutputStream(file)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/AggregateCollector.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/AggregateCollector.scala
@@ -41,7 +41,7 @@ object AggregateCollector {
 trait AggregateCollector {
 
   /** Add `b` to the aggregate. */
-  def add(b: TimeSeriesBuffer)
+  def add(b: TimeSeriesBuffer): Unit
 
   /**
     * Add a block to the aggregate directly. The underlying buffer must be using the same step size
@@ -78,7 +78,7 @@ abstract class SimpleAggregateCollector extends AggregateCollector {
 
   val statBuffer = new CollectorStatsBuilder
 
-  protected def aggregate(b1: TimeSeriesBuffer, b2: TimeSeriesBuffer)
+  protected def aggregate(b1: TimeSeriesBuffer, b2: TimeSeriesBuffer): Unit
 
   def add(b: TimeSeriesBuffer): Unit = {
     statBuffer.updateInput(b.values.length)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/TagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/TagIndex.scala
@@ -34,5 +34,5 @@ trait TagIndex[T <: TaggedItem] {
 trait MutableTagIndex[T <: TaggedItem] extends TagIndex[T] {
 
   /** Update the index with the given items. */
-  def update(items: List[T])
+  def update(items: List[T]): Unit
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/norm/ValueFunction.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/norm/ValueFunction.scala
@@ -17,7 +17,7 @@ package com.netflix.atlas.core.norm
 
 trait ValueFunction {
 
-  def apply(timestamp: Long, value: Double)
+  def apply(timestamp: Long, value: Double): Unit
 }
 
 /**

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/InternMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/InternMap.scala
@@ -35,7 +35,7 @@ trait InternMap[K <: AnyRef] extends Interner[K] {
 
   def intern(k: K): K
 
-  def retain(f: Long => Boolean)
+  def retain(f: Long => Boolean): Unit
 
   def size: Int
 }
@@ -52,7 +52,7 @@ class OpenHashInternMap[K <: AnyRef: Manifest](initialCapacity: Int, clock: Cloc
     if (h < 0) -h else h
   }
 
-  private def resize(newCapacity: Int, keep: Long => Boolean) = {
+  private def resize(newCapacity: Int, keep: Long => Boolean): Unit = {
     val oldData = data
     val oldTimestamps = timestamps
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
@@ -190,7 +190,7 @@ final class SmallHashMap[K <: Any, V <: Any] private (val data: Array[Any], data
     * Call the function `f` for each tuple in the map without requiring a temporary object to be
     * created.
     */
-  def foreachItem(f: (K, V) => Unit) {
+  def foreachItem(f: (K, V) => Unit): Unit = {
     var i = 0
     while (i < data.length) {
       if (data(i) != null) f(data(i).asInstanceOf[K], data(i + 1).asInstanceOf[V])

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/ChunkData.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/ChunkData.scala
@@ -38,7 +38,7 @@ final case class ArrayData(values: Array[Double]) extends ChunkData {
 
   def typeName: String = "array"
 
-  override def encode(gen: JsonGenerator) {
+  override def encode(gen: JsonGenerator): Unit = {
     gen.writeStartObject()
     gen.writeStringField("type", "array")
     gen.writeArrayFieldStart("values")

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeSeriesMessage.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeSeriesMessage.scala
@@ -63,7 +63,7 @@ case class TimeSeriesMessage(
   data: ChunkData
 ) extends JsonSupport {
 
-  override def encode(gen: JsonGenerator) {
+  override def encode(gen: JsonGenerator): Unit = {
     gen.writeStartObject()
     gen.writeStringField("type", "timeseries")
     gen.writeStringField("id", id)
@@ -83,7 +83,7 @@ case class TimeSeriesMessage(
     gen.writeEndObject()
   }
 
-  private def encodeTags(gen: JsonGenerator, tags: Map[String, String]) {
+  private def encodeTags(gen: JsonGenerator, tags: Map[String, String]): Unit = {
     gen.writeObjectFieldStart("tags")
     tags match {
       case m: SmallHashMap[String, String] =>

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
@@ -223,7 +223,7 @@ object PublishApi {
     finally parser.close()
   }
 
-  private def encodeTags(gen: JsonGenerator, tags: Map[String, String]) {
+  private def encodeTags(gen: JsonGenerator, tags: Map[String, String]): Unit = {
     gen.writeObjectFieldStart("tags")
     tags match {
       case m: SmallHashMap[String, String] =>
@@ -238,7 +238,7 @@ object PublishApi {
     gen.writeEndObject()
   }
 
-  def encodeDatapoint(gen: JsonGenerator, d: Datapoint) {
+  def encodeDatapoint(gen: JsonGenerator, d: Datapoint): Unit = {
     gen.writeStartObject()
     encodeTags(gen, d.tags)
     gen.writeNumberField("timestamp", d.timestamp)
@@ -254,7 +254,7 @@ object PublishApi {
     }
   }
 
-  def encodeBatch(gen: JsonGenerator, tags: Map[String, String], values: List[Datapoint]) {
+  def encodeBatch(gen: JsonGenerator, tags: Map[String, String], values: List[Datapoint]): Unit = {
     gen.writeStartObject()
     encodeTags(gen, tags)
     gen.writeArrayFieldStart("metrics")


### PR DESCRIPTION
Procedure syntax is deprecated in 2.13 and results in a
lot of warnings when trying to build on that version of
Scala.