### PR TITLE
include tags in validation result responses

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/CompositeTagRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/CompositeTagRule.scala
@@ -18,18 +18,18 @@ package com.netflix.atlas.core.validation
 /** Verifies that all of the tag rules match. */
 case class CompositeTagRule(tagRules: List[TagRule]) extends TagRule {
 
-  override def validate(k: String, v: String): ValidationResult = {
+  override def validate(k: String, v: String): String = {
     validate(tagRules, k, v)
   }
 
   @scala.annotation.tailrec
-  private def validate(rules: List[TagRule], k: String, v: String): ValidationResult = {
+  private def validate(rules: List[TagRule], k: String, v: String): String = {
     if (rules.isEmpty) {
-      ValidationResult.Pass
+      TagRule.Pass
     } else {
       val r = rules.head
       val result = r.validate(k, v)
-      if (result == ValidationResult.Pass)
+      if (result == TagRule.Pass)
         validate(rules.tail, k, v)
       else
         result

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/HasKeyRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/HasKeyRule.scala
@@ -28,7 +28,10 @@ import com.typesafe.config.Config
 case class HasKeyRule(key: String) extends Rule {
 
   def validate(tags: SmallHashMap[String, String]): ValidationResult = {
-    if (tags.contains(key)) ValidationResult.Pass else failure(s"missing '$key': ${tags.keys}")
+    if (tags.contains(key))
+      ValidationResult.Pass
+    else
+      failure(s"missing '$key': ${tags.keys}", tags)
   }
 }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/KeyLengthRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/KeyLengthRule.scala
@@ -27,14 +27,14 @@ import com.typesafe.config.Config
   */
 case class KeyLengthRule(minLength: Int, maxLength: Int) extends TagRule {
 
-  def validate(k: String, v: String): ValidationResult = {
+  def validate(k: String, v: String): String = {
     k.length match {
       case len if len > maxLength =>
-        failure(s"key too long: [$k] ($len > $maxLength)")
+        s"key too long: [$k] ($len > $maxLength)"
       case len if len < minLength =>
-        failure(s"key too short: [$k] ($len < $minLength)")
+        s"key too short: [$k] ($len < $minLength)"
       case _ =>
-        ValidationResult.Pass
+        TagRule.Pass
     }
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/KeyPatternRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/KeyPatternRule.scala
@@ -28,10 +28,10 @@ import com.typesafe.config.Config
   */
 case class KeyPatternRule(pattern: Pattern) extends TagRule {
 
-  def validate(k: String, v: String): ValidationResult = {
-    if (pattern.matcher(k).matches()) ValidationResult.Pass
+  def validate(k: String, v: String): String = {
+    if (pattern.matcher(k).matches()) TagRule.Pass
     else {
-      failure(s"key doesn't match pattern '$pattern': [$k]")
+      s"key doesn't match pattern '$pattern': [$k]"
     }
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/MaxUserTagsRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/MaxUserTagsRule.scala
@@ -37,7 +37,7 @@ case class MaxUserTagsRule(limit: Int) extends Rule {
     }
     if (count <= limit) ValidationResult.Pass
     else {
-      failure(s"too many user tags: $count > $limit")
+      failure(s"too many user tags: $count > $limit", tags)
     }
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/NameValueLengthRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/NameValueLengthRule.scala
@@ -35,7 +35,7 @@ import com.typesafe.config.Config
   */
 case class NameValueLengthRule(nameRule: TagRule, valueRule: TagRule) extends TagRule {
 
-  def validate(k: String, v: String): ValidationResult = {
+  override def validate(k: String, v: String): String = {
     if (k == "name") nameRule.validate(k, v) else valueRule.validate(k, v)
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ReservedKeyRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ReservedKeyRule.scala
@@ -31,11 +31,11 @@ import com.typesafe.config.Config
   */
 case class ReservedKeyRule(prefix: String, allowedKeys: Set[String]) extends TagRule {
 
-  override def validate(k: String, v: String): ValidationResult = {
+  override def validate(k: String, v: String): String = {
     if (k.startsWith(prefix) && !allowedKeys.contains(k))
-      failure(s"invalid key for reserved prefix '$prefix': $k")
+      s"invalid key for reserved prefix '$prefix': $k"
     else
-      ValidationResult.Pass
+      TagRule.Pass
   }
 }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/Rule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/Rule.scala
@@ -46,8 +46,8 @@ trait Rule {
   /**
     * Helper for generating the failure response.
     */
-  protected def failure(reason: String): ValidationResult = {
-    ValidationResult.Fail(ruleName, reason)
+  protected def failure(reason: String, tags: Map[String, String]): ValidationResult = {
+    ValidationResult.Fail(ruleName, reason, tags)
   }
 }
 
@@ -103,10 +103,12 @@ object Rule {
 
   @scala.annotation.tailrec
   def validate(tags: Map[String, String], rules: List[Rule]): ValidationResult = {
-    if (rules.isEmpty) ValidationResult.Pass
-    else {
-      val res = rules.head.validate(tags)
-      if (res.isFailure) res else validate(tags, rules.tail)
+    rules match {
+      case r :: rs =>
+        val result = r.validate(tags)
+        if (result.isFailure) result else validate(tags, rs)
+      case Nil =>
+        ValidationResult.Pass
     }
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/TagRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/TagRule.scala
@@ -25,12 +25,23 @@ trait TagRule extends Rule {
   def validate(tags: SmallHashMap[String, String]): ValidationResult = {
     val iter = tags.entriesIterator
     while (iter.hasNext) {
-      val res = validate(iter.key, iter.value)
-      if (res.isFailure) return res
+      val result = validate(iter.key, iter.value)
+      if (result != TagRule.Pass) return failure(result, tags)
       iter.nextEntry()
     }
     ValidationResult.Pass
   }
 
-  def validate(k: String, v: String): ValidationResult
+  /**
+    * Check the key/value pair and return `null` if it is valid or a reason string if
+    * there is a validation failure. The `null` type for success is used to avoid allocations
+    * or other overhead since the validation checks tend to be a hot path.
+    */
+  def validate(k: String, v: String): String
+}
+
+object TagRule {
+
+  /** Null string to make the code easier to follow when using null for a passing result. */
+  val Pass: String = null
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ValidCharactersRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ValidCharactersRule.scala
@@ -40,17 +40,17 @@ import com.typesafe.config.Config
 case class ValidCharactersRule(defaultSet: AsciiSet, overrides: Map[String, AsciiSet])
     extends TagRule {
 
-  def validate(k: String, v: String): ValidationResult = {
+  def validate(k: String, v: String): String = {
     if (!defaultSet.containsAll(k)) {
-      return failure(s"invalid characters in key: [$k] ([$defaultSet] are allowed)")
+      return s"invalid characters in key: [$k] ([$defaultSet] are allowed)"
     }
 
     val valueSet = overrides(k)
     if (!valueSet.containsAll(v)) {
-      return failure(s"invalid characters in value: $k = [$v] ([$valueSet] are allowed)")
+      return s"invalid characters in value: $k = [$v] ([$valueSet] are allowed)"
     }
 
-    ValidationResult.Pass
+    TagRule.Pass
   }
 }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ValidationResult.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ValidationResult.scala
@@ -24,12 +24,25 @@ sealed trait ValidationResult {
 
 object ValidationResult {
 
+  /** Indicates the tag set passed validation with no issues. */
   case object Pass extends ValidationResult {
 
     def isSuccess: Boolean = true
   }
 
-  case class Fail(rule: String, reason: String) extends ValidationResult {
+  /**
+    * Indicates the tag set violates at least one of the rules.
+    *
+    * @param rule
+    *     Name of the rule that failed.
+    * @param reason
+    *     Description of the failure.
+    * @param tags
+    *     The set of tags that was checked. This is used to help provide context
+    *     to the user when the failure is displayed.
+    */
+  case class Fail(rule: String, reason: String, tags: Map[String, String] = Map.empty)
+      extends ValidationResult {
 
     def isSuccess: Boolean = false
   }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ValueLengthRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ValueLengthRule.scala
@@ -27,14 +27,14 @@ import com.typesafe.config.Config
   */
 case class ValueLengthRule(minLength: Int, maxLength: Int) extends TagRule {
 
-  def validate(k: String, v: String): ValidationResult = {
+  def validate(k: String, v: String): String = {
     v.length match {
       case len if len > maxLength =>
-        failure(s"value too long: $k = [$v] ($len > $maxLength)")
+        s"value too long: $k = [$v] ($len > $maxLength)"
       case len if len < minLength =>
-        failure(s"value too short: $k = [$v] ($len < $minLength)")
+        s"value too short: $k = [$v] ($len < $minLength)"
       case _ =>
-        ValidationResult.Pass
+        TagRule.Pass
     }
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ValuePatternRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/ValuePatternRule.scala
@@ -27,10 +27,10 @@ import com.typesafe.config.Config
   */
 case class ValuePatternRule(pattern: PatternMatcher) extends TagRule {
 
-  def validate(k: String, v: String): ValidationResult = {
-    if (pattern.matches(v)) ValidationResult.Pass
+  def validate(k: String, v: String): String = {
+    if (pattern.matches(v)) TagRule.Pass
     else {
-      failure(s"value doesn't match pattern '$pattern': [$v]")
+      s"value doesn't match pattern '$pattern': [$v]"
     }
   }
 }

--- a/atlas-core/src/test/java/com/netflix/atlas/core/validation/JavaTestRule.java
+++ b/atlas-core/src/test/java/com/netflix/atlas/core/validation/JavaTestRule.java
@@ -25,7 +25,7 @@ public class JavaTestRule extends TagRuleWrapper {
     }
 
     @Override
-    public ValidationResult validate(String k, String v) {
-        return ValidationResult.Pass$.MODULE$;
+    public String validate(String k, String v) {
+        return null;
     }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ConfigConstructorTestRule.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ConfigConstructorTestRule.scala
@@ -18,5 +18,5 @@ package com.netflix.atlas.core.validation
 import com.typesafe.config.Config
 
 class ConfigConstructorTestRule(config: Config) extends TagRule {
-  override def validate(k: String, v: String): ValidationResult = ValidationResult.Pass
+  override def validate(k: String, v: String): String = TagRule.Pass
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/KeyLengthRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/KeyLengthRuleSuite.scala
@@ -27,19 +27,23 @@ class KeyLengthRuleSuite extends AnyFunSuite {
 
   private val rule = KeyLengthRule(config)
 
+  private def validate(k: String, v: String): ValidationResult = {
+    rule.validate(Map(k -> v))
+  }
+
   test("valid") {
-    assert(rule.validate("ab", "def") === ValidationResult.Pass)
-    assert(rule.validate("abc", "def") === ValidationResult.Pass)
-    assert(rule.validate("abcd", "def") === ValidationResult.Pass)
+    assert(validate("ab", "def") === ValidationResult.Pass)
+    assert(validate("abc", "def") === ValidationResult.Pass)
+    assert(validate("abcd", "def") === ValidationResult.Pass)
   }
 
   test("too short") {
-    val res = rule.validate("a", "def")
+    val res = validate("a", "def")
     assert(res.isFailure)
   }
 
   test("too long") {
-    val res = rule.validate("abcde", "def")
+    val res = validate("abcde", "def")
     assert(res.isFailure)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/KeyPatternRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/KeyPatternRuleSuite.scala
@@ -24,13 +24,17 @@ class KeyPatternRuleSuite extends AnyFunSuite {
 
   private val rule = KeyPatternRule(config)
 
+  private def validate(k: String, v: String): ValidationResult = {
+    rule.validate(Map(k -> v))
+  }
+
   test("valid") {
-    assert(rule.validate("abc", "ab") === ValidationResult.Pass)
-    assert(rule.validate("aaa", "abc") === ValidationResult.Pass)
+    assert(validate("abc", "ab") === ValidationResult.Pass)
+    assert(validate("aaa", "abc") === ValidationResult.Pass)
   }
 
   test("invalid") {
-    val res = rule.validate("abcd", "a")
+    val res = validate("abcd", "a")
     assert(res.isFailure)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/NameValueLengthRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/NameValueLengthRuleSuite.scala
@@ -33,35 +33,39 @@ class NameValueLengthRuleSuite extends AnyFunSuite {
 
   private val rule = NameValueLengthRule(config)
 
+  private def validate(k: String, v: String): ValidationResult = {
+    rule.validate(Map(k -> v))
+  }
+
   test("name valid") {
-    assert(rule.validate("name", "abc") === ValidationResult.Pass)
-    assert(rule.validate("name", "abcd") === ValidationResult.Pass)
-    assert(rule.validate("name", "abcde") === ValidationResult.Pass)
+    assert(validate("name", "abc") === ValidationResult.Pass)
+    assert(validate("name", "abcd") === ValidationResult.Pass)
+    assert(validate("name", "abcde") === ValidationResult.Pass)
   }
 
   test("name too short") {
-    val res = rule.validate("name", "ab")
+    val res = validate("name", "ab")
     assert(res.isFailure)
   }
 
   test("name too long") {
-    val res = rule.validate("name", "abcdef")
+    val res = validate("name", "abcdef")
     assert(res.isFailure)
   }
 
   test("others valid") {
-    assert(rule.validate("def", "ab") === ValidationResult.Pass)
-    assert(rule.validate("def", "abc") === ValidationResult.Pass)
-    assert(rule.validate("def", "abcd") === ValidationResult.Pass)
+    assert(validate("def", "ab") === ValidationResult.Pass)
+    assert(validate("def", "abc") === ValidationResult.Pass)
+    assert(validate("def", "abcd") === ValidationResult.Pass)
   }
 
   test("others too short") {
-    val res = rule.validate("def", "a")
+    val res = validate("def", "a")
     assert(res.isFailure)
   }
 
   test("others too long") {
-    val res = rule.validate("def", "abcde")
+    val res = validate("def", "abcde")
     assert(res.isFailure)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ReservedKeyRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ReservedKeyRuleSuite.scala
@@ -24,27 +24,32 @@ class ReservedKeyRuleSuite extends AnyFunSuite {
       |prefix = "nf."
       |allowed-keys = ["region", "job", "task"]
     """.stripMargin)
+
   private val rule = ReservedKeyRule(config)
 
+  private def validate(k: String, v: String): ValidationResult = {
+    rule.validate(Map(k -> v))
+  }
+
   test("valid") {
-    assert(rule.validate("nf.region", "def") === ValidationResult.Pass)
+    assert(validate("nf.region", "def") === ValidationResult.Pass)
   }
 
   test("valid, no reserved prefix") {
-    assert(rule.validate("foo", "def") === ValidationResult.Pass)
+    assert(validate("foo", "def") === ValidationResult.Pass)
   }
 
   test("invalid") {
-    val res = rule.validate("nf.foo", "def")
+    val res = validate("nf.foo", "def")
     assert(res.isFailure)
   }
 
   test("job") {
-    assert(rule.validate("nf.job", "def") === ValidationResult.Pass)
+    assert(validate("nf.job", "def") === ValidationResult.Pass)
   }
 
   test("task") {
-    assert(rule.validate("nf.task", "def") === ValidationResult.Pass)
+    assert(validate("nf.task", "def") === ValidationResult.Pass)
   }
 
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ValidCharactersRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ValidCharactersRuleSuite.scala
@@ -35,42 +35,46 @@ class ValidCharactersRuleSuite extends AnyFunSuite {
 
   private val alpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._"
 
+  private def validate(rule: Rule, k: String, v: String): ValidationResult = {
+    rule.validate(Map(k -> v))
+  }
+
   test("valid") {
     val rule = ValidCharactersRule(config)
-    assert(rule.validate(alpha, alpha) === ValidationResult.Pass)
+    assert(validate(rule, alpha, alpha) === ValidationResult.Pass)
   }
 
   test("invalid key") {
     val rule = ValidCharactersRule(config)
-    val res = rule.validate("spaces not allowed", alpha)
+    val res = validate(rule, "spaces not allowed", alpha)
     assert(res.isFailure)
   }
 
   test("invalid value") {
     val rule = ValidCharactersRule(config)
-    val res = rule.validate(alpha, "spaces not allowed")
+    val res = validate(rule, alpha, "spaces not allowed")
     assert(res.isFailure)
   }
 
   test("custom pattern valid") {
     val rule = ValidCharactersRule(customPattern)
-    assert(rule.validate("abcdef", "fedcba") === ValidationResult.Pass)
+    assert(validate(rule, "abcdef", "fedcba") === ValidationResult.Pass)
   }
 
   test("custom pattern invalid key") {
     val rule = ValidCharactersRule(customPattern)
-    val res = rule.validate(alpha, "fedcba")
+    val res = validate(rule, alpha, "fedcba")
     assert(res.isFailure)
   }
 
   test("custom pattern invalid value") {
     val rule = ValidCharactersRule(customPattern)
-    val res = rule.validate("abcdef", alpha)
+    val res = validate(rule, "abcdef", alpha)
     assert(res.isFailure)
   }
 
   test("custom pattern value override") {
     val rule = ValidCharactersRule(customPattern)
-    assert(rule.validate("nf.asg", alpha + "^~") === ValidationResult.Pass)
+    assert(validate(rule, "nf.asg", alpha + "^~") === ValidationResult.Pass)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ValueLengthRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ValueLengthRuleSuite.scala
@@ -27,19 +27,23 @@ class ValueLengthRuleSuite extends AnyFunSuite {
 
   private val rule = ValueLengthRule(config)
 
+  private def validate(k: String, v: String): ValidationResult = {
+    rule.validate(Map(k -> v))
+  }
+
   test("valid") {
-    assert(rule.validate("def", "ab") === ValidationResult.Pass)
-    assert(rule.validate("def", "abc") === ValidationResult.Pass)
-    assert(rule.validate("def", "abcd") === ValidationResult.Pass)
+    assert(validate("def", "ab") === ValidationResult.Pass)
+    assert(validate("def", "abc") === ValidationResult.Pass)
+    assert(validate("def", "abcd") === ValidationResult.Pass)
   }
 
   test("too short") {
-    val res = rule.validate("def", "a")
+    val res = validate("def", "a")
     assert(res.isFailure)
   }
 
   test("too long") {
-    val res = rule.validate("def", "abcde")
+    val res = validate("def", "abcde")
     assert(res.isFailure)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ValuePatternRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ValuePatternRuleSuite.scala
@@ -24,13 +24,17 @@ class ValuePatternRuleSuite extends AnyFunSuite {
 
   private val rule = ValuePatternRule(config)
 
+  private def validate(k: String, v: String): ValidationResult = {
+    rule.validate(Map(k -> v))
+  }
+
   test("valid") {
-    assert(rule.validate("def", "abc") === ValidationResult.Pass)
-    assert(rule.validate("def", "aaa") === ValidationResult.Pass)
+    assert(validate("def", "abc") === ValidationResult.Pass)
+    assert(validate("def", "aaa") === ValidationResult.Pass)
   }
 
   test("invalid") {
-    val res = rule.validate("def", "abcd")
+    val res = validate("def", "abcd")
     assert(res.isFailure)
   }
 }

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalPublishActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalPublishActor.scala
@@ -73,7 +73,7 @@ class LocalPublishActor(registry: Registry, db: Database) extends Actor with Act
   private def updateStats(failures: List[ValidationResult]): Unit = {
     failures.foreach {
       case ValidationResult.Pass => // Ignored
-      case ValidationResult.Fail(error, _) =>
+      case ValidationResult.Fail(error, _, _) =>
         registry.counter(numInvalid.withTag("error", error)).increment()
     }
   }


### PR DESCRIPTION
Metrics are typically submitted in large batches and
without this context it can be difficult for users to
narrow it down to particular data points that are
problematic.

Sample of updated response:

```json
{
  "type": "partial",
  "errorCount": 1,
  "message": [
    "invalid characters in value: name = [answerTo Everything] ([--.0-9A-Z^_a-z~] are allowed) (tags={\"nf.node\":\"i-123\",\"atlas.dstype\":\"gauge\",\"name\":\"answerTo Everything\"})"
  ]
}
```

Fixes #1199