### PR TITLE
1.6: try disabling gigahorse

### DIFF
--- a/project/sbt
+++ b/project/sbt
@@ -14,5 +14,6 @@ java \
   -XX:+UseCodeCacheFlushing \
   -Dsbt.boot.directory=${WORKSPACE:-$HOME}/.sbt \
   -Dsbt.ivy.home=${WORKSPACE:-$HOME}/.ivy2 \
+  -Dsbt.gigahorse=false \
   $OPTIONS \
   -jar `dirname $0`/sbt-launch-1.2.8.jar "$@"


### PR DESCRIPTION
Backport #1064 to 1.6.x.

Setting in the `build.properties` file doesn't seem to work
for this setting (tried in #1062).