### PR TITLE
disable trusted advisor collection by default

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/reference.conf
@@ -280,7 +280,7 @@ atlas {
       "sns",
       "sqs",
       "tgw",
-      "trustedadvisor",
+      //"trustedadvisor",
       "workflow",
       "workflow-activity"
     ]


### PR DESCRIPTION
The trusted advisor data in cloudwatch is only updated
when something refreshes the checks. Unless something
is doing that, there isn't much point in collecting
the cloudwatch data.