### PR TITLE
atlas-eval: expose Flow api in Executor to maximize throughput

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -163,10 +163,14 @@ private[stream] abstract class EvaluatorImpl(
   }
 
   protected def createStreamsProcessorImpl(): Processor[DataSources, MessageEnvelope] = {
-    createGroupedDataSourcesFlow.toProcessor.run()
+    createStreamsFlow.toProcessor.run()
   }
 
-  private[stream] def createGroupedDataSourcesFlow: Flow[DataSources, MessageEnvelope, NotUsed] = {
+  /**
+    * Internal API, may change in future releases, should only used by internal components
+    * to maximize throughput under heavy load by enabling operator fusion optimization.
+    */
+  def createStreamsFlow: Flow[DataSources, MessageEnvelope, NotUsed] = {
     Flow[DataSources]
       .map(dss => groupByHost(dss))
       // Emit empty DataSource if no more DataSource for a host, so that the sub-stream get the info


### PR DESCRIPTION
Converting to Processor disables operator fusion at the boundary, and reduces overall throughput. This change exposes the Flow directly and enables operator fusion optimization, and downstream delay of the boundary reduced from hundreds of microseconds to tens of microseconds.