### PR TITLE
honor user specified legend for fetch response

### DIFF
--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/FetchRequestSource.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/FetchRequestSource.scala
@@ -168,7 +168,7 @@ object FetchRequestSource {
               state = result.state
               result.data
                 .filterNot(ts => isAllNaN(ts.data, context.start, context.end, context.step))
-                .map(ts => TimeSeriesMessage(s, context, ts))
+                .map(ts => TimeSeriesMessage(s, context, ts.withLabel(s.legend(ts))))
             }
           push(out, ts)
         }


### PR DESCRIPTION
When generating the fetch response it was always using the
default legend for the time series messages. Now it will
use the legend set by the user and fallback to the default.