### PR TITLE
Add an API to indicate whether a queue should take more data

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/StreamOps.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/StreamOps.scala
@@ -224,6 +224,9 @@ object StreamOps extends StrictLogging {
 
     /** Check if the queue is done, i.e., it has been completed and the queue is empty. */
     def isDone: Boolean = completed && queue.isEmpty
+
+    /** Check if the queue is open to take more data.*/
+    def isOpen: Boolean = !completed
   }
 
   private[akka] final class QueueSource[T](queueSupplier: () => SourceQueue[T])

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/StreamOps.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/StreamOps.scala
@@ -225,7 +225,7 @@ object StreamOps extends StrictLogging {
     /** Check if the queue is done, i.e., it has been completed and the queue is empty. */
     def isDone: Boolean = completed && queue.isEmpty
 
-    /** Check if the queue is open to take more data.*/
+    /** Check if the queue is open to take more data. */
     def isOpen: Boolean = !completed
   }
 

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
@@ -145,6 +145,19 @@ class StreamOpsSuite extends AnyFunSuite {
     Await.ready(fut, Duration.Inf)
   }
 
+  test("blocking queue, not open after completed") {
+    val registry = new DefaultRegistry()
+    val source = StreamOps.blockingQueue[Int](registry, "test", 1)
+    val queue = source
+      .toMat(Sink.ignore)(Keep.left)
+      .run()
+    assert(queue.isOpen)
+    queue.offer(1)
+    assert(queue.isOpen)
+    queue.complete()
+    assert(!queue.isOpen)
+  }
+
   private def checkCounts(registry: Registry, name: String, expected: Map[String, Double]): Unit = {
     import scala.jdk.CollectionConverters._
     registry


### PR DESCRIPTION
Add an API to indicate whether a queue should take more data, useful for health check. 
The existing API isDone also checks if queue is empty so it's not a fit for health check.