### PR TITLE
Fix lambda config

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/lambda.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/lambda.conf
@@ -7,6 +7,8 @@ atlas {
       namespace = "AWS/Lambda"
       period = 1m
 
+      dimensions = []
+
       metrics = [
         {
           name = "ConcurrentExecutions"

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
@@ -266,7 +266,7 @@ class CloudWatchPoller(config: Config, registry: Registry, client: AmazonCloudWa
   }
 }
 
-object CloudWatchPoller extends StrictLogging {
+object CloudWatchPoller {
 
   case object Flush
 
@@ -288,29 +288,17 @@ object CloudWatchPoller extends StrictLogging {
 
   private[cloudwatch] def getCategories(config: Config): List[MetricCategory] = {
     import scala.collection.JavaConverters._
-    val categories = try {
-      config.getStringList("atlas.cloudwatch.categories").asScala.map { name =>
-        val cfg = config.getConfig(s"atlas.cloudwatch.$name")
-        MetricCategory.fromConfig(cfg)
-      }
-    } catch {
-      case t: Throwable =>
-        logger.error("Problem loading categories", t)
-        throw t
+    val categories = config.getStringList("atlas.cloudwatch.categories").asScala.map { name =>
+      val cfg = config.getConfig(s"atlas.cloudwatch.$name")
+      MetricCategory.fromConfig(cfg)
     }
     categories.toList
   }
 
   private[cloudwatch] def getTagger(config: Config): Tagger = {
-    try {
-      val cfg = config.getConfig("atlas.cloudwatch.tagger")
-      val cls = Class.forName(cfg.getString("class"))
-      cls.getConstructor(classOf[Config]).newInstance(cfg).asInstanceOf[Tagger]
-    } catch {
-      case t: Throwable =>
-        logger.error("Problem loading tagger", t)
-        throw t
-    }
+    val cfg = config.getConfig("atlas.cloudwatch.tagger")
+    val cls = Class.forName(cfg.getString("class"))
+    cls.getConstructor(classOf[Config]).newInstance(cfg).asInstanceOf[Tagger]
   }
 
   val PeriodLagIdName: String = "atlas.cloudwatch.periodLag"

--- a/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/NetflixTaggerSuite.scala
+++ b/atlas-poller-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/NetflixTaggerSuite.scala
@@ -27,6 +27,20 @@ class NetflixTaggerSuite extends FunSuite {
     new Dimension().withName("ClusterName").withValue("different_name-foo-bar-v002")
   )
 
+  test("production config loads") {
+    val cfg = ConfigFactory.parseResources("reference.conf").resolve()
+
+    val tagger = CloudWatchPoller.getTagger(cfg)
+    val tagged = tagger(
+      List(
+        new Dimension().withName("aTag").withValue("aValue"),
+        new Dimension().withName("LinkedAccount").withValue("12345")
+      )
+    )
+    assert(tagged.getOrElse("aTag", "fail") === "aValue")
+    assert(tagged.getOrElse("aws.account", "fail") === "12345")
+  }
+
   test("bad config") {
     val cfg = ConfigFactory.parseString("")
     intercept[ConfigException] {

--- a/atlas-poller/src/main/scala/com/netflix/atlas/poller/PollerManager.scala
+++ b/atlas-poller/src/main/scala/com/netflix/atlas/poller/PollerManager.scala
@@ -52,6 +52,7 @@ class PollerManager(registry: Registry, classFactory: ClassFactory, config: Conf
 
   override val supervisorStrategy = OneForOneStrategy() {
     case e: ActorInitializationException =>
+      logger.error(s"initialization failed for ${sender().path}", e)
       SupervisorStrategy.Escalate
     case e: Exception =>
       logRestart(sender().path, e)


### PR DESCRIPTION
The code that loads `MetricCategory` instances from the config expects
the `dimension` field, even if it's empty. This was causing the service
to silently fail.

In addition to fixing the `lambda` config, I've added tests that load
the production config to improve the chances we'll catch this at build
time. I've also added logging, so the problem will be evident in the
logs.