### PR TITLE
quote special double values for all json formats

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonGraphEngine.scala
@@ -20,11 +20,9 @@ import java.io.OutputStreamWriter
 
 import com.netflix.atlas.chart.model._
 
-class JsonGraphEngine(quoteNonNumeric: Boolean) extends GraphEngine {
+class JsonGraphEngine extends GraphEngine {
 
   import com.netflix.atlas.chart.GraphEngine._
-
-  def this() = this(false)
 
   def name: String = "json"
 
@@ -64,12 +62,7 @@ class JsonGraphEngine(quoteNonNumeric: Boolean) extends GraphEngine {
       gen.writeStartArray()
       seriesList.foreach { series =>
         val v = series.data.data(timestamp)
-        if (java.lang.Double.isFinite(v))
-          gen.writeNumber(v)
-        else if (quoteNonNumeric)
-          gen.writeString(v.toString)
-        else
-          gen.writeRawValue(v.toString)
+        gen.writeNumber(v)
       }
       gen.writeEndArray()
       timestamp += step

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/StatsJsonGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/StatsJsonGraphEngine.scala
@@ -18,7 +18,6 @@ package com.netflix.atlas.chart
 import java.io.OutputStream
 import java.io.OutputStreamWriter
 
-import com.fasterxml.jackson.core.JsonGenerator
 import com.netflix.atlas.chart.model._
 import com.netflix.atlas.core.model.SummaryStats
 
@@ -33,19 +32,9 @@ class StatsJsonGraphEngine extends GraphEngine {
 
   def contentType: String = "application/json"
 
-  private def writeRawField(gen: JsonGenerator, name: String, value: String): Unit = {
-    gen.writeFieldName(name)
-    gen.writeRawValue(value)
-  }
-
-  private def numberStr(numberFmt: String, v: Double): String = {
-    numberFmt.format(v)
-  }
-
   def write(config: GraphDef, output: OutputStream): Unit = {
     val writer = new OutputStreamWriter(output, "UTF-8")
     val seriesList = config.plots.flatMap(_.lines)
-    val numberFmt = config.numberFormat
     val gen = jsonFactory.createGenerator(writer)
 
     gen.writeStartObject()
@@ -78,11 +67,11 @@ class StatsJsonGraphEngine extends GraphEngine {
       gen.writeStartObject()
       gen.writeNumberField("count", stats.count)
       if (seriesList.nonEmpty) {
-        writeRawField(gen, "avg", numberStr(numberFmt, stats.avg))
-        writeRawField(gen, "total", numberStr(numberFmt, stats.total))
-        writeRawField(gen, "max", numberStr(numberFmt, stats.max))
-        writeRawField(gen, "min", numberStr(numberFmt, stats.min))
-        writeRawField(gen, "last", numberStr(numberFmt, stats.last))
+        gen.writeNumberField("avg", stats.avg)
+        gen.writeNumberField("total", stats.total)
+        gen.writeNumberField("max", stats.max)
+        gen.writeNumberField("min", stats.min)
+        gen.writeNumberField("last", stats.last)
       }
       gen.writeEndObject()
     }

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/StdJsonGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/StdJsonGraphEngine.scala
@@ -16,13 +16,16 @@
 package com.netflix.atlas.chart
 
 /**
+  * This is only present for backwards compatibility. There is no longer any difference between
+  * this and the `json` format.
+  *
   * Json output format that quotes non-numeric values like NaN and Infinity. Historically we
   * have always emitted them unquoted, but that is not standard JSON and so it creates issues with
   * some parsers. To avoid breaking backwards compatibility the existing "json" type will not
   * change, but this class adds a "std.json" type. The non-compatible json will not be used on
   * any v2 endpoints.
   */
-class StdJsonGraphEngine extends JsonGraphEngine(true) {
+class StdJsonGraphEngine extends JsonGraphEngine {
 
   override def name: String = "std.json"
 }

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/JsonGraphEngineSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/JsonGraphEngineSuite.scala
@@ -68,7 +68,7 @@ class JsonGraphEngineSuite extends AnyFunSuite {
         |"step":60000,
         |"legend":["0","1"],
         |"metrics":[{"name":"42.0"},{"name":"NaN"}],
-        |"values":[[42.0,NaN],[42.0,NaN],[42.0,NaN]],
+        |"values":[[42.0,"NaN"],[42.0,"NaN"],[42.0,"NaN"]],
         |"notices":[]
         |}"""
 


### PR DESCRIPTION
Updates the `json` and `stats.json` formats to output
standard json data. Before special double values like
NaN and Infinity were emitted without qoutes breaking
some systems that expected standard json. This should
make them more straightforward to consume, however it
is a potentially breaking change for some users.

Fixes #1080