### PR TITLE
add features flag to graph API

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterVocabulary.scala
@@ -261,5 +261,7 @@ object FilterVocabulary extends Vocabulary {
 
     override def examples: List[String] =
       List("name,sps,:eq,:sum,(,nf.cluster,),:by,max,5")
+
+    override def isStable: Boolean = false
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Context.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Context.scala
@@ -15,6 +15,8 @@
  */
 package com.netflix.atlas.core.stacklang
 
+import com.netflix.atlas.core.util.Features
+
 /**
   * State related to the execution of a stack language expression.
   *
@@ -32,13 +34,16 @@ package com.netflix.atlas.core.stacklang
   * @param frozenStack
   *     Separate stack that has been frozen to prevent further modification. See the
   *     `:freeze` operator for more information.
+  * @param features
+  *     Set of features that are permitted for the execution.
   */
 case class Context(
   interpreter: Interpreter,
   stack: List[Any],
   variables: Map[String, Any],
   initialVariables: Map[String, Any] = Map.empty,
-  frozenStack: List[Any] = Nil
+  frozenStack: List[Any] = Nil,
+  features: Features = Features.STABLE
 ) {
 
   /**

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Word.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Word.scala
@@ -35,6 +35,12 @@ trait Word {
   def examples: List[String]
 
   /**
+    * Returns true if this operation is considered stable. New operations should override
+    * this method to return false until the API is finalized.
+    */
+  def isStable: Boolean = true
+
+  /**
     * Check if the this word can be executed against the current stack. Can be used as a basis for
     * finding auto-completion candidates.
     */

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Features.java
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Features.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util;
+
+/**
+ * Set of features that are enabled for the API.
+ */
+public enum Features {
+  /** Default feature set that is stable and the user can rely on. */
+  STABLE,
+
+  /**
+   * Indicates that unstable features should be enabled for testing by early adopters.
+   * Features in this set can change at anytime without notice. A feature should not stay
+   * in this state for a long time. A few months should be considered an upper bound.
+   */
+  UNSTABLE
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/FreezeSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/FreezeSuite.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.core.stacklang
 
+import com.netflix.atlas.core.util.Features
 import org.scalatest.funsuite.AnyFunSuite
 
 class FreezeSuite extends AnyFunSuite {
@@ -42,7 +43,7 @@ class FreezeSuite extends AnyFunSuite {
 
   test("original variables are preserved") {
     val vars = Map("foo" -> "original", "bar" -> "2")
-    val context = interpreter.execute("foo,1,:set,:freeze,foo,:get,bar,:get", vars)
+    val context = interpreter.execute("foo,1,:set,:freeze,foo,:get,bar,:get", vars, Features.STABLE)
     assert(context.stack === List("2", "original"))
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/InterpreterSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/InterpreterSuite.scala
@@ -128,7 +128,7 @@ class InterpreterSuite extends AnyFunSuite {
   }
 
   test("toString") {
-    assert(interpreter.toString === "Interpreter(8 words)")
+    assert(interpreter.toString === "Interpreter(9 words)")
   }
 
   test("typeSummary: String") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/InterpreterSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/InterpreterSuite.scala
@@ -29,7 +29,8 @@ class InterpreterSuite extends AnyFunSuite {
       Overloaded("overloaded2", "one", false),
       Overloaded("overloaded2", "two", true),
       Overloaded("overloaded2", "three", true),
-      Overloaded("no-match", "one", false)
+      Overloaded("no-match", "one", false),
+      Unstable
     )
   )
 
@@ -62,6 +63,14 @@ class InterpreterSuite extends AnyFunSuite {
       interpreter.execute(List(":no-match"))
     }
     val expected = "no matches for word ':no-match' with stack [], candidates: [exception]"
+    assert(e.getMessage === expected)
+  }
+
+  test("using unstable word fails by default") {
+    val e = intercept[IllegalStateException] {
+      interpreter.execute(List(":unstable"))
+    }
+    val expected = "to use :unstable enable unstable features"
     assert(e.getMessage === expected)
   }
 
@@ -192,5 +201,24 @@ object InterpreterSuite {
     override def signature: String = if (matches) "* -- * v" else "exception"
 
     override def examples: List[String] = Nil
+  }
+
+  case object Unstable extends Word {
+
+    override def name: String = "unstable"
+
+    override def matches(stack: List[Any]): Boolean = true
+
+    override def execute(context: Context): Context = {
+      context.copy(stack = "unstable" :: context.stack)
+    }
+
+    override def summary: String = ""
+
+    override def signature: String = "* -- * unstable"
+
+    override def examples: List[String] = Nil
+
+    override def isStable: Boolean = false
   }
 }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/GraphConfig.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/GraphConfig.scala
@@ -17,7 +17,6 @@ package com.netflix.atlas.eval.graph
 
 import java.time.Instant
 import java.time.ZoneId
-
 import akka.http.scaladsl.model.ContentType
 import com.netflix.atlas.chart.GraphEngine
 import com.netflix.atlas.chart.model.GraphDef
@@ -26,6 +25,7 @@ import com.netflix.atlas.chart.model.LineDef
 import com.netflix.atlas.chart.model.PlotDef
 import com.netflix.atlas.core.model.EvalContext
 import com.netflix.atlas.core.model.StyleExpr
+import com.netflix.atlas.core.util.Features
 import com.netflix.atlas.core.util.Step
 import com.netflix.atlas.core.util.Strings
 
@@ -42,6 +42,7 @@ case class GraphConfig(
   flags: ImageFlags,
   format: String,
   id: String,
+  features: Features,
   isBrowser: Boolean,
   isAllowedFromBrowser: Boolean,
   uri: String

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GrapherSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GrapherSuite.scala
@@ -417,43 +417,43 @@ class GrapherSuite extends AnyFunSuite with BeforeAndAfterAll {
   }
 
   imageTest("topk") {
-    "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,max,2,:topk"
+    "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,max,2,:topk&features=unstable"
   }
 
   imageTest("topk-others-min") {
-    "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,max,2,:topk-others-min"
+    "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,max,2,:topk-others-min&features=unstable"
   }
 
   imageTest("topk-others-max") {
-    "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,max,2,:topk-others-max"
+    "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,max,2,:topk-others-max&features=unstable"
   }
 
   imageTest("topk-others-sum") {
-    "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,max,2,:topk-others-sum"
+    "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,max,2,:topk-others-sum&features=unstable"
   }
 
   imageTest("topk-others-avg") {
-    "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,max,2,:topk-others-avg"
+    "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,max,2,:topk-others-avg&features=unstable"
   }
 
   imageTest("bottomk") {
-    "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,max,2,:bottomk"
+    "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,max,2,:bottomk&features=unstable"
   }
 
   imageTest("bottomk-others-min") {
-    "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,max,2,:bottomk-others-min"
+    "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,max,2,:bottomk-others-min&features=unstable"
   }
 
   imageTest("bottomk-others-max") {
-    "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,max,2,:bottomk-others-max"
+    "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,max,2,:bottomk-others-max&features=unstable"
   }
 
   imageTest("bottomk-others-sum") {
-    "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,max,2,:bottomk-others-sum"
+    "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,max,2,:bottomk-others-sum&features=unstable"
   }
 
   imageTest("bottomk-others-avg") {
-    "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,max,2,:bottomk-others-avg"
+    "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,max,2,:bottomk-others-avg&features=unstable"
   }
 
   def renderTest(name: String)(uri: => String): Unit = {


### PR DESCRIPTION
The features flag can be used by early adopters to enable
experimental functionality. This reduces the risk on our
side of users becoming reliant on incubating features and
making it hard for us to change them before they have been
fully vetted.

For now, the recently added priority operators are the
only things enabled by selecting unstable features.