### PR TITLE
fix most 2.13 compiler warnings

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/ActorService.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/ActorService.scala
@@ -37,7 +37,7 @@ class ActorService @Inject()(system: ActorSystem, config: Config, classFactory: 
     with StrictLogging {
 
   override def startImpl(): Unit = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     config.getConfigList("atlas.akka.actors").asScala.foreach { cfg =>
       val name = cfg.getString("name")
       val cls = Class.forName(cfg.getString("class"))

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/ConfigApi.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/ConfigApi.scala
@@ -84,7 +84,7 @@ class ConfigApi(config: Config, implicit val actorRefFactory: ActorRefFactory) e
   }
 
   private def getPathValue(config: Config, p: String): Config = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     try config.getConfig(p)
     catch {
       case e: ConfigException.WrongType =>
@@ -107,7 +107,7 @@ class ConfigApi(config: Config, implicit val actorRefFactory: ActorRefFactory) e
   }
 
   private def formatProperties(config: Config): HttpResponse = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val props = new Properties
     config.entrySet.asScala.foreach { t =>
       props.setProperty(t.getKey, s"${t.getValue.unwrapped}")

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/HealthcheckApi.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/HealthcheckApi.scala
@@ -49,7 +49,7 @@ class HealthcheckApi(serviceManagerProvider: Provider[ServiceManager])
   private def serviceManager: ServiceManager = serviceManagerProvider.get
 
   private def summary: String = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val states = serviceManager.services().asScala.map(s => s.name -> s.isHealthy).toMap
     Json.encode(states)
   }

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/RequestHandler.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/RequestHandler.scala
@@ -55,17 +55,17 @@ class RequestHandler(config: Config, classFactory: ClassFactory) extends StrictL
   }
 
   private def endpoints: List[String] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     config.getStringList("atlas.akka.api-endpoints").asScala.toList.distinct
   }
 
   private def corsHostPatterns: List[String] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     config.getStringList("atlas.akka.cors-host-patterns").asScala.toList.distinct
   }
 
   private def diagnosticHeaders: List[HttpHeader] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     config
       .getConfigList("atlas.akka.diagnostic-headers")
       .asScala

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/StaticPages.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/StaticPages.scala
@@ -43,7 +43,7 @@ class StaticPages(config: Config) extends WebApi {
       getFromResourceDirectory("www")
     }
 
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val singlePagePrefixes = config.getConfigList("atlas.akka.static.single-page-prefixes")
     singlePagePrefixes.asScala.foldLeft(staticFiles) { (acc, cfg) =>
       val prefix = cfg.getString("prefix")

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/ConfigApiSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/ConfigApiSuite.scala
@@ -56,7 +56,7 @@ class ConfigApiSuite extends FunSuite with ScalatestRouteTest {
   }
 
   test("/config/os.arch") {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     Get("/api/v2/config/os.arch") ~> endpoint.routes ~> check {
       val config = ConfigFactory.parseString(responseAs[String])
       val v = sysConfig.getString("os.arch")
@@ -81,7 +81,7 @@ class ConfigApiSuite extends FunSuite with ScalatestRouteTest {
 
   test("/config format properties") {
     Get("/api/v2/config?format=properties") ~> endpoint.routes ~> check {
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       val props = new Properties
       props.load(new StringReader(responseAs[String]))
       val config = ConfigFactory.parseProperties(props)

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
@@ -46,7 +46,7 @@ class StreamOpsSuite extends FunSuite {
   private implicit val materializer = ActorMaterializer()
 
   private def checkOfferedCounts(registry: Registry, expected: Map[String, Double]): Unit = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     registry
       .stream()
       .iterator()
@@ -146,7 +146,7 @@ class StreamOpsSuite extends FunSuite {
   }
 
   private def checkCounts(registry: Registry, name: String, expected: Map[String, Double]): Unit = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     registry
       .stream()
       .iterator()

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/DefaultGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/DefaultGraphEngine.scala
@@ -33,7 +33,7 @@ import com.netflix.atlas.core.util.UnitPrefix
 class DefaultGraphEngine extends PngGraphEngine {
 
   private val renderingHints = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val config = ConfigManager.current.getConfig("atlas.chart.rendering-hints")
     config.entrySet.asScala.toList.map { entry =>
       val k = getField(entry.getKey).asInstanceOf[RenderingHints.Key]

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonCodec.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonCodec.scala
@@ -298,7 +298,7 @@ private[chart] object JsonCodec {
   private def toGraphDef(node: JsonNode): GraphDef = {
 
     // format: off
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     GraphDef(
       Nil,
       startTime  = Instant.ofEpochMilli(node.get("startTime").asLong()),
@@ -395,7 +395,7 @@ private[chart] object JsonCodec {
   }
 
   private def toTimeSeries(gdef: GraphDef, node: JsonNode): TimeSeries = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val tags = node.get("tags").fields.asScala.map(e => e.getKey -> e.getValue.asText()).toMap
     val values = node.get("data").get("values").elements.asScala.map(_.asDouble()).toArray
     val seq = new ArrayTimeSeq(DsType.Gauge, gdef.startTime.toEpochMilli, gdef.step, values)

--- a/atlas-core/src/main/scala-2.13+/com/netflix/atlas/core/util/SmallHashMap.scala
+++ b/atlas-core/src/main/scala-2.13+/com/netflix/atlas/core/util/SmallHashMap.scala
@@ -178,7 +178,7 @@ final class SmallHashMap[K <: Any, V <: Any] private (val data: Array[Any], data
 
   def get(key: K): Option[V] = Option(getOrNull(key))
 
-  override def foreach[U](f: ((K, V)) => U) {
+  override def foreach[U](f: ((K, V)) => U): Unit = {
     var i = 0
     while (i < data.length) {
       if (data(i) != null) f(data(i).asInstanceOf[K] -> data(i + 1).asInstanceOf[V])
@@ -426,7 +426,7 @@ final class SmallHashMap[K <: Any, V <: Any] private (val data: Array[Any], data
         * the entry set is needed.
         */
       override def entrySet(): java.util.Set[java.util.Map.Entry[K, V]] = {
-        import scala.collection.JavaConverters._
+        import scala.jdk.CollectionConverters._
         self.asJava.entrySet()
       }
     }

--- a/atlas-core/src/main/scala-2.13-/com/netflix/atlas/core/util/SmallHashMap.scala
+++ b/atlas-core/src/main/scala-2.13-/com/netflix/atlas/core/util/SmallHashMap.scala
@@ -426,7 +426,7 @@ final class SmallHashMap[K <: Any, V <: Any] private (val data: Array[Any], data
         * the entry set is needed.
         */
       override def entrySet(): java.util.Set[java.util.Map.Entry[K, V]] = {
-        import scala.collection.JavaConverters._
+        import scala.jdk.CollectionConverters._
         self.asJava.entrySet()
       }
     }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
@@ -171,7 +171,7 @@ class MemoryDatabase(registry: Registry, config: Config) extends Database {
         case _: DataExpr.All => tags
         case _ =>
           val resultKeys = Query.exactKeys(expr.query) ++ expr.finalGrouping
-          tags.filterKeys(resultKeys.contains).toMap
+          tags.filter(t => resultKeys.contains(t._1))
       }
       TimeSeriesBuffer(resultTags, cfStep, bufStart, bufEnd)
     }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/BatchUpdateTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/BatchUpdateTagIndex.scala
@@ -78,7 +78,7 @@ class BatchUpdateTagIndex[T <: TaggedItem: ClassTag](
   def rebuildIndex(): Unit = {
     val timerId = rebuildTimer.start()
     try {
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
 
       // Drain the update queue and create map of items for deduping, we put new items in the
       // map first so that an older item, if present, will be preferred

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/CustomVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/CustomVocabulary.scala
@@ -81,7 +81,7 @@ import com.typesafe.config.Config
   */
 class CustomVocabulary(config: Config) extends Vocabulary {
   import CustomVocabulary._
-  import scala.collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
 
   val name: String = "custom"
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
@@ -95,7 +95,9 @@ object DataExpr {
     // 32 is typically big enough to prevent a resize with a single key
     val builder = new StringBuilder(32 * keys.size)
     builder.append('(')
-    keys.foreach { k =>
+    val it = keys.iterator
+    while (it.hasNext) {
+      val k = it.next()
       val v = tags.get(k)
       if (v.isEmpty) return null
       builder.append(k).append('=').append(v.get).append(' ')

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
@@ -266,7 +266,7 @@ object StatefulExpr {
       // Update the stateful buffers for expressions that do not have an explicit value for
       // this interval. For streaming contexts only data that is reported for that interval
       // will be present, but the state needs to be moved for all entries.
-      val noDataIds = state.keySet -- rs.data.map(_.id)
+      val noDataIds = state.keySet diff rs.data.map(_.id).toSet
       noDataIds.foreach { id =>
         val algo = OnlineAlgorithm(state(id))
         algo.next(Double.NaN)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
@@ -266,7 +266,7 @@ object StatefulExpr {
       // Update the stateful buffers for expressions that do not have an explicit value for
       // this interval. For streaming contexts only data that is reported for that interval
       // will be present, but the state needs to be moved for all entries.
-      val noDataIds = state.keySet diff rs.data.map(_.id).toSet
+      val noDataIds = state.keySet.diff(rs.data.map(_.id).toSet)
       noDataIds.foreach { id =>
         val algo = OnlineAlgorithm(state(id))
         algo.next(Double.NaN)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ReservedKeyRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ReservedKeyRule.scala
@@ -41,7 +41,7 @@ case class ReservedKeyRule(prefix: String, allowedKeys: Set[String]) extends Tag
 object ReservedKeyRule {
 
   def apply(config: Config): ReservedKeyRule = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     val prefix = config.getString("prefix")
     val allowedKeys =

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/Rule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/Rule.scala
@@ -54,7 +54,7 @@ trait Rule {
 object Rule {
 
   def load(ruleConfigs: java.util.List[_ <: Config]): List[Rule] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     load(ruleConfigs.asScala.toList)
   }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ValidCharactersRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ValidCharactersRule.scala
@@ -57,7 +57,7 @@ case class ValidCharactersRule(defaultSet: AsciiSet, overrides: Map[String, Asci
 object ValidCharactersRule {
 
   def apply(config: Config): ValidCharactersRule = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     def loadOverrides: Map[String, AsciiSet] = {
       val entries = config.getConfigList("overrides").asScala.map { cfg =>

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/DataSet.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/DataSet.scala
@@ -276,7 +276,7 @@ object DataSet {
           val sps = app + ("name" -> ("sps_" + j))
 
           val idealF = wave(conf._2, conf._3, Duration.ofDays(1))
-          idealF.withTags(sps + ("type" -> "ideal", "type2" -> "IDEAL"))
+          idealF.withTags(sps ++ Seq("type" -> "ideal", "type2" -> "IDEAL"))
         }
       }
     }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/BlockSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/BlockSuite.scala
@@ -31,7 +31,7 @@ class BlockSuite extends FunSuite {
     Block.compress(block)
   }
 
-  def checkValues(b: Block, values: List[Double]) {
+  def checkValues(b: Block, values: List[Double]): Unit = {
     values.zipWithIndex.foreach { v =>
       val msg = "b(%d) => %f != %f".format(v._2, b.get(v._2), v._1)
       val res = java.lang.Double.compare(v._1, b.get(v._2))

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/PercentilesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/PercentilesSuite.scala
@@ -85,7 +85,7 @@ class PercentilesSuite extends FunSuite {
   }
 
   private val inputSpectatorTimer = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val r = new DefaultRegistry()
     val t = PercentileTimer.get(r, r.createId("test"))
     (0 until 100).foreach { i =>
@@ -102,7 +102,7 @@ class PercentilesSuite extends FunSuite {
   }
 
   private val inputSpectatorDistSummary = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val r = new DefaultRegistry()
     val t = PercentileDistributionSummary.get(r, r.createId("test"))
     (0 until 100).foreach { i =>

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/SmallHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/SmallHashMapSuite.scala
@@ -284,7 +284,7 @@ class SmallHashMapSuite extends FunSuite {
     assert(expected === actual)
   }
 
-  private def testNumCollisions(m: SmallHashMap[String, String]) {
+  private def testNumCollisions(m: SmallHashMap[String, String]): Unit = {
 
     //printf("%d: %d collisions, %.2f probes%n", m.size, m.numCollisions, m.numProbesPerKey)
     assert(m.numProbesPerKey < m.size / 4)

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/DefaultSettings.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/DefaultSettings.scala
@@ -77,7 +77,7 @@ case class DefaultSettings(root: Config, config: Config) {
 
   /** Available engines for rendering a chart. */
   val engines: Map[String, GraphEngine] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     config
       .getStringList("engines")
       .asScala
@@ -92,7 +92,7 @@ case class DefaultSettings(root: Config, config: Config) {
   /** Content types for the various rendering options. */
   val contentTypes: Map[String, ContentType] = engines.map {
     case (k, e) =>
-      k -> ContentType.parse(e.contentType).right.get
+      k -> ContentType.parse(e.contentType).toOption.get
   }
 
   /** Vocabulary to use in the interpreter when evaluating a graph expression. */

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookup.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookup.scala
@@ -55,7 +55,7 @@ private[stream] class EurekaGroupsLookup(context: StreamContext, frequency: Fini
       private var continue = new AtomicBoolean(true)
 
       override def onPush(): Unit = {
-        import scala.collection.JavaConverters._
+        import scala.jdk.CollectionConverters._
 
         // If there is an existing source polling Eureka, then tell it to stop. Create a
         // new instance of the flag for the next source

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -52,7 +52,7 @@ import com.typesafe.config.Config
 import org.reactivestreams.Processor
 import org.reactivestreams.Publisher
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -265,7 +265,7 @@ private[stream] abstract class EvaluatorImpl(
           exprs.filter(_.query.matches(tags)).map { expr =>
             // Restrict the tags to the common set for all matches to the data expression
             val keys = Query.exactKeys(expr.query) ++ expr.finalGrouping
-            val exprTags = tags.filterKeys(keys.contains).toMap
+            val exprTags = tags.filter(t => keys.contains(t._1))
 
             // Need to do the init for count aggregate
             val v = d.getValue

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
@@ -57,7 +57,7 @@ private[stream] class ExprInterpreter(config: Config) {
   }
 
   def dataExprMap(ds: DataSources): Map[DataExpr, List[DataSource]] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     ds.getSources.asScala.toList
       .flatMap { s =>
         val exprs = eval(Uri(s.getUri)).flatMap(_.expr.dataExprs).distinct

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
@@ -84,7 +84,7 @@ private[stream] class FinalExprEval(interpreter: ExprInterpreter)
 
       // Updates the recipients list
       private def handleDataSources(ds: DataSources): Unit = {
-        import scala.collection.JavaConverters._
+        import scala.jdk.CollectionConverters._
         val sources = ds.getSources.asScala.toList
         step = ds.stepSize()
 

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -61,7 +61,7 @@ private[stream] class StreamContext(
   private val config = rootConfig.getConfig("atlas.eval.stream")
 
   private val backends = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     config.getConfigList("backends").asScala.toList.map { cfg =>
       EurekaBackend(
         cfg.getString("host"),
@@ -72,7 +72,7 @@ private[stream] class StreamContext(
   }
 
   private val ignoredTagKeys = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     config.getStringList("ignored-tag-keys").asScala.toSet
   }
 
@@ -123,7 +123,7 @@ private[stream] class StreamContext(
     * message will be written to the `dsLogger` for any failures.
     */
   def validate(input: DataSources): DataSources = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val valid = new java.util.HashSet[DataSource]()
     input.getSources.asScala.foreach { ds =>
       validateDataSource(ds) match {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/SubscriptionManager.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/SubscriptionManager.scala
@@ -90,7 +90,7 @@ private[stream] class SubscriptionManager(context: StreamContext)
 
       private def handleDataSources(dataSources: DataSources): Unit = {
         // Log changes to the data sources for easier debugging
-        import scala.collection.JavaConverters._
+        import scala.jdk.CollectionConverters._
         logSources("added", dataSources.addedSources(sources).asScala.toList)
         logSources("removed", dataSources.removedSources(sources).asScala.toList)
         sources = dataSources

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
@@ -107,7 +107,7 @@ private[stream] class TimeGrouped(
         * so it can be used for a new time window.
         */
       private def flush(i: Int): Unit = {
-        val vs = buf(i).mapValues(_.datapoints).toMap
+        val vs = buf(i).map(t => t._1 -> t._2.datapoints).toMap
         val t = timestamps(i)
         if (t > 0) push(out, TimeGroup(t, step, vs)) else pull(in)
         cutoffTime = t
@@ -149,7 +149,7 @@ private[stream] class TimeGrouped(
 
       override def onUpstreamFinish(): Unit = {
         val groups = buf.indices.map { i =>
-          val vs = buf(i).mapValues(_.datapoints).toMap
+          val vs = buf(i).map(t => t._1 -> t._2.datapoints).toMap
           TimeGroup(timestamps(i), step, vs)
         }.toList
         pending = groups.filter(_.timestamp > 0).sortWith(_.timestamp < _.timestamp)

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -432,7 +432,7 @@ class EvaluatorSuite extends FunSuite with BeforeAndAfter {
   private val datapointStep = Duration.ofMillis(1)
 
   private def sampleData(numGroups: Int, numDatapoints: Int): List[Evaluator.DatapointGroup] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     (0 until numGroups).map { i =>
       val ds = (0 until numDatapoints)
         .map { j =>

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
@@ -64,8 +64,12 @@ class FinalExprEvalSuite extends FunSuite {
 
   private def group(i: Long, vs: AggrDatapoint*): TimeGroup = {
     val timestamp = i * step
-    val values = vs.map(_.copy(timestamp = timestamp)).groupBy(_.expr).mapValues(_.toList)
-    TimeGroup(timestamp, step, values.toMap)
+    val values = vs
+      .map(_.copy(timestamp = timestamp))
+      .groupBy(_.expr)
+      .map(t => t._1 -> t._2.toList)
+      .toMap
+    TimeGroup(timestamp, step, values)
   }
 
   test("exception while parsing exprs") {

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/SubscriptionManagerSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/SubscriptionManagerSuite.scala
@@ -38,7 +38,7 @@ class SubscriptionManagerSuite extends FunSuite with BeforeAndAfter {
 
   import EurekaSource._
   import Evaluator._
-  import scala.collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
 
   private implicit val system = ActorSystem(getClass.getSimpleName)
   private implicit val mat = ActorMaterializer()

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
@@ -44,7 +44,7 @@ class TimeGroupedSuite extends FunSuite {
     Await
       .result(future, Duration.Inf)
       .reverse
-      .map(g => g.copy(values = g.values.mapValues(_.sortWith(_.value < _.value)).toMap))
+      .map(g => g.copy(values = g.values.map(t => t._1 -> t._2.sortWith(_.value < _.value))))
   }
 
   private def run(data: List[AggrDatapoint]): List[TimeGroup] = {

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/ListMerge.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/ListMerge.scala
@@ -55,7 +55,7 @@ class ListMerge {
 
   @Benchmark
   def treeSet(bh: Blackhole): Unit = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val set = new java.util.TreeSet[String]()
     vs.foreach(_.foreach(set.add))
     bh.consume(set.asScala.toList.take(1000))

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/SmallHashMapJavaGet.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/SmallHashMapJavaGet.scala
@@ -37,7 +37,7 @@ import org.openjdk.jmh.infra.Blackhole
 @State(Scope.Thread)
 class SmallHashMapJavaGet {
 
-  import scala.collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
 
   private val tagMap = Map(
     "nf.app"     -> "atlas_backend",

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Reflection.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Reflection.scala
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedParameter
 import com.fasterxml.jackson.databind.introspect.AnnotationMap
 import com.fasterxml.jackson.databind.util.ClassUtil
 
+import scala.collection.compat.immutable.ArraySeq
 import scala.reflect.runtime.currentMirror
 import scala.reflect.runtime.universe._
 
@@ -223,7 +224,7 @@ private[json] object Reflection {
 
     /** Create a new instance of the case class using the provided arguments. */
     def newInstance(args: Array[Any]): AnyRef = {
-      try ctor.apply(args: _*).asInstanceOf[AnyRef]
+      try ctor.apply(ArraySeq.unsafeWrapArray(args)).asInstanceOf[AnyRef]
       catch {
         case e: InvocationTargetException => throw e.getCause
       }

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Reflection.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Reflection.scala
@@ -224,7 +224,7 @@ private[json] object Reflection {
 
     /** Create a new instance of the case class using the provided arguments. */
     def newInstance(args: Array[Any]): AnyRef = {
-      try ctor.apply(ArraySeq.unsafeWrapArray(args)).asInstanceOf[AnyRef]
+      try ctor.apply(ArraySeq.unsafeWrapArray(args): _*).asInstanceOf[AnyRef]
       catch {
         case e: InvocationTargetException => throw e.getCause
       }

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionApi.scala
@@ -97,6 +97,6 @@ object ExpressionApi {
     // TODO: This should get refactored so we do not need to recompute each time
     val str = expressions.sorted.mkString(";")
     val hash = Strings.zeroPad(Hash.sha1bytes(str), 40).substring(20)
-    '"' + hash + '"'
+    s""""$hash""""
   }
 }

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
@@ -23,7 +23,7 @@ import com.netflix.atlas.core.index.QueryIndex
 import com.netflix.frigga.Names
 import com.typesafe.scalalogging.StrictLogging
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
   * Manages the set of streams and associated subscriptions. There are two basic concepts:
@@ -258,7 +258,7 @@ object SubscriptionManager {
     }
 
     def values: List[T] = {
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       data.values().asScala.toList
     }
   }

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
@@ -287,7 +287,7 @@ object CloudWatchPoller {
     .withUnit(StandardUnit.None)
 
   private[cloudwatch] def getCategories(config: Config): List[MetricCategory] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val categories = config.getStringList("atlas.cloudwatch.categories").asScala.map { name =>
       val cfg = config.getConfig(s"atlas.cloudwatch.$name")
       MetricCategory.fromConfig(cfg)

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/DefaultTagger.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/DefaultTagger.scala
@@ -27,7 +27,7 @@ import scala.util.matching.Regex
   * and we would rather have a single key in use for common concepts.
   */
 class DefaultTagger(config: Config) extends Tagger {
-  import scala.collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
 
   private val extractors: Map[String, List[(Regex, String)]] = config
     .getConfigList("extractors")

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/GetMetricActor.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/GetMetricActor.scala
@@ -57,7 +57,7 @@ class GetMetricActor(
     */
   private def getMetric(m: MetricMetadata): Option[Datapoint] = {
     try {
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       val now = Instant.now()
       val start = now.minusSeconds(m.category.periodCount * m.category.period)
 

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/ListMetricsActor.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/ListMetricsActor.scala
@@ -46,7 +46,7 @@ class ListMetricsActor(client: AmazonCloudWatch, tagger: Tagger) extends Actor w
   }
 
   private def listMetrics(category: MetricCategory): List[MetricMetadata] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     category.toListRequests.flatMap {
       case (definition, request) =>
         val mname = s"${category.namespace}/${definition.name}"
@@ -65,7 +65,7 @@ class ListMetricsActor(client: AmazonCloudWatch, tagger: Tagger) extends Actor w
 
   @scala.annotation.tailrec
   private def listMetrics(request: ListMetricsRequest, metrics: List[Metric]): List[Metric] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val result = client.listMetrics(request)
     val ms = metrics ++ result.getMetrics.asScala
     if (result.getNextToken == null) ms

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricCategory.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricCategory.scala
@@ -84,7 +84,7 @@ case class MetricCategory(
     * about rather than a single request fetching everything for the namespace.
     */
   def toListRequests: List[(MetricDefinition, ListMetricsRequest)] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     metrics.map { m =>
       m -> new ListMetricsRequest()
         .withNamespace(namespace)
@@ -108,7 +108,7 @@ object MetricCategory extends StrictLogging {
   }
 
   def fromConfig(config: Config): MetricCategory = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val metrics = config.getConfigList("metrics").asScala.toList
     val filter =
       if (!config.hasPath("filter")) Query.True

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricDefinition.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricDefinition.scala
@@ -61,7 +61,7 @@ object MetricDefinition {
     * unit.
     */
   def fromConfig(config: Config): List[MetricDefinition] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val tags =
       if (!config.hasPath("tags")) Map.empty[String, String]
       else {

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricMetadata.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricMetadata.scala
@@ -35,7 +35,7 @@ case class MetricMetadata(
   def convert(d: Datapoint): Double = definition.conversion(this, d)
 
   def toGetRequest(s: Instant, e: Instant): GetMetricStatisticsRequest = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     new GetMetricStatisticsRequest()
       .withMetricName(definition.name)
       .withNamespace(category.namespace)

--- a/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/NetflixTagger.scala
+++ b/atlas-poller-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/NetflixTagger.scala
@@ -24,7 +24,7 @@ import com.typesafe.config.Config
   * on naming conventions used by Spinnaker and Asgard.
   */
 class NetflixTagger(config: Config) extends DefaultTagger(config) {
-  import scala.collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
 
   private val keys = config.getStringList("netflix-keys").asScala
 

--- a/atlas-poller/src/main/scala/com/netflix/atlas/poller/ClientActor.scala
+++ b/atlas-poller/src/main/scala/com/netflix/atlas/poller/ClientActor.scala
@@ -61,7 +61,7 @@ class ClientActor(registry: Registry, config: Config, implicit val materializer:
   private val validTagChars = AsciiSet.fromPattern(config.getString("valid-tag-characters"))
 
   private val validTagValueChars = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     config
       .getConfigList("valid-tag-value-characters")
       .asScala

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
@@ -62,7 +62,7 @@ class ApiSettings(root: => Config) {
   def maxDatapoints: Int = config.getInt("graph.max-datapoints")
 
   def engines: List[GraphEngine] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     config.getStringList("graph.engines").asScala.toList.map { cname =>
       newInstance[GraphEngine](cname)
     }
@@ -82,7 +82,7 @@ class ApiSettings(root: => Config) {
   def validationRules: List[Rule] = Rule.load(config.getConfigList("publish.rules"))
 
   def excludedWords: Set[String] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     config.getStringList("expr.complete.excluded-words").asScala.toSet
   }
 

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
@@ -52,7 +52,7 @@ class ExprApi extends WebApi {
 
   private val excludedWords = ApiSettings.excludedWords
 
-  def routes: Route = parameters(('q, 'vocab ? vocabulary.name)) { (q, vocab) =>
+  def routes: Route = parameters(("q", "vocab" ? vocabulary.name)) { (q, vocab) =>
     endpointPath("api" / "v1" / "expr") {
       get { complete(processDebugRequest(q, vocab)) }
     } ~

--- a/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/TimeZones.scala
+++ b/atlas-wiki/src/main/scala/com/netflix/atlas/wiki/pages/TimeZones.scala
@@ -52,7 +52,7 @@ class TimeZones extends SimplePage {
     """.stripMargin
 
   private def supportedIds: String = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val zones = ZoneId.getAvailableZoneIds.asScala.toList.sortWith(_ < _).map { id =>
       s"| $id | ${ZoneId.of(id).getDisplayName(TextStyle.SHORT, Locale.US)} |"
     }
@@ -63,7 +63,7 @@ class TimeZones extends SimplePage {
   }
 
   private def displayNameToZoneId: String = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val zones = ZoneId.getAvailableZoneIds.asScala.toList
     val byName = zones.groupBy(id => ZoneId.of(id).getDisplayName(TextStyle.SHORT, Locale.US))
     val sorted = byName.toList.sortWith(_._1 < _._1).map {

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -75,6 +75,7 @@ object BuildSettings {
 
   val commonDeps = Seq(
     Dependencies.jsr305,
+    Dependencies.scalaCompat,
     Dependencies.scalaLogging,
     Dependencies.slf4jApi,
     Dependencies.spectatorApi,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,6 +58,7 @@ object Dependencies {
   val log4jJul          = "org.apache.logging.log4j" % "log4j-jul" % log4j
   val log4jSlf4j        = "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4j
   val roaringBitmap     = "org.roaringbitmap" % "RoaringBitmap" % "0.8.9"
+  val scalaCompat       = "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.1"
   val scalaCompiler     = "org.scala-lang" % "scala-compiler"
   val scalaLibrary      = "org.scala-lang" % "scala-library"
   val scalaLibraryAll   = "org.scala-lang" % "scala-library-all"


### PR DESCRIPTION
There is still one related to ordering doubles, but is not
easily fixable until the 2.12 build is dropped.