### PR TITLE
exclude ec2 cloudwatch category by default

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/reference.conf
@@ -246,6 +246,9 @@ atlas {
 
     // Categories to load. The name will be used to load another config block:
     // atlas.cloudwatch.${name}
+    //
+    // ec2 is excluded by default because at Netflix it tends to add a lot of load in terms of
+    // CW calls and offers little value over internal system metrics.
     categories = [
       "alb",
       "alb-zone",
@@ -255,7 +258,7 @@ atlas {
       "dynamodb-table-1m",
       "dynamodb-table-5m",
       "dynamodb-table-ops",
-      "ec2",
+      //"ec2",
       "ec2-api",
       "ec2-credit",
       "efs",


### PR DESCRIPTION
A user can opt-in if desired. This makes the default config
line up with internal usage.