### PR TITLE
freeze should reset to initial variables

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Context.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Context.scala
@@ -25,6 +25,10 @@ package com.netflix.atlas.core.stacklang
   * @param variables
   *     Variables that can be set to keep state outside of the main stack. See the
   *     `:get` and `:set` operators for more information.
+  * @param initialVariables
+  *     Initial set of variables used when beginning the execution. These values will be
+  *     used when operations like `:freeze` need to reset the interpreter to the initial
+  *     state.
   * @param frozenStack
   *     Separate stack that has been frozen to prevent further modification. See the
   *     `:freeze` operator for more information.
@@ -33,6 +37,7 @@ case class Context(
   interpreter: Interpreter,
   stack: List[Any],
   variables: Map[String, Any],
+  initialVariables: Map[String, Any] = Map.empty,
   frozenStack: List[Any] = Nil
 ) {
 
@@ -41,7 +46,7 @@ case class Context(
     * state will also be cleared.
     */
   def freeze: Context = {
-    copy(stack = Nil, variables = Map.empty[String, Any], frozenStack = stack ::: frozenStack)
+    copy(stack = Nil, variables = initialVariables, frozenStack = stack ::: frozenStack)
   }
 
   /**

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
@@ -113,7 +113,7 @@ case class Interpreter(vocabulary: List[Word]) {
   }
 
   final def execute(program: String, vars: Map[String, Any]): Context = {
-    execute(splitAndTrim(program), Context(this, Nil, vars))
+    execute(splitAndTrim(program), Context(this, Nil, vars, vars))
   }
 
   @scala.annotation.tailrec

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/FreezeSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/FreezeSuite.scala
@@ -40,6 +40,12 @@ class FreezeSuite extends AnyFunSuite {
     assert(e.getMessage === "key not found: foo")
   }
 
+  test("original variables are preserved") {
+    val vars = Map("foo" -> "original", "bar" -> "2")
+    val context = interpreter.execute("foo,1,:set,:freeze,foo,:get,bar,:get", vars)
+    assert(context.stack === List("2", "original"))
+  }
+
   test("multiple freeze operations") {
     val context = interpreter.execute("a,b,c,:freeze,d,e,f,:freeze,g,h,i,:freeze,j,k,l,:clear")
     assert(context.stack === List("i", "h", "g", "f", "e", "d", "c", "b", "a"))


### PR DESCRIPTION
The freeze operation is meant to reset the state of the
interpreter to isolate expressions. Before it was clearing
the variables meaning that after a freeze operation any
variables passed in at the start of the execution would
not be available. This change fixes it to reset to the
initial set of variables used when starting the execution.