### PR TITLE
preserve offset for named rewrites

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -925,7 +925,11 @@ object MathExpr {
 
           buffer.toString()
         case t: TimeSeriesExpr if t.finalGrouping == evalExpr.finalGrouping =>
-          s"$t,:$name"
+          val evalOffset = getOffset(evalExpr)
+          evalOffset.fold(s"$t,:$name") { d =>
+            val displayOffset = getOffset(t).getOrElse(Duration.ZERO)
+            if (d != displayOffset) s"${t.withOffset(d)},:$name" else s"$t,:$name"
+          }
         case _ =>
           val grouping = evalExpr.finalGrouping
           val by = if (grouping.nonEmpty) grouping.mkString(",(,", ",", ",),:by") else ""

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/NamedRewriteSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/NamedRewriteSuite.scala
@@ -220,4 +220,16 @@ class NamedRewriteSuite extends FunSuite {
     val expected = eval("name,a,:eq,:sum,:cf-max,name,a,:eq,:count,:cf-max,:div")
     assert(actual === expected)
   }
+
+  test("issue-1021: offset with des macros, af") {
+    val actual = eval("name,a,:eq,:des-fast,1w,:offset,foo,bar,:eq,:cq")
+    val expected = eval("name,a,:eq,foo,bar,:eq,:and,:des-fast,1w,:offset")
+    assert(actual === expected)
+  }
+
+  test("issue-1021: offset with des macros, math") {
+    val actual = eval("name,a,:eq,:sum,:des-fast,1w,:offset,foo,bar,:eq,:cq")
+    val expected = eval("name,a,:eq,foo,bar,:eq,:and,:sum,:des-fast,1w,:offset")
+    assert(actual === expected)
+  }
 }


### PR DESCRIPTION
In some cases when the rewrite was not being used like
an aggregate function, the offset would get lost.

Fixes #1021.