### PR TITLE
tune ByteStringInputStream for composites

### DIFF
--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/ByteStringInputStreamSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/ByteStringInputStreamSuite.scala
@@ -16,48 +16,85 @@
 package com.netflix.atlas.akka
 
 import java.io.ByteArrayInputStream
+import java.security.MessageDigest
 import java.util.Random
 
 import akka.util.ByteString
 import org.scalatest.funsuite.AnyFunSuite
 
 class ByteStringInputStreamSuite extends AnyFunSuite {
-  test("read() and available()") {
-    val random = new Random(42)
-    val data = new Array[Byte](4096)
-    random.nextBytes(data)
 
-    val bais = new ByteArrayInputStream(data)
-    val bsis = new ByteStringInputStream(ByteString(data))
+  private def singleRead(name: String, data: ByteString): Unit = {
+    test(s"$name: read() and available()") {
+      val bais = new ByteArrayInputStream(data.toArray)
+      val bsis = new ByteStringInputStream(data)
 
-    data.indices.foreach { i =>
-      assert(bais.available() === data.length - i)
-      assert(bsis.available() === data.length - i)
+      data.indices.foreach { i =>
+        if (data.isCompact) {
+          assert(bais.available() === data.length - i)
+          assert(bsis.available() === data.length - i)
+        } else {
+          assert(bsis.available() > 0)
+        }
+        assert(bais.read() === bsis.read())
+      }
+
       assert(bais.read() === bsis.read())
     }
-
-    assert(bais.read() === bsis.read())
   }
 
-  test("read(buffer, offset, length)") {
-    val random = new Random(42)
-    val data = new Array[Byte](4096)
-    random.nextBytes(data)
+  private def bulkRead(name: String, data: ByteString): Unit = {
+    test(s"$name: read(buffer, offset, length)") {
+      val bais = new ByteArrayInputStream(data.toArray)
+      val bsis = new ByteStringInputStream(data)
 
-    val bais = new ByteArrayInputStream(data)
-    val bsis = new ByteStringInputStream(ByteString(data))
+      val h1 = MessageDigest.getInstance("SHA-256")
+      val h2 = MessageDigest.getInstance("SHA-256")
 
-    val b1 = new Array[Byte](13)
-    val b2 = new Array[Byte](13)
-    var i = 0
-    while (i < data.length) {
-      val len1 = bais.read(b1)
-      val len2 = bsis.read(b2)
-      assert(len1 === len2)
-      assert(b1 === b2)
-      i += len2
+      val b1 = new Array[Byte](13)
+      val b2 = new Array[Byte](13)
+      var i = 0
+      while (i < data.length) {
+        val len1 = bais.read(b1)
+        val len2 = bsis.read(b2)
+        if (data.isCompact) {
+          assert(len1 === len2)
+          assert(b1 === b2)
+        }
+        if (len1 > 0) h1.update(b1, 0, len1)
+        if (len2 > 0) h2.update(b2, 0, len2)
+        i += len2
+      }
+
+      assert(bais.read(b1) === bsis.read(b2))
+      assert(h1.digest() === h2.digest())
     }
-
-    assert(bais.read(b1) === bsis.read(b2))
   }
+
+  private def compactByteString(n: Int): ByteString = {
+    val random = new Random()
+    val data = new Array[Byte](n)
+    random.nextBytes(data)
+    ByteString(data)
+  }
+
+  private def compositeByteString(n: Int, m: Int): ByteString = {
+    val builder = ByteString.newBuilder
+    (0 until n).foreach { _ =>
+      builder.append(compactByteString(m))
+    }
+    builder.result()
+  }
+
+  singleRead("compact", compactByteString(4096))
+  bulkRead("compact", compactByteString(4096))
+
+  singleRead("composite small", compositeByteString(100, 1))
+  bulkRead("composite small", compositeByteString(100, 1))
+
+  singleRead("composite large", compositeByteString(100, 1024 * 10))
+  bulkRead("composite large", compositeByteString(100, 1024 * 10))
+
+  singleRead("empty", ByteString.empty)
+  bulkRead("empty", ByteString.empty)
 }

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/akka/ByteStringReading.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/akka/ByteStringReading.scala
@@ -44,6 +44,16 @@ class ByteStringReading {
   random.nextBytes(byteArray)
   private val byteString = ByteString(byteArray)
 
+  private val compositeByteString = {
+    val builder = ByteString.newBuilder
+    (0 until 1024).foreach { _ =>
+      val bytes = new Array[Byte](1024 * 100)
+      random.nextBytes(bytes)
+      builder.append(ByteString(bytes))
+    }
+    builder.result()
+  }
+
   @Benchmark
   def toArray(bh: Blackhole): Unit = {
     bh.consume(byteString.toArray)
@@ -52,6 +62,22 @@ class ByteStringReading {
   @Benchmark
   def inputStream(bh: Blackhole): Unit = {
     val in = new ByteStringInputStream(byteString)
+    val buffer = new Array[Byte](4096)
+    var len = in.read(buffer)
+    while (len > 0) {
+      bh.consume(buffer)
+      len = in.read(buffer)
+    }
+  }
+
+  @Benchmark
+  def compositeToArray(bh: Blackhole): Unit = {
+    bh.consume(compositeByteString.toArray)
+  }
+
+  @Benchmark
+  def compositeInputStream(bh: Blackhole): Unit = {
+    val in = new ByteStringInputStream(compositeByteString)
     val buffer = new Array[Byte](4096)
     var len = in.read(buffer)
     while (len > 0) {


### PR DESCRIPTION
Adjusts the ByteStringInputStream to work better for composite
ByteString objects. Before it was using `asByteBuffer` which
forces a compaction on composite types. Now it uses the
`asByteBuffers` method. This results in a large reduction in
allocations and increase in throughput.

**Throughput**

| Benchmark            |        Before |         After | % Delta |
|----------------------|---------------|---------------|---------|
| compositeInputStream |          31.8 |         137.6 |   332.9 |
| compositeToArray     |          44.6 |          46.2 |     3.5 |
| inputStream          |         115.1 |         126.5 |     9.9 |
| toArray              |          42.8 |          45.0 |     5.2 |

**Allocations**

| Benchmark            |        Before |         After | % Delta |
|----------------------|---------------|---------------|---------|
| compositeInputStream | 104,887,113.5 |      69,769.8 |   -99.9 |
| compositeToArray     | 104,875,451.8 | 104,875,038.6 |    -0.0 |
| inputStream          |       8,418.3 |       7,987.6 |    -5.1 |
| toArray              | 104,874,398.1 | 104,874,682.8 |     0.0 |