### PR TITLE
move metadata counter to separate category

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/ec2.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/ec2.conf
@@ -129,17 +129,34 @@ atlas {
             }
           ]
         },
-        {
-          name = "MetadataNoToken"
-          alias = "aws.ec2.metadataNoTokenRequests"
-          conversion = "sum,rate"
-        },
       ]
     }
 
     ec2-instance = ${atlas.cloudwatch.ec2} {
       dimensions = [
         "InstanceId"
+      ]
+    }
+
+    // Only needed for transition period
+    // http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/ec2-metricscollected.html
+    // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-transition-to-version-2
+    ec2-imdsv2 = {
+      namespace = "AWS/EC2"
+      period = 5m
+      end-period-offset = 1
+      period-count = 4
+
+      dimensions = [
+        "AutoScalingGroupName"
+      ]
+
+      metrics = [
+        {
+          name = "MetadataNoToken"
+          alias = "aws.ec2.metadataNoTokenRequests"
+          conversion = "sum,rate"
+        }
       ]
     }
 


### PR DESCRIPTION
During the transition period it is desirable to have
this metric for ASGs even though we do not need other
EC2 CW data.