### PR TITLE
fix empty data case for math/count

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -619,11 +619,16 @@ object MathExpr {
 
     override def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
       val rs = expr.eval(context, data)
-      val init = rs.data.map { t =>
-        TimeSeries(t.tags, t.label, t.data.mapValues(v => if (v.isNaN) Double.NaN else 1.0))
-      }
-      val t = TimeSeries.aggregate(init.iterator, context.start, context.end, this)
-      ResultSet(this, List(TimeSeries(t.tags, s"$name(${t.label})", t.data)), rs.state)
+      val ts =
+        if (rs.data.isEmpty) Nil
+        else {
+          val init = rs.data.map { t =>
+            TimeSeries(t.tags, t.label, t.data.mapValues(v => if (v.isNaN) Double.NaN else 1.0))
+          }
+          val t = TimeSeries.aggregate(init.iterator, context.start, context.end, this)
+          List(TimeSeries(t.tags, s"$name(${t.label})", t.data))
+        }
+      ResultSet(this, ts, rs.state)
     }
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
@@ -183,6 +183,7 @@ class TimeSeriesExprSuite extends FunSuite {
     ":true,1w,:offset"             -> const(ts(unknownTag, "name=unknown (offset=1w)", 55)),
     ":true,5,:add,1w,:offset"      -> const(ts(unknownTag, "(name=unknown (offset=1w) + 5.0)", 60)),
     "issue,283,:eq"                -> const(ts(Map("issue" -> "283"), "NO DATA", Double.NaN)),
+    ":false,(,name,),:by,:count"   -> const(Nil),
     ":true,(,name,),:by,:stddev" -> const(
       ts(Map.empty[String, String], stddevLegend("NO TAGS"), 3.1622776601683795)
     ),


### PR DESCRIPTION
It wasn't checking if the input was empty like the other
aggregate functions. Now it performs the same check which
avoids errors like:

```
must have 1 or more time series to perform aggregation
```