### PR TITLE
fix aws.ec2.badInstances mapping

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/ec2.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/ec2.conf
@@ -119,7 +119,7 @@ atlas {
           ]
         },
         {
-          name = "StatusCheckFailed_Instance"
+          name = "StatusCheckFailed_System"
           alias = "aws.ec2.badInstances"
           conversion = "max"
           tags = [


### PR DESCRIPTION
map the `system` id to `StatusCheckFailed_System`, instead of
`StatusCheckFailed_Instance`