### PR TITLE
fix logic for skipNext

### DIFF
--- a/atlas-json/src/main/scala/com/netflix/atlas/json/JsonParserHelper.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/JsonParserHelper.scala
@@ -34,17 +34,9 @@ object JsonParserHelper {
 
   def skipNext(parser: JsonParser): Unit = {
     parser.nextToken() match {
-      case JsonToken.START_ARRAY =>
-        var t = parser.currentToken()
-        while (t != null && t != JsonToken.END_ARRAY) {
-          skipNext(parser)
-          t = parser.nextToken()
-        }
-      case JsonToken.START_OBJECT =>
-        foreachField(parser) {
-          case f => skipNext(parser)
-        }
-      case _ =>
+      case JsonToken.START_ARRAY  => parser.skipChildren()
+      case JsonToken.START_OBJECT => parser.skipChildren()
+      case _                      =>
     }
   }
 

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/JsonParserHelperSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/JsonParserHelperSuite.scala
@@ -15,7 +15,14 @@
  */
 package com.netflix.atlas.json
 
+import java.util.Random
+import java.util.UUID
+
 import com.fasterxml.jackson.core.JsonToken
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.scalatest.funsuite.AnyFunSuite
 
 class JsonParserHelperSuite extends AnyFunSuite {
@@ -102,5 +109,88 @@ class JsonParserHelperSuite extends AnyFunSuite {
     assert(parser.nextToken() === JsonToken.START_ARRAY)
     skipNext(parser)
     assert(parser.nextToken() === JsonToken.END_ARRAY)
+  }
+
+  test("skipNext: complex object") {
+    val parser = Json.newJsonParser(
+      """
+        |[
+        |  {
+        |    "af": {
+        |      "query": {
+        |        "q1": {
+        |          "q1": {
+        |            "k": "name",
+        |            "v": "discovery.status"
+        |          },
+        |          "q2": {
+        |            "k": "state",
+        |            "vs": [
+        |              "NOT_REGISTERED",
+        |              "DOWN"
+        |            ]
+        |          }
+        |        },
+        |        "q2": {
+        |          "k": "nf.app",
+        |          "v": "sentrytesterspringboot"
+        |        }
+        |      },
+        |      "offset": 0,
+        |      "grouped": false
+        |    },
+        |    "keys": [
+        |      "nf.node"
+        |    ],
+        |    "grouped": true
+        |  }
+        |]
+        |""".stripMargin)
+    assert(parser.nextToken() === JsonToken.START_ARRAY)
+    skipNext(parser)
+    assert(parser.nextToken() === JsonToken.END_ARRAY)
+  }
+
+  test("skipNext: random") {
+    (0 until 10000).foreach { i =>
+      val json = s"""[${randomJson(i)}]"""
+      val parser = Json.newJsonParser(json)
+      assert(parser.nextToken() === JsonToken.START_ARRAY)
+      skipNext(parser)
+      assert(parser.nextToken() === JsonToken.END_ARRAY, s"json: $json")
+    }
+  }
+
+  private def randomJson(seed: Int): JsonNode = {
+    val r = new Random(seed) // use fixed seed so issues are reproducible
+    randomJson(r)
+  }
+
+  private def randomJson(r: Random): JsonNode = {
+    r.nextInt(7) match {
+      case 0 => randomObject(r)
+      case 1 => randomArray(r)
+      case 2 => JsonNodeFactory.instance.numberNode(r.nextInt())
+      case 3 => JsonNodeFactory.instance.numberNode(r.nextDouble())
+      case 4 => JsonNodeFactory.instance.booleanNode(r.nextBoolean())
+      case 5 => JsonNodeFactory.instance.nullNode()
+      case 6 => JsonNodeFactory.instance.textNode(UUID.randomUUID().toString)
+    }
+  }
+
+  private def randomObject(r: Random): ObjectNode = {
+    val obj = JsonNodeFactory.instance.objectNode()
+    (0 until r.nextInt(5)).foreach { i =>
+      obj.set[ObjectNode](i.toString, randomJson(r))
+    }
+    obj
+  }
+
+  private def randomArray(r: Random): ArrayNode = {
+    val arr = JsonNodeFactory.instance.arrayNode()
+    (0 until r.nextInt(5)).foreach { i =>
+      arr.add(randomJson(r))
+    }
+    arr
   }
 }

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/JsonParserHelperSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/JsonParserHelperSuite.scala
@@ -112,8 +112,7 @@ class JsonParserHelperSuite extends AnyFunSuite {
   }
 
   test("skipNext: complex object") {
-    val parser = Json.newJsonParser(
-      """
+    val parser = Json.newJsonParser("""
         |[
         |  {
         |    "af": {


### PR DESCRIPTION
The `skipNext` helper did not work correctly in the case
of some complex objects with nested arrays. This change
fixes the logic and adds more extensive testing with
randomly generated JSON objects.