### PR TITLE
Allow updating ID of MessageEnvelope

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/Evaluator.java
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/Evaluator.java
@@ -327,7 +327,7 @@ public final class Evaluator extends EvaluatorImpl {
    * can be used to route the message back to the appropriate consumer.
    */
   public final static class MessageEnvelope {
-    private final String id;
+    private String id;
     private final JsonSupport message;
 
     /** Create a new instance. */
@@ -344,6 +344,10 @@ public final class Evaluator extends EvaluatorImpl {
     /** Returns the message. */
     public JsonSupport getMessage() {
       return message;
+    }
+
+    public void setId(String id) {
+      this.id = id;
     }
 
     @Override public boolean equals(Object o) {

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -328,6 +328,7 @@ class EvaluatorSuite extends AnyFunSuite with BeforeAndAfter {
     EqualsVerifier
       .forClass(classOf[Evaluator.MessageEnvelope])
       .suppress(Warning.NULL_FIELDS)
+      .suppress(Warning.NONFINAL_FIELDS)
       .verify()
   }
 


### PR DESCRIPTION
Allow updating ID of MessageEnvelope: need to remove streamId from message ID for single evaluator.