### PR TITLE
add support for simplified legends

### DIFF
--- a/atlas-eval/src/main/resources/reference.conf
+++ b/atlas-eval/src/main/resources/reference.conf
@@ -74,6 +74,11 @@ atlas.eval {
 
     // Pattern to use to detect that a user-agent is a web-browser
     browser-agent-pattern = "mozilla|msie|gecko|chrome|opera|webkit"
+
+    // If set to true, then it will try to generate a simple legend for the set of expressions
+    // on the graph. By default the legend will just summarize the expression which is often
+    // long and hard to read for users.
+    simple-legends-enabled = true
   }
 
   host-rewrite {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/DefaultSettings.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/DefaultSettings.scala
@@ -79,6 +79,9 @@ case class DefaultSettings(root: Config, config: Config) {
     Pattern.compile(config.getString("browser-agent-pattern"), Pattern.CASE_INSENSITIVE)
   }
 
+  /** Should the system try to generate a simplified legend? */
+  val simpleLegendsEnabled: Boolean = config.getBoolean("simple-legends-enabled")
+
   /** Maximum number of datapoints allowed for a line in a chart. */
   val maxDatapoints: Int = config.getInt("max-datapoints")
 

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
@@ -115,10 +115,18 @@ case class Grapher(settings: DefaultSettings) {
     val timezones = params.getAll("tz").reverse
     val parsedQuery = Try {
       val vars = Map("tz" -> GraphConfig.getTimeZoneIds(settings, timezones).head)
-      settings.interpreter.execute(q.get, vars).stack.reverse.flatMap {
-        case ModelExtractors.PresentationType(s) => s.perOffset
-        case v                                   => throw new MatchError(v)
-      }
+      val exprs = settings.interpreter
+        .execute(q.get, vars)
+        .stack
+        .reverse
+        .flatMap {
+          case ModelExtractors.PresentationType(s) => s.perOffset
+          case v                                   => throw new MatchError(v)
+        }
+      if (settings.simpleLegendsEnabled)
+        SimpleLegends.generate(exprs)
+      else
+        exprs
     }
 
     GraphConfig(

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/SimpleLegends.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/SimpleLegends.scala
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.graph
+
+import com.netflix.atlas.core.model.DataExpr
+import com.netflix.atlas.core.model.MathExpr
+import com.netflix.atlas.core.model.Query
+import com.netflix.atlas.core.model.Query.KeyValueQuery
+import com.netflix.atlas.core.model.StyleExpr
+import com.typesafe.scalalogging.StrictLogging
+
+/**
+  * Helper to analyze a set of expressions and try to automatically set a reasonable
+  * human readable legend.
+  */
+private[graph] object SimpleLegends extends StrictLogging {
+
+  def generate(exprs: List[StyleExpr]): List[StyleExpr] = {
+    try {
+      // Extract key/value pairs from all expressions
+      val kvs = exprs
+        .map(e => e -> extractKeyValues(e))
+        .filterNot(_._2.isEmpty)
+        .toMap
+
+      if (kvs.isEmpty) {
+        exprs
+      } else {
+        // Figure out the unique set
+        val common = kvs.values.reduce(intersect)
+        exprs.map { expr =>
+          if (hasExplicitLegend(expr)) {
+            expr
+          } else if (kvs.contains(expr)) {
+            val kv = kvs(expr)
+            val uniq = diff(kv, common)
+            if (uniq.nonEmpty)
+              generateLegend(expr, uniq)
+            else if (common.nonEmpty)
+              generateLegend(expr, common)
+            else
+              expr
+          } else {
+            expr
+          }
+        }
+      }
+    } catch {
+      // This is a nice to have presentation detail. In case it fails for any reason we
+      // just fallback to the defaults. Under normal usage this is not expected to ever
+      // be reached.
+      case e: Exception =>
+        logger.warn("failed to generate simple legend, using default", e)
+        exprs
+    }
+  }
+
+  private def hasExplicitLegend(expr: StyleExpr): Boolean = {
+    expr.settings.contains("legend")
+  }
+
+  private def withLegend(expr: StyleExpr, legend: String): StyleExpr = {
+    val label = if (expr.offset > 0L) s"$legend (offset=$$atlas.offset)" else legend
+    expr.copy(settings = expr.settings + ("legend" -> label))
+  }
+
+  private def keyValues(query: Query): Map[String, String] = {
+    query match {
+      case Query.And(q1, q2)            => keyValues(q1) ++ keyValues(q2)
+      case Query.Equal(k, v)            => Map(k -> v)
+      case Query.LessThan(k, v)         => Map(k -> v)
+      case Query.LessThanEqual(k, v)    => Map(k -> v)
+      case Query.GreaterThan(k, v)      => Map(k -> v)
+      case Query.GreaterThanEqual(k, v) => Map(k -> v)
+      case Query.Regex(k, v)            => Map(k -> v)
+      case Query.RegexIgnoreCase(k, v)  => Map(k -> v)
+      case Query.Not(q: KeyValueQuery)  => keyValues(q).map(t => t._1 -> s"!${t._2}")
+      case _                            => Map.empty
+    }
+  }
+
+  private def generateLegend(expr: StyleExpr, kv: Map[String, String]): StyleExpr = {
+    if (expr.expr.isGrouped) {
+      val fmt = expr.expr.finalGrouping.mkString("$", " $", "")
+      withLegend(expr, fmt)
+    } else if (kv.contains("name")) {
+      withLegend(expr, kv("name"))
+    } else {
+      val legend = kv.toList.sortWith(_._1 < _._1).map(_._2).mkString(" ")
+      withLegend(expr, legend)
+    }
+  }
+
+  private def extractKeyValues(expr: StyleExpr): Map[String, String] = {
+    val dataExprs = removeNamedRewrites(expr).expr.dataExprs
+    if (dataExprs.isEmpty)
+      Map.empty
+    else
+      dataExprs.map(de => keyValues(de.query)).reduce(intersect)
+  }
+
+  private def removeNamedRewrites(expr: StyleExpr): StyleExpr = {
+    // Custom averages like dist-avg and node-avg are done with rewrites that can
+    // lead to confusing legends. For the purposes here those can be rewritten to
+    // a simple aggregate like sum based on the display expression.
+    expr
+      .rewrite {
+        case MathExpr.NamedRewrite(n, q: Query, _, _, _) if n.endsWith("-avg") =>
+          DataExpr.Sum(q)
+      }
+      .asInstanceOf[StyleExpr]
+  }
+
+  private def intersect(m1: Map[String, String], m2: Map[String, String]): Map[String, String] = {
+    m1.toSet.intersect(m2.toSet).toMap
+  }
+
+  private def diff(m1: Map[String, String], m2: Map[String, String]): Map[String, String] = {
+    m1.toSet.diff(m2.toSet).toMap
+  }
+}

--- a/atlas-eval/src/test/resources/application.conf
+++ b/atlas-eval/src/test/resources/application.conf
@@ -18,5 +18,9 @@ atlas {
       pattern = "^foo\\.([^.]+)\\.example\\.com$"
       key = "region"
     }
+
+    graph {
+      simple-legends-enabled = false
+    }
   }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/SimpleLegendsSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/SimpleLegendsSuite.scala
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.graph
+
+import com.netflix.atlas.core.model.CustomVocabulary
+import com.netflix.atlas.core.model.ModelExtractors
+import com.netflix.atlas.core.model.StyleExpr
+import com.netflix.atlas.core.stacklang.Interpreter
+import com.typesafe.config.ConfigFactory
+import org.scalatest.funsuite.AnyFunSuite
+
+class SimpleLegendsSuite extends AnyFunSuite {
+
+  private val notSet = "__NOT_SET__"
+
+  private val interpreter = Interpreter(new CustomVocabulary(ConfigFactory.load()).allWords)
+
+  private def eval(str: String): List[StyleExpr] = {
+    interpreter
+      .execute(str)
+      .stack
+      .map {
+        case ModelExtractors.PresentationType(t) => t
+        case v                                   => throw new MatchError(v)
+      }
+      .reverse
+      .flatMap(_.perOffset)
+  }
+
+  private def legends(str: String): List[String] = {
+    SimpleLegends.generate(eval(str)).map(_.settings.getOrElse("legend", notSet))
+  }
+
+  test("honor explicit legend") {
+    assert(legends("name,cpu,:eq,:sum,foo,:legend") === List("foo"))
+  }
+
+  test("just math") {
+    assert(legends("4,5,:add,10,:mul") === List(notSet))
+  }
+
+  test("reqular query and just math") {
+    assert(legends("name,cpu,:eq,:sum,seconds,:time") === List("cpu", notSet))
+  }
+
+  test("prefer just name") {
+    assert(legends("name,cpu,:eq,:sum") === List("cpu"))
+    assert(legends("name,cpu,:eq,id,user,:eq,:and,:sum") === List("cpu"))
+  }
+
+  test("use group by keys") {
+    assert(legends("name,cpu,:eq,:sum,(,app,id,),:by") === List("$app $id"))
+  }
+
+  test("name with math") {
+    assert(legends("name,cpu,:eq,:sum,4,:add,6,:mul,:abs") === List("cpu"))
+  }
+
+  test("name regex") {
+    assert(legends("name,cpu,:re,:sum") === List("cpu"))
+  }
+
+  test("name not present") {
+    assert(legends("id,user,:eq,:sum") === List("user"))
+  }
+
+  test("name with offsets") {
+    val expr = "name,cpu,:eq,:sum,(,0h,1w,),:offset"
+    assert(legends(expr) === List("cpu", "cpu (offset=$atlas.offset)"))
+  }
+
+  test("name with avg") {
+    assert(legends("name,cpu,:eq,:avg") === List("cpu"))
+  }
+
+  test("name with dist avg") {
+    assert(legends("name,cpu,:eq,:dist-avg") === List("cpu"))
+  }
+
+  test("name with dist-stddev") {
+    assert(legends("name,cpu,:eq,:dist-stddev") === List("cpu"))
+  }
+
+  test("name not clause") {
+    assert(legends("name,cpu,:eq,:not,:sum") === List("!cpu"))
+  }
+
+  test("name with node avg") {
+    assert(legends("name,cpu,:eq,:node-avg") === List("cpu"))
+  }
+
+  test("group by with offsets") {
+    val expr = "name,cpu,:eq,:sum,(,id,),:by,(,0h,1w,),:offset"
+    assert(legends(expr) === List("$id", "$id (offset=$atlas.offset)"))
+  }
+
+  test("complex: same name and math") {
+    assert(legends("name,cpu,:eq,:sum,:dup,:add") === List("cpu"))
+  }
+
+  test("complex: not clause") {
+    val expr = "name,cpu,:eq,:dup,id,user,:eq,:and,:sum,:swap,id,user,:eq,:not,:and,:sum"
+    assert(legends(expr) === List("user", "!user"))
+  }
+
+  test("complex: different names and math") {
+    assert(legends("name,cpu,:eq,:sum,name,disk,:eq,:sum,:and") === List(notSet))
+  }
+
+  test("multi: different names") {
+    assert(legends("name,cpu,:eq,:sum,name,disk,:eq,:sum") === List("cpu", "disk"))
+  }
+
+  test("multi: same name further restricted") {
+    val vs = legends(
+      "name,cpu,:eq,:sum," +
+      "name,cpu,:eq,id,user,:eq,:and,:sum," +
+      "name,cpu,:eq,id,system,:eq,:and,:sum," +
+      "name,cpu,:eq,id,idle,:eq,:and,:sum,"
+    )
+    assert(vs === List("cpu", "user", "system", "idle"))
+  }
+
+  test("multi: same name with math") {
+    val vs = legends("name,cpu,:eq,:sum,:dup,4,:add")
+    assert(vs === List("cpu", "cpu"))
+  }
+}


### PR DESCRIPTION
The default legends just summarize the expression and are
often hard to read and get truncated. This change adds a
helper that tries to generate a simplified legend if the
user has not set the legend explicitly. It will look at
the full set of expressions being rendered and try to
emphasize differences where possible.

Example:

```
  Expr:
       nf.cluster,www-main,:eq,
       name,apache.http.request,:eq,:and,
       :dist-stddev

Before:
       sqrt(
         (
           (
             (
               (statistic=count) and (
                 (nf.cluster=www-main) and (name=apache.http.request)
               )
               *
               (statistic=totalOfSquares) and (
                 (nf.cluster=www-main) and (name=apache.http.request)
               )
             )
             -
             (
               (statistic in (totalAmount,totalTime)) and (
                 (nf.cluster=www-main) and (name=apache.http.request)
               )
               *
               (statistic in (totalAmount,totalTime)) and (
                 (nf.cluster=www-main) and (name=apache.http.request)
               )
             )
           )
           /
           (
             (statistic=count) and (
               (nf.cluster=www-main) and (name=apache.http.request)
             )
             *
             (statistic=count) and (
               (nf.cluster=www-main) and (name=apache.http.request)
             )
           )
         )
       )

 After:
       apache.http.request
```

This can be disabled by setting:

```
atlas.eval.graph.simple-legends-enabled = false
```