### PR TITLE
switch to foreachEntry for SmallHashMap

### DIFF
--- a/atlas-core/src/main/scala-2.13+/com/netflix/atlas/core/util/SmallHashMap.scala
+++ b/atlas-core/src/main/scala-2.13+/com/netflix/atlas/core/util/SmallHashMap.scala
@@ -190,12 +190,21 @@ final class SmallHashMap[K <: Any, V <: Any] private (val data: Array[Any], data
     * Call the function `f` for each tuple in the map without requiring a temporary object to be
     * created.
     */
-  def foreachItem(f: (K, V) => Unit): Unit = {
+  override def foreachEntry[U](f: (K, V) => U): Unit = {
     var i = 0
     while (i < data.length) {
       if (data(i) != null) f(data(i).asInstanceOf[K], data(i + 1).asInstanceOf[V])
       i += 2
     }
+  }
+
+  /**
+    * Call the function `f` for each tuple in the map without requiring a temporary object to be
+    * created.
+    */
+  @deprecated("Use `foreachEntry` instead.", "1.7.0")
+  def foreachItem(f: (K, V) => Unit): Unit = {
+    foreachEntry(f)
   }
 
   def find(f: (K, V) => Boolean): Option[(K, V)] = {

--- a/atlas-core/src/main/scala-2.13-/com/netflix/atlas/core/util/SmallHashMap.scala
+++ b/atlas-core/src/main/scala-2.13-/com/netflix/atlas/core/util/SmallHashMap.scala
@@ -190,12 +190,21 @@ final class SmallHashMap[K <: Any, V <: Any] private (val data: Array[Any], data
     * Call the function `f` for each tuple in the map without requiring a temporary object to be
     * created.
     */
-  def foreachItem(f: (K, V) => Unit): Unit = {
+  def foreachEntry(f: (K, V) => Unit): Unit = {
     var i = 0
     while (i < data.length) {
       if (data(i) != null) f(data(i).asInstanceOf[K], data(i + 1).asInstanceOf[V])
       i += 2
     }
+  }
+
+  /**
+    * Call the function `f` for each tuple in the map without requiring a temporary object to be
+    * created.
+    */
+  @deprecated("Use `foreachEntry` instead.", "1.7.0")
+  def foreachItem(f: (K, V) => Unit): Unit = {
+    foreachEntry(f)
   }
 
   def find(f: (K, V) => Boolean): Option[(K, V)] = {
@@ -272,7 +281,7 @@ final class SmallHashMap[K <: Any, V <: Any] private (val data: Array[Any], data
 
   def +[V1 >: V](kv: (K, V1)): collection.immutable.Map[K, V1] = {
     val b = new SmallHashMap.Builder[K, V1](size + 1)
-    foreachItem(b.add)
+    foreachEntry(b.add)
     b.add(kv._1, kv._2)
     b.result
   }
@@ -280,7 +289,7 @@ final class SmallHashMap[K <: Any, V <: Any] private (val data: Array[Any], data
   def -(key: K): collection.immutable.Map[K, V] = {
     if (contains(key)) {
       val b = new SmallHashMap.Builder[K, V](size - 1)
-      foreachItem { (k, v) =>
+      foreachEntry { (k, v) =>
         if (!areEqual(key, k)) b.add(k, v)
       }
       b.result

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TaggedItem.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TaggedItem.scala
@@ -176,7 +176,7 @@ trait TaggedItem {
     */
   def foreach(f: (String, String) => Unit): Unit = {
     tags match {
-      case m: SmallHashMap[String, String] => m.foreachItem(f)
+      case m: SmallHashMap[String, String] => m.foreachEntry(f)
       case m: Map[String, String] =>
         m.foreach { t =>
           f(t._1, t._2)

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeSeriesMessage.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeSeriesMessage.scala
@@ -87,7 +87,7 @@ case class TimeSeriesMessage(
     gen.writeObjectFieldStart("tags")
     tags match {
       case m: SmallHashMap[String, String] =>
-        m.foreachItem { (k, v) =>
+        m.foreachEntry { (k, v) =>
           gen.writeStringField(k, v)
         }
       case m: Map[String, String] =>

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
@@ -212,7 +212,7 @@ object PublishApi {
     gen.writeObjectFieldStart("tags")
     tags match {
       case m: SmallHashMap[String, String] =>
-        m.foreachItem { (k, v) =>
+        m.foreachEntry { (k, v) =>
           gen.writeStringField(k, v)
         }
       case m: Map[String, String] =>


### PR DESCRIPTION
This method is available for maps in scala 2.13.0. This makes
the custom SmallHashMap more inline with the scala maps.