### PR TITLE
fix shared WebSocket handler issue

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -19,6 +19,7 @@ import java.nio.file.OpenOption
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
 import java.time.Duration
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
@@ -449,7 +450,8 @@ private[stream] abstract class EvaluatorImpl(
     instance: EurekaSource.Instance,
     context: StreamContext
   ): Flow[DataSources, ByteString, NotUsed] = {
-    val uri = instance.substitute("ws://{local-ipv4}:{port}") + "/api/v1/subscribe"
+    val uri = instance.substitute("ws://{local-ipv4}:{port}") + "/api/v1/subscribe/" +
+      UUID.randomUUID().toString
     val webSocketFlowOrigin = Http(system).webSocketClientFlow(WebSocketRequest(uri))
     Flow[DataSources]
       .via(StreamOps.unique) // Updating subscriptions only if there's a change

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
@@ -74,7 +74,7 @@ class SubscribeApiSuite extends AnyFunSuite with BeforeAndAfter with ScalatestRo
 
   test("subscribe websocket") {
     val client = WSProbe()
-    WS("/api/v1/subscribe", client.flow) ~> routes ~> check {
+    WS("/api/v1/subscribe/123", client.flow) ~> routes ~> check {
       assert(isWebSocketUpgrade)
 
       // Send list of expressions to subscribe to


### PR DESCRIPTION
Currently WebSocket handler is singleton with the same streamID shared by different client connection, so only the first connection works. The fix is to create 1 instance of handler per request, also getting streamId from request allows client to have same streamId for all LWC API calls.