### PR TITLE
remove duplicate mapping for GetRecords.Bytes

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/kinesis.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/kinesis.conf
@@ -137,17 +137,6 @@ atlas {
               value = "getRecords"
             }
           ]
-        },
-        {
-          name = "GetRecords.Bytes"
-          alias = "aws.kinesis.messageSize"
-          conversion = "dist-summary"
-          tags = [
-            {
-              key = "id"
-              value = "getRecords"
-            }
-          ]
         }
       ]
     }


### PR DESCRIPTION
This causes it to get double published which can cause
minor differences depending on the order when the values
are normalized.