### PR TITLE
atlas-eval: lower eval input queue-size, it's for the DataSources updates at low rate

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/ClusterOps.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/ClusterOps.scala
@@ -135,7 +135,11 @@ object ClusterOps extends StrictLogging {
           val sources = added.toList
             .map { m =>
               val queue =
-                new SourceQueue[D](registry, "_", new ArrayBlockingQueue[D](context.queueSize))
+                new SourceQueue[D](
+                  registry,
+                  "ClusterGroupBy",
+                  new ArrayBlockingQueue[D](context.queueSize)
+                )
               membersSources += m -> queue
               Source
                 .fromGraph(new QueueSource[D](() => queue))

--- a/atlas-eval/src/main/resources/reference.conf
+++ b/atlas-eval/src/main/resources/reference.conf
@@ -1,7 +1,6 @@
 
 atlas.eval {
   stream {
-    queue-size = 1000
     backends = [
       {
         host = "localhost"

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -425,7 +425,7 @@ private[stream] abstract class EvaluatorImpl(
     ClusterOps.GroupByContext(
       instance => createWebSocketFlow(instance, context),
       registry,
-      queueSize = config.getInt("atlas.eval.stream.queue-size")
+      queueSize = 10
     )
   }
 


### PR DESCRIPTION
atlas-eval: lower eval input queue-size, it's for the DataSources updates at low rate