### PR TITLE
Add rolling-sum stateful operator

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineAlgorithm.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineAlgorithm.scala
@@ -48,6 +48,7 @@ object OnlineAlgorithm {
       case "integral"      => OnlineIntegral(state)
       case "pipeline"      => Pipeline(state)
       case "rolling-count" => OnlineRollingCount(state)
+      case "rolling-sum"   => OnlineRollingSum(state)
       case "rolling-max"   => OnlineRollingMax(state)
       case "rolling-mean"  => OnlineRollingMean(state)
       case "rolling-min"   => OnlineRollingMin(state)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingSum.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingSum.scala
@@ -18,8 +18,7 @@ package com.netflix.atlas.core.algorithm
 import com.netflix.atlas.core.util.Math
 
 /**
-  * Sum of the values within a moving window of the input. The denominator is the number
-  * of values (non-NaN entries) in the rolling buffer.
+  * Sum of the values within a moving window of the input.
   *
   * @param buf
   *     Rolling buffer to keep track of the input for a given window.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingSum.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingSum.scala
@@ -55,7 +55,7 @@ case class OnlineRollingSum(buf: RollingBuffer) extends OnlineAlgorithm {
   override def state: AlgoState = {
     AlgoState(
       "rolling-sum",
-      "buffer"       -> buf.state
+      "buffer" -> buf.state
     )
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingSum.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingSum.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+import com.netflix.atlas.core.util.Math
+
+/**
+  * Sum of the values within a moving window of the input. The denominator is the number
+  * of values (non-NaN entries) in the rolling buffer.
+  *
+  * @param buf
+  *     Rolling buffer to keep track of the input for a given window.
+  * @param minNumValues
+  *     Minimum number of values that must be present within the buffer for a sum
+  *     to be emitted. If there are not enough non-NaN values, then NaN will be emitted.
+  */
+case class OnlineRollingSum(buf: RollingBuffer, minNumValues: Int) extends OnlineAlgorithm {
+
+  import java.lang.{Double => JDouble}
+
+  require(minNumValues > 0, "minimum number of values must be >= 1")
+  require(buf.values.length >= minNumValues, "minimum number of values must be <= window size")
+
+  private[this] var sum = Math.addNaN(0.0, buf.sum)
+  private[this] var count = buf.values.count(v => !JDouble.isNaN(v))
+
+  override def next(v: Double): Double = {
+    val removed = buf.add(v)
+
+    if (!JDouble.isNaN(removed)) {
+      sum -= removed
+      count -= 1
+    }
+
+    if (!JDouble.isNaN(v)) {
+      sum += v
+      count += 1
+    }
+
+    if (count >= minNumValues) sum else Double.NaN
+  }
+
+  override def reset(): Unit = {
+    buf.clear()
+    sum = 0.0
+    count = 0
+  }
+
+  override def state: AlgoState = {
+    AlgoState(
+      "rolling-sum",
+      "buffer"       -> buf.state,
+      "minNumValues" -> minNumValues
+    )
+  }
+}
+
+object OnlineRollingSum {
+
+  def apply(n: Int, minNumValues: Int): OnlineRollingSum = apply(RollingBuffer(n), minNumValues)
+
+  def apply(state: AlgoState): OnlineRollingSum = {
+    val minIntervals = state.getInt("minNumValues")
+    apply(RollingBuffer(state.getState("buffer")), minIntervals)
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
@@ -30,6 +30,7 @@ import com.netflix.atlas.core.algorithm.OnlineDerivative
 import com.netflix.atlas.core.algorithm.OnlineIntegral
 import com.netflix.atlas.core.algorithm.OnlineRollingCount
 import com.netflix.atlas.core.algorithm.OnlineRollingMean
+import com.netflix.atlas.core.algorithm.OnlineRollingSum
 import com.netflix.atlas.core.algorithm.OnlineTrend
 
 trait StatefulExpr extends TimeSeriesExpr {}
@@ -159,15 +160,15 @@ object StatefulExpr {
   /**
     * Computes the sum of the values over the last `n` intervals.
     */
-  case class RollingSum(expr: TimeSeriesExpr, n: Int, minNumValues: Int) extends OnlineExpr {
+  case class RollingSum(expr: TimeSeriesExpr, n: Int) extends OnlineExpr {
 
     override protected def name: String = "rolling-sum"
 
     override protected def newAlgorithmInstance(context: EvalContext): OnlineAlgorithm = {
-      OnlineRollingMean(n, minNumValues)
+      OnlineRollingSum(n)
     }
 
-    override def toString: String = s"$expr,$n,$minNumValues,:rolling-sum"
+    override def toString: String = s"$expr,$n,:rolling-sum"
   }
 
   /**

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
@@ -157,6 +157,20 @@ object StatefulExpr {
   }
 
   /**
+    * Computes the sum of the values over the last `n` intervals.
+    */
+  case class RollingSum(expr: TimeSeriesExpr, n: Int, minNumValues: Int) extends OnlineExpr {
+
+    override protected def name: String = "rolling-sum"
+
+    override protected def newAlgorithmInstance(context: EvalContext): OnlineAlgorithm = {
+      OnlineRollingMean(n, minNumValues)
+    }
+
+    override def toString: String = s"$expr,$n,$minNumValues,:rolling-sum"
+  }
+
+  /**
     * DES expression. In order to get the same results, it must be replayed from the same
     * starting point. Used sliding DES if deterministic results are important.
     */

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
@@ -314,39 +314,36 @@ object StatefulVocabulary extends Vocabulary {
     override def name: String = "rolling-sum"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
-      case IntType(_) :: IntType(_) :: TimeSeriesType(_) :: _ => true
-      case IntType(_) :: IntType(_) :: (_: StyleExpr) :: _    => true
+      case IntType(_) :: TimeSeriesType(_) :: _ => true
+      case IntType(_) :: (_: StyleExpr) :: _    => true
     }
 
     protected def executor: PartialFunction[List[Any], List[Any]] = {
-      case IntType(m) :: IntType(n) :: TimeSeriesType(t) :: s =>
-        StatefulExpr.RollingMean(t, n, m) :: s
-      case IntType(m) :: IntType(n) :: (t: StyleExpr) :: s =>
-        t.copy(expr = StatefulExpr.RollingSum(t.expr, n, m)) :: s
+      case IntType(n) :: TimeSeriesType(t) :: s =>
+        StatefulExpr.RollingSum(t, n) :: s
+      case IntType(n) :: (t: StyleExpr) :: s =>
+        t.copy(expr = StatefulExpr.RollingSum(t.expr, n)) :: s
     }
 
     override def summary: String =
       """
-        |Sum of the values within a specified window. The sum will only be emitted
-        |if there are at least a minimum number of actual values (not `NaN`) within
-        |the window. Otherwise `NaN` will be emitted for that time period.
+        |Sum of the values within a specified window.
         |
-        || Input | 3,2,:rolling-sum    |
+        || Input | 3,:rolling-sum    |
         ||-------|---------------------|
-        || 0     | NaN                 |
+        || 0     | 0.0                 |
         || 1     | 1.0                 |
         || -1    | 0.0                 |
         || NaN   | 0.0                 |
+        || NaN   | -1.0                |
         || NaN   | NaN                 |
-        || 0     | NaN                 |
         || 1     | 1.0                 |
         || 1     | 2.0                 |
         || 1     | 3.0                 |
         || 0     | 2.0                 |
         |
         |The window size, `n`, is the number of datapoints to consider including the current
-        |value. There must be at least `minNumValues` non-NaN values within that window before
-        |it will emit a sum. Note that it is based on datapoints, not a specific amount of time.
+        |value. Note that it is based on datapoints, not a specific amount of time.
         |As a result the number of occurrences will be reduced when transitioning to a larger time
         |frame that causes consolidation.
         |

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
@@ -36,6 +36,7 @@ object StatefulVocabulary extends Vocabulary {
     RollingMin,
     RollingMax,
     RollingMean,
+    RollingSum,
     Des,
     SlidingDes,
     Trend,

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingSumSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingSumSuite.scala
@@ -17,44 +17,39 @@ package com.netflix.atlas.core.algorithm
 
 class OnlineRollingSumSuite extends BaseOnlineAlgorithmSuite {
 
-  override def newInstance: OnlineAlgorithm = OnlineRollingSum(50, 30)
+  override def newInstance: OnlineAlgorithm = OnlineRollingSum(50)
 
-  test("n = 1, min = 1") {
-    val algo = OnlineRollingSum(1, 1)
+  test("n = 1") {
+    val algo = OnlineRollingSum(1)
     assert(algo.next(0.0) === 0.0)
     assert(algo.next(1.0) === 1.0)
+    assert(algo.next(2.0) === 2.0)
   }
 
-  test("n = 2, min = 1") {
-    val algo = OnlineRollingSum(2, 1)
+  test("n = 2") {
+    val algo = OnlineRollingSum(2)
     assert(algo.next(0.0) === 0.0)
     assert(algo.next(1.0) === 1.0)
     assert(algo.next(2.0) === 3.0)
   }
 
-  test("n = 2, min = 2") {
-    val algo = OnlineRollingSum(2, 2)
-    assert(algo.next(0.0).isNaN)
-    assert(algo.next(1.0) === 1.0)
-    assert(algo.next(2.0) === 3.0)
-  }
-
-  test("n = 3, min = 2 - up and down") {
-    val algo = OnlineRollingSum(3, 2)
-    assert(algo.next(0.0).isNaN)
+  test("n = 3 - up and down") {
+    val algo = OnlineRollingSum(3)
+    assert(algo.next(0.0) === 0.0)
     assert(algo.next(1.0) === 1.0)
     assert(algo.next(-1.0) === 0.0)
     assert(algo.next(Double.NaN) === 0.0)
+    assert(algo.next(Double.NaN) === -1.0)
     assert(algo.next(Double.NaN).isNaN)
-    assert(algo.next(0.0).isNaN)
+    assert(algo.next(0.0) === 0.0)
     assert(algo.next(1.0) === 1.0)
     assert(algo.next(1.0) === 2.0)
     assert(algo.next(1.0) === 3.0)
     assert(algo.next(0.0) === 2.0)
   }
 
-  test("n = 2, min = 1, NaNs") {
-    val algo = OnlineRollingSum(2, 1)
+  test("n = 2, NaNs") {
+    val algo = OnlineRollingSum(2)
     assert(algo.next(0.0) === 0.0)
     assert(algo.next(1.0) === 1.0)
     assert(algo.next(2.0) === 3.0)
@@ -62,28 +57,10 @@ class OnlineRollingSumSuite extends BaseOnlineAlgorithmSuite {
     assert(algo.next(Double.NaN).isNaN)
   }
 
-  test("n = 2, min = 1, reset") {
-    val algo = OnlineRollingSum(2, 1)
+  test("n = 2, reset") {
+    val algo = OnlineRollingSum(2)
     assert(algo.next(1.0) === 1.0)
     algo.reset()
     assert(algo.next(5.0) === 5.0)
-  }
-
-  test("min < n") {
-    intercept[IllegalArgumentException] {
-      OnlineRollingSum(1, 2)
-    }
-  }
-
-  test("min = 0") {
-    intercept[IllegalArgumentException] {
-      OnlineRollingSum(2, 0)
-    }
-  }
-
-  test("min < 0") {
-    intercept[IllegalArgumentException] {
-      OnlineRollingSum(2, -4)
-    }
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingSumSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingSumSuite.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+class OnlineRollingSumSuite extends BaseOnlineAlgorithmSuite {
+
+  override def newInstance: OnlineAlgorithm = OnlineRollingSum(50, 30)
+
+  test("n = 1, min = 1") {
+    val algo = OnlineRollingSum(1, 1)
+    assert(algo.next(0.0) === 0.0)
+    assert(algo.next(1.0) === 1.0)
+  }
+
+  test("n = 2, min = 1") {
+    val algo = OnlineRollingSum(2, 1)
+    assert(algo.next(0.0) === 0.0)
+    assert(algo.next(1.0) === 1.0)
+    assert(algo.next(2.0) === 3.0)
+  }
+
+  test("n = 2, min = 2") {
+    val algo = OnlineRollingSum(2, 2)
+    assert(algo.next(0.0).isNaN)
+    assert(algo.next(1.0) === 1.0)
+    assert(algo.next(2.0) === 3.0)
+  }
+
+  test("n = 3, min = 2 - up and down") {
+    val algo = OnlineRollingSum(3, 2)
+    assert(algo.next(0.0).isNaN)
+    assert(algo.next(1.0) === 1.0)
+    assert(algo.next(-1.0) === 0.0)
+    assert(algo.next(Double.NaN) === 0.0)
+    assert(algo.next(Double.NaN).isNaN)
+    assert(algo.next(0.0).isNaN)
+    assert(algo.next(1.0) === 1.0)
+    assert(algo.next(1.0) === 2.0)
+    assert(algo.next(1.0) === 3.0)
+    assert(algo.next(0.0) === 2.0)
+  }
+
+  test("n = 2, min = 1, NaNs") {
+    val algo = OnlineRollingSum(2, 1)
+    assert(algo.next(0.0) === 0.0)
+    assert(algo.next(1.0) === 1.0)
+    assert(algo.next(2.0) === 3.0)
+    assert(algo.next(Double.NaN) === 2.0)
+    assert(algo.next(Double.NaN).isNaN)
+  }
+
+  test("n = 2, min = 1, reset") {
+    val algo = OnlineRollingSum(2, 1)
+    assert(algo.next(1.0) === 1.0)
+    algo.reset()
+    assert(algo.next(5.0) === 5.0)
+  }
+
+  test("min < n") {
+    intercept[IllegalArgumentException] {
+      OnlineRollingSum(1, 2)
+    }
+  }
+
+  test("min = 0") {
+    intercept[IllegalArgumentException] {
+      OnlineRollingSum(2, 0)
+    }
+  }
+
+  test("min < 0") {
+    intercept[IllegalArgumentException] {
+      OnlineRollingSum(2, -4)
+    }
+  }
+}


### PR DESCRIPTION
Sum of the values within a specified window. The sum will only be emitted
if there are at least a minimum number of actual values (not `NaN`) within
the window. Otherwise `NaN` will be emitted for that time period.