### PR TITLE
sbt 1.3.0

### DIFF
--- a/atlas-module-cloudwatch/src/test/scala/com/netflix/atlas/guice/CloudWatchModuleSuite.scala
+++ b/atlas-module-cloudwatch/src/test/scala/com/netflix/atlas/guice/CloudWatchModuleSuite.scala
@@ -15,8 +15,7 @@
  */
 package com.netflix.atlas.guice
 
-import java.util.concurrent.TimeUnit
-
+import akka.actor.ActorSystem
 import com.google.inject.AbstractModule
 import com.google.inject.Guice
 import com.netflix.atlas.akka.ActorService
@@ -25,6 +24,9 @@ import com.netflix.spectator.api.Registry
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import org.scalatest.FunSuite
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 class CloudWatchModuleSuite extends FunSuite {
 
@@ -40,20 +42,7 @@ class CloudWatchModuleSuite extends FunSuite {
     val actors = injector.getInstance(classOf[ActorService])
     assert(actors.isHealthy)
     actors.stop()
-  }
 
-  ignore("run locally") {
-    val deps = new AbstractModule {
-
-      override def configure(): Unit = {
-        bind(classOf[Config]).toInstance(ConfigFactory.load("local"))
-        bind(classOf[Registry]).toInstance(new DefaultRegistry())
-      }
-    }
-    val injector = Guice.createInjector(deps, new CloudWatchModule)
-    val actors = injector.getInstance(classOf[ActorService])
-    assert(actors.isHealthy)
-    Thread.sleep(TimeUnit.MILLISECONDS.convert(10, TimeUnit.MINUTES))
-    actors.stop()
+    Await.ready(injector.getInstance(classOf[ActorSystem]).terminate(), Duration.Inf)
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.0


### PR DESCRIPTION
CloudWatch test case fixed to properly shutdown the
ActorSystem and avoid:

```
java.lang.NoClassDefFoundError: akka/actor/dungeon/FaultHandling$$anonfun$handleNonFatalOrInterruptedException$1
	at akka.actor.dungeon.FaultHandling.handleNonFatalOrInterruptedException(FaultHandling.scala:310)
	at akka.actor.dungeon.FaultHandling.handleNonFatalOrInterruptedException$(FaultHandling.scala:310)
	at akka.actor.ActorCell.handleNonFatalOrInterruptedException(ActorCell.scala:447)
	at akka.actor.ActorCell.invokeAll$1(ActorCell.scala:557)
	at akka.actor.ActorCell.systemInvoke(ActorCell.scala:569)
	at akka.dispatch.Mailbox.processAllSystemMessages(Mailbox.scala:293)
	at akka.dispatch.Mailbox.run(Mailbox.scala:228)
	at akka.dispatch.Mailbox.exec(Mailbox.scala:241)
	at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
Caused by: java.lang.ClassNotFoundException: akka.actor.dungeon.FaultHandling$$anonfun$handleNonFatalOrInterruptedException$1
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 12 more
```

For more details see sbt/sbt#5075.