### PR TITLE
1.5: fix tag results on MemoryDatabase.execute

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
@@ -71,11 +71,18 @@ class MemoryDatabaseSuite extends FunSuite {
 
   private def ts(name: String, label: String, mul: Int, values: Double*): TimeSeries = {
     val seq = new ArrayTimeSeq(DsType.Gauge, 0L, mul * step, values.toArray)
-    TimeSeries(Map("name" -> name), label, seq)
+    TimeSeries(Map("name" -> name, "foo" -> "bar"), label, seq)
+  }
+
+  private def expTS(name: String, label: String, mul: Int, values: Double*): TimeSeries = {
+    val tmp = ts(name, label, mul, values: _*)
+    tmp.withTags(tmp.tags - "foo")
   }
 
   test(":eq query") {
-    assert(exec("name,a,:eq") === List(ts("a", "sum(name=a)", 1, 1.0, 2.0, 3.0)))
+    val result = exec("name,a,:eq")
+    assert(result.map(_.tags) === List(Map("name" -> "a")))
+    assert(result === List(expTS("a", "sum(name=a)", 1, 1.0, 2.0, 3.0)))
   }
 
   test(":in query") {
@@ -112,39 +119,39 @@ class MemoryDatabaseSuite extends FunSuite {
 
   test(":by expr") {
     val expected = List(
-      ts("a", "(name=a)", 1, 1.0, 2.0, 3.0),
-      ts("b", "(name=b)", 1, 3.0, 2.0, 1.0)
+      expTS("a", "(name=a)", 1, 1.0, 2.0, 3.0),
+      expTS("b", "(name=b)", 1, 3.0, 2.0, 1.0)
     )
     assert(exec(":true,(,name,),:by") === expected)
   }
 
   test(":all expr") {
     val expected = List(
-      ts("a", "name=a", 1, 1.0, 2.0, 3.0),
-      ts("b", "name=b", 1, 3.0, 2.0, 1.0)
+      expTS("a", "name=a", 1, 1.0, 2.0, 3.0),
+      expTS("b", "name=b", 1, 3.0, 2.0, 1.0)
     )
     assert(exec(":true,:all") === expected)
   }
 
   test(":by,1,:head expr") {
     val expected = List(
-      ts("a", "(name=a)", 1, 1.0, 2.0, 3.0)
+      expTS("a", "(name=a)", 1, 1.0, 2.0, 3.0)
     )
     assert(exec(":true,(,name,),:by,1,:head") === expected)
   }
 
   test(":by,2,:head expr") {
     val expected = List(
-      ts("a", "(name=a)", 1, 1.0, 2.0, 3.0),
-      ts("b", "(name=b)", 1, 3.0, 2.0, 1.0)
+      expTS("a", "(name=a)", 1, 1.0, 2.0, 3.0),
+      expTS("b", "(name=b)", 1, 3.0, 2.0, 1.0)
     )
     assert(exec(":true,(,name,),:by,2,:head") === expected)
   }
 
   test(":by,3,:head expr") {
     val expected = List(
-      ts("a", "(name=a)", 1, 1.0, 2.0, 3.0),
-      ts("b", "(name=b)", 1, 3.0, 2.0, 1.0)
+      expTS("a", "(name=a)", 1, 1.0, 2.0, 3.0),
+      expTS("b", "(name=b)", 1, 3.0, 2.0, 1.0)
     )
     assert(exec(":true,(,name,),:by,3,:head") === expected)
   }
@@ -183,16 +190,16 @@ class MemoryDatabaseSuite extends FunSuite {
 
   test(":by expr, c=3") {
     val expected = List(
-      ts("a", "(name=a)", 3, 2.0),
-      ts("b", "(name=b)", 3, 2.0)
+      expTS("a", "(name=a)", 3, 2.0),
+      expTS("b", "(name=b)", 3, 2.0)
     )
     assert(exec(":true,(,name,),:by", 3 * step) === expected)
   }
 
   test(":all expr, c=3") {
     val expected = List(
-      ts("a", "name=a", 3, 6.0),
-      ts("b", "name=b", 3, 6.0)
+      expTS("a", "name=a", 3, 6.0),
+      expTS("b", "name=b", 3, 6.0)
     )
     assert(exec(":true,:all", 3 * step) === expected)
   }


### PR DESCRIPTION
Backport of #1031 to 1.5.x.

The set of tags for the aggregated lines should be limited
to the set that are exact matches in the query or are a part
of a group by. Otherwise the grouping can have incorrect
duplicates in the result set.

Fixes #629.