### PR TITLE
QueryIndex: reduce iteration cost for tags map

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/QueryIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/QueryIndexSuite.scala
@@ -40,8 +40,8 @@ class QueryIndexSuite extends AnyFunSuite {
   }
 
   private def matchingEntries[T](index: QueryIndex[T], tags: Map[String, String]): List[T] = {
-    val r1 = index.matchingEntries(tags)
-    val r2 = index.matchingEntries(SmallHashMap(tags))
+    val r1 = index.matchingEntries(tags).sortWith(_.toString < _.toString)
+    val r2 = index.matchingEntries(SmallHashMap(tags)).sortWith(_.toString < _.toString)
     assert(r1 === r2)
     r1
   }
@@ -200,8 +200,8 @@ class QueryIndexSuite extends AnyFunSuite {
     )
     assert(
       matchingEntries(index, Map("name" -> "diskUsage", "nf.node" -> "i-00099")) === List(
-          diskUsagePerNode.last,
-          diskUsage
+          diskUsage,
+          diskUsagePerNode.last
         )
     )
     assert(
@@ -229,7 +229,7 @@ class QueryIndexSuite extends AnyFunSuite {
   test("queries for both nf.app and nf.cluster") {
     val appQuery = Query.Equal("nf.app", "testapp")
     val clusterQuery = Query.Equal("nf.cluster", "testapp-test")
-    val queries = List(clusterQuery, appQuery)
+    val queries = List(appQuery, clusterQuery)
     val index = QueryIndex(queries)
 
     val tags = Map("nf.app" -> "testapp", "nf.cluster" -> "testapp-test")


### PR DESCRIPTION
In #1225, we switched to using the EntriesIterator for
`SmallHashMap`s to avoid allocations. This works well for
compact maps. However, when there is free space in the map
it adds some computational overhead to search for the next
entry. Since the traversal occurs multiple times when
searching for matches this overhead can add up. In this
change we switch to a simple array with thread local so
we can iterate the tags map a single time and avoid the
allocations for most calls.

The benchmark doesn't show much improvement, but it
shows considerable improvement on a test cluster with
real data.