### PR TITLE
optimization for tag validation

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/CompositeTagRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/CompositeTagRule.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.validation
+
+/** Verifies that all of the tag rules match. */
+case class CompositeTagRule(tagRules: List[TagRule]) extends TagRule {
+  override def validate(k: String, v: String): ValidationResult = {
+    validate(tagRules, k, v)
+  }
+
+  @scala.annotation.tailrec
+  private def validate(rules: List[TagRule], k: String, v: String): ValidationResult = {
+    if (rules.isEmpty) {
+      ValidationResult.Pass
+    } else {
+      val r = rules.head
+      val result = r.validate(k, v)
+      if (result == ValidationResult.Pass)
+        validate(rules.tail, k, v)
+      else
+        result
+    }
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/Rule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/Rule.scala
@@ -60,7 +60,7 @@ object Rule {
 
   def load(ruleConfigs: List[_ <: Config]): List[Rule] = {
     val configClass = classOf[Config]
-    ruleConfigs.map { cfg =>
+    val rules = ruleConfigs.map { cfg =>
       val cls = Class.forName(cfg.getString("class"))
 
       try {
@@ -93,6 +93,12 @@ object Rule {
             .asInstanceOf[Rule]
       }
     }
+
+    val (tagRules, others) = rules.partition(_.isInstanceOf[TagRule])
+    if (tagRules.isEmpty)
+      others
+    else
+      CompositeTagRule(tagRules.map(_.asInstanceOf[TagRule])) :: others
   }
 
   @scala.annotation.tailrec

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/RuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/RuleSuite.scala
@@ -65,7 +65,9 @@ class RuleSuite extends FunSuite {
 
   test("load") {
     val rules = Rule.load(config.getConfigList("rules"))
-    assert(rules.size === 9)
+    assert(rules.size === 3)
+    assert(rules.head.isInstanceOf[CompositeTagRule])
+    assert(rules.head.asInstanceOf[CompositeTagRule].tagRules.size === 7)
   }
 
   test("validate ok") {

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/validation/TagRules.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/validation/TagRules.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.validation
+
+import com.netflix.atlas.core.util.SmallHashMap
+import com.netflix.spectator.impl.AsciiSet
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.infra.Blackhole
+
+/**
+  * TagRule needs to loop over all the entries in the map. This benchmark compares
+  * looping over the tags for each rule to looping over the rules for each tag.
+  *
+  * ```
+  * > jmh:run -prof gc -wi 10 -i 10 -f1 -t1 .*TagRules.*
+  * ```
+  *
+  * Throughput
+  *
+  * ```
+  * Benchmark           Mode  Cnt        Score        Error   Units
+  * composite          thrpt   10  9138888.219 ± 338096.662   ops/s
+  * separate           thrpt   10  1909872.604 ±   5324.498   ops/s
+  * ```
+  */
+@State(Scope.Thread)
+class TagRules {
+
+  private val tags = SmallHashMap(
+    "nf.app"     -> "atlas_backend",
+    "nf.cluster" -> "atlas_backend-dev",
+    "nf.asg"     -> "atlas_backend-dev-v001",
+    "nf.stack"   -> "dev",
+    "nf.region"  -> "us-east-1",
+    "nf.zone"    -> "us-east-1e",
+    "nf.node"    -> "i-123456789",
+    "nf.ami"     -> "ami-987654321",
+    "nf.vmtype"  -> "r3.2xlarge",
+    "name"       -> "jvm.gc.pause",
+    "cause"      -> "Allocation_Failure",
+    "action"     -> "end_of_major_GC",
+    "statistic"  -> "totalTime"
+  )
+
+  private val rules = List(
+    KeyLengthRule(2, 80),
+    NameValueLengthRule(ValueLengthRule(2, 255), ValueLengthRule(2, 120)),
+    ValidCharactersRule(
+      AsciiSet.fromPattern("-._A-Za-z0-9"),
+      Map.empty.withDefaultValue(AsciiSet.fromPattern("-._A-Za-z0-9"))
+    ),
+    ReservedKeyRule(
+      "nf.",
+      Set("app", "cluster", "asg", "stack", "region", "zone", "node", "ami", "vmtype")
+    ),
+    ReservedKeyRule("atlas.", Set("legacy"))
+  )
+
+  private val composite = CompositeTagRule(rules)
+
+  @Benchmark
+  def separate(bh: Blackhole): Unit = {
+    bh.consume(Rule.validate(tags, rules))
+  }
+
+  @Benchmark
+  def composite(bh: Blackhole): Unit = {
+    bh.consume(composite.validate(tags))
+  }
+}


### PR DESCRIPTION
A lot of time is spent iterating the maps. It is faster to
iterate over the set of rules for each key/value pair.