### PR TITLE
stream helper to filter out duplicates

### DIFF
--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
@@ -236,4 +236,13 @@ class StreamOpsSuite extends AnyFunSuite {
     val c = registry.counter("akka.stream.exceptions", "error", "ArithmeticException")
     assert(c.count() === 1)
   }
+
+  test("unique") {
+    val future = Source(List(1, 1, 2, 3, 3, 3, 4, 5, 6, 6, 7, 1))
+      .via(StreamOps.unique)
+      .runWith(Sink.seq[Int])
+    val vs = Await.result(future, Duration.Inf)
+    // Only consecutive repeated values are filtered out, so the final 1 should get repeated
+    assert(vs === List(1, 2, 3, 4, 5, 6, 7, 1))
+  }
 }


### PR DESCRIPTION
Works similar to the `uniq` command on unix and filters
out consecutive values that are repeated.