### PR TITLE
add mapping for CloudWatch IoT metrics

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/iot.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/iot.conf
@@ -1,0 +1,387 @@
+
+atlas {
+  cloudwatch {
+
+    // https://docs.aws.amazon.com/iot/latest/developerguide/metrics_dimensions.html
+    iot-base = {
+      namespace = "AWS/IoT"
+      period = 1m
+
+      dimensions = [
+        //"RuleName"
+      ]
+
+      metrics = [
+        {
+          name = "RulesExecuted"
+          alias = "aws.iot.rulesExecuted"
+          conversion = "sum,rate"
+        }
+      ]
+    }
+
+    // Rule metrics
+    iot-rule = {
+      namespace = "AWS/IoT"
+      period = 1m
+
+      dimensions = [
+        "RuleName"
+      ]
+
+      metrics = [
+        {
+          name = "TopicMatch"
+          alias = "aws.iot.topicMatches"
+          conversion = "sum,rate"
+        },
+        {
+          name = "ParseError"
+          alias = "aws.iot.ruleErrors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "error"
+              value = "ParseError"
+            }
+          ]
+        },
+        {
+          name = "RuleMessageThrottled"
+          alias = "aws.iot.ruleErrors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "error"
+              value = "RuleMessageThrottled"
+            }
+          ]
+        },
+        {
+          name = "RuleNotFound"
+          alias = "aws.iot.ruleErrors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "error"
+              value = "RuleNotFound"
+            }
+          ]
+        }
+      ]
+    }
+
+    // Rule action metrics
+    iot-rule-action = {
+      namespace = "AWS/IoT"
+      period = 1m
+
+      dimensions = [
+        "RuleName",
+        "ActionType"
+      ]
+
+      metrics = [
+        {
+          name = "Success"
+          alias = "aws.iot.actionInvocations"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Success"
+            }
+          ]
+        },
+        {
+          name = "Failure"
+          alias = "aws.iot.actionInvocations"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Failure"
+            }
+          ]
+        }
+      ]
+    }
+
+    // Message broker metrics
+    iot-message-broker = {
+      namespace = "AWS/IoT"
+      period = 1m
+
+      dimensions = [
+        "Protocol"
+      ]
+
+      metrics = [
+        {
+          name = "Connect.AuthError"
+          alias = "aws.iot.connectionRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "AuthError"
+            }
+          ]
+        },
+        {
+          name = "Connect.ClientError"
+          alias = "aws.iot.connectionRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "ClientError"
+            }
+          ]
+        },
+        {
+          name = "Connect.ClientIDThrottle"
+          alias = "aws.iot.connectionRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "ClientIDThrottle"
+            }
+          ]
+        },
+        {
+          name = "Connect.ServerError"
+          alias = "aws.iot.connectionRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "ServerError"
+            }
+          ]
+        },
+        {
+          name = "Connect.Success"
+          alias = "aws.iot.connectionRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Success"
+            }
+          ]
+        },
+        {
+          name = "Connect.Throttle"
+          alias = "aws.iot.connectionRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Throttle"
+            }
+          ]
+        },
+        {
+          name = "Ping.Success"
+          alias = "aws.iot.pingMessages"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Success"
+            }
+          ]
+        },
+        {
+          name = "PublishIn.AuthError"
+          alias = "aws.iot.publishInRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "AuthError"
+            }
+          ]
+        },
+        {
+          name = "PublishIn.ClientError"
+          alias = "aws.iot.publishInRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "ClientError"
+            }
+          ]
+        },
+        {
+          name = "PublishIn.ServerError"
+          alias = "aws.iot.publishInRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "ServerError"
+            }
+          ]
+        },
+        {
+          name = "PublishIn.Success"
+          alias = "aws.iot.publishInRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Success"
+            }
+          ]
+        },
+        {
+          name = "PublishIn.Throttle"
+          alias = "aws.iot.publishInRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Throttle"
+            }
+          ]
+        },
+        {
+          name = "PublishOut.AuthError"
+          alias = "aws.iot.publishOutRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "AuthError"
+            }
+          ]
+        },
+        {
+          name = "PublishOut.ClientError"
+          alias = "aws.iot.publishOutRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "ClientError"
+            }
+          ]
+        },
+        {
+          name = "PublishOut.Success"
+          alias = "aws.iot.publishOutRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Success"
+            }
+          ]
+        },
+        {
+          name = "Subscribe.AuthError"
+          alias = "aws.iot.subscribeRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "AuthError"
+            }
+          ]
+        },
+        {
+          name = "Subscribe.ClientError"
+          alias = "aws.iot.subscribeRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "ClientError"
+            }
+          ]
+        },
+        {
+          name = "Subscribe.ServerError"
+          alias = "aws.iot.subscribeRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "ServerError"
+            }
+          ]
+        },
+        {
+          name = "Subscribe.Success"
+          alias = "aws.iot.subscribeRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Success"
+            }
+          ]
+        },
+        {
+          name = "Subscribe.Throttle"
+          alias = "aws.iot.subscribeRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Throttle"
+            }
+          ]
+        },
+        {
+          name = "Unsubscribe.ClientError"
+          alias = "aws.iot.unsubscribeRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "ClientError"
+            }
+          ]
+        },
+        {
+          name = "Unsubscribe.ServerError"
+          alias = "aws.iot.unsubscribeRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "ServerError"
+            }
+          ]
+        },
+        {
+          name = "Unsubscribe.Success"
+          alias = "aws.iot.unsubscribeRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Success"
+            }
+          ]
+        },
+        {
+          name = "Unsubscribe.Throttle"
+          alias = "aws.iot.unsubscribeRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Throttle"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/atlas-poller-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/reference.conf
@@ -226,6 +226,14 @@ atlas {
           name = "TransitGateway"
           alias = "aws.tgw"
         },
+        {
+          name = "ActionType"
+          alias = "aws.action"
+        },
+        {
+          name = "Protocol"
+          alias = "aws.protocol"
+        },
       ]
 
       // Tags that should get applied to all metrics from cloudwatch.
@@ -266,6 +274,10 @@ atlas {
       "elb",
       "es",
       "events",
+      "iot-base",
+      "iot-rule",
+      "iot-rule-action",
+      "iot-message-broker"
       "kinesis",
       "lambda",
       "lambda-fn-res",
@@ -298,6 +310,7 @@ include "elb.conf"
 include "efs.conf"
 include "es.conf"
 include "events.conf"
+include "iot.conf"
 include "kinesis.conf"
 include "lambda.conf"
 include "nat-gateway.conf"


### PR DESCRIPTION
Adds initial mapping. Omits a few of the metrics where
we do not have any samples to test with current usage.