### PR TITLE
avoid BoxesRunTime.equals for SmallHashMap

### DIFF
--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/BoxesRuntime.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/BoxesRuntime.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.infra.Blackhole
+
+/**
+  * ```
+  * Benchmark                         Mode  Cnt          Score         Error  Units
+  * BoxesRuntime.javaEquals          thrpt   10  112495954.095 ± 2795842.625  ops/s
+  * BoxesRuntime.scalaEquals         thrpt   10   82963668.047 ± 6225820.287  ops/s
+  * ```
+  */
+@State(Scope.Thread)
+class BoxesRuntime {
+
+  private val a = "a896b12f-1863-4568-98b2-1f3b1aee55cA"
+  private val b = "a896b12f-1863-4568-98b2-1f3b1aee55cB"
+
+  @Benchmark
+  def javaEquals(bh: Blackhole): Unit = {
+    bh.consume(a != null && a.equals(b))
+  }
+
+  @Benchmark
+  def scalaEquals(bh: Blackhole): Unit = {
+    // Compiles to BoxesRunTime.equals(a, b)
+    bh.consume(a == b)
+  }
+}

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/SmallHashMapJavaGet.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/SmallHashMapJavaGet.scala
@@ -25,7 +25,7 @@ import org.openjdk.jmh.infra.Blackhole
   * calls.
   *
   * ```
-  * > jmh:run -prof jmh.extras.JFR -wi 10 -i 10 -f1 -t1 .*SmallHashMapHashCode.*
+  * > jmh:run -prof gc -wi 10 -i 10 -f1 -t1 .*SmallHashMapJavaGet.*
   * ...
   * [info] Benchmark               Mode  Cnt         Score         Error  Units
   * [info] customGetFound         thrpt   10  94270900.203 ± 5825997.538  ops/s


### PR DESCRIPTION
For the QueryIndex on the streaming clusters a hot spot
is `SmallHashMap.get`. Flame graphs show a significant
and unnecessary overhead being `BoxesRunTime.equals`.
This change updates 7 places in the code to avoid that
call:

**Before**

```
$ javap -verbose ./atlas-core/target/scala-2.12/classes/com/netflix/atlas/core/util/SmallHashMap.class | grep Boxes
        46: invokestatic  #1101               // Method scala/runtime/BoxesRunTime.equals:(Ljava/lang/Object;Ljava/lang/Object;)Z
        79: invokestatic  #1101               // Method scala/runtime/BoxesRunTime.equals:(Ljava/lang/Object;Ljava/lang/Object;)Z
       105: invokestatic  #1101               // Method scala/runtime/BoxesRunTime.equals:(Ljava/lang/Object;Ljava/lang/Object;)Z
        40: invokestatic  #1155               // Method scala/runtime/BoxesRunTime.unboxToBoolean:(Ljava/lang/Object;)Z
        29: invokestatic  #1101               // Method scala/runtime/BoxesRunTime.equals:(Ljava/lang/Object;Ljava/lang/Object;)Z
        59: invokestatic  #1101               // Method scala/runtime/BoxesRunTime.equals:(Ljava/lang/Object;Ljava/lang/Object;)Z
        17: invokestatic  #1101               // Method scala/runtime/BoxesRunTime.equals:(Ljava/lang/Object;Ljava/lang/Object;)Z
         2: invokestatic  #1101               // Method scala/runtime/BoxesRunTime.equals:(Ljava/lang/Object;Ljava/lang/Object;)Z
```

**After**

```
$ javap -verbose ./atlas-core/target/scala-2.12/classes/com/netflix/atlas/core/util/SmallHashMap.class | grep Boxes
        40: invokestatic  #1154               // Method scala/runtime/BoxesRunTime.unboxToBoolean:(Ljava/lang/Object;)Z
```