### PR TITLE
enable WRITE_NAN_AS_STRINGS by default

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/AlgoStateSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/AlgoStateSuite.scala
@@ -60,6 +60,21 @@ class AlgoStateSuite extends AnyFunSuite {
     assert(serde(s).getDouble("test").isNaN)
   }
 
+  test("double: invalid string") {
+    val s = AlgoState("foo", "test" -> "invalid_numeric_value")
+    intercept[NumberFormatException] {
+      s.getDouble("test")
+    }
+  }
+
+  test("double: invalid type") {
+    val s = AlgoState("foo", "test" -> new Object)
+    val e = intercept[IllegalStateException] {
+      s.getDouble("test")
+    }
+    assert(e.getMessage === "test has non-numeric type: class java.lang.Object")
+  }
+
   test("double array") {
     val s = AlgoState("foo", "test" -> Array(42.0, 1.0))
     assertEquals(s, _.getDoubleArray("test"), Array(42.0, 1.0))

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
@@ -65,7 +65,7 @@ object Json {
     .enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)
     .enable(StreamReadFeature.AUTO_CLOSE_SOURCE)
     .enable(StreamWriteFeature.AUTO_CLOSE_TARGET)
-    .disable(JsonWriteFeature.WRITE_NAN_AS_STRINGS)
+    .enable(JsonWriteFeature.WRITE_NAN_AS_STRINGS)
     .build()
 
   private val smileFactory = SmileFactory

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
@@ -20,6 +20,7 @@ import java.util
 import java.util.Optional
 import java.util.regex.Pattern
 
+import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.core.JsonToken
 import com.fasterxml.jackson.databind.JsonNode
@@ -91,7 +92,7 @@ class JsonSuite extends AnyFunSuite {
   // This is non-standard, but we prefer to differentiate from infinity or other special values
   test("double NaN") {
     val v = Double.NaN
-    assert(encode(v) === "NaN")
+    assert(encode(v) === "\"NaN\"")
     assert(JDouble.isNaN(decode[Double](encode(v))))
   }
 
@@ -463,6 +464,11 @@ class JsonSuite extends AnyFunSuite {
     val obj = parse("""{"foo":42,"bar":"abc"}""")
     assert(list === obj)
   }
+
+  test("JsonSupport NaN encoding") {
+    val obj = JsonObjectWithSupport(Double.NaN)
+    assert(obj.toJson === """{"v":"NaN"}""")
+  }
 }
 
 case class JsonKeyWithDot(`a.b`: String)
@@ -498,3 +504,12 @@ case class JsonSuiteObjectWithDefaults(
   bar: String = "abc",
   values: List[String] = Nil
 )
+
+case class JsonObjectWithSupport(v: Double) extends JsonSupport {
+
+  override def encode(gen: JsonGenerator): Unit = {
+    gen.writeStartObject()
+    gen.writeNumberField("v", v)
+    gen.writeEndObject()
+  }
+}


### PR DESCRIPTION
Historically some endpoints wrote the special double values
without quotes to make it clear they were numeric. However,
that creates problems with tools using standard JSON parsing
libraries. New uses should always emit standard JSON so this
change updates the default so these values are quoted.

The encoding for the legacy `json` format on the graph API
still emits data without the quotes for backwards compatibility.