### PR TITLE
fix memory.conf to include from classpath

### DIFF
--- a/conf/memory.conf
+++ b/conf/memory.conf
@@ -1,4 +1,4 @@
-include "static.conf"
+include classpath("static.conf")
 
 atlas {
 


### PR DESCRIPTION
Before depending on how the path for the `memory.conf` file
was specified, it would try to load from the file system
instead of the classpath and the base config would be missing.
Now it is explicit about including from the classpath.

Fixes #1146.