### PR TITLE
improve hash function for int collections

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Hash.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Hash.scala
@@ -36,6 +36,20 @@ object Hash {
     MurmurHash3.bytesHash(buf.array())
   }
 
+  /**
+    * Hash function for use with 32-bit integers. For more details on this hash see:
+    * https://nullprogram.com/blog/2018/07/31/
+    */
+  def lowbias32(v: Int): Int = {
+    var h = v
+    h ^= h >>> 16
+    h *= 0x7feb352d
+    h ^= h >>> 15
+    h *= 0x846ca68b
+    h ^= h >>> 16
+    h
+  }
+
   // Seeing contention on MessageDigest.getInstance, following pattern used by jruby:
   // https://github.com/jruby/jruby/commit/e840823c435393e8365be1bae93f646c1bb0043f
   private val cloneableDigests = createDigests()

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntHashSet.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntHashSet.scala
@@ -36,6 +36,10 @@ class IntHashSet(noData: Int, capacity: Int = 10) {
   // memory use. See IntIntMap benchmark.
   private def computeCutoff(n: Int): Int = math.max(3, n / 2)
 
+  private def hash(k: Int, length: Int): Int = {
+    Hash.absOrZero(Hash.lowbias32(k)) % length
+  }
+
   private def newArray(n: Int): Array[Int] = {
     val tmp = new Array[Int](PrimeFinder.nextPrime(n))
     var i = 0
@@ -59,7 +63,7 @@ class IntHashSet(noData: Int, capacity: Int = 10) {
   }
 
   private def add(buffer: Array[Int], v: Int): Boolean = {
-    var pos = Hash.absOrZero(v) % buffer.length
+    var pos = hash(v, buffer.length)
     var posV = buffer(pos)
     while (posV != noData && posV != v) {
       pos = (pos + 1) % buffer.length

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntIntHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntIntHashMap.scala
@@ -37,6 +37,10 @@ class IntIntHashMap(noData: Int, capacity: Int = 10) {
   // memory use. See IntIntMap benchmark.
   private def computeCutoff(n: Int): Int = math.max(3, n / 2)
 
+  private def hash(k: Int, length: Int): Int = {
+    Hash.absOrZero(Hash.lowbias32(k)) % length
+  }
+
   private def newArray(n: Int): Array[Int] = {
     val tmp = new Array[Int](PrimeFinder.nextPrime(n))
     var i = 0
@@ -62,7 +66,7 @@ class IntIntHashMap(noData: Int, capacity: Int = 10) {
   }
 
   private def put(ks: Array[Int], vs: Array[Int], k: Int, v: Int): Boolean = {
-    var pos = Hash.absOrZero(k) % ks.length
+    var pos = hash(k, ks.length)
     var posV = ks(pos)
     while (posV != noData && posV != k) {
       pos = (pos + 1) % ks.length
@@ -88,7 +92,7 @@ class IntIntHashMap(noData: Int, capacity: Int = 10) {
     * `dflt` value will be returned.
     */
   def get(k: Int, dflt: Int): Int = {
-    var pos = Hash.absOrZero(k) % keys.length
+    var pos = hash(k, keys.length)
     while (true) {
       val prev = keys(pos)
       if (prev == noData)
@@ -113,7 +117,7 @@ class IntIntHashMap(noData: Int, capacity: Int = 10) {
     */
   def increment(k: Int, amount: Int): Unit = {
     if (used >= cutoff) resize()
-    var pos = Hash.absOrZero(k) % keys.length
+    var pos = hash(k, keys.length)
     var prev = keys(pos)
     while (prev != noData && prev != k) {
       pos = (pos + 1) % keys.length

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntRefHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntRefHashMap.scala
@@ -59,7 +59,7 @@ class IntRefHashMap[T <: AnyRef: Manifest](noData: Int, capacity: Int = 10) {
   }
 
   private def hash(k: Int, length: Int): Int = {
-    Hash.absOrZero(k) % length
+    Hash.absOrZero(Hash.lowbias32(k)) % length
   }
 
   private def put(ks: Array[Int], vs: Array[T], k: Int, v: T): Boolean = {


### PR DESCRIPTION
For some data sets we are seeing it take a long time
to rebuild the index with most of the time being spent
doing get/put for the `RefIntHashMap`s used. Testing
with an improved int hash reduces collisions providing
a significant improvement.

Table showing reduction in build time using the newer
hash:

| Index size | Before | After  |
|------------|--------|--------|
| 1M         |    11s |    11s |
| 2M         |  1m43s |    20s |
| 5M         | 12m34s |    55s |