### PR TITLE
1.6: update settings in memory.conf

### DIFF
--- a/conf/memory.conf
+++ b/conf/memory.conf
@@ -22,10 +22,13 @@ atlas {
     }
   }
 
-  webapi {
+  eval {
     graph {
       // Change default start time on graph to smaller range more typical for testing
       start-time = e-30m
+
+      // Ensure default step time for rendering matches storage
+      step = ${atlas.core.model.step}
     }
   }
 


### PR DESCRIPTION
Update the memory.conf example to reflect move of graphing
logic to eval library.

Fixes #1135