### PR TITLE
add mapping for transit gateway metrics

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/reference.conf
@@ -222,6 +222,10 @@ atlas {
           name = "Action"
           alias = "aws.action"
         },
+        {
+          name = "TransitGateway"
+          alias = "aws.tgw"
+        },
       ]
 
       // Tags that should get applied to all metrics from cloudwatch.
@@ -272,6 +276,7 @@ atlas {
       "s3-request",
       "sns",
       "sqs",
+      "tgw",
       "trustedadvisor",
       "workflow",
       "workflow-activity"
@@ -301,4 +306,5 @@ include "s3-request.conf"
 include "sns.conf"
 include "sqs.conf"
 include "swf.conf"
+include "tgw.conf"
 include "trustedadvisor.conf"

--- a/atlas-poller-cloudwatch/src/main/resources/tgw.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/tgw.conf
@@ -1,0 +1,107 @@
+
+atlas {
+  cloudwatch {
+
+    // Metrics for the transit gateway service
+    // https://docs.aws.amazon.com/vpc/latest/tgw/transit-gateway-cloudwatch-metrics.html
+    tgw = {
+      namespace = "AWS/TransitGateway"
+      period = 1m
+
+      dimensions = [
+        "TransitGateway"
+      ]
+
+      metrics = [
+        {
+          name = "BytesIn"
+          alias = "aws.tgw.bytes"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "BytesOut"
+          alias = "aws.tgw.bytes"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+        {
+          name = "PacketsIn"
+          alias = "aws.tgw.packets"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "PacketsOut"
+          alias = "aws.tgw.packets"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+        {
+          name = "BytesDropCountBlackhole"
+          alias = "aws.tgw.bytesDropped"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Blackhole"
+            }
+          ]
+        },
+        {
+          name = "BytesDropCountNoRoute"
+          alias = "aws.tgw.bytesDropped"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "NoRoute"
+            }
+          ]
+        },
+        {
+          name = "PacketDropCountBlackhole"
+          alias = "aws.tgw.packetsDropped"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Blackhole"
+            }
+          ]
+        },
+        {
+          name = "PacketDropCountNoRoute"
+          alias = "aws.tgw.packetsDropped"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "NoRoute"
+            }
+          ]
+        },
+      ]
+    }
+  }
+}


### PR DESCRIPTION
CloudWatch mappings for [TGW metrics]. Note, in CW there
are drop counts for bytes as well as packets, though the
docs only shows packets.

[TGW metrics]: https://docs.aws.amazon.com/vpc/latest/tgw/transit-gateway-cloudwatch-metrics.html