### PR TITLE
remove jackson-datatype-joda usage

### DIFF
--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.core._
 import com.fasterxml.jackson.databind._
 import com.fasterxml.jackson.dataformat.smile.SmileFactory
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
-import com.fasterxml.jackson.datatype.joda.JodaModule
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 
@@ -82,7 +81,6 @@ object Json {
     mapper.registerModule(new AtlasModule)
     mapper.registerModule(new JavaTimeModule)
     mapper.registerModule(new Jdk8Module)
-    mapper.registerModule(new JodaModule)
     mapper
   }
 

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
@@ -23,10 +23,6 @@ import java.util.regex.Pattern
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.core.JsonToken
 import com.fasterxml.jackson.databind.JsonNode
-import org.joda.time.DateTime
-import org.joda.time.DateTimeZone
-import org.joda.time.Duration
-import org.joda.time.Period
 import org.scalatest.FunSuite
 
 /**
@@ -181,24 +177,6 @@ class JsonSuite extends FunSuite {
     val v = JsonToken.NOT_AVAILABLE
     assert(encode(v) === "\"NOT_AVAILABLE\"")
     assert(decode[JsonToken](encode(v)) === v)
-  }
-
-  test("joda DateTime") {
-    val v = new DateTime(2012, 1, 13, 4, 37, 52, 0, DateTimeZone.UTC)
-    assert(encode(v) === v.getMillis.toString)
-    assert(decode[DateTime](encode(v)) === v)
-  }
-
-  test("joda Duration") {
-    val v = Duration.standardSeconds(42)
-    assert(encode(v) === v.getMillis.toString)
-    assert(decode[Duration](encode(v)) === v)
-  }
-
-  test("joda Period") {
-    val v = Period.seconds(42)
-    assert(encode(v) === "\"PT42S\"")
-    assert(decode[Period](encode(v)) === v)
   }
 
   test("java8 Instant") {

--- a/build.sbt
+++ b/build.sbt
@@ -76,12 +76,10 @@ lazy val `atlas-json` = project
   .settings(libraryDependencies ++= Seq(
     Dependencies.jacksonCore,
     Dependencies.jacksonJava8,
-    Dependencies.jacksonJoda,
     Dependencies.jacksonJsr310,
     Dependencies.jacksonMapper,
     Dependencies.jacksonScala,
-    Dependencies.jacksonSmile,
-    Dependencies.jodaConvert
+    Dependencies.jacksonSmile
   ))
 
 lazy val `atlas-lwcapi` = project

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,12 +45,10 @@ object Dependencies {
   val jacksonAnno       = "com.fasterxml.jackson.core" % "jackson-annotations" % jackson
   val jacksonCore       = "com.fasterxml.jackson.core" % "jackson-core" % jackson
   val jacksonJava8      = "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jackson
-  val jacksonJoda       = "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % jackson
   val jacksonJsr310     = "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jackson
   val jacksonMapper     = "com.fasterxml.jackson.core" % "jackson-databind" % jackson
   val jacksonScala      = "com.fasterxml.jackson.module" %% "jackson-module-scala" % jackson
   val jacksonSmile      = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-smile" % jackson
-  val jodaConvert       = "org.joda" % "joda-convert" % "2.2.1"
   val jol               = "org.openjdk.jol" % "jol-core" % "0.9"
   val jsr250            = "javax.annotation" % "jsr250-api" % "1.0"
   val jsr305            = "com.google.code.findbugs" % "jsr305" % "3.0.2"


### PR DESCRIPTION
Uses for Atlas moved to `java.time` a long time ago. Users can
add this manually by calling `Json.registerModule` if it is
still needed.