### PR TITLE
simplify hash for long values

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -78,7 +78,7 @@ object MathExpr {
 
     def rand(t: Long): Double = {
       // Compute the hash and map the value to the range 0.0 to 1.0
-      (math.abs(Hash.murmur3(t)) % 1000) / 1000.0
+      (math.abs(Hash.lowbias64(t)) % 1000) / 1000.0
     }
   }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Hash.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Hash.scala
@@ -16,24 +16,17 @@
 package com.netflix.atlas.core.util
 
 import java.math.BigInteger
-import java.nio.ByteBuffer
 import java.security.MessageDigest
 
 import scala.util.Try
-import scala.util.hashing.MurmurHash3
 
 object Hash {
 
-  // Used for computing the hash code for Long values.
-  private[this] val buffer = ThreadLocal
-    .withInitial[ByteBuffer](() => ByteBuffer.allocate(java.lang.Long.BYTES))
-
-  /** Compute MurmurHash3 for a java long value. */
-  def murmur3(v: Long): Int = {
-    val buf = buffer.get()
-    buf.clear()
-    buf.putLong(v)
-    MurmurHash3.bytesHash(buf.array())
+  /** Hash function for use with 64-bit integers. */
+  def lowbias64(v: Long): Int = {
+    val h1 = lowbias32((v >>> 32).toInt)
+    val h2 = lowbias32(v.toInt)
+    h1 ^ h2
   }
 
   /**

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongHashSet.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongHashSet.scala
@@ -59,7 +59,7 @@ class LongHashSet(noData: Long, capacity: Int = 10) {
   }
 
   private def add(buffer: Array[Long], v: Long): Boolean = {
-    var pos = Hash.absOrZero(Hash.murmur3(v)) % buffer.length
+    var pos = Hash.absOrZero(Hash.lowbias64(v)) % buffer.length
     var posV = buffer(pos)
     while (posV != noData && posV != v) {
       pos = (pos + 1) % buffer.length

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongIntHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongIntHashMap.scala
@@ -62,7 +62,7 @@ class LongIntHashMap(noData: Long, capacity: Int = 10) {
   }
 
   private def hash(ks: Array[Long], k: Long): Int = {
-    Hash.absOrZero(Hash.murmur3(k)) % ks.length
+    Hash.absOrZero(Hash.lowbias64(k)) % ks.length
   }
 
   private def put(ks: Array[Long], vs: Array[Int], k: Long, v: Int): Boolean = {


### PR DESCRIPTION
Avoids thread local and testing with some actual datasets
plus 100M random long values shows it has about the same
collision rate as the previous implementation.