### PR TITLE
increase poll period for rds metric "VolumeBytesUsed" 

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/rds.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/rds.conf
@@ -424,7 +424,14 @@ atlas {
 
     rds-cluster = {
       namespace = "AWS/RDS"
-      period = 10m
+      #
+      # Note: these period parameters are for now based on metric "VolumeBytesUsed" being published
+      # about every hour, and they are configured to include data points within last 90 minutes
+      # (1m * (91 - 1)) to avoid gaps in minutely timeseries.
+      #
+      period = 1m
+      period-count = 91
+      end-period-offset = 1
       timeout = 15m
 
       dimensions = [


### PR DESCRIPTION
Increase poll period for rds metric "VolumeBytesUsed" to avoid data point gaps.