### PR TITLE
Use passed in registry

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/ClusterOps.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/ClusterOps.scala
@@ -103,7 +103,7 @@ object ClusterOps extends StrictLogging {
     override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
       new GraphStageLogic(shape) with InHandler with OutHandler {
 
-        private val registry = new NoopRegistry
+        private val registry = context.registry
         private val membersSources = mutable.AnyRefMap.empty[M, SourceQueue[D]]
 
         override def onPush(): Unit = {


### PR DESCRIPTION
Use passed in registry instead of `NoopRegistry`.