### PR TITLE
reduce allocations for query index matching

### DIFF
--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/index/QueryIndexMatching.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/index/QueryIndexMatching.scala
@@ -16,6 +16,7 @@
 package com.netflix.atlas.core.index
 
 import com.netflix.atlas.core.model.Query
+import com.netflix.atlas.core.util.SmallHashMap
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
@@ -93,6 +94,8 @@ class QueryIndexMatching {
     "statistic"  -> "totalTime"
   )
 
+  private val smallId = SmallHashMap(id)
+
   @Threads(1)
   @Benchmark
   def loop_100(bh: Blackhole): Unit = {
@@ -139,6 +142,12 @@ class QueryIndexMatching {
   @Benchmark
   def index_100000(bh: Blackhole): Unit = {
     bh.consume(index_100000.matches(id))
+  }
+
+  @Threads(1)
+  @Benchmark
+  def index_smallmap_100000(bh: Blackhole): Unit = {
+    bh.consume(index_100000.matches(smallId))
   }
 
 }


### PR DESCRIPTION
The two changes are:

1. Always use small map for subindexes to avoid allocation
   of `Some` objects when performing a get.
2. If a `SmallHashMap` is used for the tags, then use the
   entries iterator to avoid allocating the query list. This
   avoids the allocation of the list nodes and short circuits
   creation of `Query.Equal` in some cases.

On sample benchmark with index size of 100k the throughput
increased from ~1.8M ops/second to ~2.6M ops/second. Allocation
rate was reduced from ~624 B/op to ~24 B/op.