### PR TITLE
add helper for getting intValue from ItemId

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/ItemId.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/ItemId.scala
@@ -67,6 +67,19 @@ class ItemId private (private val data: Array[Byte], private val hc: Int)
   }
 
   def toBigInteger: BigInteger = new BigInteger(1, data)
+
+  def intValue: Int = {
+    var result = 0
+    val end = math.max(0, data.length - 4)
+    var i = data.length - 1
+    var shift = 0
+    while (i >= end) {
+      result |= (data(i) & 0xFF) << shift
+      i -= 1
+      shift += 8
+    }
+    result
+  }
 }
 
 object ItemId {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Shards.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Shards.scala
@@ -17,6 +17,8 @@ package com.netflix.atlas.core.util
 
 import java.math.BigInteger
 
+import com.netflix.atlas.core.model.ItemId
+
 /**
   * Utility functions for mapping ids or indices to a shard. For our purposes, a shard
   * is an instance with a set of server groups. The union of data from all groups comprises
@@ -146,6 +148,12 @@ object Shards {
     /** Return the instance that should receive the data associated with `id`. */
     def instanceForId(id: BigInteger): T = {
       val i = math.abs(id.intValue())
+      instanceForIndex(i)
+    }
+
+    /** Return the instance that should receive the data associated with `id`. */
+    def instanceForId(id: ItemId): T = {
+      val i = math.abs(id.intValue)
       instanceForIndex(i)
     }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ItemIdSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ItemIdSuite.scala
@@ -109,4 +109,26 @@ class ItemIdSuite extends AnyFunSuite {
     assert(id1.compareTo(id2) < 0)
     assert(id2.compareTo(id1) > 0)
   }
+
+  test("int value") {
+    (0 until 100).foreach { i =>
+      val id = ItemId(Hash.sha1bytes(i.toString))
+      assert(id.intValue === id.toBigInteger.intValue())
+    }
+  }
+
+  test("int value: one byte") {
+    val id = ItemId(Array(57.toByte))
+    assert(id.intValue === id.toBigInteger.intValue())
+  }
+
+  test("int value: two bytes") {
+    val id = ItemId(Array(1.toByte, 2.toByte))
+    assert(id.intValue === id.toBigInteger.intValue())
+  }
+
+  test("int value: three bytes") {
+    val id = ItemId(Array(1.toByte, 2.toByte, 0xFF.toByte))
+    assert(id.intValue === id.toBigInteger.intValue())
+  }
 }


### PR DESCRIPTION
This method is compatible with what you would get by calling
`toBigInteger.intValue` but avoids the overhead of creating
an intermediate BigInteger object if that is the only use.