### PR TITLE
emit empty DataSources for a host if no more DataSource

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookup.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookup.scala
@@ -57,7 +57,7 @@ private[stream] class EurekaGroupsLookup(context: StreamContext, frequency: Fini
 
         // If there is an existing source polling Eureka, then tell it to stop. Create a
         // new instance of the flag for the next source
-        lookupTickSwitch.map(_.stop())
+        lookupTickSwitch.foreach(_.stop())
 
         val next = grab(in)
 
@@ -107,7 +107,7 @@ private[stream] class EurekaGroupsLookup(context: StreamContext, frequency: Fini
 
       override def onUpstreamFinish(): Unit = {
         completeStage()
-        lookupTickSwitch.map(_.stop())
+        lookupTickSwitch.foreach(_.stop())
       }
 
       override def onUpstreamFailure(ex: Throwable): Unit = {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookup.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookup.scala
@@ -66,7 +66,8 @@ private[stream] class EurekaGroupsLookup(context: StreamContext, frequency: Fini
         if (next.getSources.isEmpty) {
           // If the Eureka based sources are empty, then just use an empty source to avoid
           // potential delays to shutting down when the upstream completes.
-          Source.empty[SourcesAndGroups]
+          lookupTickSwitch = None // No need to stop Source.single
+          push(out, Source.single[SourcesAndGroups](DataSources.empty() -> Groups(List.empty)))
         } else {
           val eurekaSources = next.getSources.asScala
             .flatMap { s =>
@@ -106,6 +107,11 @@ private[stream] class EurekaGroupsLookup(context: StreamContext, frequency: Fini
 
       override def onUpstreamFinish(): Unit = {
         completeStage()
+        lookupTickSwitch.map(_.stop())
+      }
+
+      override def onUpstreamFailure(ex: Throwable): Unit = {
+        super.onUpstreamFailure(ex)
         lookupTickSwitch.map(_.stop())
       }
 

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FillRemovedKeysWith.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FillRemovedKeysWith.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import akka.stream.Attributes
+import akka.stream.FlowShape
+import akka.stream.Inlet
+import akka.stream.Outlet
+import akka.stream.stage.GraphStage
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.InHandler
+import akka.stream.stage.OutHandler
+
+import scala.collection.Map
+
+/**
+  * This operator compares keys of current Map with the very previous one in the stream, and fill
+  * removed keys using "valueForRemovedKey" function.
+  *
+  * Typical usage is to plug this flow before groupBy, so that if a key is removed, a custom value
+  * can be pushed down to sub-streams to trigger appropriate action immediately, as apposed to wait
+  * for subscription timeout and then cleanup.
+  */
+private[stream] class FillRemovedKeysWith[K, V](valueForRemovedKey: K => V)
+    extends GraphStage[FlowShape[Map[K, V], Map[K, V]]] {
+
+  private val in = Inlet[Map[K, V]]("FillRemovedKeys.in")
+  private val out = Outlet[Map[K, V]]("FillRemovedKeys.out")
+
+  override val shape: FlowShape[Map[K, V], Map[K, V]] = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
+    new GraphStageLogic(shape) with InHandler with OutHandler {
+
+      private var prevKeySet = scala.collection.Set.empty[K]
+
+      override def onPush(): Unit = {
+        val map = grab(in)
+        val newMap = scala.collection.mutable.Map.empty[K, V] ++ map
+
+        val removedKeys = prevKeySet -- newMap.keySet
+        removedKeys.foreach(k => {
+          newMap.put(k, valueForRemovedKey(k))
+        })
+
+        prevKeySet = map.keySet
+        push(out, newMap)
+      }
+
+      override def onPull(): Unit = {
+        pull(in)
+      }
+      setHandlers(in, out, this)
+    }
+  }
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FillRemovedKeysWith.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FillRemovedKeysWith.scala
@@ -52,9 +52,9 @@ private[stream] class FillRemovedKeysWith[K, V](valueForRemovedKey: K => V)
         val newMap = scala.collection.mutable.Map.empty[K, V] ++ map
 
         val removedKeys = prevKeySet -- newMap.keySet
-        removedKeys.foreach(k => {
+        removedKeys.foreach { k =>
           newMap.put(k, valueForRemovedKey(k))
-        })
+        }
 
         prevKeySet = map.keySet
         push(out, newMap)
@@ -63,6 +63,7 @@ private[stream] class FillRemovedKeysWith[K, V](valueForRemovedKey: K => V)
       override def onPull(): Unit = {
         pull(in)
       }
+
       setHandlers(in, out, this)
     }
   }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookupSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookupSuite.scala
@@ -93,15 +93,14 @@ class EurekaGroupsLookupSuite extends AnyFunSuite {
     Await.result(future, Duration.Inf)
   }
 
-  test("no data sources") {
+  test("empty sources produces 1 empty sources") {
     val input = List(
       DataSources.empty()
     )
-    val future = Source(input)
-      .via(lookupFlow)
-      .runWith(Sink.seq)
-    val output = Await.result(future, Duration.Inf)
-    assert(output.isEmpty)
+    val output = run(input)
+    assert(output.size === 1)
+    assert(output.head._1.getSources.size() === 0)
+    assert(output.head._2.groups.size === 0)
   }
 
   test("one data source") {

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FillRemovedKeysWithSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FillRemovedKeysWithSuite.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+class FillRemovedKeysWithSuite extends AnyFunSuite {
+
+  implicit val system = ActorSystem(getClass.getSimpleName)
+  implicit val materializer = ActorMaterializer()
+
+  val map1 = Map[String, String]("a" -> "1")
+  val map2 = Map[String, String]("b" -> "2")
+  val map3 = Map[String, String]("c" -> "3", "d" -> "4")
+
+  test("test fill keys") {
+
+    val future = Source(List(map1, map2, map3))
+      .via(new FillRemovedKeysWith[String, String](_ => "?"))
+      .runWith(Sink.seq)
+
+    val outputList = Await.result(future, Duration.Inf).toList
+
+    assert(
+      outputList ===
+        List(Map("a" -> "1"), Map("a" -> "?", "b" -> "2"), Map("b" -> "?", "c" -> "3", "d" -> "4"))
+    )
+  }
+}


### PR DESCRIPTION
Emit empty DataSources for a host if no more DataSource so that downstream can stop stream from LWC timely for this host, this is preparing for single evaluator at atlas-stream API.