### PR TITLE
cache hash code for Query

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
@@ -48,6 +48,14 @@ sealed trait Query extends Expr {
   }
 
   def not: Query = Query.Not(this)
+
+  /**
+    * Hash code is cached to allow cheaper lookup during evaluation. This implementation
+    * in the base interface depends on the main fields of the case class being set prior
+    * to `super()` being called in the case class constructor. That appears to be the case
+    * with current scala versions.
+    */
+  override val hashCode: Int = scala.util.hashing.MurmurHash3.productHash(this)
 }
 
 object Query {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeSeriesMessage.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeSeriesMessage.scala
@@ -18,7 +18,6 @@ package com.netflix.atlas.eval.model
 import com.fasterxml.jackson.core.JsonGenerator
 import com.netflix.atlas.core.model._
 import com.netflix.atlas.json.JsonSupport
-import com.netflix.atlas.core.util.SmallHashMap
 
 /**
   * Message type use for emitting time series data in LWC and fetch responses.

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/index/QueryIndexMatching.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/index/QueryIndexMatching.scala
@@ -30,7 +30,7 @@ import org.openjdk.jmh.infra.Blackhole
   * regex being used in real queries and not being used in this synthetic data.
   *
   * ```
-  * > jmh:run -wi 10 -i 10 -f1 -t1 .*QueryIndexMatching.*
+  * > jmh:run -prof stack -prof gc -wi 10 -i 10 -f1 -t1 .*QueryIndexMatching.*
   * ```
   *
   * Initial results:


### PR DESCRIPTION
This get computed a lot when leveraging a query index. In
some cases it is over 5% of the time. Current JMH benchmark
shows a similar improvement after caching.

| Benchmark            |        Before |         After | % Delta |
|----------------------|---------------|---------------|---------|
| index_100            |   2,950,658.3 |   3,032,810.1 |     2.8 |
| index_1000           |   2,072,328.3 |   2,122,367.3 |     2.4 |
| index_10000          |   2,527,147.8 |   2,714,280.1 |     7.4 |
| index_100000         |   2,028,644.4 |   2,152,331.2 |     6.1 |