### PR TITLE
update lwcapi to accept `step`

### DIFF
--- a/atlas-lwcapi/src/main/resources/reference.conf
+++ b/atlas-lwcapi/src/main/resources/reference.conf
@@ -1,7 +1,7 @@
 atlas {
   lwcapi {
     register = {
-      default-frequency = 60s
+      default-step = 60s
     }
 
     # For an lwcapi instance to be ready to receive data, the consumer clients must have

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ApiSettings.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ApiSettings.scala
@@ -24,5 +24,5 @@ class ApiSettings(root: => Config) {
 
   private def config = root.getConfig("atlas.lwcapi")
 
-  def defaultFrequency: Long = config.getDuration("register.default-frequency").toMillis
+  def defaultStep: Long = config.getDuration("register.default-step").toMillis
 }

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionMetadata.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionMetadata.scala
@@ -15,13 +15,14 @@
  */
 package com.netflix.atlas.lwcapi
 
+import com.fasterxml.jackson.annotation.JsonAlias
 import com.netflix.atlas.core.util.Hash
 import com.netflix.atlas.core.util.Strings
 import com.netflix.atlas.json.JsonSupport
 
 case class ExpressionMetadata(
   expression: String,
-  frequency: Long = ApiSettings.defaultFrequency,
+  @JsonAlias(Array("step")) frequency: Long = ApiSettings.defaultStep,
   id: String = ""
 ) extends JsonSupport
     with Ordered[ExpressionMetadata] {
@@ -36,13 +37,13 @@ case class ExpressionMetadata(
 
 object ExpressionMetadata {
 
-  def apply(expression: String, frequency: Long): ExpressionMetadata = {
-    val f = if (frequency > 0) frequency else ApiSettings.defaultFrequency
+  def apply(expression: String, step: Long): ExpressionMetadata = {
+    val f = if (step > 0) step else ApiSettings.defaultStep
     new ExpressionMetadata(expression, f, computeId(expression, f))
   }
 
   def apply(expression: String): ExpressionMetadata = {
-    apply(expression, ApiSettings.defaultFrequency)
+    apply(expression, ApiSettings.defaultStep)
   }
 
   def computeId(e: String, f: Long): String = {

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ApiSettingsSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ApiSettingsSuite.scala
@@ -19,6 +19,6 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class ApiSettingsSuite extends AnyFunSuite {
   test("loads") {
-    assert(ApiSettings.defaultFrequency > 0)
+    assert(ApiSettings.defaultStep > 0)
   }
 }

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionMetadataSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionMetadataSuite.scala
@@ -22,7 +22,7 @@ import org.scalatest.funsuite.AnyFunSuite
 class ExpressionMetadataSuite extends AnyFunSuite {
   test("default frequency is applied") {
     val ret1 = ExpressionMetadata("this")
-    val ret2 = ExpressionMetadata("this", ApiSettings.defaultFrequency)
+    val ret2 = ExpressionMetadata("this", ApiSettings.defaultStep)
     assert(ret1 === ret2)
   }
 
@@ -40,7 +40,7 @@ class ExpressionMetadataSuite extends AnyFunSuite {
 
   test("default frequency") {
     val expr = ExpressionMetadata("test")
-    assert(expr.frequency === ApiSettings.defaultFrequency)
+    assert(expr.frequency === ApiSettings.defaultStep)
   }
 
   test("computes id") {
@@ -59,7 +59,7 @@ class ExpressionMetadataSuite extends AnyFunSuite {
 
     val o = Json.decode[ExpressionMetadata](json)
     assert(o.expression === "this")
-    assert(o.frequency === ApiSettings.defaultFrequency)
+    assert(o.frequency === ApiSettings.defaultStep)
   }
 
   test("parses from json with frequency, without id") {

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
@@ -136,6 +136,25 @@ class SubscribeApiSuite extends AnyFunSuite with BeforeAndAfter with ScalatestRo
       |{
       |  "streamId": "abc123",
       |  "expressions": [
+      |    { "expression": "nf.name,foo,:eq,:sum", "step": 99 }
+      |  ]
+      |}""".stripMargin
+    Post("/lwc/api/v1/subscribe", json) ~> routes ~> check {
+      assert(response.status === StatusCodes.OK)
+      val subs = sm.subscriptionsForStream("abc123")
+      assert(subs.length === 1)
+      assert(subs.head.metadata.expression === "nf.name,foo,:eq,:sum")
+      assert(subs.head.metadata.frequency === 99L)
+    }
+  }
+
+  test("subscribe: frequency is treated as alias to step") {
+    sm.register("abc123", queue)
+
+    val json = """
+      |{
+      |  "streamId": "abc123",
+      |  "expressions": [
       |    { "expression": "nf.name,foo,:eq,:sum", "frequency": 99 }
       |  ]
       |}""".stripMargin
@@ -161,7 +180,7 @@ class SubscribeApiSuite extends AnyFunSuite with BeforeAndAfter with ScalatestRo
         |{
         |  "streamId": "abc123",
         |  "expressions": [
-        |    { "expression": "$expr", "frequency": 99 }
+        |    { "expression": "$expr", "step": 99 }
         |  ]
         |}""".stripMargin
       Post("/lwc/api/v1/subscribe", json) ~> routes ~> check {
@@ -187,8 +206,8 @@ class SubscribeApiSuite extends AnyFunSuite with BeforeAndAfter with ScalatestRo
         |{
         |  "streamId": "abc123",
         |  "expressions": [
-        |    { "expression": "name,fixed,:eq,:sum", "frequency": 99 },
-        |    { "expression": "$expr", "frequency": 99 }
+        |    { "expression": "name,fixed,:eq,:sum", "step": 99 },
+        |    { "expression": "$expr", "step": 99 }
         |  ]
         |}""".stripMargin
       Post("/lwc/api/v1/subscribe", json) ~> routes ~> check {


### PR DESCRIPTION
The goal is to try and make the naming more consistent
and standardize on `step` everywhere. Parts of lwcapi
were the only places that referred to this as `frequency`.

This updates the `ExpressionMetadata` class so it will
treat `step` as an alias. This will allow the eval library
to be updated. For now the output of the expressions api
needs to keep it as `frequency` to ensure backwards
compatibility with clients.