### PR TITLE
detect empty state and stop tracking it

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineAlgorithm.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineAlgorithm.scala
@@ -27,6 +27,15 @@ trait OnlineAlgorithm {
   def reset(): Unit
 
   /**
+    * Returns true if the state is the same as if it had been reset. This means that the state
+    * does not need to be stored and can just be recreated if a new values shows up. When
+    * processing a stream this is needed to avoid a memory leak for state objects if there are
+    * some transient values associated with a group by. This check becomes the effective lifespan
+    * for the state if no data is received for a given interval.
+    */
+  def isEmpty: Boolean
+
+  /**
     * Capture the current state of the algorithm. It can be restored in a new instance
     * with the [OnlineAlgorithm#apply] method.
     */

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineDelay.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineDelay.scala
@@ -27,6 +27,8 @@ case class OnlineDelay(buf: RollingBuffer) extends OnlineAlgorithm {
 
   override def reset(): Unit = buf.clear()
 
+  override def isEmpty: Boolean = buf.isEmpty
+
   override def state: AlgoState = {
     AlgoState("delay", "buffer" -> buf.state)
   }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineDerivative.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineDerivative.scala
@@ -30,6 +30,8 @@ case class OnlineDerivative(private var prev: Double) extends OnlineAlgorithm {
     prev = Double.NaN
   }
 
+  override def isEmpty: Boolean = java.lang.Double.isNaN(prev)
+
   override def state: AlgoState = {
     AlgoState("derivative", "prev" -> prev)
   }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineDes.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineDes.scala
@@ -28,6 +28,7 @@ package com.netflix.atlas.core.algorithm
 case class OnlineDes(training: Int, alpha: Double, beta: Double) extends OnlineAlgorithm {
 
   private var currentSample = 0
+  private var missingSamples = 0
   private var sp = Double.NaN
   private var bp = Double.NaN
 
@@ -43,26 +44,33 @@ case class OnlineDes(training: Int, alpha: Double, beta: Double) extends OnlineA
         sp = sn; bp = bn
       }
       currentSample += 1
+      missingSamples = 0
+    } else {
+      missingSamples += 1
     }
     retval
   }
 
   override def reset(): Unit = {
     currentSample = 0
+    missingSamples = 0
     sp = Double.NaN
     bp = Double.NaN
   }
 
+  override def isEmpty: Boolean = missingSamples >= training
+
   override def state: AlgoState = {
     AlgoState(
       "des",
-      "type"          -> "des",
-      "training"      -> training,
-      "alpha"         -> alpha,
-      "beta"          -> beta,
-      "currentSample" -> currentSample,
-      "sp"            -> sp,
-      "bp"            -> bp
+      "type"           -> "des",
+      "training"       -> training,
+      "alpha"          -> alpha,
+      "beta"           -> beta,
+      "currentSample"  -> currentSample,
+      "missingSamples" -> missingSamples,
+      "sp"             -> sp,
+      "bp"             -> bp
     )
   }
 }
@@ -73,6 +81,7 @@ object OnlineDes {
     val des =
       new OnlineDes(state.getInt("training"), state.getDouble("alpha"), state.getDouble("beta"))
     des.currentSample = state.getInt("currentSample")
+    des.missingSamples = state.getInt("missingSamples")
     des.sp = state.getDouble("sp")
     des.bp = state.getDouble("bp")
     des

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineIgnoreN.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineIgnoreN.scala
@@ -34,6 +34,8 @@ case class OnlineIgnoreN(n: Int) extends OnlineAlgorithm {
     pos = 0
   }
 
+  override def isEmpty: Boolean = false
+
   override def state: AlgoState = {
     AlgoState("ignore", "n" -> n, "pos" -> pos)
   }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineIntegral.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineIntegral.scala
@@ -34,6 +34,8 @@ case class OnlineIntegral(private var value: Double) extends OnlineAlgorithm {
     value = Double.NaN
   }
 
+  override def isEmpty: Boolean = false
+
   override def state: AlgoState = {
     AlgoState("integral", "value" -> value)
   }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingCount.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingCount.scala
@@ -37,6 +37,8 @@ case class OnlineRollingCount(buf: RollingBuffer) extends OnlineAlgorithm {
     count = 0.0
   }
 
+  override def isEmpty: Boolean = buf.isEmpty
+
   override def state: AlgoState = {
     AlgoState("rolling-count", "buffer" -> buf.state)
   }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingMax.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingMax.scala
@@ -37,6 +37,8 @@ case class OnlineRollingMax(buf: RollingBuffer) extends OnlineAlgorithm {
     max = Double.NaN
   }
 
+  override def isEmpty: Boolean = buf.isEmpty
+
   override def state: AlgoState = {
     AlgoState("rolling-max", "buffer" -> buf.state)
   }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingMean.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingMean.scala
@@ -59,6 +59,8 @@ case class OnlineRollingMean(buf: RollingBuffer, minNumValues: Int) extends Onli
     count = 0
   }
 
+  override def isEmpty: Boolean = buf.isEmpty
+
   override def state: AlgoState = {
     AlgoState(
       "rolling-mean",

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingMin.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingMin.scala
@@ -37,6 +37,8 @@ case class OnlineRollingMin(buf: RollingBuffer) extends OnlineAlgorithm {
     min = Double.NaN
   }
 
+  override def isEmpty: Boolean = buf.isEmpty
+
   override def state: AlgoState = {
     AlgoState("rolling-min", "buffer" -> buf.state)
   }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingSum.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingSum.scala
@@ -52,6 +52,8 @@ case class OnlineRollingSum(buf: RollingBuffer) extends OnlineAlgorithm {
     count = 0
   }
 
+  override def isEmpty: Boolean = buf.isEmpty
+
   override def state: AlgoState = {
     AlgoState(
       "rolling-sum",

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineSlidingDes.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineSlidingDes.scala
@@ -56,6 +56,8 @@ case class OnlineSlidingDes(
     des2.reset()
   }
 
+  override def isEmpty: Boolean = false
+
   override def state: AlgoState = {
     AlgoState(
       "sliding-des",

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineTrend.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineTrend.scala
@@ -57,6 +57,8 @@ case class OnlineTrend(buf: RollingBuffer) extends OnlineAlgorithm {
     nanCount = 0
   }
 
+  override def isEmpty: Boolean = buf.isEmpty
+
   override def state: AlgoState = {
     AlgoState(
       "trend",

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/Pipeline.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/Pipeline.scala
@@ -30,6 +30,8 @@ case class Pipeline(stages: List[OnlineAlgorithm]) extends OnlineAlgorithm {
     stages.foreach(_.reset())
   }
 
+  override def isEmpty: Boolean = stages.forall(_.isEmpty)
+
   override def state: AlgoState = {
     AlgoState("pipeline", "stages" -> stages.map(_.state))
   }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/RollingBuffer.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/RollingBuffer.scala
@@ -102,6 +102,8 @@ class RollingBuffer(val values: Array[Double], start: Int = 0) {
     size = 0
   }
 
+  def isEmpty: Boolean = size == 0
+
   def state: AlgoState = {
     val vs = java.util.Arrays.copyOf(values, values.length)
     AlgoState("rolling-buffer", "values" -> vs, "pos" -> pos)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
@@ -254,7 +254,10 @@ object StatefulExpr {
           bounded.data(i) = algo.next(bounded.data(i))
           i += 1
         }
-        state(t.id) = algo.state
+        if (algo.isEmpty)
+          state -= t.id
+        else
+          state(t.id) = algo.state
         TimeSeries(t.tags, s"$name(${t.label})", bounded)
       }
       ResultSet(this, newData, rs.state + (this -> state))

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineDelaySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineDelaySuite.scala
@@ -25,6 +25,7 @@ class OnlineDelaySuite extends BaseOnlineAlgorithmSuite {
     assert(algo.next(1.0) === 0.0)
     assert(algo.next(2.0) === 1.0)
     assert(algo.next(Double.NaN) === 2.0)
+    assert(algo.isEmpty)
     assert(algo.next(Double.NaN).isNaN)
   }
 
@@ -43,7 +44,10 @@ class OnlineDelaySuite extends BaseOnlineAlgorithmSuite {
     assert(algo.next(1.0).isNaN)
     assert(algo.next(2.0) === 0.0)
     assert(algo.next(Double.NaN) === 1.0)
+    assert(!algo.isEmpty)
     assert(algo.next(Double.NaN) === 2.0)
+    assert(algo.isEmpty)
     assert(algo.next(Double.NaN).isNaN)
+    assert(algo.isEmpty)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineDerivativeSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineDerivativeSuite.scala
@@ -53,8 +53,10 @@ class OnlineDerivativeSuite extends BaseOnlineAlgorithmSuite {
   test("reset") {
     val algo = OnlineDerivative(Double.NaN)
     assert(algo.next(1.0).isNaN)
+    assert(!algo.isEmpty)
     assert(algo.next(2.0) === 1.0)
     algo.reset()
+    assert(algo.isEmpty)
     assert(algo.next(3.0).isNaN)
     assert(algo.next(7.0) === 4.0)
   }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineDesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineDesSuite.scala
@@ -18,4 +18,15 @@ package com.netflix.atlas.core.algorithm
 class OnlineDesSuite extends BaseOnlineAlgorithmSuite {
 
   override def newInstance: OnlineAlgorithm = OnlineDes(10, 0.1, 0.2)
+
+  test("training = 2, NaNs") {
+    val algo = OnlineDes(2, 0.25, 0.25)
+    assert(algo.next(0.0).isNaN)
+    assert(algo.next(1.0).isNaN)
+    algo.next(2.0)
+    algo.next(Double.NaN)
+    assert(!algo.isEmpty)
+    algo.next(Double.NaN)
+    assert(algo.isEmpty)
+  }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingCountSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingCountSuite.scala
@@ -45,7 +45,9 @@ class OnlineRollingCountSuite extends BaseOnlineAlgorithmSuite {
     assert(algo.next(1.0) === 1.0)
     assert(algo.next(2.0) === 2.0)
     assert(algo.next(Double.NaN) === 1.0)
+    assert(!algo.isEmpty)
     assert(algo.next(Double.NaN) === 0.0)
+    assert(algo.isEmpty)
   }
 
   test("n = 2, reset") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMaxSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMaxSuite.scala
@@ -45,7 +45,9 @@ class OnlineRollingMaxSuite extends BaseOnlineAlgorithmSuite {
     assert(algo.next(1.0) === 1.0)
     assert(algo.next(2.0) === 2.0)
     assert(algo.next(Double.NaN) === 2.0)
+    assert(!algo.isEmpty)
     assert(algo.next(Double.NaN).isNaN)
+    assert(algo.isEmpty)
   }
 
   test("n = 2, reset") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMeanSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMeanSuite.scala
@@ -52,7 +52,9 @@ class OnlineRollingMeanSuite extends BaseOnlineAlgorithmSuite {
     assert(algo.next(1.0) === 0.5)
     assert(algo.next(2.0) === 1.5)
     assert(algo.next(Double.NaN) === 2.0)
+    assert(!algo.isEmpty)
     assert(algo.next(Double.NaN).isNaN)
+    assert(algo.isEmpty)
   }
 
   test("n = 2, min = 1, reset") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMinSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMinSuite.scala
@@ -45,7 +45,9 @@ class OnlineRollingMinSuite extends BaseOnlineAlgorithmSuite {
     assert(algo.next(1.0) === 0.0)
     assert(algo.next(2.0) === 1.0)
     assert(algo.next(Double.NaN) === 2.0)
+    assert(!algo.isEmpty)
     assert(algo.next(Double.NaN).isNaN)
+    assert(algo.isEmpty)
   }
 
   test("n = 2, reset") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingSumSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingSumSuite.scala
@@ -39,8 +39,11 @@ class OnlineRollingSumSuite extends BaseOnlineAlgorithmSuite {
     assert(algo.next(1.0) === 1.0)
     assert(algo.next(-1.0) === 0.0)
     assert(algo.next(Double.NaN) === 0.0)
+    assert(!algo.isEmpty)
     assert(algo.next(Double.NaN) === -1.0)
+    assert(!algo.isEmpty)
     assert(algo.next(Double.NaN).isNaN)
+    assert(algo.isEmpty)
     assert(algo.next(0.0) === 0.0)
     assert(algo.next(1.0) === 1.0)
     assert(algo.next(1.0) === 2.0)
@@ -54,7 +57,9 @@ class OnlineRollingSumSuite extends BaseOnlineAlgorithmSuite {
     assert(algo.next(1.0) === 1.0)
     assert(algo.next(2.0) === 3.0)
     assert(algo.next(Double.NaN) === 2.0)
+    assert(!algo.isEmpty)
     assert(algo.next(Double.NaN).isNaN)
+    assert(algo.isEmpty)
   }
 
   test("n = 2, reset") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineTrendSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineTrendSuite.scala
@@ -45,7 +45,9 @@ class OnlineTrendSuite extends BaseOnlineAlgorithmSuite {
     assert(algo.next(1.0) === 0.5)
     assert(algo.next(2.0) === 1.5)
     assert(algo.next(Double.NaN) === 1.0)
+    assert(!algo.isEmpty)
     assert(algo.next(Double.NaN).isNaN)
+    assert(algo.isEmpty)
   }
 
   test("n = 2, reset") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/DerivativeSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/DerivativeSuite.scala
@@ -71,4 +71,13 @@ class DerivativeSuite extends FunSuite {
         assert(actual === expected)
     }
   }
+
+  test("state will expire and get cleaned up") {
+    val expr = StatefulExpr.Derivative(DataExpr.Sum(Query.True))
+
+    val context = EvalContext(start, start + step * 4, step)
+    val rs = expr.eval(context, List(ts(1.0, 2.0, 3.0, Double.NaN)))
+
+    assert(rs.state(expr).asInstanceOf[scala.collection.mutable.Map[_, _]].isEmpty)
+  }
 }


### PR DESCRIPTION
Updates the online algorithms used with stateful operators
to detect if the state is effectively empty. In that case
the state will be dropped from the state map maintained
during evaluation. This is useful to avoid leaking memory
for tracking the state during long running streaming
evaluations.

There are currently three exceptions that have an unbounded
window and never become empty: ignore-N, sdes, and integral.
Integral is generally not very useful in a streaming context
so we may just prohibit that operation. For sdes (and ignore-N
which is typically only used to align sdes), the current uses
do not involve group by operations, so it shouldn't be an
issue for now. We'll revisit in the future when there are
concrete use-cases that are problematic for that operation.