### PR TITLE
switch to foreachEntry iterating maps

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/ClusterOps.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/ClusterOps.scala
@@ -163,8 +163,8 @@ object ClusterOps extends StrictLogging {
         }
 
         private def pushData(data: Map[M, D]): Unit = {
-          data.foreach {
-            case (m, d) => membersSources.get(m).foreach(_.offer(d))
+          data.foreachEntry { (m, d) =>
+            membersSources.get(m).foreach(_.offer(d))
           }
           if (isAvailable(out)) {
             pull(in)

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonCodec.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonCodec.scala
@@ -201,7 +201,7 @@ private[chart] object JsonCodec {
     gen.writeStringField("lineStyle", line.lineStyle.name())
     gen.writeNumberField("lineWidth", line.lineWidth)
     gen.writeObjectFieldStart("tags")
-    line.data.tags.foreach { case (k, v) => gen.writeStringField(k, v) }
+    line.data.tags.foreachEntry(gen.writeStringField)
     gen.writeEndObject()
     gen.writeObjectFieldStart("data")
     gen.writeStringField("type", "array")

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonGraphEngine.scala
@@ -33,7 +33,6 @@ class JsonGraphEngine(quoteNonNumeric: Boolean) extends GraphEngine {
   def write(config: GraphDef, output: OutputStream): Unit = {
     val writer = new OutputStreamWriter(output, "UTF-8")
     val seriesList = config.plots.flatMap(_.lines)
-    val count = seriesList.size
     val gen = jsonFactory.createGenerator(writer)
 
     gen.writeStartObject()
@@ -41,10 +40,9 @@ class JsonGraphEngine(quoteNonNumeric: Boolean) extends GraphEngine {
     gen.writeNumberField("step", config.step)
 
     gen.writeArrayFieldStart("legend")
-    (0 until count).zip(seriesList).foreach {
-      case (i, series) =>
-        val label = series.data.label
-        gen.writeString(label)
+    seriesList.foreach { series =>
+      val label = series.data.label
+      gen.writeString(label)
     }
     gen.writeEndArray()
 

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/StatsJsonGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/StatsJsonGraphEngine.scala
@@ -45,7 +45,6 @@ class StatsJsonGraphEngine extends GraphEngine {
   def write(config: GraphDef, output: OutputStream): Unit = {
     val writer = new OutputStreamWriter(output, "UTF-8")
     val seriesList = config.plots.flatMap(_.lines)
-    val count = seriesList.size
     val numberFmt = config.numberFormat
     val gen = jsonFactory.createGenerator(writer)
 
@@ -55,10 +54,9 @@ class StatsJsonGraphEngine extends GraphEngine {
     gen.writeNumberField("step", config.step)
 
     gen.writeArrayFieldStart("legend")
-    (0 until count).zip(seriesList).foreach {
-      case (i, series) =>
-        val label = series.data.label
-        gen.writeString(label)
+    seriesList.foreach { series =>
+      val label = series.data.label
+      gen.writeString(label)
     }
     gen.writeEndArray()
 
@@ -79,7 +77,7 @@ class StatsJsonGraphEngine extends GraphEngine {
 
       gen.writeStartObject()
       gen.writeNumberField("count", stats.count)
-      if (count > 0) {
+      if (seriesList.nonEmpty) {
         writeRawField(gen, "avg", numberStr(numberFmt, stats.avg))
         writeRawField(gen, "total", numberStr(numberFmt, stats.total))
         writeRawField(gen, "max", numberStr(numberFmt, stats.max))

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/util/PngImage.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/util/PngImage.scala
@@ -219,11 +219,11 @@ case class PngImage(data: RenderedImage, metadata: Map[String, String] = Map.emp
       writer.setOutput(ImageIO.createImageOutputStream(output))
 
       val pngMeta = writer.getDefaultImageMetadata(new ImageTypeSpecifier(data), null)
-      metadata.foreach { t =>
+      metadata.foreachEntry { (k, v) =>
         val textEntry = new IIOMetadataNode("TextEntry")
-        textEntry.setAttribute("keyword", t._1)
-        textEntry.setAttribute("value", t._2)
-        textEntry.setAttribute("compression", if (t._2.length > 100) "zip" else "none")
+        textEntry.setAttribute("keyword", k)
+        textEntry.setAttribute("value", v)
+        textEntry.setAttribute("compression", if (v.length > 100) "zip" else "none")
 
         val text = new IIOMetadataNode("Text")
         text.appendChild(textEntry)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/IdentityMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/IdentityMap.scala
@@ -35,6 +35,10 @@ class IdentityMap[K <: AnyRef, V] private (jmap: java.util.IdentityHashMap[K, V]
     }
   }
 
+  override def foreachEntry[U](f: (K, V) => U): Unit = {
+    jmap.forEach((k, v) => f(k, v))
+  }
+
   override def updated[V1 >: V](k: K, v: V1): IdentityMap[K, V1] = {
     val copy = new java.util.IdentityHashMap[K, V1](jmap)
     copy.put(k, v)
@@ -75,9 +79,7 @@ object IdentityMap {
 
   def apply[K <: AnyRef, V](map: Map[K, V]): IdentityMap[K, V] = {
     val copy = new java.util.IdentityHashMap[K, V]()
-    map.foreach { t =>
-      copy.put(t._1, t._2)
-    }
+    map.foreachEntry(copy.put)
     new IdentityMap[K, V](copy)
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/IdentityMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/IdentityMapSuite.scala
@@ -40,6 +40,17 @@ class IdentityMapSuite extends AnyFunSuite {
     assert(values === Set(1, 2, 3))
   }
 
+  test("foreachEntry") {
+    val m = IdentityMap(Map("a" -> 42, "b" -> 2))
+    m.foreachEntry { (k, v) =>
+      k match {
+        case "a" => assert(v == 42)
+        case "b" => assert(v == 2)
+        case _   => fail(s"unexpected key: $k")
+      }
+    }
+  }
+
   test("toString") {
     val m = IdentityMap(new String("a") -> 2, new String("a") -> 1, "b" -> 3)
 

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcDatapoint.scala
@@ -42,9 +42,7 @@ case class LwcDatapoint(timestamp: Long, id: String, tags: Map[String, String], 
     gen.writeNumberField("timestamp", timestamp)
     gen.writeStringField("id", id)
     gen.writeObjectFieldStart("tags")
-    tags.foreach { t =>
-      gen.writeStringField(t._1, t._2)
-    }
+    tags.foreachEntry(gen.writeStringField)
     gen.writeEndObject()
     gen.writeNumberField("value", value)
     gen.writeEndObject()

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
@@ -210,9 +210,7 @@ object PublishApi {
 
   private def encodeTags(gen: JsonGenerator, tags: Map[String, String]): Unit = {
     gen.writeObjectFieldStart("tags")
-    tags.foreachEntry { (k, v) =>
-      gen.writeStringField(k, v)
-    }
+    tags.foreachEntry(gen.writeStringField)
     gen.writeEndObject()
   }
 


### PR DESCRIPTION
This method is more efficient in many cases and avoids
temporary tuple objects. Now that we do not need to worry
about 2.12 compatibility, switch to using it where possible.