### PR TITLE
atlas-eval: expose data rate per datasource via diagnostic messages

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/DiagnosticMessage.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/DiagnosticMessage.scala
@@ -26,7 +26,6 @@ object DiagnosticMessage {
   final val Warning: String = "warn"
   final val Error: String = "error"
   final val Close: String = "close"
-  final val Rate: String = "rate"
 
   def info(message: String): DiagnosticMessage = {
     DiagnosticMessage(Info, message, None)
@@ -42,14 +41,6 @@ object DiagnosticMessage {
 
   def error(t: Throwable): DiagnosticMessage = {
     error(s"${t.getClass.getSimpleName}: ${t.getMessage}")
-  }
-
-  def rate(dataType: String, count: Long, timestamp: Long, step: Long): DiagnosticMessage = {
-    DiagnosticMessage(
-      Rate,
-      s"dataType=$dataType,count=$count,timestamp=$timestamp,step=$step",
-      None
-    )
   }
 
   val close: DiagnosticMessage = {

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/DiagnosticMessage.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/DiagnosticMessage.scala
@@ -26,6 +26,7 @@ object DiagnosticMessage {
   final val Warning: String = "warn"
   final val Error: String = "error"
   final val Close: String = "close"
+  final val Rate: String = "rate"
 
   def info(message: String): DiagnosticMessage = {
     DiagnosticMessage(Info, message, None)
@@ -41,6 +42,14 @@ object DiagnosticMessage {
 
   def error(t: Throwable): DiagnosticMessage = {
     error(s"${t.getClass.getSimpleName}: ${t.getMessage}")
+  }
+
+  def rate(dataType: String, count: Long, timestamp: Long, step: Long): DiagnosticMessage = {
+    DiagnosticMessage(
+      Rate,
+      s"dataType=$dataType,count=$count,timestamp=$timestamp,step=$step",
+      None
+    )
   }
 
   val close: DiagnosticMessage = {

--- a/atlas-eval/README.md
+++ b/atlas-eval/README.md
@@ -49,3 +49,43 @@ Processor<Evaluator.DataSources, Evaluator.MessageEnvelope> processor =
 Each `DataSource` for the input has a string id that will be added to corresponding
 `MessageEnvelope` objects in the output. This allows the messages to be matched with
 the correct input by the user.
+
+### Data Rate Messages
+The library also emits data rate messages to help gain insights in the data rate per `DataSource` 
+per step. There are 3 type of data sizes in a data rate message:
+ - Input size: number of data points coming in as raw input.
+ - Intermediate size: number of aggregate data points that are used in the eval step.
+ - Output size: number of data points for the final result.
+
+The "size" has the 2 fields: 
+ - `total`: total number of data points 
+ - `details`: number of data points per data expression (empty for "outputSize")
+
+For example, given a query of "app,www,:eq,name,request,:eq,:and,:sum,(,cluster,),:by" with 4 nodes
+and 2 clusters, one of the data rate message evelope may look like this:
+```json5
+{
+  "id": "_",
+  "message": {
+    "type": "rate",
+    "timestamp": 1596570660000,
+    "step": 60000,
+    "inputSize": {
+      "total": 4,
+      "details": {
+        "app,www,:eq,name,request,:eq,:and,:sum,(,cluster,),:by": 4
+      }
+    },
+    "intermediateSize": {
+      "total": 2,
+      "details": {
+        "app,www,:eq,name,request,:eq,:and,:sum,(,cluster,),:by": 2
+      }
+    },
+    "outputSize": {
+      "total": 2,
+      "details": {}
+    }
+  }
+}
+```

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
@@ -89,7 +89,7 @@ object AggrDatapoint {
     */
   trait Aggregator {
     protected[this] var rawDatapointCounter = 0
-    def numRawDatapoints: Long = rawDatapointCounter
+    def numRawDatapoints: Int = rawDatapointCounter
     def aggregate(datapoint: AggrDatapoint): Aggregator
     def datapoints: List[AggrDatapoint]
   }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/EvalDataRate.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/EvalDataRate.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+import com.netflix.atlas.json.JsonSupport
+
+case class EvalDataRate(
+  timestamp: Long,
+  step: Long,
+  inputSize: EvalDataSize,
+  intermediateSize: EvalDataSize,
+  outputSize: EvalDataSize
+) extends JsonSupport {
+  val `type`: String = "rate"
+}
+
+case class EvalDataSize(total: Int, details: Map[String, Int] = Map.empty[String, Int])

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeGroup.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeGroup.scala
@@ -32,4 +32,4 @@ import com.netflix.atlas.core.model.DataExpr
   *     Values associated with this time.
   */
 case class TimeGroup(timestamp: Long, step: Long, dataExprValues: Map[DataExpr, AggrValuesInfo])
-case class AggrValuesInfo(values: List[AggrDatapoint], numRawDatapoints: Long)
+case class AggrValuesInfo(values: List[AggrDatapoint], numRawDatapoints: Int)

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeGroup.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeGroup.scala
@@ -28,7 +28,8 @@ import com.netflix.atlas.core.model.DataExpr
   *     Timestamp that applies to all values within the group.
   * @param step
   *     Step size for the data within this group.
-  * @param values
+  * @param dataExprValues
   *     Values associated with this time.
   */
-case class TimeGroup(timestamp: Long, step: Long, values: Map[DataExpr, List[AggrDatapoint]])
+case class TimeGroup(timestamp: Long, step: Long, dataExprValues: Map[DataExpr, AggrValuesInfo])
+case class AggrValuesInfo(values: List[AggrDatapoint], numRawDatapoints: Long)

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvalDataRateCollector.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvalDataRateCollector.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import com.netflix.atlas.core.model.DataExpr
+import com.netflix.atlas.core.util.RefIntHashMap
+import com.netflix.atlas.eval.model.EvalDataRate
+import com.netflix.atlas.eval.model.EvalDataSize
+
+import scala.collection.mutable
+
+class EvalDataRateCollector(timestamp: Long, step: Long) {
+
+  private val inputCounts = mutable.Map.empty[String, RefIntHashMap[DataExpr]]
+  private val intermediateCounts = mutable.Map.empty[String, RefIntHashMap[DataExpr]]
+  private val outputCounts = new RefIntHashMap[String]
+
+  def incrementOutput(id: String, amount: Int): Unit = {
+    outputCounts.increment(id, amount)
+  }
+
+  def incrementIntermediate(id: String, dataExpr: DataExpr, amount: Int): Unit = {
+    increment(intermediateCounts, id, dataExpr, amount)
+  }
+
+  def incrementInput(id: String, dataExpr: DataExpr, amount: Int): Unit = {
+    increment(inputCounts, id, dataExpr, amount)
+  }
+
+  def getAll: Map[String, EvalDataRate] = {
+    inputCounts.map {
+      case (id, _) => {
+        id -> EvalDataRate(
+          timestamp,
+          step,
+          getDataRate(inputCounts, id),
+          getDataRate(intermediateCounts, id),
+          EvalDataSize(outputCounts.get(id, 0))
+        )
+      }
+    }.toMap
+  }
+
+  private def getDataRate(
+    counts: mutable.Map[String, RefIntHashMap[DataExpr]],
+    id: String
+  ): EvalDataSize = {
+    counts.get(id) match {
+      case Some(v: RefIntHashMap[DataExpr]) =>
+        var total = 0
+        val builder = Map.newBuilder[String, Int]
+        v.foreach { (dataExpr, count) =>
+          builder += dataExpr.toString -> count
+          total += count
+        }
+        EvalDataSize(total, builder.result())
+      case None => EvalDataRateCollector.EmptyRate
+    }
+  }
+
+  private def increment(
+    counts: mutable.Map[String, RefIntHashMap[DataExpr]],
+    id: String,
+    dataExpr: DataExpr,
+    amount: Int
+  ): Unit = {
+    counts.get(id) match {
+      case Some(v: RefIntHashMap[DataExpr]) => v.increment(dataExpr, amount)
+      case None =>
+        val temp = new RefIntHashMap[DataExpr]
+        temp.increment(dataExpr, amount)
+        counts += (id -> temp)
+    }
+  }
+}
+
+object EvalDataRateCollector {
+  val EmptyRate = EvalDataSize(0)
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvalDataRateCollector.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvalDataRateCollector.scala
@@ -77,13 +77,7 @@ class EvalDataRateCollector(timestamp: Long, step: Long) {
     dataExpr: DataExpr,
     amount: Int
   ): Unit = {
-    counts.get(id) match {
-      case Some(v: RefIntHashMap[DataExpr]) => v.increment(dataExpr, amount)
-      case None =>
-        val temp = new RefIntHashMap[DataExpr]
-        temp.increment(dataExpr, amount)
-        counts += (id -> temp)
-    }
+    counts.getOrElseUpdate(id, new RefIntHashMap[DataExpr]).increment(dataExpr, amount)
   }
 }
 

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -47,6 +47,7 @@ import com.netflix.atlas.akka.StreamOps
 import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.eval.model.AggrDatapoint
+import com.netflix.atlas.eval.model.AggrValuesInfo
 import com.netflix.atlas.eval.model.TimeGroup
 import com.netflix.atlas.eval.stream.EurekaSource.Instance
 import com.netflix.atlas.eval.stream.Evaluator.DataSource
@@ -303,7 +304,7 @@ private[stream] abstract class EvaluatorImpl(
   }
 
   private def toTimeGroup(step: Long, exprs: List[DataExpr], group: DatapointGroup): TimeGroup = {
-    val values = group.getDatapoints.asScala.zipWithIndex
+    val valuesInfo = group.getDatapoints.asScala.zipWithIndex
       .flatMap {
         case (d, i) =>
           val tags = d.getTags.asScala.toMap
@@ -321,8 +322,8 @@ private[stream] abstract class EvaluatorImpl(
           }
       }
       .groupBy(_.expr)
-      .map(t => t._1 -> AggrDatapoint.aggregate(t._2.toList))
-    TimeGroup(group.getTimestamp, step, values)
+      .map(t => t._1 -> AggrValuesInfo(AggrDatapoint.aggregate(t._2.toList), t._2.size))
+    TimeGroup(group.getTimestamp, step, valuesInfo)
   }
 
   @scala.annotation.tailrec

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
@@ -25,6 +25,7 @@ import com.netflix.atlas.core.model.MathExpr
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.StatefulExpr
 import com.netflix.atlas.eval.model.AggrDatapoint
+import com.netflix.atlas.eval.model.AggrValuesInfo
 import com.netflix.atlas.eval.model.ArrayData
 import com.netflix.atlas.eval.model.TimeGroup
 import com.netflix.atlas.eval.model.TimeSeriesMessage
@@ -67,7 +68,7 @@ class FinalExprEvalSuite extends AnyFunSuite {
     val values = vs
       .map(_.copy(timestamp = timestamp))
       .groupBy(_.expr)
-      .map(t => t._1 -> t._2.toList)
+      .map(t => t._1 -> AggrValuesInfo(t._2.toList, t._2.size))
       .toMap
     TimeGroup(timestamp, step, values)
   }


### PR DESCRIPTION
Expose raw data rate (from LWC) and final data out put rate for each DataSource. 
Raw data rate is collected at TimedGroup for each DataExpr and carry it to down stream, and summarized in FinalExprEval and emit.