### PR TITLE
remove ElasticSearch MasterFreeStorageSpace metric

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/es.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/es.conf
@@ -119,11 +119,6 @@ atlas {
           conversion = "min"
         },
         {
-          name = "MasterFreeStorageSpace"
-          alias = "aws.esmaster.freeStorageSpace"
-          conversion = "min"
-        },
-        {
           name = "JVMMemoryPressure"
           alias = "aws.es.jvmMemoryPressure"
           conversion = "max"


### PR DESCRIPTION
From the ElasticSearch CloudWatch metrics documentation:

https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-managedomains.html#es-managedomains-cloudwatchmetrics-master-node-metrics

This metric is not relevant and can be ignored. The service does not use
master nodes as data nodes.