### PR TITLE
update to scala 2.13.4

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         java: [15]
-        scala: [2.13.3]
+        scala: [2.13.4]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java }}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/AlgoState.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/AlgoState.scala
@@ -68,6 +68,7 @@ case class AlgoState(algorithm: String, settings: Map[String, Any]) {
     settings(key) match {
       case vs: Seq[_]        => vs.map(v => toNumber(key, v).doubleValue()).toArray
       case vs: Array[Double] => vs
+      case v                 => throw new MatchError(v)
     }
   }
 
@@ -95,6 +96,7 @@ object AlgoState {
     value match {
       case s: AlgoState => s
       case m: Map[_, _] => apply(m)
+      case v            => throw new MatchError(v)
     }
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/BlockStore.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/BlockStore.scala
@@ -191,6 +191,7 @@ class MemoryBlockStore(step: Long, blockSize: Int, numBlocks: Int) extends Block
     val oldBlock = currentBlock match {
       case b: ArrayBlock  => Block.compress(b)
       case b: RollupBlock => b.compress
+      case b              => throw new MatchError(b)
     }
     val newBlock =
       if (oldBlock eq currentBlock) {
@@ -267,6 +268,7 @@ class MemoryBlockStore(step: Long, blockSize: Int, numBlocks: Int) extends Block
       val oldBlock = currentBlock match {
         case b: ArrayBlock  => Block.compress(b)
         case b: RollupBlock => b.compress
+        case b              => throw new MatchError(b)
       }
       BlockStats.update(currentBlock, oldBlock)
       blocks(currentPos) = oldBlock

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Block.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Block.scala
@@ -217,13 +217,13 @@ sealed trait Block {
     * primitives.
     */
   def sizeOf(value: Any): Int = value match {
-    case v: Boolean => 1
-    case v: Byte    => 1
-    case v: Short   => 2
-    case v: Int     => 4
-    case v: Long    => 8
-    case v: Float   => 4
-    case v: Double  => 8
+    case _: Boolean => 1
+    case _: Byte    => 1
+    case _: Short   => 2
+    case _: Int     => 4
+    case _: Long    => 8
+    case _: Float   => 4
+    case _: Double  => 8
 
     // Assume integer length + size for each value
     case vs: Array[Boolean] => 4 + vs.length
@@ -233,6 +233,8 @@ sealed trait Block {
     case vs: Array[Long]    => 4 + 8 * vs.length
     case vs: Array[Float]   => 4 + 4 * vs.length
     case vs: Array[Double]  => 4 + 8 * vs.length
+
+    case v => throw new MatchError(v)
   }
 }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
@@ -184,7 +184,7 @@ object Interpreter {
   private def toStringImpl(items: List[Any]): String = {
     val parts = items.map {
       case vs: List[_] => s"(,${toStringImpl(vs)},)"
-      case v: AnyRef   => v.toString
+      case v           => v.toString
     }
     parts.mkString(",")
   }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
@@ -43,6 +43,7 @@ object SmallHashMap {
 
     def +=(pair: (K, V)): Unit = add(pair._1, pair._2)
 
+    @scala.annotation.nowarn
     def add(k: K, v: V): Builder[K, V] = {
       val pos = Hash.absOrZero(k.hashCode) % size
       var i = pos
@@ -160,6 +161,7 @@ final class SmallHashMap[K <: Any, V <: Any] private (val data: Array[Any], data
     Hash.absOrZero(k.hashCode) % capacity
   }
 
+  @scala.annotation.nowarn
   def getOrNull(key: K): V = {
     if (dataLength == 0) return null.asInstanceOf[V]
     val capacity = data.length / 2
@@ -420,6 +422,7 @@ final class SmallHashMap[K <: Any, V <: Any] private (val data: Array[Any], data
     * Helper function to avoid BoxesRunTime.equals. This function should be easy for
     * hotspot to inline.
     */
+  @scala.annotation.nowarn
   private def areEqual[T](v1: T, v2: T): Boolean = {
     (v1 == null && v2 == null) || (v1 != null && v1.equals(v2))
   }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/CustomVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/CustomVocabularySuite.scala
@@ -51,6 +51,7 @@ class CustomVocabularySuite extends AnyFunSuite {
     val result = interpreter.execute(program)
     result.stack match {
       case ModelExtractors.TimeSeriesType(v) :: Nil => v
+      case v                                        => throw new MatchError(v)
     }
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/NamedRewriteSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/NamedRewriteSuite.scala
@@ -41,6 +41,7 @@ class NamedRewriteSuite extends AnyFunSuite {
   private def rawEval(program: String): List[StyleExpr] = {
     interpreter.execute(program).stack.flatMap {
       case ModelExtractors.PresentationType(t) => t.perOffset
+      case v                                   => throw new MatchError(v)
     }
   }
 
@@ -51,6 +52,8 @@ class NamedRewriteSuite extends AnyFunSuite {
           case nr: MathExpr.NamedRewrite => nr.evalExpr
         }
         expanded.asInstanceOf[StyleExpr].perOffset
+      case v =>
+        throw new MatchError(v)
     }
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleVocabularySuite.scala
@@ -26,6 +26,7 @@ class StyleVocabularySuite extends AnyFunSuite {
   def eval(s: String): StyleExpr = {
     interpreter.execute(s).stack match {
       case PresentationType(v) :: Nil => v
+      case v                          => throw new MatchError(v)
     }
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/BaseExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/BaseExamplesSuite.scala
@@ -29,6 +29,7 @@ abstract class BaseExamplesSuite extends AnyFunSuite {
   protected def eval(program: String): TimeSeriesExpr = {
     interpreter.execute(program).stack match {
       case ModelExtractors.TimeSeriesType(t) :: Nil => t
+      case v                                        => throw new MatchError(v)
     }
   }
 

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
@@ -117,6 +117,7 @@ case class Grapher(settings: DefaultSettings) {
       val vars = Map("tz" -> GraphConfig.getTimeZoneIds(settings, timezones).head)
       settings.interpreter.execute(q.get, vars).stack.reverse.flatMap {
         case ModelExtractors.PresentationType(s) => s.perOffset
+        case v                                   => throw new MatchError(v)
       }
     }
 

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
@@ -35,6 +35,7 @@ private[stream] class ExprInterpreter(config: Config) {
   def eval(expr: String): List[StyleExpr] = {
     interpreter.execute(expr).stack.map {
       case ModelExtractors.PresentationType(t) => t
+      case v                                   => throw new MatchError(v)
     }
   }
 

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
@@ -228,6 +228,7 @@ private[stream] class FinalExprEval(interpreter: ExprInterpreter)
         grab(in) match {
           case ds: DataSources => handleDataSources(ds)
           case data: TimeGroup => handleData(data)
+          case v               => throw new MatchError(v)
         }
       }
 

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -112,6 +112,8 @@ class EvaluatorSuite extends AnyFunSuite with BeforeAndAfter {
         assert(
           msg === "IllegalArgumentException: missing required URI parameter `q`: resource:///gc-pause.dat/api/v1/graph"
         )
+      case v =>
+        throw new MatchError(v)
     }
   }
 
@@ -223,6 +225,8 @@ class EvaluatorSuite extends AnyFunSuite with BeforeAndAfter {
       case DiagnosticMessage(t, msg, None) =>
         assert(t === "error")
         assert(msg === expectedMsg)
+      case v =>
+        throw new MatchError(v)
     }
   }
 

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/util/HostRewriterSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/util/HostRewriterSuite.scala
@@ -30,6 +30,7 @@ class HostRewriterSuite extends AnyFunSuite {
   private def interpret(str: String): List[StyleExpr] = {
     interpreter.execute(str).stack.reverse.flatMap {
       case ModelExtractors.PresentationType(t) => t.perOffset
+      case v                                   => throw new MatchError(v)
     }
   }
 

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
@@ -85,9 +85,10 @@ class SubscribeApiSuite extends AnyFunSuite with BeforeAndAfter with ScalatestRo
       var subscriptions = List.empty[LwcSubscription]
       while (subscriptions.size < 2) {
         parse(client.expectMessage()) match {
-          case msg: DiagnosticMessage =>
-          case sub: LwcSubscription   => subscriptions = sub :: subscriptions
-          case h: LwcHeartbeat        => assert(h.step === 60000)
+          case _: DiagnosticMessage =>
+          case sub: LwcSubscription => subscriptions = sub :: subscriptions
+          case h: LwcHeartbeat      => assert(h.step === 60000)
+          case v                    => throw new MatchError(v)
         }
       }
 

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsApi.scala
@@ -73,6 +73,7 @@ class TagsApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi {
             case KeyListResponse(vs) if req.useJson   => asJson(vs, offsetString(limit, vs))
             case ValueListResponse(vs) if req.useJson => asJson(vs, offsetString(limit, vs))
             case Failure(t)                           => throw t
+            case v                                    => throw new MatchError(v)
           }
       }
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val guice      = "4.1.0"
     val jackson    = "2.11.3"
     val log4j      = "2.14.0"
-    val scala      = "2.13.3"
+    val scala      = "2.13.4"
     val slf4j      = "1.7.30"
     val spectator  = "0.120.0"
 


### PR DESCRIPTION
A number of new warnings needed to be fixed. Most were
for exhaustivity checks. For cooperative equality checks
that impact SmallHashMap the new warnings are currently
just being suppressed.