### PR TITLE
optimize ByteStringInputStream for large payloads

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/ByteStringInputStream.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/ByteStringInputStream.scala
@@ -24,15 +24,22 @@ import akka.util.ByteString
   * can be used to avoid allocating a temporary array and using `ByteArrayInputStream`.
   */
 class ByteStringInputStream(data: ByteString) extends InputStream {
-  private var pos = -1
-  private val length = data.length
+  private val buffer = data.asByteBuffer
 
   override def read(): Int = {
-    pos += 1
-    if (pos >= length) -1 else data(pos) & 255
+    if (!buffer.hasRemaining) -1 else buffer.get() & 255
+  }
+
+  override def read(bytes: Array[Byte], offset: Int, length: Int): Int = {
+    val amount = math.min(buffer.remaining(), length)
+    if (amount == 0) -1
+    else {
+      buffer.get(bytes, offset, amount)
+      amount
+    }
   }
 
   override def available(): Int = {
-    if (pos >= length) 0 else length - pos - 1
+    buffer.remaining()
   }
 }

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/akka/ByteStringReading.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/akka/ByteStringReading.scala
@@ -27,13 +27,13 @@ import org.openjdk.jmh.infra.Blackhole
   * Results:
   *
   * ```
-  * Benchmark                          Mode  Cnt          Score        Error   Units
-  * toArray                           thrpt   10         13.051 ±      0.549   ops/s
-  * inputStream                       thrpt   10         14.363 ±      0.420   ops/s
+  * Benchmark                        Mode  Cnt          Score          Error   Units
+  * toArray                         thrpt   10          9.092 ±        0.540   ops/s
+  * inputStream                     thrpt   10        159.626 ±       21.220   ops/s
   *
-  * Benchmark                          Mode  Cnt          Score        Error   Units
-  * toArray              gc.alloc.rate.norm   10  104857643.179 ±      0.278    B/op
-  * inputStream          gc.alloc.rate.norm   10       4138.877 ±      0.191    B/op
+  * Benchmark                        Mode  Cnt          Score          Error   Units
+  * toArray            gc.alloc.rate.norm   10  104857658.225 ±       64.153    B/op
+  * inputStream        gc.alloc.rate.norm   10       4185.017 ±        3.531    B/op
   * ```
   */
 @State(Scope.Benchmark)


### PR DESCRIPTION
Uses the `asByteBuffer` conversion to allow for more
efficient reads. The `copyToArray` was really slow and
was worse than just always using `apply` and reading
a single byte. The byte buffer approach avoids the
intermediate array allocation and supports a fast copy
to another array. For the sample benchmark it is about
10x faster.