### PR TITLE
add mapping for MetadataNoToken

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/ec2.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/ec2.conf
@@ -129,6 +129,11 @@ atlas {
             }
           ]
         },
+        {
+          name = "MetadataNoToken"
+          alias = "aws.ec2.metadataNoTokenRequests"
+          conversion = "sum,rate"
+        },
       ]
     }
 


### PR DESCRIPTION
Tracks the number of requests to IMDSv1. Used to help with
tracking migration to IMDSv2.