### PR TITLE
Switch 2.12 build back to `osx`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ matrix:
     env: BINTRAY_PUBLISH=true
   - jdk: openjdk11
     scala: 2.12.8
-    os: osx
+    os: linux
+    dist: trusty
     env: BINTRAY_PUBLISH=true
 script:
 - ./scripts/buildViaTravis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ matrix:
     env: BINTRAY_PUBLISH=true
   - jdk: openjdk11
     scala: 2.12.8
-    os: linux
-    dist: trusty
+    os: osx
     env: BINTRAY_PUBLISH=true
 script:
 - ./scripts/buildViaTravis.sh

--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,14 @@ build:
 snapshot:
 	# Travis uses a depth when fetching git data so the tags needed for versioning may not
 	# be available unless we explicitly fetch them
-	git fetch --unshallow
+	git fetch --unshallow --tags
 	$(SBT) storeBintrayCredentials
 	$(SBT) clean test checkLicenseHeaders publish
 
 release:
 	# Travis uses a depth when fetching git data so the tags needed for versioning may not
 	# be available unless we explicitly fetch them
-	git fetch --unshallow
+	git fetch --unshallow --tags
 
 	# Storing the bintray credentials needs to be done as a separate command so they will
 	# be available early enough for the publish task.

--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,14 @@ build:
 snapshot:
 	# Travis uses a depth when fetching git data so the tags needed for versioning may not
 	# be available unless we explicitly fetch them
-	git fetch --tags
+	git fetch --unshallow
 	$(SBT) storeBintrayCredentials
 	$(SBT) clean test checkLicenseHeaders publish
 
 release:
 	# Travis uses a depth when fetching git data so the tags needed for versioning may not
 	# be available unless we explicitly fetch them
-	git fetch --tags
+	git fetch --unshallow
 
 	# Storing the bintray credentials needs to be done as a separate command so they will
 	# be available early enough for the publish task.


### PR DESCRIPTION
Expermient showed that the 2.12 build with linux/trusty _does_ result in
the correct version.