### PR TITLE
SmallHashMap: avoid lambda overhead for add/remove

### DIFF
--- a/atlas-core/src/main/scala-2.13+/com/netflix/atlas/core/util/SmallHashMap.scala
+++ b/atlas-core/src/main/scala-2.13+/com/netflix/atlas/core/util/SmallHashMap.scala
@@ -272,7 +272,13 @@ final class SmallHashMap[K <: Any, V <: Any] private (val data: Array[Any], data
 
   def updated[V1 >: V](k: K, v: V1): collection.immutable.Map[K, V1] = {
     val b = new SmallHashMap.Builder[K, V1](size + 1)
-    foreachItem(b.add)
+    var i = 0
+    while (i < data.length) {
+      if (data(i) != null) {
+        b.add(data(i).asInstanceOf[K], data(i + 1).asInstanceOf[V])
+      }
+      i += 2
+    }
     b.add(k, v)
     b.result
   }
@@ -280,8 +286,13 @@ final class SmallHashMap[K <: Any, V <: Any] private (val data: Array[Any], data
   def removed(key: K): collection.immutable.Map[K, V] = {
     if (contains(key)) {
       val b = new SmallHashMap.Builder[K, V](size - 1)
-      foreachItem { (k, v) =>
-        if (!areEqual(key, k)) b.add(k, v)
+      var i = 0
+      while (i < data.length) {
+        val k = data(i).asInstanceOf[K]
+        if (k != null && !areEqual(key, k)) {
+          b.add(k, data(i + 1).asInstanceOf[V])
+        }
+        i += 2
       }
       b.result
     } else {

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/SmallHashMapModify.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/SmallHashMapModify.scala
@@ -25,11 +25,11 @@ import org.openjdk.jmh.infra.Blackhole
   * Check performance of creating a copy of the map when adding/removing a single pair.
   *
   * ```
-  * > jmh:run -prof jmh.extras.JFR -wi 10 -i 10 -f1 -t1 .*SmallHashMapModify.*
+  * > jmh:run -prof gc -wi 10 -i 10 -f1 -t1 .*SmallHashMapModify.*
   * ...
   * [info] Benchmark                           Mode  Cnt        Score       Error  Units
-  * [info] SmallHashMapModify.addPair         thrpt   10  1637470.772 ± 29948.315  ops/s
-  * [info] SmallHashMapModify.removePair      thrpt   10  2520939.662 ± 32320.759  ops/s
+  * [info] SmallHashMapModify.addPair         thrpt    5  2541571.202 ± 239240.513   ops/s
+  * [info] SmallHashMapModify.removePair      thrpt    5  3840622.669 ± 439259.261   ops/s
   * ```
   */
 @State(Scope.Thread)


### PR DESCRIPTION
Loop over the array directly to avoid the lambda overhead
for adding or removing an item. This can be a hot path for
some use-cases.