### PR TITLE
1.5: update to latest jackson 2.8.x

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
     val aws        = "1.11.49"
     val iep        = "0.4.9"
     val guice      = "4.1.0"
-    val jackson    = "2.8.3"
+    val jackson    = "2.8.11"
     val log4j      = "2.10.0"
     val scala      = "2.11.12"
     val slf4j      = "1.7.21"
@@ -36,7 +36,7 @@ object Dependencies {
   val jacksonAnno2    = "com.fasterxml.jackson.core" % "jackson-annotations" % jackson
   val jacksonCore2    = "com.fasterxml.jackson.core" % "jackson-core" % jackson
   val jacksonJoda2    = "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % jackson
-  val jacksonMapper2  = "com.fasterxml.jackson.core" % "jackson-databind" % jackson
+  val jacksonMapper2  = "com.fasterxml.jackson.core" % "jackson-databind" % s"$jackson.3"
   val jacksonScala2   = "com.fasterxml.jackson.module" %% "jackson-module-scala" % jackson
   val jacksonSmile2   = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-smile" % jackson
   val jodaConvert     = "org.joda" % "joda-convert" % "1.8.1"


### PR DESCRIPTION
Fixes a number of security vulnerabilities. Most of these
are [serialization gadgets].

[serialization gadgets]: https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062