### PR TITLE
QueryIndex: reduce overhead for checking entries

### DIFF
--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
@@ -87,7 +87,7 @@ class ExpressionApiSuite extends FunSuite with ScalatestRouteTest {
     }
     sm.regenerateQueryIndex()
     Get("/lwc/api/v1/expressions/skan") ~> endpoint.routes ~> check {
-      val expected = s"""{"expressions":[$skanSum,$skanCount]}"""
+      val expected = s"""{"expressions":[$skanCount,$skanSum]}"""
       assert(responseAs[String] === expected)
     }
   }


### PR DESCRIPTION
Flame graphs on the prod clusters show a bit of overhead
for filter and exists calls on the list of entries. This
change converts it to a simple array and avoids using the
collections framework methods. For the existing JMH test
this resulted in about a 12% improvement.