### PR TITLE
allow timeout for unique operator

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/StreamOps.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/StreamOps.scala
@@ -386,7 +386,7 @@ object StreamOps extends StrictLogging {
     *
     * @param timeout
     *     Repeated value will still be emitted if elapsed time since last emit exceeds
-    *     timeout.
+    *     timeout. Unit is milliseconds.
     */
   def unique[V](timeout: Long = Long.MaxValue, clock: Clock = Clock.SYSTEM): Flow[V, V, NotUsed] = {
     Flow[V].via(new UniqueFlow[V](timeout, clock))

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/StreamOps.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/StreamOps.scala
@@ -382,8 +382,10 @@ object StreamOps extends StrictLogging {
 
   /**
     * Filter out repeated values in a stream. Similar to the unix `uniq` command.
-    * @param timeout Repeated value will still be emitted if elapsed time since last emit exceeds
-    *                timeout; repeated value is never emitted if timeout <= 0.
+    *
+    * @param timeout
+    *     Repeated value will still be emitted if elapsed time since last emit exceeds
+    *     timeout; repeated value is never emitted if timeout <= 0.
     */
   def unique[V](timeout: Long = 0): Flow[V, V, NotUsed] = {
     Flow[V].via(new UniqueFlow[V](timeout))

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
@@ -260,7 +260,6 @@ class StreamOpsSuite extends AnyFunSuite {
   }
 
   test("unique timeout") {
-    println(Long.MaxValue == Long.MaxValue)
     val clock = new ManualClock
     clock.setWallTime(0)
     var count = 0

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
@@ -258,4 +258,23 @@ class StreamOpsSuite extends AnyFunSuite {
     // Only consecutive repeated values are filtered out, so the final 1 should get repeated
     assert(vs === List(1, 2, 3, 4, 5, 6, 7, 1))
   }
+
+  test("unique timeout") {
+    println(Long.MaxValue == Long.MaxValue)
+    val clock = new ManualClock
+    clock.setWallTime(0)
+    var count = 0
+
+    val future = Source(List(1, 1, 1, 2, 2, 2))
+      .map(v => {
+        count += 1
+        // Set the timestamp same as value count, simulating 1 value per ms
+        clock.setWallTime(count)
+        v
+      })
+      .via(StreamOps.unique(1, clock))
+      .runWith(Sink.seq[Int])
+    val vs = Await.result(future, Duration.Inf)
+    assert(vs === List(1, 1, 2, 2))
+  }
 }

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
@@ -252,7 +252,7 @@ class StreamOpsSuite extends AnyFunSuite {
 
   test("unique") {
     val future = Source(List(1, 1, 2, 3, 3, 3, 4, 5, 6, 6, 7, 1))
-      .via(StreamOps.unique)
+      .via(StreamOps.unique())
       .runWith(Sink.seq[Int])
     val vs = Await.result(future, Duration.Inf)
     // Only consecutive repeated values are filtered out, so the final 1 should get repeated

--- a/atlas-eval/src/main/resources/reference.conf
+++ b/atlas-eval/src/main/resources/reference.conf
@@ -1,5 +1,6 @@
 
 atlas.eval {
+  unique-timeout = 60s
   stream {
     backends = [
       {
@@ -8,7 +9,6 @@ atlas.eval {
         instance-uri = "http://{local-ipv4}:{port}"
       }
     ]
-
     // Number of buffers to use for the time grouping. More buffers means that data has
     // more time to accumulate and there is less chance of data being dropped because it
     // is too old


### PR DESCRIPTION
Allow unique operator to emit repeated element after given time elapses. This should help keep subscriptions update to date for all lwc api instances in a cluster.