### PR TITLE
improve error message for invalid percentile data

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -819,7 +819,10 @@ object MathExpr {
         var i = 0
         while (i < usedCounts.length) {
           val vs = byBucket(usedCounts(i))
-          assert(vs.size == 1)
+          require(
+            vs.lengthCompare(1) == 0,
+            s"invalid percentile encoding: [${vs.map(_.tags(TagKey.percentile)).mkString(",")}]"
+          )
           bounded(i) = vs.head.data.bounded(context.start, context.end)
           i += 1
         }


### PR DESCRIPTION
The spectator-js client had a bug (Netflix/spectator-js#22)
leading to duplicate values for a given count. This change
updates the error message so it is easier to understand what
is happening. Before it would just say `assertion failed`.