### PR TITLE
use https for jfrog resolver

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -87,7 +87,7 @@ object BuildSettings {
     Resolver.mavenLocal,
     Resolver.mavenCentral,
     Resolver.jcenterRepo,
-    "jfrog".at("http://oss.jfrog.org/oss-snapshot-local")
+    "jfrog".at("https://oss.jfrog.org/oss-snapshot-local")
   )
 
   def profile: Project => Project = p => {


### PR DESCRIPTION
Helps avoid risk of MITM attack introducing bad dependencies.