### PR TITLE
Revert "Ensure git tags are available for build"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,14 @@ build:
 snapshot:
 	# Travis uses a depth when fetching git data so the tags needed for versioning may not
 	# be available unless we explicitly fetch them
-	git fetch --tags
+	git fetch --unshallow
 	$(SBT) storeBintrayCredentials
 	$(SBT) clean test checkLicenseHeaders publish
 
 release:
 	# Travis uses a depth when fetching git data so the tags needed for versioning may not
 	# be available unless we explicitly fetch them
-	git fetch --tags
+	git fetch --unshallow
 
 	# Storing the bintray credentials needs to be done as a separate command so they will
 	# be available early enough for the publish task.


### PR DESCRIPTION
This did not have the desired affect and seems to have caused the 2.11
build to no longer work.

This reverts commit 7f30c26.