### PR TITLE
fix delay of stopping host lookup

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluationFlows.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluationFlows.scala
@@ -15,8 +15,6 @@
  */
 package com.netflix.atlas.eval.stream
 
-import java.util.concurrent.atomic.AtomicBoolean
-
 import akka.Done
 import akka.NotUsed
 import akka.stream.KillSwitches
@@ -77,20 +75,6 @@ private[stream] object EvaluationFlows {
     */
   def repeat[T](item: T, delay: FiniteDuration): Source[T, NotUsed] = {
     Source.repeat(item).throttle(1, delay, 1, ThrottleMode.Shaping)
-  }
-
-  /**
-    * Source that will repeat the item with the specified delay in between while the
-    * condition is still true.
-    */
-  def repeatWhile[T](item: T, delay: FiniteDuration): (Source[T, NotUsed], AtomicBoolean) = {
-    val continue = new AtomicBoolean(true)
-    val iterator = new Iterator[T] {
-      override def hasNext: Boolean = continue.get()
-      override def next(): T = item
-    }
-    val src = Source.fromIterator(() => iterator).throttle(1, delay, 1, ThrottleMode.Shaping)
-    src -> continue
   }
 
   /**


### PR DESCRIPTION
There's a delay on stopping host lookup caused by EvaluationFlows.repeatWhile, use EvaluationFlows.stoppableSource instead. 
The delay can cause temporary incorrect lwc subscriptions when subscriptions change.