### PR TITLE
add stat-count for consistency

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterExpr.scala
@@ -86,6 +86,11 @@ object FilterExpr {
     def name: String = "last"
   }
 
+  case object StatCount extends StatExpr {
+
+    def name: String = "count"
+  }
+
   case object StatTotal extends StatExpr {
 
     def name: String = "total"

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterVocabulary.scala
@@ -35,6 +35,7 @@ object FilterVocabulary extends Vocabulary {
     StatMax,
     StatMin,
     StatLast,
+    StatCount,
     StatTotal,
     Filter,
     // Legacy operations equivalent to `max,:stat`
@@ -180,6 +181,18 @@ object FilterVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
+  case object StatCount extends StatWord {
+
+    override def name: String = "stat-count"
+
+    def value: FilterExpr = FilterExpr.StatCount
+
+    override def summary: String =
+      """
+        |Represents the `count,:stat` line when used with the filter operation.
+      """.stripMargin.trim
+  }
+
   case object StatTotal extends StatWord {
 
     override def name: String = "stat-total"
@@ -189,18 +202,6 @@ object FilterVocabulary extends Vocabulary {
     override def summary: String =
       """
         |Represents the `total,:stat` line when used with the filter operation.
-      """.stripMargin.trim
-  }
-
-  case object StatCount extends StatWord {
-
-    override def name: String = "stat-count"
-
-    def value: FilterExpr = FilterExpr.StatTotal
-
-    override def summary: String =
-      """
-        |Represents the `count,:stat` line when used with the filter operation.
       """.stripMargin.trim
   }
 

--- a/atlas-webapi/src/main/resources/reference.conf
+++ b/atlas-webapi/src/main/resources/reference.conf
@@ -213,6 +213,7 @@ atlas {
           "stat-max",
           "stat-min",
           "stat-last",
+          "stat-count",
           "stat-total",
           "stat-min-mf",
           "stat-max-mf",


### PR DESCRIPTION
Count was the only summary statistic for which there was
not a helper macro for use with filtering. This adds that
helper to improve consistency.