### PR TITLE
update Streams.scope to work with AutoCloseable

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Streams.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Streams.scala
@@ -97,7 +97,7 @@ object Streams {
     }
   }
 
-  def scope[R <: Closeable, T](res: R)(f: R => T): T = {
+  def scope[R <: AutoCloseable, T](res: R)(f: R => T): T = {
     var thrown = false
     try f(res)
     catch {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StreamsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StreamsSuite.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class StreamsSuite extends AnyFunSuite {
+
+  test("scope with Stream") {
+    val cwd = Paths.get(".")
+    val cnt = Streams.scope(Files.list(cwd))(_.count())
+    assert(cnt >= 0)
+  }
+}


### PR DESCRIPTION
This is the base interface for Closeable so it is more
generic than it was before. Allows this helper to be used
with Stream's that need to be closed such as those returned
by `Files.list`.