### PR TITLE
avoid delay on finish for local eval processor

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
@@ -157,7 +157,7 @@ private[stream] class TimeGrouped(
       }
 
       private def flushPending(): Unit = {
-        if (pending.nonEmpty) {
+        if (pending.nonEmpty && isAvailable(out)) {
           push(out, pending.head)
           pending = pending.tail
         }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookupSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookupSuite.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.eval.stream
 
+import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.HttpResponse
@@ -68,7 +69,7 @@ class EurekaGroupsLookupSuite extends FunSuite {
     new DataSource(id, java.time.Duration.ofMinutes(1), uri)
   }
 
-  private def run(input: List[DataSources], n: Int = 1): List[SourcesAndGroups] = {
+  private def lookupFlow: Flow[DataSources, Source[SourcesAndGroups, NotUsed], NotUsed] = {
     val client = Flow[(HttpRequest, AccessLogger)]
       .map {
         case (_, v) =>
@@ -76,9 +77,13 @@ class EurekaGroupsLookupSuite extends FunSuite {
           Success(HttpResponse(StatusCodes.OK, entity = json)) -> v
       }
     val context = TestContext.createContext(mat, client)
+    Flow[DataSources].via(new EurekaGroupsLookup(context, 5.microseconds))
+  }
+
+  private def run(input: List[DataSources], n: Int = 1): List[SourcesAndGroups] = {
     val future = Source(input)
       .concat(Source.repeat(input.last)) // Need to avoid source stopping until sink is full
-      .via(new EurekaGroupsLookup(context, 5.microseconds))
+      .via(lookupFlow)
       .flatMapConcat(s => s)
       .take(n)
       .fold(List.empty[SourcesAndGroups]) { (acc, v) =>
@@ -92,8 +97,11 @@ class EurekaGroupsLookupSuite extends FunSuite {
     val input = List(
       DataSources.empty()
     )
-    val output = run(input)
-    assert(output.head._2.groups.size === 0)
+    val future = Source(input)
+        .via(lookupFlow)
+        .runWith(Sink.seq)
+    val output = Await.result(future, Duration.Inf)
+    assert(output.isEmpty)
   }
 
   test("one data source") {

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookupSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookupSuite.scala
@@ -98,8 +98,8 @@ class EurekaGroupsLookupSuite extends FunSuite {
       DataSources.empty()
     )
     val future = Source(input)
-        .via(lookupFlow)
-        .runWith(Sink.seq)
+      .via(lookupFlow)
+      .runWith(Sink.seq)
     val output = Await.result(future, Duration.Inf)
     assert(output.isEmpty)
   }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -292,7 +292,6 @@ class EvaluatorSuite extends FunSuite with BeforeAndAfter {
     val future = Source
       .single(ds1)
       .via(Flow.fromProcessor(() => evaluator.createStreamsProcessor()))
-      .take(256) // Needed to force the stream to stop
       .runWith(Sink.seq[MessageEnvelope])
 
     val result = Await.result(future, scala.concurrent.duration.Duration.Inf)
@@ -301,13 +300,13 @@ class EvaluatorSuite extends FunSuite with BeforeAndAfter {
       .filter(env => env.getId == "one" && env.getMessage.isInstanceOf[TimeSeriesMessage])
       .map(_.getMessage.asInstanceOf[TimeSeriesMessage])
     assert(dsOne.forall(_.step === 5000))
-    assert(dsOne.size === 119)
+    assert(dsOne.size === 120)
 
     val dsTwo = result
       .filter(env => env.getId == "two" && env.getMessage.isInstanceOf[TimeSeriesMessage])
       .map(_.getMessage.asInstanceOf[TimeSeriesMessage])
     assert(dsTwo.forall(_.step === 60000))
-    assert(dsTwo.size === 9)
+    assert(dsTwo.size === 10)
   }
 
   test("DataSource equals contract") {


### PR DESCRIPTION
When using the eval processor for local data, it should
stop quickly after the upstream is complete. Before the
throttling on the Eureka lookup would cause about a 30s
delay.

This changes the Eureka lookup to use an empty source
if there are no remote data sources. Also fixes a bug
with TimeGrouped where it could potentially push without
a downstream pull when the upstream finishes.