### PR TITLE
remove printStackTrace

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/OpportunisticEC.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/OpportunisticEC.scala
@@ -30,7 +30,7 @@ object OpportunisticEC {
         .invoke(ExecutionContext)
         .asInstanceOf[ExecutionContext]
     } catch {
-      case e: NoSuchMethodException => e.printStackTrace(); ExecutionContext.global
+      case e: NoSuchMethodException => ExecutionContext.global
     }
   }
 }


### PR DESCRIPTION
Cleanup printStackTrace call that was used for some
debugging and shouldn't have gotten checked in.