### PR TITLE
update travis to use Mac OS 10.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 matrix:
   include:
-  - jdk: openjdk11
+  - jdk: openjdk12
     scala: 2.13.1
     os: osx
     osx_image: xcode11

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ language: scala
 matrix:
   include:
   - jdk: openjdk11
-    scala: 2.12.10
+    scala: 2.13.1
     os: osx
+    osx_image: xcode11
     env: BINTRAY_PUBLISH=true
   - jdk: openjdk11
-    scala: 2.13.1
+    scala: 2.12.10
     os: linux
     dist: xenial
     env: BINTRAY_PUBLISH=true


### PR DESCRIPTION
Looks like the font rendering in Mac OS changed so we get
diffs when running locally. See if this causes travis to
fail so we can update to get consistent rendering again.