### PR TITLE
lwc: change log level for ignored msg

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/EvaluateApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/EvaluateApi.scala
@@ -65,7 +65,7 @@ class EvaluateApi(registry: Registry, sm: StreamSubscriptionManager)
         queue.offer(msg)
       }
     } else {
-      logger.trace(s"no subscriptions, ignoring $msg (from: $addr)")
+      logger.debug(s"no subscriptions, ignoring $msg (from: $addr)")
       ignoredCounter.increment()
     }
   }


### PR DESCRIPTION
Using different level for regular and ignored message, big cpu and disk hit to log every message for debugging.