### PR TITLE
fix build settings for 2.13 to use `-release 8`

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -11,7 +11,7 @@ object BuildSettings {
     "-feature"
   )
 
-  private val isJdk11 = System.getProperty("java.specification.version") == "11"
+  private val isRecentJdk = System.getProperty("java.specification.version").toDouble >= 11.0
 
   lazy val checkLicenseHeaders = taskKey[Unit]("Check the license headers for all source files.")
   lazy val formatLicenseHeaders = taskKey[Unit]("Fix the license headers for all source files.")
@@ -28,12 +28,12 @@ object BuildSettings {
       // -release option is not supported in scala 2.11
       val v = scalaVersion.value
       CrossVersion.partialVersion(v).map(_._2.toInt) match {
-        case Some(12) if isJdk11 => compilerFlags ++ Seq("-release", "8")
-        case _                   => compilerFlags ++ Seq("-target:jvm-1.8")
+        case Some(v) if v > 11 && isRecentJdk => compilerFlags ++ Seq("-release", "8")
+        case _                                => compilerFlags ++ Seq("-target:jvm-1.8")
       }
     },
     javacOptions ++= {
-      if (isJdk11)
+      if (isRecentJdk)
         Seq("--release", "8")
       else
         Seq("-source", "1.8", "-target", "1.8")


### PR DESCRIPTION
Port #1055 from 1.6.x branch to master.

Before it was looking specifically for version 12. For now
we still need to be able to run on jdk8+. The specific issue
encountered was:

```
java.lang.NoSuchMethodError: java.nio.CharBuffer.clear()Ljava/nio/CharBuffer;
   at com.netflix.atlas.core.model.TaggedItem$.writePair(TaggedItem.scala:59)
   at com.netflix.atlas.core.model.TaggedItem$.computeId(TaggedItem.scala:105)
   at com.netflix.atlas.core.model.TimeSeries$.<clinit>(TimeSeries.scala:22)
   at com.netflix.atlas.core.model.EvalContext.<init>(EvalContext.scala:32)
   at com.netflix.atlas.druid.DruidDatabaseActorSuite.<init>(DruidDatabaseActorSuite.scala:259)
   at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
   at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
   at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
   at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
   at java.lang.Class.newInstance(Class.java:442)
```

Also improves the check for recent JDKs.