### PR TITLE
optimize parsing of LWC messages

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcDataExpr.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcDataExpr.scala
@@ -16,6 +16,7 @@
 package com.netflix.atlas.eval.model
 
 import com.fasterxml.jackson.annotation.JsonAlias
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.DataVocabulary
 import com.netflix.atlas.core.stacklang.Interpreter
@@ -35,6 +36,8 @@ import com.netflix.atlas.core.stacklang.Interpreter
   *     The step size used for this stream of data.
   */
 case class LwcDataExpr(id: String, expression: String, @JsonAlias(Array("frequency")) step: Long) {
+
+  @JsonIgnore
   val expr: DataExpr = LwcDataExpr.parseExpr(expression)
 }
 

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcMessagesSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcMessagesSuite.scala
@@ -24,10 +24,15 @@ class LwcMessagesSuite extends AnyFunSuite {
   private val step = 60000
 
   test("data expr, decode with legacy frequency field") {
-    val json = """{"id":"1234","expression":"name,cpu,:eq,:sum","frequency":10}"""
-    val actual = Json.decode[LwcDataExpr](json)
-    val expected = LwcDataExpr("1234", "name,cpu,:eq,:sum", 10)
-    assert(actual === expected)
+    val json = """[{"id":"1234","expression":"name,cpu,:eq,:sum","frequency":10}]"""
+    val parser = Json.newJsonParser(json)
+    try {
+      val actual = LwcMessages.parseDataExprs(parser).head
+      val expected = LwcDataExpr("1234", "name,cpu,:eq,:sum", 10)
+      assert(actual === expected)
+    } finally {
+      parser.close()
+    }
   }
 
   test("subscription info") {

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/eval/model/LwcMessagesParse.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/eval/model/LwcMessagesParse.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+import com.netflix.atlas.json.Json
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.infra.Blackhole
+
+/**
+  * ```
+  * > jmh:run -prof gc -wi 10 -i 10 -f1 -t1 .*LwcMessagesParse.*
+  * ```
+  *
+  * Results:
+  *
+  * ```
+  * Benchmark                          Mode  Cnt        Score       Error   Units
+  * parseDatapoint                    thrpt    5  1228277.874 ± 43946.724   ops/s
+  * parseDatapoint       gc.alloc.rate.norm    5     1632.000 ±     0.001    B/op
+  * ```
+  **/
+@State(Scope.Thread)
+class LwcMessagesParse {
+
+  private val tags = Map(
+    "nf.app"     -> "atlas_backend",
+    "nf.cluster" -> "atlas_backend-dev",
+    "nf.node"    -> "i-123456789",
+    "name"       -> "jvm.gc.pause",
+    "statistic"  -> "totalTime"
+  )
+
+  private val datapoint = LwcDatapoint(1234567890L, "i-12345", tags, 42.0)
+  private val json = Json.encode(datapoint)
+
+  @Benchmark
+  def parseDatapoint(bh: Blackhole): Unit = {
+    bh.consume(LwcMessages.parse(json))
+  }
+}

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/JsonParserHelper.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/JsonParserHelper.scala
@@ -32,6 +32,22 @@ object JsonParserHelper {
     if (t == null || t == token || t == stop) t == token else skipTo(parser, token, stop)
   }
 
+  def skipNext(parser: JsonParser): Unit = {
+    parser.nextToken() match {
+      case JsonToken.START_ARRAY =>
+        var t = parser.currentToken()
+        while (t != null && t != JsonToken.END_ARRAY) {
+          skipNext(parser)
+          t = parser.nextToken()
+        }
+      case JsonToken.START_OBJECT =>
+        foreachField(parser) {
+          case f => skipNext(parser)
+        }
+      case _ =>
+    }
+  }
+
   def fail(parser: JsonParser, msg: String): Nothing = {
     val loc = parser.getCurrentLocation
     val line = loc.getLineNr

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/JsonParserHelperSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/JsonParserHelperSuite.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.json
 
+import com.fasterxml.jackson.core.JsonToken
 import org.scalatest.funsuite.AnyFunSuite
 
 class JsonParserHelperSuite extends AnyFunSuite {
@@ -80,5 +81,26 @@ class JsonParserHelperSuite extends AnyFunSuite {
         builder += parser.nextIntValue(-1)
       }
     }
+  }
+
+  test("skipNext: empty object") {
+    val parser = Json.newJsonParser("""[{}]""")
+    assert(parser.nextToken() === JsonToken.START_ARRAY)
+    skipNext(parser)
+    assert(parser.nextToken() === JsonToken.END_ARRAY)
+  }
+
+  test("skipNext: object with simple fields") {
+    val parser = Json.newJsonParser("""[{"a":1,"b":"foo","c":false,"d":null}]""")
+    assert(parser.nextToken() === JsonToken.START_ARRAY)
+    skipNext(parser)
+    assert(parser.nextToken() === JsonToken.END_ARRAY)
+  }
+
+  test("skipNext: object with complex field") {
+    val parser = Json.newJsonParser("""[{"a":{"b":[{"c":{"d":["f",1,null]}}]}}]""")
+    assert(parser.nextToken() === JsonToken.START_ARRAY)
+    skipNext(parser)
+    assert(parser.nextToken() === JsonToken.END_ARRAY)
   }
 }


### PR DESCRIPTION
For some recent tests around 9% of the CPU time was spent
parsing these messages when under heavy load. Using the JMH
benchmark this provides a little over 2x faster parsing and
similar reduction in allocations.