### PR TITLE
improve logging for poller actor failures

### DIFF
--- a/atlas-poller/src/main/scala/com/netflix/atlas/poller/PollerManager.scala
+++ b/atlas-poller/src/main/scala/com/netflix/atlas/poller/PollerManager.scala
@@ -52,6 +52,7 @@ class PollerManager(registry: Registry, classFactory: ClassFactory, config: Conf
 
   override val supervisorStrategy = OneForOneStrategy() {
     case e: ActorInitializationException =>
+      logger.error(s"initialization failed for ${sender().path}", e)
       SupervisorStrategy.Escalate
     case e: Exception =>
       logRestart(sender().path, e)


### PR DESCRIPTION
Clearly log the initialization failure as an error for the
poller manager. Avoids this getting overlooked if the detailed
actor logging is not enabled.