### PR TITLE
add NameValueLengthRule

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/NameValueLengthRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/NameValueLengthRule.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.validation
+
+import com.typesafe.config.Config
+
+/**
+  * Verifies that the name and values are within the specified length bounds. The limits for
+  * the value of the name key can be set independently from the values of other keys. Sample
+  * config:
+  *
+  * ```
+  * name {
+  *   min-length = 2
+  *   max-length = 80
+  * }
+  * others {
+  *   min-length = 2
+  *   max-length = 60
+  * }
+  * ```
+  */
+case class NameValueLengthRule(nameRule: TagRule, valueRule: TagRule) extends TagRule {
+
+  def validate(k: String, v: String): ValidationResult = {
+    if (k == "name") nameRule.validate(k, v) else valueRule.validate(k, v)
+  }
+}
+
+object NameValueLengthRule {
+
+  def apply(config: Config): NameValueLengthRule = {
+    val nameRule = ValueLengthRule(config.getConfig("name"))
+    val valueRule = ValueLengthRule(config.getConfig("others"))
+    apply(nameRule, valueRule)
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/NameValueLengthRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/NameValueLengthRuleSuite.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.validation
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.FunSuite
+
+class NameValueLengthRuleSuite extends FunSuite {
+
+  private val config = ConfigFactory.parseString("""
+      |name {
+      |  min-length = 3
+      |  max-length = 5
+      |}
+      |others {
+      |  min-length = 2
+      |  max-length = 4
+      |}
+    """.stripMargin)
+
+  private val rule = NameValueLengthRule(config)
+
+  test("name valid") {
+    assert(rule.validate("name", "abc") === ValidationResult.Pass)
+    assert(rule.validate("name", "abcd") === ValidationResult.Pass)
+    assert(rule.validate("name", "abcde") === ValidationResult.Pass)
+  }
+
+  test("name too short") {
+    val res = rule.validate("name", "ab")
+    assert(res.isFailure)
+  }
+
+  test("name too long") {
+    val res = rule.validate("name", "abcdef")
+    assert(res.isFailure)
+  }
+
+  test("others valid") {
+    assert(rule.validate("def", "ab") === ValidationResult.Pass)
+    assert(rule.validate("def", "abc") === ValidationResult.Pass)
+    assert(rule.validate("def", "abcd") === ValidationResult.Pass)
+  }
+
+  test("others too short") {
+    val res = rule.validate("def", "a")
+    assert(res.isFailure)
+  }
+
+  test("others too long") {
+    val res = rule.validate("def", "abcde")
+    assert(res.isFailure)
+  }
+}

--- a/atlas-webapi/src/main/resources/reference.conf
+++ b/atlas-webapi/src/main/resources/reference.conf
@@ -84,15 +84,23 @@ atlas {
         {
           class = "com.netflix.atlas.core.validation.KeyLengthRule"
           min-length = 2
-          max-length = 40
+          max-length = 60
         },
         {
-          class = "com.netflix.atlas.core.validation.ValueLengthRule"
-          min-length = 1
-          max-length = 80
+          class = "com.netflix.atlas.core.validation.NameValueLengthRule"
+          name {
+            min-length = 2
+            max-length = 255
+          }
+          others {
+            min-length = 1
+            max-length = 120
+          }
         },
         {
           class = "com.netflix.atlas.core.validation.ValidCharactersRule"
+          default-pattern = "-._A-Za-z0-9^~"
+          overrides = []
         },
         {
           class = "com.netflix.atlas.core.validation.MaxUserTagsRule"


### PR DESCRIPTION
Allows different limits to be used for the value of the
name key compared to other keys. This is mostly to remove
a difference between the internal Atlas setup at Netflix
and OSS. Internally for historical reasons the value for
the name key is allowed to be longer than other values.
With this change there is no longer a need to have custom
rules.