### PR TITLE
add helper for accessing opportunistic EC

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/ClusterOps.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/ClusterOps.scala
@@ -37,7 +37,6 @@ import com.netflix.spectator.api.Registry
 import com.typesafe.scalalogging.StrictLogging
 
 import scala.collection.mutable
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
@@ -152,7 +151,7 @@ object ClusterOps extends StrictLogging {
         }
 
         private def newSubFlow(m: M): Flow[D, O, NotUsed] = {
-          implicit val xc: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+          import OpportunisticEC._
           RestartFlow
             .withBackoff(RestartSettings(100.millis, 1.second, 0.0)) { () =>
               context.client(m).watchTermination() { (_, f) =>

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/OpportunisticEC.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/OpportunisticEC.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.akka
+
+import scala.concurrent.ExecutionContext
+
+/**
+  * Helper for accessing the opportunistic execution context added in 2.13.4. See
+  * https://github.com/scala/scala/releases/tag/v2.13.4
+  */
+object OpportunisticEC {
+
+  implicit val ec: ExecutionContext = {
+    try {
+      ExecutionContext.getClass
+        .getDeclaredMethod("opportunistic")
+        .invoke(ExecutionContext)
+        .asInstanceOf[ExecutionContext]
+    } catch {
+      case e: NoSuchMethodException => e.printStackTrace(); ExecutionContext.global
+    }
+  }
+}

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/StreamOps.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/StreamOps.scala
@@ -106,7 +106,7 @@ object StreamOps extends StrictLogging {
     queue: SourceQueueWithComplete[T]
   ) extends SourceQueueWithComplete[T] {
 
-    private implicit val ec = scala.concurrent.ExecutionContext.global
+    import OpportunisticEC._
 
     private val baseId = registry.createId("akka.stream.offeredToQueue", "id", id)
     private val enqueued = registry.counter(baseId.withTag("result", "enqueued"))

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/OpportunisticECSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/OpportunisticECSuite.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.akka
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+
+class OpportunisticECSuite extends AnyFunSuite {
+
+  test("implicit ec available") {
+    import OpportunisticEC._
+    val future = Future(1).map(_ + 1)
+    val result = Await.result(future, Duration.Inf)
+    assert(result === 2)
+  }
+}

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
@@ -39,7 +39,7 @@ import scala.util.Success
 
 class StreamOpsSuite extends AnyFunSuite {
 
-  private implicit val ec = scala.concurrent.ExecutionContext.global
+  import OpportunisticEC._
 
   private implicit val system = ActorSystem(getClass.getSimpleName)
 

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamApi.scala
@@ -55,8 +55,7 @@ class StreamApi @Inject() (
     with StrictLogging {
 
   import StreamApi._
-
-  private implicit val ec = scala.concurrent.ExecutionContext.global
+  import com.netflix.atlas.akka.OpportunisticEC._
 
   private val queueSize = config.getInt("atlas.lwcapi.queue-size")
 

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
@@ -63,8 +63,7 @@ class SubscribeApi @Inject() (
     with StrictLogging {
 
   import SubscribeApi._
-
-  private implicit val ec = scala.concurrent.ExecutionContext.global
+  import com.netflix.atlas.akka.OpportunisticEC._
 
   private val queueSize = config.getInt("atlas.lwcapi.queue-size")
 


### PR DESCRIPTION
In scala 2.13.4 the behavior of the default global execution
context changed. See:

https://github.com/scala/scala/releases/tag/v2.13.4

This change adds a helper class for accessing the opportunistic
context that was used before and switches some use-cases to
use that version as it is more well tested on our use-cases.
We can reevaluate in the future as needed.

/cc @jfz 