### PR TITLE
update default set of `atlas.` reserved keys

### DIFF
--- a/atlas-webapi/src/main/resources/reference.conf
+++ b/atlas-webapi/src/main/resources/reference.conf
@@ -110,10 +110,10 @@ atlas {
           class = "com.netflix.atlas.core.validation.ReservedKeyRule"
           prefix = "atlas."
           allowed-keys = [
+            "aggr",
             "dstype",
             "offset",
-            "legacy",
-            "rollup"
+            "legacy"
           ]
         },
         {


### PR DESCRIPTION
Include `atlas.aggr` used for inline aggregation. Remove the
`atlas.rollup` which was for an experimental rollup support
that we ended up not doing.