### PR TITLE
rename root project to atlas 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 
-lazy val root = project.in(file("."))
+lazy val atlas = project.in(file("."))
   .configure(BuildSettings.profile)
   .aggregate(
     `atlas-akka`,


### PR DESCRIPTION
rename root project to atlas to be more IDE friendly