### PR TITLE
avoid intermediate tuple allocations

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/QueryIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/QueryIndex.scala
@@ -42,7 +42,10 @@ case class QueryIndex[T](
 
   /** Returns true if the tags match any of the queries in the index. */
   def matches(tags: Map[String, String]): Boolean = {
-    val qs = tags.map(t => Query.Equal(t._1, t._2)).toList
+    var qs = List.empty[Query.Equal]
+    tags.foreachEntry { (k, v) =>
+      qs = Query.Equal(k, v) :: qs
+    }
     matches(tags, qs)
   }
 
@@ -61,7 +64,10 @@ case class QueryIndex[T](
 
   /** Finds the set of items that match the provided tags. */
   def matchingEntries(tags: Map[String, String]): List[T] = {
-    val qs = tags.map(t => Query.Equal(t._1, t._2)).toList
+    var qs = List.empty[Query.Equal]
+    tags.foreachEntry { (k, v) =>
+      qs = Query.Equal(k, v) :: qs
+    }
     matchingEntries(tags, qs).distinct
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/QueryIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/QueryIndexSuite.scala
@@ -212,7 +212,7 @@ class QueryIndexSuite extends AnyFunSuite {
   test("queries for both nf.app and nf.cluster") {
     val appQuery = Query.Equal("nf.app", "testapp")
     val clusterQuery = Query.Equal("nf.cluster", "testapp-test")
-    val queries = List(appQuery, clusterQuery)
+    val queries = List(clusterQuery, appQuery)
     val index = QueryIndex(queries)
 
     val tags = Map("nf.app" -> "testapp", "nf.cluster" -> "testapp-test")


### PR DESCRIPTION
Update QueryIndex matching methods to use foreachEntry
to avoid temporary tuples.