### PR TITLE
fix compiler warnings for 2.13.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: scala
 matrix:
   include:
   - jdk: openjdk11
-    scala: 2.13.1
+    scala: 2.13.2
     os: osx
     env: BINTRAY_PUBLISH=false
   - jdk: openjdk11
-    scala: 2.13.1
+    scala: 2.13.2
     os: linux
     dist: xenial
     env: BINTRAY_PUBLISH=true

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/ClusterOps.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/ClusterOps.scala
@@ -115,7 +115,7 @@ object ClusterOps extends StrictLogging {
         }
 
         private def updateMembers(members: Set[M]): Unit = {
-          val current = membersSources.keySet
+          val current = membersSources.keySet.toSet
 
           val removed = current -- members
           if (removed.nonEmpty) {

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/DefaultGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/DefaultGraphEngine.scala
@@ -121,12 +121,12 @@ class DefaultGraphEngine extends PngGraphEngine {
         val graphDatapoints = graphLines * ((end - start) / (config.step / 1000) + 1)
         val stats = "Fetch: %sms (L: %s, %s, %s; D: %s, %s, %s)".format(
           config.loadTime.toString,
-          UnitPrefix.format(config.stats.inputLines),
-          UnitPrefix.format(config.stats.outputLines),
+          UnitPrefix.format(config.stats.inputLines.toDouble),
+          UnitPrefix.format(config.stats.outputLines.toDouble),
           UnitPrefix.format(graphLines),
-          UnitPrefix.format(config.stats.inputDatapoints),
-          UnitPrefix.format(config.stats.outputDatapoints),
-          UnitPrefix.format(graphDatapoints)
+          UnitPrefix.format(config.stats.inputDatapoints.toDouble),
+          UnitPrefix.format(config.stats.outputDatapoints.toDouble),
+          UnitPrefix.format(graphDatapoints.toDouble)
         )
         belowCanvas += Text(
           stats,

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/graphics/Scales.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/graphics/Scales.scala
@@ -95,8 +95,10 @@ object Scales {
   }
 
   /** Factory for creating a mapping for time values. */
-  def time(d1: Long, d2: Long, step: Long, r1: Int, r2: Int): LongScale = {
-    val dr = (d2 - d1).toDouble / step
+  def time(t1: Long, t2: Long, step: Long, r1: Int, r2: Int): LongScale = {
+    val d1 = t1.toDouble
+    val d2 = t2.toDouble
+    val dr = (d2 - d1) / step
     val pixelsPerStep = (r2 - r1) / dr
     v => ((v - d1) / step * pixelsPerStep).toInt + r1
   }

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/graphics/Scales.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/graphics/Scales.scala
@@ -95,8 +95,8 @@ object Scales {
   }
 
   /** Factory for creating a mapping for time values. */
-  def time(d1: Double, d2: Double, step: Long, r1: Int, r2: Int): LongScale = {
-    val dr = (d2 - d1) / step
+  def time(d1: Long, d2: Long, step: Long, r1: Int, r2: Int): LongScale = {
+    val dr = (d2 - d1).toDouble / step
     val pixelsPerStep = (r2 - r1) / dr
     v => ((v - d1) / step * pixelsPerStep).toInt + r1
   }

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/graphics/Text.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/graphics/Text.scala
@@ -66,7 +66,7 @@ case class Text(
     val wrap = width - Text.rightPadding
     var y = 0.0f
     while (measurer.getPosition < str.length) {
-      val layout = measurer.nextLayout(wrap)
+      val layout = measurer.nextLayout(wrap.toFloat)
       y += layout.getAscent + layout.getDescent + layout.getLeading
     }
     math.ceil(y).toInt
@@ -84,7 +84,7 @@ case class Text(
     val wrap = width - Text.rightPadding
     var y = y1.toFloat
     while (measurer.getPosition < str.length) {
-      val layout = measurer.nextLayout(wrap)
+      val layout = measurer.nextLayout(wrap.toFloat)
       y += layout.getAscent
       alignment match {
         case TextAlignment.LEFT =>

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -147,7 +147,7 @@ object MathExpr {
       ZonedDateTime.ofInstant(Instant.ofEpochMilli(t), ZoneOffset.UTC).get(chronoField)
     }
 
-    private def sinceEpoch(divisor: Long)(t: Long): Double = t / divisor
+    private def sinceEpoch(divisor: Long)(t: Long): Double = t.toDouble / divisor
 
     def dataExprs: List[DataExpr] = Nil
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
@@ -208,8 +208,8 @@ object Query {
 
       case Query.Or(Query.True, _)  => Query.True
       case Query.Or(_, Query.True)  => Query.True
-      case Query.Or(Query.False, q) => simplify(q)
-      case Query.Or(q, Query.False) => simplify(q)
+      case Query.Or(Query.False, q) => simplify(q, ignore)
+      case Query.Or(q, Query.False) => simplify(q, ignore)
       case Query.Or(q1, q2)         => Query.Or(simplify(q1, ignore), simplify(q2, ignore))
 
       case Query.Not(Query.True)  => if (ignore) Query.True else Query.False

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
@@ -551,6 +551,11 @@ class QuerySuite extends AnyFunSuite {
     assert(Query.simplify(q, ignore = true) === Not(Equal("a", "b")))
   }
 
+  test("simplify not recursive ignore - Or") {
+    val q = Or(And(Not(True), Equal("a", "b")), False)
+    assert(Query.simplify(q, ignore = true) === Equal("a", "b"))
+  }
+
   test("expandInClauses, simple query") {
     val q = Equal("a", "b")
     assert(Query.expandInClauses(q) === List(q))

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FillRemovedKeysWith.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FillRemovedKeysWith.scala
@@ -45,7 +45,7 @@ private[stream] class FillRemovedKeysWith[K, V](valueForRemovedKey: K => V)
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
     new GraphStageLogic(shape) with InHandler with OutHandler {
 
-      private var prevKeySet = scala.collection.Set.empty[K]
+      private var prevKeySet = Set.empty[K]
 
       override def onPush(): Unit = {
         val map = grab(in)
@@ -56,7 +56,7 @@ private[stream] class FillRemovedKeysWith[K, V](valueForRemovedKey: K => V)
           newMap.put(k, valueForRemovedKey(k))
         }
 
-        prevKeySet = map.keySet
+        prevKeySet = map.keySet.toSet
         push(out, newMap)
       }
 

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
@@ -134,7 +134,7 @@ class LwcToAggrDatapointSuite extends AnyFunSuite {
 
   test("invalid message") {
     val msg =
-      """{"timestamp":20000,"id":"sum","tags":{"name":"cpu"},\u007F"value":3.0}"""
+      """{"timestamp":20000,"id":"sum","tags":{"name":"cpu"},&"value":3.0}"""
     val results = eval(List(msg))
     assert(results.size === 0)
   }

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/JsonParserHelper.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/JsonParserHelper.scala
@@ -91,7 +91,7 @@ object JsonParserHelper {
   def nextDouble(parser: JsonParser): Double = {
     import com.fasterxml.jackson.core.JsonToken._
     parser.nextToken() match {
-      case VALUE_NUMBER_INT   => parser.getValueAsLong
+      case VALUE_NUMBER_INT   => parser.getValueAsLong.toDouble
       case VALUE_NUMBER_FLOAT => parser.getValueAsDouble
       case VALUE_STRING       => java.lang.Double.valueOf(parser.getText)
       case t                  => fail(parser, s"expected VALUE_NUMBER_FLOAT but received $t")

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -7,6 +7,7 @@ object BuildSettings {
     "-deprecation",
     "-unchecked",
     "-Xlint:_,-infer-any",
+    "-Xfatal-warnings",
     "-feature"
   )
 


### PR DESCRIPTION
Most of the new warnings were for widening conversions from
long to double. Since cross-building has been disabled, all
warnings have been cleared up with no issues. Enabled fatal
warnings to help keep the build clean.