### PR TITLE
binary ops with a subset of group by keys

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
@@ -34,9 +34,7 @@ sealed trait DataExpr extends TimeSeriesExpr with Product {
 
   def isGrouped: Boolean = false
 
-  def groupByKey(tags: Map[String, String]): Option[String] = {
-    Some(TaggedItem.computeId(tags).toString)
-  }
+  def groupByKey(tags: Map[String, String]): Option[String] = None
 
   def finalGrouping: List[String] = Nil
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataExprSuite.scala
@@ -21,8 +21,6 @@ class DataExprSuite extends AnyFunSuite {
   test("groupByKey") {
     val expr = DataExpr.Sum(Query.True)
     val tags = Map("name" -> "foo")
-    val expected = Some(TaggedItem.computeId(tags).toString)
-    val key = expr.groupByKey(tags)
-    assert(expected === key)
+    assert(expr.groupByKey(tags) === None)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataGroupBySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataGroupBySuite.scala
@@ -109,10 +109,25 @@ class DataGroupBySuite extends AnyFunSuite {
     assert(e.getMessage.startsWith("both sides of binary operation"))
   }
 
-  test("binary ops: subset") {
-    val e = intercept[IllegalArgumentException] {
-      binaryOp(List("name", "value"), List("name"))
+  test("binary ops: lhs subset") {
+    // LHS: sum of even values < 10 (20)
+    // RHS: all values from 0 until 10
+    val rs = binaryOp(List("name"), List("name", "value"))
+    assert(rs.size === 10)
+    rs.foreach { t =>
+      val rhsValue = t.tags("value").toDouble
+      assert(t.datapoint(start).value === 20.0 + rhsValue)
     }
-    assert(e.getMessage.startsWith("both sides of binary operation"))
+  }
+
+  test("binary ops: rhs subset") {
+    // LHS: even values 0, 2, 4, 6, and 8
+    // RHS: sum of 0 to 9 (45)
+    val rs = binaryOp(List("name", "value"), List("name"))
+    assert(rs.size === 5)
+    rs.foreach { t =>
+      val lhsValue = t.tags("value").toDouble
+      assert(t.datapoint(start).value === 45.0 + lhsValue)
+    }
   }
 }


### PR DESCRIPTION
This change add support for binary operations where both
sides are grouped and the keys for one side is a subset
of the other. Before the keys would have to match exactly.
When one side has a subset, the matching for entries will
be performed using the smaller set of keys.

For example, suppose that dimensions `a` and `b` each have
two values:

```
Expr: q1,(,a,b,),:by, q2,(,a,),:by, :add

Result Set:
      q1:a1b1 + q2:a1
      q1:a1b2 + q2:a1
      q1:a2b1 + q2:a2
      q1:a2b2 + q2:a2
```