### PR TITLE
adjust default serialization for java.time

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/Evaluator.java
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/Evaluator.java
@@ -25,6 +25,7 @@ import akka.stream.javadsl.Source;
 import akka.stream.javadsl.StreamConverters;
 import akka.util.ByteString;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.atlas.core.util.Strings$;
 import com.netflix.atlas.json.JsonSupport;
@@ -298,6 +299,7 @@ public final class Evaluator extends EvaluatorImpl {
     }
 
     /** Returns true if the URI is for a local file or classpath resource. */
+    @JsonIgnore
     public boolean isLocal() {
       return uri.startsWith("/")
           || uri.startsWith("file:")

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -546,4 +546,10 @@ class EvaluatorSuite extends AnyFunSuite with BeforeAndAfter {
       assert(ts.data === ArrayData(Array(45.0)))
     }
   }
+
+  test("DataSource serde") {
+    val ds = new Evaluator.DataSource("_", Duration.ofSeconds(42L), ":true")
+    assert(Json.encode(ds) === """{"id":"_","step":42000,"uri":":true"}""")
+    assert(Json.decode[Evaluator.DataSource](Json.encode(ds)) === ds)
+  }
 }

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
@@ -81,6 +81,8 @@ object Json {
   private def newMapper(factory: JsonFactory): ObjectMapper = {
     val mapper = new ObjectMapper(factory)
     mapper.setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
+    mapper.configure(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, false)
+    mapper.configure(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS, false)
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     mapper.registerModule(DefaultScalaModule)
     mapper.registerModule(new AtlasModule)

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
@@ -180,17 +180,14 @@ class JsonSuite extends AnyFunSuite {
   }
 
   test("java8 Instant") {
-    // This form is a bit strange with floating point seconds, it would probably be
-    // better long term to disable WRITE_DATES_AS_TIMESTAMPS. However, that potentially
-    // breaks existing usages. Wait for 1.7.x
     val v = java.time.Instant.parse("2012-01-13T04:37:52Z")
-    assert(encode(v) === "1326429472.000000000")
+    assert(encode(v) === "1326429472000")
     assert(decode[java.time.Instant](encode(v)) === v)
   }
 
   test("java8 Duration") {
     val v = java.time.Duration.ofSeconds(42)
-    assert(encode(v) === "42.000000000")
+    assert(encode(v) === "42000")
     assert(decode[java.time.Duration](encode(v)) === v)
   }
 


### PR DESCRIPTION
Set the default serialization to use millisecond timestamps.
This keeps it more consistent with other usage in Atlas.