### PR TITLE
remove cross build for 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: scala
 matrix:
   include:
-  - jdk: openjdk8
-    scala: 2.11.12
-    os: linux
-    dist: trusty
-    env: BINTRAY_PUBLISH=true
   - jdk: openjdk11
     scala: 2.12.8
     os: osx

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
     val slf4j      = "1.7.26"
     val spectator  = "0.92.0"
 
-    val crossScala = Seq("2.11.12", scala, "2.13.0-RC3")
+    val crossScala = Seq(scala, "2.13.0-RC3")
   }
 
   import Versions._


### PR DESCRIPTION
Use 1.6.x if 2.11 support is still needed.