### PR TITLE
remove -Xexperimental flag

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -6,7 +6,6 @@ object BuildSettings {
   val compilerFlags = Seq(
     "-deprecation",
     "-unchecked",
-    "-Xexperimental",
     "-Xlint:_,-infer-any",
     "-feature"
   )


### PR DESCRIPTION
Not needed now that we are on 2.13 only. Clears up warnings
during the build.