### PR TITLE
1.6: switch from trusty to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
   - jdk: openjdk8
     scala: 2.11.12
     os: linux
-    dist: trusty
+    dist: xenial
     env: BINTRAY_PUBLISH=true
   - jdk: openjdk11
     scala: 2.12.8


### PR DESCRIPTION
Update travis build for 2.11 to use xenial.