### PR TITLE
1.6: switch to discovery.status metric for eureka-avg 

### DIFF
--- a/atlas-core/src/main/resources/reference.conf
+++ b/atlas-core/src/main/resources/reference.conf
@@ -79,7 +79,7 @@ atlas {
         },
         {
           name = "eureka-avg"
-          base-query = "name,DiscoveryStatus_.*_UP,:re"
+          base-query = "name,discovery.status,:eq,state,UP,:eq,:and"
           keys = ${atlas.core.vocabulary.nflx-keys}
         }
       ]


### PR DESCRIPTION
Backport of #1039 

This is a newer version that avoids the need for regex and
follows current conventions.