### PR TITLE
add topk/bottomk operators

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/SummaryStats.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/SummaryStats.scala
@@ -56,4 +56,15 @@ case class SummaryStats(count: Int, min: Double, max: Double, last: Double, tota
     TagKey.last  -> formatter(last),
     TagKey.total -> formatter(total)
   )
+
+  /** Return the value of a statistic based on the name. */
+  def get(stat: String): Double = stat match {
+    case "avg"   => avg
+    case "max"   => max
+    case "min"   => min
+    case "last"  => last
+    case "total" => total
+    case "count" => count
+    case s       => throw new IllegalArgumentException(s"unknown statistic: $s")
+  }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/BoundedPriorityBuffer.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/BoundedPriorityBuffer.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import java.util.Comparator
+import java.util.PriorityQueue
+
+/**
+  * Fixed size buffer that can be used for computing the top-K items.
+  *
+  * @param maxSize
+  *     Maximum size of the buffer.
+  * @param comparator
+  *     Comparator used for checking the relative priority of entries.
+  */
+class BoundedPriorityBuffer[T <: AnyRef](maxSize: Int, comparator: Comparator[T]) {
+  require(maxSize > 0, "maxSize must be > 0")
+
+  private val queue = new PriorityQueue[T](comparator.reversed())
+
+  /**
+    * Add a value into the buffer if there is space or it has a higher priority than the
+    * lowest priority item currently in the buffer. If it has the same priority as the lowest
+    * priority item, then the previous value will be retained and the new value will be
+    * rejected.
+    *
+    * @param value
+    *     Value to attempt to add into the buffer.
+    * @return
+    *     True if the value was added into the buffer.
+    */
+  def add(value: T): Boolean = {
+    if (queue.size == maxSize) {
+      // Buffer is full, check if the new value is higher priority than the lowest priority
+      // item in the heap
+      val lowestPriorityItem = queue.peek()
+      if (comparator.compare(value, lowestPriorityItem) < 0) {
+        queue.poll()
+        queue.offer(value)
+      } else {
+        false
+      }
+    } else {
+      queue.offer(value)
+    }
+  }
+
+  /** Number of items in the buffer. */
+  def size: Int = {
+    queue.size
+  }
+
+  /** Invoke the function `f` for all items in the buffer. */
+  def foreach(f: T => Unit): Unit = {
+    queue.forEach(v => f(v))
+  }
+
+  /** Return a list containing all of the items in the buffer. */
+  def toList: List[T] = {
+    val builder = List.newBuilder[T]
+    val it = queue.iterator()
+    while (it.hasNext) {
+      builder += it.next()
+    }
+    builder.result()
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/BoundedPriorityBufferSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/BoundedPriorityBufferSuite.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.util.Comparator
+
+class BoundedPriorityBufferSuite extends AnyFunSuite {
+
+  test("buffer is bounded, natural order") {
+    val buffer = new BoundedPriorityBuffer[Integer](5, Comparator.naturalOrder[Integer]())
+    (0 until 10).foreach(v => buffer.add(v))
+    assert(buffer.toList.toSet === (0 until 5).toSet)
+    assert(buffer.size == 5)
+  }
+
+  test("buffer is bounded, reversed order") {
+    val cmp = Comparator.naturalOrder[Integer]().reversed()
+    val buffer = new BoundedPriorityBuffer[Integer](5, cmp)
+    (0 until 10).foreach(v => buffer.add(v))
+    assert(buffer.toList.toSet === (5 until 10).toSet)
+    assert(buffer.size == 5)
+  }
+
+  test("duplicate values, prefer first to come") {
+    val cmp: Comparator[(Integer, Integer)] = (a, b) => Integer.compare(a._1, b._1)
+    val buffer = new BoundedPriorityBuffer[(Integer, Integer)](5, cmp)
+    (0 until 10).foreach(v => buffer.add(1.asInstanceOf[Integer] -> (9 - v).asInstanceOf[Integer]))
+    assert(buffer.toList.map(_._2).toSet === (5 until 10).toSet)
+  }
+
+  test("foreach") {
+    val buffer = new BoundedPriorityBuffer[Integer](3, Comparator.naturalOrder[Integer]())
+    (0 until 10).foreach(v => buffer.add(v))
+    val builder = Set.newBuilder[Integer]
+    buffer.foreach(v => builder += v)
+    assert(builder.result() === Set(0, 1, 2))
+  }
+
+  test("max size of 0") {
+    intercept[IllegalArgumentException] {
+      new BoundedPriorityBuffer[Integer](0, Comparator.naturalOrder[Integer]())
+    }
+  }
+
+  test("negative max size") {
+    intercept[IllegalArgumentException] {
+      new BoundedPriorityBuffer[Integer](-3, Comparator.naturalOrder[Integer]())
+    }
+  }
+}


### PR DESCRIPTION
Add filtering operators to collect the top/bottom `K`
time series based on a summary statistic. This is the
first part of #1224. A follow up PR will add the
variant that aggregates the others category.