### PR TITLE
Allow nf.shard tags

### DIFF
--- a/atlas-webapi/src/main/resources/reference.conf
+++ b/atlas-webapi/src/main/resources/reference.conf
@@ -130,6 +130,8 @@ atlas {
             "job",
             "node",
             "region",
+            "shard1",
+            "shard2",
             "stack",
             "subnet",
             "task",


### PR DESCRIPTION
In order to support a new method of sharding internally at Netflix,
allow `nf.shard1` and `nf.shard2` tags