### PR TITLE
improve error for invalid stack

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
@@ -126,8 +126,11 @@ case class Grapher(settings: DefaultSettings) {
         .stack
         .reverse
         .flatMap {
-          case ModelExtractors.PresentationType(s) => s.perOffset
-          case v                                   => throw new MatchError(v)
+          case ModelExtractors.PresentationType(s) =>
+            s.perOffset
+          case v =>
+            val tpe = v.getClass.getSimpleName
+            throw new IllegalArgumentException(s"expecting time series expr, found $tpe '$v'")
         }
       if (settings.simpleLegendsEnabled)
         SimpleLegends.generate(exprs)

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GrapherSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GrapherSuite.scala
@@ -456,6 +456,14 @@ class GrapherSuite extends AnyFunSuite with BeforeAndAfterAll {
     "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,max,2,:bottomk-others-avg&features=unstable"
   }
 
+  test("invalid stuff on stack") {
+    val uri = "/api/v1/graph?e=2012-01-01&q=name,sps,:eq,(,nf.cluster,),:by,foo"
+    val e = intercept[IllegalArgumentException] {
+      grapher.toGraphConfig(Uri(uri)).parsedQuery.get
+    }
+    assert(e.getMessage === "expecting time series expr, found String 'foo'")
+  }
+
   def renderTest(name: String)(uri: => String): Unit = {
     test(name) {
       val fname = Strings.zeroPad(Hash.sha1bytes(name), 40).substring(0, 8) + ".png"


### PR DESCRIPTION
If invalid stuff is left on the stack, then return a 400
that gives an indication of the problematic contents rather
than the default MatchError which results in the user getting
a 500 error.