### PR TITLE
Ensure git tags are available for build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,14 @@ build:
 snapshot:
 	# Travis uses a depth when fetching git data so the tags needed for versioning may not
 	# be available unless we explicitly fetch them
-	git fetch --unshallow
+	git fetch --tags
 	$(SBT) storeBintrayCredentials
 	$(SBT) clean test checkLicenseHeaders publish
 
 release:
 	# Travis uses a depth when fetching git data so the tags needed for versioning may not
 	# be available unless we explicitly fetch them
-	git fetch --unshallow
+	git fetch --tags
 
 	# Storing the bintray credentials needs to be done as a separate command so they will
 	# be available early enough for the publish task.


### PR DESCRIPTION
`git fetch --unshallow` was being used to get tags to set the artifact
version. This has started failing on one of the builds. This commit
switches to explicitly fetching tags via `git fetch --tags`.