### PR TITLE
add binding for materializer

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/WebServer.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/WebServer.scala
@@ -21,7 +21,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.server.Route
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import com.netflix.iep.service.AbstractService
 import com.netflix.iep.service.ClassFactory
 import com.netflix.spectator.api.Registry
@@ -51,11 +51,11 @@ class WebServer @Inject()(
   config: Config,
   classFactory: ClassFactory,
   registry: Registry,
-  implicit val system: ActorSystem
+  implicit val system: ActorSystem,
+  implicit val materializer: Materializer
 ) extends AbstractService
     with StrictLogging {
 
-  private implicit val materializer = ActorMaterializer()
   private implicit val executionContext = system.dispatcher
 
   private val port = config.getInt("atlas.akka.port")

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluationFlows.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluationFlows.scala
@@ -19,8 +19,8 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import akka.Done
 import akka.NotUsed
-import akka.stream.ActorMaterializer
 import akka.stream.KillSwitches
+import akka.stream.Materializer
 import akka.stream.ThrottleMode
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Framing
@@ -42,7 +42,7 @@ private[stream] object EvaluationFlows {
     * Run a stream connecting the source to the sink.
     */
   def run[T, M1, M2](source: Source[T, M1], sink: Sink[T, M2])(
-    implicit materializer: ActorMaterializer
+    implicit materializer: Materializer
   ): StreamRef[M2] = {
 
     val (killSwitch, value) = source

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -26,7 +26,6 @@ import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.Uri
-import akka.stream.ActorMaterializer
 import akka.stream.FlowShape
 import akka.stream.ThrottleMode
 import akka.stream.scaladsl.Broadcast
@@ -67,7 +66,7 @@ private[stream] abstract class EvaluatorImpl(
   implicit val system: ActorSystem
 ) {
 
-  private implicit val materializer = ActorMaterializer()
+  private implicit val materializer = StreamOps.materializer(system, registry)
 
   // Cached context instance used for things like expression validation.
   private val validationStreamContext = newStreamContext()

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -22,8 +22,8 @@ import java.util.UUID
 import akka.NotUsed
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.Uri
-import akka.stream.ActorMaterializer
 import akka.stream.IOResult
+import akka.stream.Materializer
 import akka.stream.scaladsl.FileIO
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
@@ -49,7 +49,7 @@ import scala.util.Try
 private[stream] class StreamContext(
   rootConfig: Config,
   val client: Client,
-  val materializer: ActorMaterializer,
+  val materializer: Materializer,
   val registry: Registry = new NoopRegistry,
   val dsLogger: DataSourceLogger = (_, _) => ()
 ) {

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
@@ -17,7 +17,6 @@ package com.netflix.atlas.lwcapi
 
 import akka.NotUsed
 import javax.inject.Inject
-import akka.actor.ActorRefFactory
 import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.model.HttpEntity.ChunkStreamPart
 import akka.http.scaladsl.model.HttpResponse
@@ -25,7 +24,7 @@ import akka.http.scaladsl.model.MediaTypes
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.stream.ThrottleMode
 import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Sink
@@ -51,14 +50,13 @@ class StreamApi @Inject()(
   registry: Registry,
   sm: StreamSubscriptionManager,
   splitter: ExpressionSplitter,
-  implicit val actorRefFactory: ActorRefFactory
+  implicit val materializer: Materializer
 ) extends WebApi
     with StrictLogging {
 
   import StreamApi._
 
   private implicit val ec = scala.concurrent.ExecutionContext.global
-  private implicit val materializer = ActorMaterializer()
 
   private val queueSize = config.getInt("atlas.lwcapi.queue-size")
 

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
@@ -19,7 +19,6 @@ import java.nio.charset.StandardCharsets
 import java.util.UUID
 
 import akka.NotUsed
-import akka.actor.ActorSystem
 import javax.inject.Inject
 import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.model.HttpResponse
@@ -30,7 +29,7 @@ import akka.http.scaladsl.model.ws.Message
 import akka.http.scaladsl.model.ws.TextMessage
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.stream.ThrottleMode
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Keep
@@ -62,15 +61,13 @@ class SubscribeApi @Inject()(
   registry: Registry,
   sm: StreamSubscriptionManager,
   splitter: ExpressionSplitter,
-  implicit val system: ActorSystem
+  implicit val materializer: Materializer
 ) extends WebApi
     with StrictLogging {
 
   import SubscribeApi._
-  import StreamApi._
 
   private implicit val ec = scala.concurrent.ExecutionContext.global
-  private implicit val materializer = ActorMaterializer()
 
   private val queueSize = config.getInt("atlas.lwcapi.queue-size")
 

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
@@ -56,7 +56,7 @@ class SubscribeApiSuite extends FunSuite with BeforeAndAfter with ScalatestRoute
   private val sm = new StreamSubscriptionManager
   private val splitter = new ExpressionSplitter(config)
 
-  private val api = new SubscribeApi(config, new NoopRegistry, sm, splitter, system)
+  private val api = new SubscribeApi(config, new NoopRegistry, sm, splitter, materializer)
 
   private val routes = RequestHandler.standardOptions(api.routes)
 

--- a/atlas-poller/src/main/scala/com/netflix/atlas/poller/ClientActor.scala
+++ b/atlas-poller/src/main/scala/com/netflix/atlas/poller/ClientActor.scala
@@ -24,7 +24,7 @@ import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.model.MediaTypes
 import akka.http.scaladsl.model.headers._
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import com.netflix.atlas.akka.AccessLogger
 import com.netflix.atlas.akka.CustomMediaTypes
 import com.netflix.atlas.core.model.Datapoint
@@ -46,10 +46,10 @@ import scala.util.Success
   * be logged and reflected in the `atlas.client.dropped` counter as well as standard
   * client access logging.
   */
-class ClientActor(registry: Registry, config: Config) extends Actor {
+class ClientActor(registry: Registry, config: Config, implicit val materializer: Materializer)
+    extends Actor {
 
   private implicit val xc = scala.concurrent.ExecutionContext.global
-  private implicit val materializer = ActorMaterializer()
 
   private val logger = LoggerFactory.getLogger(getClass)
 

--- a/atlas-poller/src/test/scala/com/netflix/atlas/poller/ClientActorSuite.scala
+++ b/atlas-poller/src/test/scala/com/netflix/atlas/poller/ClientActorSuite.scala
@@ -18,6 +18,8 @@ package com.netflix.atlas.poller
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.model.StatusCodes
+import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.testkit.ImplicitSender
 import akka.testkit.TestActorRef
 import akka.testkit.TestKit
@@ -51,7 +53,8 @@ class ClientActorSuite
   private val clock = new ManualClock()
   private val registry = new DefaultRegistry(clock)
   private val config = ConfigFactory.load().getConfig("atlas.poller.sink")
-  private val ref = TestActorRef(new TestClientActor(registry, config))
+  private val materializer = ActorMaterializer()(system)
+  private val ref = TestActorRef(new TestClientActor(registry, config, materializer))
 
   override def afterAll(): Unit = {
     system.terminate()
@@ -148,7 +151,8 @@ object ClientActorSuite {
 
   object Done
 
-  class TestClientActor(registry: Registry, config: Config) extends ClientActor(registry, config) {
+  class TestClientActor(registry: Registry, config: Config, materializer: Materializer)
+      extends ClientActor(registry, config, materializer) {
 
     var response: Try[HttpResponse] = Failure(new RuntimeException("not set"))
 


### PR DESCRIPTION
Setup a default binding for the materializer using a
supervision strategy that will provide better visibility
into failures.