### PR TITLE
handle some shard groups being empty

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Shards.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Shards.scala
@@ -141,6 +141,7 @@ object Shards {
 
   /** Mapper for finding the instance that should receive data for an id or index of a file. */
   class Mapper[T](groups: Array[Group[T]]) {
+    require(groups.length > 0, "set of groups cannot be empty")
 
     /** Return the instance that should receive the data associated with `id`. */
     def instanceForId(id: BigInteger): T = {
@@ -152,7 +153,10 @@ object Shards {
     def instanceForIndex(i: Int): T = {
       require(i >= 0, "index cannot be negative")
       val group = groups(i % groups.length)
-      group.instances((i / groups.length) % group.size)
+      if (group.size > 0)
+        group.instances((i / groups.length) % group.size)
+      else
+        null.asInstanceOf[T]
     }
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/ShardsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/ShardsSuite.scala
@@ -129,6 +129,17 @@ class ShardsSuite extends FunSuite {
     }
   }
 
+  test("empty group") {
+    val groups = List(
+      Shards.Group("a", Array("0", "1")),
+      Shards.Group("b", Array.empty[String]),
+      Shards.Group("c", Array("6", "7"))
+    )
+
+    val mapper = Shards.mapper(groups)
+    assert(mapper.instanceForIndex(1) === null)
+  }
+
   test("local mapper containsIndex") {
     val groups = List(
       Shards.Group("a", Array(0, 1)),


### PR DESCRIPTION
In intermediate deployment stages, some of the shard
groups may be empty. Before this would result in a
divide by zero error. Now it will return null. Null
is used instead of `Option[T]` to maintain backwards
compatibility and avoid the extra allocation if used
in a hot path.