### PR TITLE
Switch to linux/trusty for 2.12 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ matrix:
     env: BINTRAY_PUBLISH=true
   - jdk: openjdk11
     scala: 2.12.8
-    os: osx
+    os: linux
+    dist: trusty
     env: BINTRAY_PUBLISH=true
 script:
 - ./scripts/buildViaTravis.sh


### PR DESCRIPTION
Switch to linux/trusty for 2.12 build to match the 2.11 build. This is
to observe whether the issue determining the version to use for
publication has an OS component.