### PR TITLE
make datetime zone parsing more lenient

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/IsoDateTimeParser.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/IsoDateTimeParser.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+/**
+  * Helper for parsing the variations of ISO date/time formats that are used with Atlas. Since
+  * the DateTimeFormatter doesn't have a way to check if a string matches, this class uses
+  * pattern matching to normalize to a small number of cases (with and without zone) and avoid
+  * using exceptions as the control flow.
+  */
+object IsoDateTimeParser {
+
+  private val IsoDate = """^(\d{4}-\d{2}-\d{2})$""".r
+  private val IsoDateZ = """^(\d{4}-\d{2}-\d{2})([-+Z].*)$""".r
+  private val IsoDateTimeHHMM = """^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2})$""".r
+  private val IsoDateTimeHHMMZ = """^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2})([-+Z].*)$""".r
+  private val IsoDateTimeHHMMSS = """^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})$""".r
+  private val IsoDateTimeHHMMSSZ = """^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})([-+Z].*)$""".r
+  private val IsoDateTimeHHMMSSmmm = """^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3})$""".r
+
+  private val IsoDateTimeHHMMSSmmmZ =
+    """^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3})([-+Z].*)$""".r
+
+  private val ZoneHour = """^([-+]\d{2})$""".r
+  private val ZoneHourMinute = """^([-+]\d{2}):?(\d{2})$""".r
+  private val ZoneHourMinuteSecond = """^([-+]\d{2})(\d{2})(\d{2})$""".r
+
+  private val HasZone = """^.*([-+]\d{2}:\d{2}:\d{2}|Z)$""".r
+
+  private def normalizeZone(zone: String): String = {
+    zone match {
+      case ZoneHour(h)                   => s"$h:00:00"
+      case ZoneHourMinute(h, m)          => s"$h:$m:00"
+      case ZoneHourMinuteSecond(h, m, s) => s"$h:$m:$s"
+      case _                             => zone
+    }
+  }
+
+  private def normalize(str: String): String = {
+    str match {
+      case IsoDate(d)                  => s"${d}T00:00:00"
+      case IsoDateZ(d, z)              => s"${d}T00:00:00${normalizeZone(z)}"
+      case IsoDateTimeHHMM(d)          => s"${d}:00"
+      case IsoDateTimeHHMMZ(d, z)      => s"${d}:00${normalizeZone(z)}"
+      case IsoDateTimeHHMMSS(d)        => s"${d}"
+      case IsoDateTimeHHMMSSZ(d, z)    => s"${d}${normalizeZone(z)}"
+      case IsoDateTimeHHMMSSmmm(d)     => s"${d}"
+      case IsoDateTimeHHMMSSmmmZ(d, z) => s"${d}${normalizeZone(z)}"
+      case _                           => str
+    }
+  }
+
+  private def hasExplicitZone(str: String): Boolean = {
+    str match {
+      case HasZone(_) => true
+      case _          => false
+    }
+  }
+
+  def parse(str: String, tz: ZoneId): ZonedDateTime = {
+    val timeStr = normalize(str)
+    if (hasExplicitZone(timeStr))
+      ZonedDateTime.parse(timeStr, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+    else
+      ZonedDateTime.parse(timeStr, DateTimeFormatter.ISO_DATE_TIME.withZone(tz))
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/IsoDateTimeParserSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/IsoDateTimeParserSuite.scala
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class IsoDateTimeParserSuite extends AnyFunSuite {
+
+  private val utcZones = List("Z", "+00", "+0000", "+000000", "+00:00", "+00:00:00")
+
+  private val offsetZones = List("07", "0700", "070000", "07:00", "07:00:00")
+
+  test("date") {
+    val t = "2020-07-28"
+    val expected = ZonedDateTime.parse(s"${t}T00:00:00Z")
+    assert(expected === IsoDateTimeParser.parse(t, ZoneOffset.UTC))
+  }
+
+  utcZones.foreach { zone =>
+    test(s"date $zone") {
+      val t = s"2020-07-28"
+      val expected = ZonedDateTime.parse(s"${t}T00:00:00Z")
+      assert(expected === IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
+    }
+  }
+
+  offsetZones.foreach { offset =>
+    List("-", "+").map(s => s"$s$offset").foreach { zone =>
+      test(s"date $zone") {
+        val t = s"2020-07-28"
+        val z = if (zone.startsWith("-")) "-07:00:00" else "+07:00:00"
+        val expected = ZonedDateTime.parse(s"${t}T00:00:00$z")
+        assert(expected === IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
+      }
+    }
+  }
+
+  test("date time hh:mm") {
+    val t = "2020-07-28T21:07"
+    val expected = ZonedDateTime.parse(s"$t:00Z")
+    assert(expected === IsoDateTimeParser.parse(t, ZoneOffset.UTC))
+  }
+
+  utcZones.foreach { zone =>
+    test(s"date time hh:mm $zone") {
+      val t = s"2020-07-28T21:07"
+      val expected = ZonedDateTime.parse(s"$t:00Z")
+      assert(expected === IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
+    }
+  }
+
+  offsetZones.foreach { offset =>
+    List("-", "+").map(s => s"$s$offset").foreach { zone =>
+      test(s"date time hh:mm $zone") {
+        val t = s"2020-07-28T21:07"
+        val z = if (zone.startsWith("-")) "-07:00:00" else "+07:00:00"
+        val expected = ZonedDateTime.parse(s"$t:00$z")
+        assert(expected === IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
+      }
+    }
+  }
+
+  test("date time hh:mm:ss") {
+    val t = "2020-07-28T21:07:56"
+    val expected = ZonedDateTime.parse(s"${t}Z")
+    assert(expected === IsoDateTimeParser.parse(t, ZoneOffset.UTC))
+  }
+
+  utcZones.foreach { zone =>
+    test(s"date time hh:mm:ss $zone") {
+      val t = s"2020-07-28T21:07:56"
+      val expected = ZonedDateTime.parse(s"${t}Z")
+      assert(expected === IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
+    }
+  }
+
+  offsetZones.foreach { offset =>
+    List("-", "+").map(s => s"$s$offset").foreach { zone =>
+      test(s"date time hh:mm:ss $zone") {
+        val t = s"2020-07-28T21:07:56"
+        val z = if (zone.startsWith("-")) "-07:00:00" else "+07:00:00"
+        val expected = ZonedDateTime.parse(s"$t$z")
+        assert(expected === IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
+      }
+    }
+  }
+
+  test("date time hh:mm:ss.mmm") {
+    val t = "2020-07-28T21:07:56.195"
+    val expected = ZonedDateTime.parse(s"${t}Z")
+    assert(expected === IsoDateTimeParser.parse(t, ZoneOffset.UTC))
+  }
+
+  utcZones.foreach { zone =>
+    test(s"date time hh:mm:ss.mmm $zone") {
+      val t = s"2020-07-28T21:07:56.195"
+      val expected = ZonedDateTime.parse(s"${t}Z")
+      assert(expected === IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
+    }
+  }
+
+  offsetZones.foreach { offset =>
+    List("-", "+").map(s => s"$s$offset").foreach { zone =>
+      test(s"date time hh:mm:ss.mmm $zone") {
+        val t = s"2020-07-28T21:07:56.195"
+        val z = if (zone.startsWith("-")) "-07:00:00" else "+07:00:00"
+        val expected = ZonedDateTime.parse(s"$t$z")
+        assert(expected === IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
+      }
+    }
+  }
+
+  test("date odd zone") {
+    val t = "2020-07-28"
+    val zone = "+12:34:56"
+    val expected = ZonedDateTime.parse(s"${t}T00:00:00$zone")
+    assert(expected === IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
+  }
+
+  test("date default US/Pacific") {
+    val t = "2020-07-28"
+    val zone = ZoneId.of("US/Pacific")
+    val expected =
+      ZonedDateTime.parse(s"${t}T00:00:00", DateTimeFormatter.ISO_DATE_TIME.withZone(zone))
+    assert(expected === IsoDateTimeParser.parse(t, zone))
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
@@ -335,10 +335,54 @@ class StringsSuite extends AnyFunSuite {
     assert(parseDate("2012-02-01T04:05:06.123Z") === expected)
   }
 
+  test("parseDate, iso date with time with millis and zone (+00:00)") {
+    val nanos = TimeUnit.MILLISECONDS.toNanos(123).toInt
+    val expected = ZonedDateTime.of(2012, 2, 1, 4, 5, 6, nanos, ZoneOffset.UTC)
+    assert(parseDate("2012-02-01T04:05:06.123+00:00") === expected)
+  }
+
+  test("parseDate, iso date with time with millis and zone (+0000)") {
+    val nanos = TimeUnit.MILLISECONDS.toNanos(123).toInt
+    val expected = ZonedDateTime.of(2012, 2, 1, 4, 5, 6, nanos, ZoneOffset.UTC)
+    assert(parseDate("2012-02-01T04:05:06.123+0000") === expected)
+  }
+
+  test("parseDate, iso date with time with millis and zone (+00)") {
+    val nanos = TimeUnit.MILLISECONDS.toNanos(123).toInt
+    val expected = ZonedDateTime.of(2012, 2, 1, 4, 5, 6, nanos, ZoneOffset.UTC)
+    assert(parseDate("2012-02-01T04:05:06.123+00") === expected)
+  }
+
   test("parseDate, iso date with time with millis and zone offset") {
     val nanos = TimeUnit.MILLISECONDS.toNanos(123).toInt
     val expected = ZonedDateTime.of(2012, 2, 1, 7, 5, 6, nanos, ZoneOffset.UTC).toInstant
     assert(parseDate("2012-02-01T04:05:06.123-03:00").toInstant === expected)
+  }
+
+  test("parseDate, iso formats") {
+    val offsets = List(
+      "",
+      "Z",
+      "+00",
+      "+0000",
+      "+000000",
+      "+00:00",
+      "+00:00:00",
+      "-04",
+      "-0402",
+      "-040231",
+      "-04:02",
+      "-04:02:31"
+    )
+    val times = List(
+      "2020-07-28",
+      "2020-07-28T05:43",
+      "2020-07-28T05:43:02",
+      "2020-07-28T05:43:02.143"
+    )
+    for (t <- times; o <- offsets) {
+      parseDate(s"$t$o")
+    }
   }
 
   test("parseDate, iso date with time with millis") {


### PR DESCRIPTION
In particular, it will now support zone offsets that do not
have the colons to make integration easier for some JS use
case.

/cc @nathfisher 