### PR TITLE
atlas-eval: make queue size configurable for lwc call

### DIFF
--- a/atlas-eval/src/main/resources/reference.conf
+++ b/atlas-eval/src/main/resources/reference.conf
@@ -1,6 +1,7 @@
 
 atlas.eval {
   stream {
+    queue-size = 1000
     backends = [
       {
         host = "localhost"

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -418,7 +418,7 @@ private[stream] abstract class EvaluatorImpl(
     ClusterOps.GroupByContext(
       instance => createWebSocketFlow(instance, context),
       registry,
-      queueSize = 10
+      queueSize = config.getInt("atlas.eval.stream.queue-size")
     )
   }
 


### PR DESCRIPTION
atlas-eval: make queue size configurable for lwc call