### PR TITLE
Add RDS OldestReplicationSlotLag

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/rds.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/rds.conf
@@ -99,6 +99,17 @@ atlas {
           conversion = "max"
         },
         {
+          name = "OldestReplicationSlotLag"
+          alias = "aws.rds.replicationDataBacklog"
+          conversion = "max"
+          tags = [
+            {
+              key = "engine"
+              value = "postgresql"
+            }
+          ]
+        },
+        {
           name = "SwapUsage"
           alias = "aws.rds.swapUsage"
           conversion = "max"


### PR DESCRIPTION
This commit adds collection of AWS/RDS/OldestReplicationSlotLag. Other
`Lag` metrics represent time lag. This metric represents more data
coming in that being replicated. So, in order to avoid confusion with
those other lag metrics, I've suffixed this with `DataBacklog`.

Resolves #1067