### PR TITLE
Improve CloudWatch metric lag handling

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/billing.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/billing.conf
@@ -6,6 +6,8 @@ atlas {
     billing = {
       namespace = "AWS/Billing"
       period = 6h
+      end-period-offset = 1
+      period-count = 1
 
       dimensions = [
         "LinkedAccount",

--- a/atlas-poller-cloudwatch/src/main/resources/billing.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/billing.conf
@@ -7,7 +7,7 @@ atlas {
       namespace = "AWS/Billing"
       period = 6h
       end-period-offset = 1
-      period-count = 1
+      period-count = 2
 
       dimensions = [
         "LinkedAccount",

--- a/atlas-poller-cloudwatch/src/main/resources/dynamodb.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/dynamodb.conf
@@ -68,7 +68,7 @@ atlas {
       namespace = "AWS/DynamoDB"
       period = 5m
       end-period-offset = 1
-      period-count = 3
+      period-count = 4
 
       dimensions = [
         "TableName"

--- a/atlas-poller-cloudwatch/src/main/resources/dynamodb.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/dynamodb.conf
@@ -67,6 +67,8 @@ atlas {
     dynamodb-table-5m = {
       namespace = "AWS/DynamoDB"
       period = 5m
+      end-period-offset = 1
+      period-count = 3
 
       dimensions = [
         "TableName"

--- a/atlas-poller-cloudwatch/src/main/resources/ec2.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/ec2.conf
@@ -7,7 +7,7 @@ atlas {
       namespace = "AWS/EC2"
       period = 5m
       end-period-offset = 1
-      period-count = 3
+      period-count = 4
 
       dimensions = [
         "AutoScalingGroupName"
@@ -143,7 +143,7 @@ atlas {
       namespace = "AWS/EC2"
       period = 5m
       end-period-offset = 1
-      period-count = 3
+      period-count = 4
 
       dimensions = [
         "AutoScalingGroupName"

--- a/atlas-poller-cloudwatch/src/main/resources/ec2.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/ec2.conf
@@ -6,6 +6,8 @@ atlas {
     ec2 = {
       namespace = "AWS/EC2"
       period = 5m
+      end-period-offset = 1
+      period-count = 3
 
       dimensions = [
         "AutoScalingGroupName"
@@ -140,6 +142,8 @@ atlas {
     ec2-credit = {
       namespace = "AWS/EC2"
       period = 5m
+      end-period-offset = 1
+      period-count = 3
 
       dimensions = [
         "AutoScalingGroupName"

--- a/atlas-poller-cloudwatch/src/main/resources/es.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/es.conf
@@ -6,6 +6,8 @@ atlas {
     es = {
       namespace = "AWS/ES"
       period = 5m
+      end-period-offset = 1
+      period-count = 3
 
       dimensions = [
         "ClientId",

--- a/atlas-poller-cloudwatch/src/main/resources/es.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/es.conf
@@ -7,7 +7,7 @@ atlas {
       namespace = "AWS/ES"
       period = 5m
       end-period-offset = 1
-      period-count = 3
+      period-count = 4
 
       dimensions = [
         "ClientId",

--- a/atlas-poller-cloudwatch/src/main/resources/s3.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/s3.conf
@@ -6,6 +6,8 @@ atlas {
     s3 = {
       namespace = "AWS/S3"
       period = 1d
+      end-period-offset = 1
+      period-count = 1
 
       dimensions = [
         "BucketName",

--- a/atlas-poller-cloudwatch/src/main/resources/s3.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/s3.conf
@@ -7,7 +7,7 @@ atlas {
       namespace = "AWS/S3"
       period = 1d
       end-period-offset = 1
-      period-count = 1
+      period-count = 2
 
       dimensions = [
         "BucketName",

--- a/atlas-poller-cloudwatch/src/main/resources/sns.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/sns.conf
@@ -7,7 +7,7 @@ atlas {
       namespace = "AWS/SNS"
       period = 5m
       end-period-offset = 1
-      period-count = 3
+      period-count = 4
 
       dimensions = [
         "TopicName"

--- a/atlas-poller-cloudwatch/src/main/resources/sns.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/sns.conf
@@ -6,6 +6,8 @@ atlas {
     sns = {
       namespace = "AWS/SNS"
       period = 5m
+      end-period-offset = 1
+      period-count = 3
 
       dimensions = [
         "TopicName"

--- a/atlas-poller-cloudwatch/src/main/resources/sqs.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/sqs.conf
@@ -6,6 +6,8 @@ atlas {
     sqs = {
       namespace = "AWS/SQS"
       period = 5m
+      end-period-offset = 1
+      period-count = 3
 
       dimensions = [
         "QueueName"

--- a/atlas-poller-cloudwatch/src/main/resources/sqs.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/sqs.conf
@@ -7,7 +7,7 @@ atlas {
       namespace = "AWS/SQS"
       period = 5m
       end-period-offset = 1
-      period-count = 3
+      period-count = 4
 
       dimensions = [
         "QueueName"

--- a/atlas-poller-cloudwatch/src/main/resources/trustedadvisor.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/trustedadvisor.conf
@@ -11,6 +11,8 @@ atlas {
       // Update frequency seems to be ~1h15m, but isn't as regular as most other cloudwatch
       // data. Using 2h to provide some buffer.
       period = 2h
+      end-period-offset = 1
+      period-count = 1
 
       // Note, TA data for all regions seems to show up in CloudWatch for us-east-1
       dimensions = [

--- a/atlas-poller-cloudwatch/src/main/resources/trustedadvisor.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/trustedadvisor.conf
@@ -12,7 +12,7 @@ atlas {
       // data. Using 2h to provide some buffer.
       period = 2h
       end-period-offset = 1
-      period-count = 1
+      period-count = 2
 
       // Note, TA data for all regions seems to show up in CloudWatch for us-east-1
       dimensions = [

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
@@ -21,6 +21,7 @@ import java.util.Date
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
+import java.util.function.LongFunction
 
 import akka.actor.Actor
 import akka.actor.ActorRef
@@ -37,7 +38,9 @@ import com.amazonaws.services.cloudwatch.model.StandardUnit
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.netflix.atlas.poller.Messages
 import com.netflix.spectator.api.Functions
+import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.histogram.BucketCounter
 import com.netflix.spectator.api.patterns.PolledMeter
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
@@ -86,7 +89,17 @@ class CloudWatchPoller(config: Config, registry: Registry, client: AmazonCloudWa
   // Child actor for getting the data for a metric. This will do the call using the
   // AWS SDK which is blocking and should be run in an isolated dispatcher.
   private val metricsGetRef =
-    context.actorOf(FromConfig.props(Props(new GetMetricActor(client))), "metrics-get")
+    context.actorOf(
+      FromConfig.props(
+        Props(
+          classOf[GetMetricActor],
+          client,
+          registry,
+          buildBucketCounterCache(registry, categories)
+        )
+      ),
+      "metrics-get"
+    )
 
   // Throttler to control the rate of get metrics calls in order to stay within AWS SDK limits.
   private val throttledMetricsGetRef = Source
@@ -286,6 +299,40 @@ object CloudWatchPoller {
     val cfg = config.getConfig("atlas.cloudwatch.tagger")
     val cls = Class.forName(cfg.getString("class"))
     cls.getConstructor(classOf[Config]).newInstance(cfg).asInstanceOf[Tagger]
+  }
+
+  val PeriodLagIdName: String = "atlas.cloudwatch.periodLag"
+
+  private def buildBucketCounterCache(
+    registry: Registry,
+    metricCategories: List[MetricCategory]
+  ): Map[Id, BucketCounter] = {
+
+    metricCategories.flatMap { category =>
+      val periodCount = category.periodCount
+      val bucketFunction: LongFunction[String] =
+        (periods: Long) =>
+          if (periods > periodCount) // periodCount is intended to be small (< 10)
+            "no_data"
+          else
+            periods.toString
+
+      val id = registry
+        .createId(PeriodLagIdName)
+        .withTag("cwNamespace", category.namespace)
+        .withTag("periodSeconds", category.period.toString)
+
+      category.metrics.map { metric =>
+        val periodLagId = id.withTag("cwMetricName", metric.name)
+        periodLagId -> BucketCounter
+          .get(
+            registry,
+            periodLagId,
+            bucketFunction
+          )
+
+      }
+    }.toMap
   }
 
   case class GetMetricData(metric: MetricMetadata)

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
@@ -309,13 +309,14 @@ object CloudWatchPoller {
   ): Map[Id, BucketCounter] = {
 
     metricCategories.flatMap { category =>
-      val periodCount = category.periodCount
+      val noDataThreshold = category.periodCount + category.endPeriodOffset
+
       val bucketFunction: LongFunction[String] =
-        (periods: Long) =>
-          if (periods > periodCount) // periodCount is intended to be small (< 10)
+        (periodCount: Long) =>
+          if (periodCount > noDataThreshold) // threshold is intended to be small (< 10)
             "no_data"
           else
-            periods.toString
+            periodCount.toString
 
       val id = registry
         .createId(PeriodLagIdName)

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/GetMetricActor.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/GetMetricActor.scala
@@ -15,19 +15,31 @@
  */
 package com.netflix.atlas.cloudwatch
 
+import java.time.Duration
 import java.time.Instant
+import java.util.Date
 
 import akka.actor.Actor
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.cloudwatch.model.Datapoint
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.histogram.BucketCounter
 import com.typesafe.scalalogging.StrictLogging
 
 /**
   * Queries CloudWatch to get a datapoint for given metric. This actor makes blocking
   * calls to the Amazon SDK, it should be run in a dedicated dispatcher.
   */
-class GetMetricActor(client: AmazonCloudWatch) extends Actor with StrictLogging {
+class GetMetricActor(
+  client: AmazonCloudWatch,
+  registry: Registry,
+  bucketCounterCache: Map[Id, BucketCounter]
+) extends Actor
+    with StrictLogging {
   import CloudWatchPoller._
+
+  private val basePeriodLagId = registry.createId(PeriodLagIdName)
 
   def receive: Receive = {
     case m: MetricMetadata =>
@@ -37,14 +49,17 @@ class GetMetricActor(client: AmazonCloudWatch) extends Actor with StrictLogging 
   }
 
   /**
-    * Queries cloudwatch for two periods of the metric and returns the most recent
-    * value or None if no values were reported in that window.
+    * Queries CloudWatch for the metric with a time range ending at the configured end
+    * offset and starting at the configured number of periods prior to that end. It returns
+    * the most recent value or None if no values were reported in that time range.
     */
   private def getMetric(m: MetricMetadata): Option[Datapoint] = {
     try {
       import scala.collection.JavaConverters._
-      val e = Instant.now().minusSeconds(m.category.period)
-      val s = e.minusSeconds(2 * m.category.period)
+      val now = Instant.now()
+      val e = now.minusSeconds(m.category.endPeriodOffset * m.category.period)
+      val s = e.minusSeconds(m.category.periodCount * m.category.period)
+
       val request = m.toGetRequest(s, e)
       val result = client.getMetricStatistics(request)
 
@@ -53,11 +68,31 @@ class GetMetricActor(client: AmazonCloudWatch) extends Actor with StrictLogging 
       val sorted = datapoints
         .filter(!_.getSum.isNaN)
         .sortWith(_.getTimestamp.getTime > _.getTimestamp.getTime)
-      sorted.headOption
+      val maybeDatapoint = sorted.headOption
+      recordLag(now, maybeDatapoint.map(_.getTimestamp), m)
+      maybeDatapoint
     } catch {
       case e: Exception =>
         logger.warn(s"failed to get data for ${m.category.namespace}/${m.definition.name}", e)
         None
     }
+  }
+
+  /**
+    * Record how many periods back from now the latest returned datapoint is. Though not perfect,
+    * this will give a reasonable approximation of data latency across the collected metrics.
+    */
+  private def recordLag(now: Instant, maybeTimestamp: Option[Date], m: MetricMetadata): Unit = {
+    val mostRecentDatapointTimestamp = maybeTimestamp.map(_.toInstant).getOrElse(Instant.EPOCH)
+    val lagDuration = Duration.between(mostRecentDatapointTimestamp, now)
+
+    val lagSeconds = lagDuration.toMillis / 1000L
+    val periodLag = lagSeconds / m.category.period
+    val id = basePeriodLagId
+      .withTag("cwMetricName", m.definition.name)
+      .withTag("cwNamespace", m.category.namespace)
+      .withTag("periodSeconds", m.category.period.toString)
+
+    bucketCounterCache.get(id).foreach(_.record(periodLag))
   }
 }

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricCategory.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricCategory.scala
@@ -117,8 +117,8 @@ object MetricCategory extends StrictLogging {
       }
     val timeout = if (config.hasPath("timeout")) Some(config.getDuration("timeout")) else None
     val endPeriodOffset =
-      if (config.hasPath("end-period-offset")) config.getInt("end-period-offset") else 1
-    val periodCount = if (config.hasPath("period-count")) config.getInt("period-count") else 5
+      if (config.hasPath("end-period-offset")) config.getInt("end-period-offset") else 2
+    val periodCount = if (config.hasPath("period-count")) config.getInt("period-count") else 6
 
     apply(
       namespace = config.getString("namespace"),

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricCategory.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricCategory.scala
@@ -117,7 +117,7 @@ object MetricCategory extends StrictLogging {
       }
     val timeout = if (config.hasPath("timeout")) Some(config.getDuration("timeout")) else None
     val endPeriodOffset =
-      if (config.hasPath("end-period-offset")) config.getInt("end-period-offset") else 2
+      if (config.hasPath("end-period-offset")) config.getInt("end-period-offset") else 1
     val periodCount = if (config.hasPath("period-count")) config.getInt("period-count") else 6
 
     apply(

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricCategory.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricCategory.scala
@@ -40,6 +40,10 @@ import com.typesafe.scalalogging.StrictLogging
   *     for CloudWatch data we use the last reported value in CloudWatch as long as it
   *     is within one period from the polling time. The period is also needed for
   *     performing rate conversions on some metrics.
+  * @param endPeriodOffset
+  *     How many periods back from `now` to set the end of the time range.
+  * @param periodCount
+  *     How many periods total to retrieve.
   * @param timeout
   *     How long the system should interpolate a base value for unreported CloudWatch
   *     metrics before ceasing to send them. CloudWatch will return 0 metrics for at
@@ -65,6 +69,8 @@ import com.typesafe.scalalogging.StrictLogging
 case class MetricCategory(
   namespace: String,
   period: Int,
+  endPeriodOffset: Int,
+  periodCount: Int,
   timeout: Option[Duration],
   dimensions: List[String],
   metrics: List[MetricDefinition],
@@ -110,10 +116,15 @@ object MetricCategory extends StrictLogging {
         parseQuery(config.getString("filter"))
       }
     val timeout = if (config.hasPath("timeout")) Some(config.getDuration("timeout")) else None
+    val endPeriodOffset =
+      if (config.hasPath("end-period-offset")) config.getInt("end-period-offset") else 1
+    val periodCount = if (config.hasPath("period-count")) config.getInt("period-count") else 5
 
     apply(
       namespace = config.getString("namespace"),
       period = config.getDuration("period", TimeUnit.SECONDS).toInt,
+      endPeriodOffset = endPeriodOffset,
+      periodCount = periodCount,
       timeout = timeout,
       dimensions = config.getStringList("dimensions").asScala.toList,
       metrics = metrics.flatMap(MetricDefinition.fromConfig),

--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionsSuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionsSuite.scala
@@ -75,7 +75,7 @@ class ConversionsSuite extends FunSuite {
   test("rate") {
     val cnv = Conversions.fromName("sum,rate")
     val meta = MetricMetadata(
-      MetricCategory("NFLX/Test", 300, None, Nil, Nil, Query.True),
+      MetricCategory("NFLX/Test", 300, 1, 3, None, Nil, Nil, Query.True),
       MetricDefinition("test", "test-alias", cnv, false, Map.empty),
       Nil
     )
@@ -86,7 +86,7 @@ class ConversionsSuite extends FunSuite {
   test("rate already") {
     val cnv = Conversions.fromName("sum,rate")
     val meta = MetricMetadata(
-      MetricCategory("NFLX/Test", 300, None, Nil, Nil, Query.True),
+      MetricCategory("NFLX/Test", 300, 1, 3, None, Nil, Nil, Query.True),
       MetricDefinition("test", "test-alias", cnv, false, Map.empty),
       Nil
     )

--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDataSuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDataSuite.scala
@@ -30,7 +30,7 @@ class MetricDataSuite extends FunSuite {
   private val definition =
     MetricDefinition("test", "alias", Conversions.fromName("sum"), false, Map.empty)
   private val category =
-    MetricCategory("namespace", 60, None, List("dimension"), List(definition), Query.True)
+    MetricCategory("namespace", 60, 1, 5, None, List("dimension"), List(definition), Query.True)
   private val metadata = MetricMetadata(category, definition, Nil)
 
   private val monotonicMetadata = metadata.copy(definition = definition.copy(monotonicValue = true))

--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDefinitionSuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDefinitionSuite.scala
@@ -27,7 +27,7 @@ import org.scalatest.FunSuite
 class MetricDefinitionSuite extends FunSuite {
 
   private val meta = MetricMetadata(
-    MetricCategory("AWS/ELB", 60, None, Nil, Nil, Query.True),
+    MetricCategory("AWS/ELB", 60, 1, 5, None, Nil, Nil, Query.True),
     null,
     Nil
   )


### PR DESCRIPTION
This is the first of potentially multiple commits to improve handling
of CloudWatch metric lag. This first commit makes the time range of
the query configurable and adds a metric to track the age (in
CloudWatch periods) of the latest datapoint returned. This will enable
assessing the distribution of ages across the namespaces and metrics
collected. Those data will influence the approach for datapoints that
are older than Atlas will accept.