### PR TITLE
add support for rewrite based on host name

### DIFF
--- a/atlas-eval/src/main/resources/reference.conf
+++ b/atlas-eval/src/main/resources/reference.conf
@@ -60,4 +60,10 @@ atlas.eval {
     // Pattern to use to detect that a user-agent is a web-browser
     browser-agent-pattern = "mozilla|msie|gecko|chrome|opera|webkit"
   }
+
+  host-rewrite {
+    // Default is a pattern that doesn't match anything
+    pattern = "$^"
+    key = ""
+  }
 }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/DefaultSettings.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/DefaultSettings.scala
@@ -23,6 +23,7 @@ import com.netflix.atlas.chart.GraphEngine
 import com.netflix.atlas.core.model.CustomVocabulary
 import com.netflix.atlas.core.stacklang.Interpreter
 import com.netflix.atlas.core.stacklang.Vocabulary
+import com.netflix.atlas.eval.util.HostRewriter
 import com.typesafe.config.Config
 
 /**
@@ -109,6 +110,9 @@ case class DefaultSettings(root: Config, config: Config) {
   private def newInstance[T](cls: String): T = {
     Class.forName(cls).getDeclaredConstructor().newInstance().asInstanceOf[T]
   }
+
+  /** Host rewriter for restricting the expressions based on how the service was accessed. */
+  val hostRewriter = new HostRewriter(root.getConfig("atlas.eval.host-rewrite"))
 }
 
 object DefaultSettings {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/util/HostRewriter.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/util/HostRewriter.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.util
+
+import java.util.regex.Pattern
+
+import com.netflix.atlas.core.model.Query
+import com.netflix.atlas.core.model.StyleExpr
+import com.typesafe.config.Config
+
+/**
+  * Utility for rewriting an Atlas query expression based on the host used. This is useful
+  * for cases where the same backend is serving requests, but there might be multiple DNS
+  * names used that are intended to provide specific views.
+  *
+  * Sample config:
+  *
+  * ```
+  * pattern = "&#94;foo\\.([&#94;.]+)\\.example\\.com$"
+  * key = "region"
+  * ```
+  *
+  * This config would extract the second portion of the host name and use it as a region
+  * restriction (`region,$1,:eq`). The first group will be used as the value for the restriction
+  * query.
+  */
+class HostRewriter(config: Config) {
+
+  private val pattern = Pattern.compile(config.getString("pattern"))
+  private val key = config.getString("key")
+
+  def rewrite(host: String, inputExprs: List[StyleExpr]): List[StyleExpr] = {
+    val matcher = pattern.matcher(host)
+    if (matcher.matches()) {
+      val value = matcher.group(1)
+      val restrictionQuery = Query.Equal(key, value)
+      inputExprs.map(e => rewrite(restrictionQuery, e))
+    } else {
+      inputExprs
+    }
+  }
+
+  private def rewrite(restrictionQuery: Query, styleExpr: StyleExpr): StyleExpr = {
+    val newExpr = styleExpr.rewrite {
+      case q: Query => Query.And(q, restrictionQuery)
+    }
+    newExpr.asInstanceOf[StyleExpr]
+  }
+}

--- a/atlas-eval/src/test/resources/application.conf
+++ b/atlas-eval/src/test/resources/application.conf
@@ -11,4 +11,12 @@ atlas {
       KEY_TEXT_ANTIALIASING = "VALUE_TEXT_ANTIALIAS_OFF"
     }
   }
+
+  eval {
+    // For testing region rewrite in grapher
+    host-rewrite {
+      pattern = "^foo\\.([^.]+)\\.example\\.com$"
+      key = "region"
+    }
+  }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
@@ -55,6 +55,11 @@ object TestContext {
       |
       |  ignored-tag-keys = []
       |}
+      |
+      |atlas.eval.host-rewrite {
+      |  pattern = "$^"
+      |  key = ""
+      |}
     """.stripMargin)
 
   def createContext(

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/util/HostRewriterSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/util/HostRewriterSuite.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.util
+
+import com.netflix.atlas.core.model.CustomVocabulary
+import com.netflix.atlas.core.model.ModelExtractors
+import com.netflix.atlas.core.model.StyleExpr
+import com.netflix.atlas.core.stacklang.Interpreter
+import com.typesafe.config.ConfigFactory
+import org.scalatest.funsuite.AnyFunSuite
+
+class HostRewriterSuite extends AnyFunSuite {
+
+  private val config = ConfigFactory.load()
+  private val interpreter = Interpreter(new CustomVocabulary(config).allWords)
+
+  private def interpret(str: String): List[StyleExpr] = {
+    interpreter.execute(str).stack.reverse.flatMap {
+      case ModelExtractors.PresentationType(t) => t.perOffset
+    }
+  }
+
+  test("default shouldn't change the expr") {
+    val rewriter = new HostRewriter(config.getConfig("atlas.eval.host-rewrite"))
+    val exprs = interpret("name,sps,:eq,:sum")
+    val host = "foo.example.com"
+    assert(rewriter.rewrite(host, exprs) === exprs)
+  }
+
+  test("restrict by region extracted from host") {
+    val regionConfig = ConfigFactory.parseString("""
+        |pattern = "^foo\\.([^.]+)\\.example.com$"
+        |key = "region"
+        |""".stripMargin)
+    val rewriter = new HostRewriter(regionConfig)
+    val exprs = interpret("name,sps,:eq,:sum")
+    val expected = interpret("name,sps,:eq,region,us-east-1,:eq,:and,:sum")
+    val host = "foo.us-east-1.example.com"
+    assert(rewriter.rewrite(host, exprs) === expected)
+  }
+
+  test("use first group if multiple in pattern") {
+    val regionConfig =
+      ConfigFactory.parseString("""
+        |pattern = "^foo\\.([^.]+)\\.(example|example2).com$"
+        |key = "region"
+        |""".stripMargin)
+    val rewriter = new HostRewriter(regionConfig)
+    val exprs = interpret("name,sps,:eq,:sum")
+    val expected = interpret("name,sps,:eq,region,us-east-1,:eq,:and,:sum")
+    val host = "foo.us-east-1.example.com"
+    assert(rewriter.rewrite(host, exprs) === expected)
+  }
+
+  test("no group in pattern") {
+    val regionConfig = ConfigFactory.parseString("""
+        |pattern = "^foo\\.example\\.com$"
+        |key = "region"
+        |""".stripMargin)
+    val rewriter = new HostRewriter(regionConfig)
+    val exprs = interpret("name,sps,:eq,:sum")
+    val host = "foo.example.com"
+    intercept[IndexOutOfBoundsException] {
+      rewriter.rewrite(host, exprs)
+    }
+  }
+}


### PR DESCRIPTION
In some cases we have multiple DNS names for the same
backend, but the behavior varies a bit depending on the
host name. Internally this has been done for quite a
while on the main backends, but was not done for the
streaming execution. This change adds support for host
based rewrite that will be consistent between streaming
and the main backends.