### PR TITLE
fix deprecation warnings for 2.13.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: scala
 matrix:
   include:
   - jdk: openjdk14
-    scala: 2.13.2
+    scala: 2.13.3
     os: osx
     env: BINTRAY_PUBLISH=false
   - jdk: openjdk14
-    scala: 2.13.2
+    scala: 2.13.3
     os: linux
     dist: xenial
     env: BINTRAY_PUBLISH=true

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/AggregateCollector.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/AggregateCollector.scala
@@ -269,7 +269,7 @@ class AllAggregateCollector extends LimitedAggregateCollector {
     buffer.values.length
   }
 
-  def result: List[TimeSeriesBuffer] = builder.result
+  def result: List[TimeSeriesBuffer] = builder.result()
 
   def stats: CollectorStats = statBuffer.result
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/BlockStore.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/BlockStore.scala
@@ -311,7 +311,7 @@ class MemoryBlockStore(step: Long, blockSize: Int, numBlocks: Int) extends Block
       if (b != null) bs += b
       pos += 1
     }
-    bs.result
+    bs.result()
   }
 
   def fetch(start: Long, end: Long, aggr: Int): Array[Double] = {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/EvalContext.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/EvalContext.scala
@@ -47,7 +47,7 @@ case class EvalContext(
       builder += EvalContext(stime, etime, step)
       t = e
     }
-    builder.result
+    builder.result()
   }
 
   def partitionByHour: List[EvalContext] =

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/norm/ValueFunction.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/norm/ValueFunction.scala
@@ -32,7 +32,7 @@ class ListValueFunction extends ValueFunction {
   def update(timestamp: Long, value: Double): List[(Long, Double)] = {
     builder = List.newBuilder[(Long, Double)]
     f(timestamp, value)
-    builder.result
+    builder.result()
   }
 
   def apply(timestamp: Long, value: Double): Unit = {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/TagIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/TagIndexSuite.scala
@@ -47,8 +47,8 @@ abstract class TagIndexSuite extends AnyFunSuite {
       tmp = index.findTags(TagQuery(None, offset = last, limit = pageSize)).map(_.copy(count = -1))
     }
     builder ++= tmp
-    assert(expected.size === builder.result.size)
-    assert(expected === builder.result)
+    assert(expected.size === builder.result().size)
+    assert(expected === builder.result())
   }
 
   test("findTags all with key restriction") {
@@ -71,8 +71,8 @@ abstract class TagIndexSuite extends AnyFunSuite {
         .map(_.copy(count = -1))
     }
     builder ++= tmp
-    assert(expected.size === builder.result.size)
-    assert(expected === builder.result)
+    assert(expected.size === builder.result().size)
+    assert(expected === builder.result())
   }
 
   test("findTags query") {
@@ -216,8 +216,8 @@ abstract class TagIndexSuite extends AnyFunSuite {
       tmp = index.findItems(TagQuery(Some(q), offset = last, limit = pageSize))
     }
     builder ++= tmp
-    assert(result.size === builder.result.size)
-    assert(result === builder.result)
+    assert(result.size === builder.result().size)
+    assert(result === builder.result())
   }
 
   test("gt query") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StreamsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StreamsSuite.scala
@@ -20,12 +20,13 @@ import java.nio.file.Paths
 
 import org.scalatest.funsuite.AnyFunSuite
 
-@scala.annotation.nowarn
+import scala.util.Using
+
 class StreamsSuite extends AnyFunSuite {
 
   test("scope with Stream") {
     val cwd = Paths.get(".")
-    val cnt = Streams.scope(Files.list(cwd))(_.count())
+    val cnt = Using.resource(Files.list(cwd))(_.count())
     assert(cnt >= 0)
   }
 }

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
@@ -201,7 +201,7 @@ class SubscriptionManager[T] extends StrictLogging {
       tags += ("nf.app" -> name.getApp)
     if (name.getStack != null)
       tags += ("nf.stack" -> name.getStack)
-    queryIndex.matchingEntries(tags.result)
+    queryIndex.matchingEntries(tags.result())
   }
 
   /**

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
@@ -183,7 +183,7 @@ object PublishApi {
         tagsLoadedFirst = (tags != null)
         val builder = List.newBuilder[Datapoint]
         foreachItem(parser) { builder += decode(parser, tags, intern) }
-        metrics = builder.result
+        metrics = builder.result()
     }
 
     // If the tags were loaded first they got merged with the datapoints while parsing. Otherwise
@@ -200,7 +200,7 @@ object PublishApi {
     foreachItem(parser) {
       builder += decode(parser, null, intern)
     }
-    builder.result
+    builder.result()
   }
 
   def decodeList(json: String): List[Datapoint] = {


### PR DESCRIPTION
Updates the travis build to use 2.13.3 and fixes the new
deprecation warnings that were introduced.