### PR TITLE
switch blockingQueue to use BoundedSourceQueue

### DIFF
--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
@@ -150,10 +150,15 @@ class StreamOpsSuite extends AnyFunSuite {
       .toMat(Sink.ignore)(Keep.left)
       .run()
     assert(queue.isOpen)
+
     queue.offer(1)
     assert(queue.isOpen)
+    checkOfferedCounts(registry, Map("enqueued" -> 1.0, "droppedQueueClosed" -> 0.0))
+
     queue.complete()
     assert(!queue.isOpen)
+    queue.offer(1)
+    checkOfferedCounts(registry, Map("enqueued" -> 1.0, "droppedQueueClosed" -> 1.0))
   }
 
   private def checkCounts(registry: Registry, name: String, expected: Map[String, Double]): Unit = {


### PR DESCRIPTION
There are some race conditions in the implementation of
the custom blocking queue source that result in:

- The source hanging after complete.
- An item in the queue not getting processed until another
  item is offered if the source is pulled after the push
  immediately check and before the poll call.

In recent versions of akka there is now a bounded source
queue that addresses the memory concerns we had. Rather
than track down the race conditions, this change switches
the internals of the `blockingQueue` helper to use the
BoundedSourceQueue in akka.