### PR TITLE
Fix stream result aggregation issue when multiple URLs with same query in one session

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/ByteStringInputStream.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/ByteStringInputStream.scala
@@ -24,15 +24,22 @@ import akka.util.ByteString
   * can be used to avoid allocating a temporary array and using `ByteArrayInputStream`.
   */
 class ByteStringInputStream(data: ByteString) extends InputStream {
-  private var pos = -1
-  private val length = data.length
+  private val buffer = data.asByteBuffer
 
   override def read(): Int = {
-    pos += 1
-    if (pos >= length) -1 else data(pos) & 255
+    if (!buffer.hasRemaining) -1 else buffer.get() & 255
+  }
+
+  override def read(bytes: Array[Byte], offset: Int, length: Int): Int = {
+    val amount = math.min(buffer.remaining(), length)
+    if (amount == 0) -1
+    else {
+      buffer.get(bytes, offset, amount)
+      amount
+    }
   }
 
   override def available(): Int = {
-    if (pos >= length) 0 else length - pos - 1
+    buffer.remaining()
   }
 }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
@@ -157,7 +157,7 @@ private[stream] class TimeGrouped(
       }
 
       private def flushPending(): Unit = {
-        if (pending.nonEmpty) {
+        if (pending.nonEmpty && isAvailable(out)) {
           push(out, pending.head)
           pending = pending.tail
         }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -292,7 +292,6 @@ class EvaluatorSuite extends FunSuite with BeforeAndAfter {
     val future = Source
       .single(ds1)
       .via(Flow.fromProcessor(() => evaluator.createStreamsProcessor()))
-      .take(256) // Needed to force the stream to stop
       .runWith(Sink.seq[MessageEnvelope])
 
     val result = Await.result(future, scala.concurrent.duration.Duration.Inf)
@@ -301,13 +300,13 @@ class EvaluatorSuite extends FunSuite with BeforeAndAfter {
       .filter(env => env.getId == "one" && env.getMessage.isInstanceOf[TimeSeriesMessage])
       .map(_.getMessage.asInstanceOf[TimeSeriesMessage])
     assert(dsOne.forall(_.step === 5000))
-    assert(dsOne.size === 119)
+    assert(dsOne.size === 120)
 
     val dsTwo = result
       .filter(env => env.getId == "two" && env.getMessage.isInstanceOf[TimeSeriesMessage])
       .map(_.getMessage.asInstanceOf[TimeSeriesMessage])
     assert(dsTwo.forall(_.step === 60000))
-    assert(dsTwo.size === 9)
+    assert(dsTwo.size === 10)
   }
 
   test("DataSource equals contract") {

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/akka/ByteStringReading.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/akka/ByteStringReading.scala
@@ -27,13 +27,13 @@ import org.openjdk.jmh.infra.Blackhole
   * Results:
   *
   * ```
-  * Benchmark                          Mode  Cnt          Score        Error   Units
-  * toArray                           thrpt   10         13.051 ±      0.549   ops/s
-  * inputStream                       thrpt   10         14.363 ±      0.420   ops/s
+  * Benchmark                        Mode  Cnt          Score          Error   Units
+  * toArray                         thrpt   10          9.092 ±        0.540   ops/s
+  * inputStream                     thrpt   10        159.626 ±       21.220   ops/s
   *
-  * Benchmark                          Mode  Cnt          Score        Error   Units
-  * toArray              gc.alloc.rate.norm   10  104857643.179 ±      0.278    B/op
-  * inputStream          gc.alloc.rate.norm   10       4138.877 ±      0.191    B/op
+  * Benchmark                        Mode  Cnt          Score          Error   Units
+  * toArray            gc.alloc.rate.norm   10  104857658.225 ±       64.153    B/op
+  * inputStream        gc.alloc.rate.norm   10       4185.017 ±        3.531    B/op
   * ```
   */
 @State(Scope.Benchmark)


### PR DESCRIPTION
Fix stream result aggregation issue when multiple URLs with same query in one session

When multiple urls have the same query but different host, the result is aggregation of all data from urls with the same query ignoring different host. Fixed by grouping host, processing them in sub-streams with the exact existing flow and then merging results back to 1 stream.