### PR TITLE
cache the hash code for DataExprs

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
@@ -118,6 +118,8 @@ object DataExpr {
       val rs = consolidate(context.step, data.filter(t => query.matches(t.tags)))
       ResultSet(this, rs, context.state)
     }
+
+    override val hashCode: Int = scala.util.hashing.MurmurHash3.productHash(this)
   }
 
   sealed trait AggregateFunction extends DataExpr with BinaryOp {
@@ -165,6 +167,8 @@ object DataExpr {
     }
 
     def apply(v1: Double, v2: Double): Double = Math.addNaN(v1, v2)
+
+    override val hashCode: Int = scala.util.hashing.MurmurHash3.productHash(this)
   }
 
   case class Count(
@@ -202,6 +206,8 @@ object DataExpr {
     }
 
     def apply(v1: Double, v2: Double): Double = Math.addNaN(v1, v2)
+
+    override val hashCode: Int = scala.util.hashing.MurmurHash3.productHash(this)
   }
 
   case class Min(query: Query, offset: Duration = Duration.ZERO) extends AggregateFunction {
@@ -219,6 +225,8 @@ object DataExpr {
     override def exprString: String = s"$query,:min"
 
     def apply(v1: Double, v2: Double): Double = Math.minNaN(v1, v2)
+
+    override val hashCode: Int = scala.util.hashing.MurmurHash3.productHash(this)
   }
 
   case class Max(query: Query, offset: Duration = Duration.ZERO) extends AggregateFunction {
@@ -236,6 +244,8 @@ object DataExpr {
     override def exprString: String = s"$query,:max"
 
     def apply(v1: Double, v2: Double): Double = Math.maxNaN(v1, v2)
+
+    override val hashCode: Int = scala.util.hashing.MurmurHash3.productHash(this)
   }
 
   case class Consolidation(af: AggregateFunction, cf: ConsolidationFunction)
@@ -262,6 +272,8 @@ object DataExpr {
     override def exprString: String = s"$af,$cf"
 
     def apply(v1: Double, v2: Double): Double = af(v1, v2)
+
+    override val hashCode: Int = scala.util.hashing.MurmurHash3.productHash(this)
   }
 
   case class GroupBy(af: AggregateFunction, keys: List[String]) extends DataExpr {
@@ -306,5 +318,7 @@ object DataExpr {
       val rs = consolidate(context.step, newData)
       ResultSet(this, rs, context.state)
     }
+
+    override val hashCode: Int = scala.util.hashing.MurmurHash3.productHash(this)
   }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcDataExprSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcDataExprSuite.scala
@@ -36,6 +36,6 @@ class LwcDataExprSuite extends AnyFunSuite {
     val distExprStr = "name,foo,:eq,:dist-max,(,nf.asg,),:by"
     val lwcExpr = LwcDataExpr("123", exprStr, 10L)
     assert(lwcExpr.expr === styleExpr(distExprStr).expr.dataExprs.head)
-    assert(lwcExpr.expr.hashCode() === styleExpr(exprStr).expr.hashCode())
+    assert(lwcExpr.expr.hashCode === styleExpr(exprStr).expr.hashCode)
   }
 }


### PR DESCRIPTION
For streaming evaluation the DataExpr is the key in the
time grouping stage. The largest expense in the time
grouping stage was computing the hash code of the DataExpr
to aggregate the datapoints as they were flowing through.