### PR TITLE
adjust names for DX metrics

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/dx.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/dx.conf
@@ -7,7 +7,7 @@ atlas {
       namespace = "AWS/DX"
       period = 1m
       end-period-offset = 4
-      period-count = 2
+      period-count = 6
 
       dimensions = [
         "ConnectionId"
@@ -26,7 +26,7 @@ atlas {
       namespace = "AWS/DX"
       period = 1m
       end-period-offset = 4
-      period-count = 2
+      period-count = 6
 
       dimensions = [
         "ConnectionId",
@@ -36,7 +36,7 @@ atlas {
       metrics = [
         {
           name = "VirtualInterfaceBpsEgress"
-          alias = "aws.dx.virtualInterfaceBits"
+          alias = "aws.dx.virtualInterfaceBytes"
           conversion = "sum"
           tags = [
             {
@@ -47,7 +47,7 @@ atlas {
         },
         {
           name = "VirtualInterfaceBpsIngress"
-          alias = "aws.dx.virtualInterfaceBits"
+          alias = "aws.dx.virtualInterfaceBytes"
           conversion = "sum"
           tags = [
             {


### PR DESCRIPTION
Two minor adjustments for the DX metric mapping:

1. Adjust period count to exceed the offset. It seems to
   always use now as the end time and the period count needs
   to exceed the offset to get data. That can be fixed later
   to respect the offset for the time fetched and sanity check
   the configs as part of tests.
2. Fix the name for the throughput metric. The unit is specified
   and the ingestion code will automatically normalize to a base
   unit of `bytes/second`. Update the name to reduce confusion.