### PR TITLE
ensure alpha setting is not lost with toString

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
@@ -27,7 +27,12 @@ import com.netflix.atlas.core.util.Strings
 case class StyleExpr(expr: TimeSeriesExpr, settings: Map[String, String]) extends Expr {
 
   override def toString: String = {
-    val vs = settings.toList.sortWith(_._1 < _._1).map {
+    // Use descending order to ensure that an explicit alpha used with
+    // a palette is not overwritten when reprocessing the expression string.
+    // This works because palette will be sorted before alpha, though a better
+    // future solution would be to use a map that preserves the order of
+    // updates to the object.
+    val vs = settings.toList.sortWith(_._1 > _._1).map {
       case ("sed", v) => v
       case (k, v)     => s"$v,:$k"
     }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleExprSuite.scala
@@ -15,11 +15,14 @@
  */
 package com.netflix.atlas.core.model
 
-import java.time.Duration
+import com.netflix.atlas.core.stacklang.Interpreter
 
+import java.time.Duration
 import org.scalatest.funsuite.AnyFunSuite
 
 class StyleExprSuite extends AnyFunSuite {
+
+  private val interpreter = Interpreter(StyleVocabulary.allWords)
 
   private val oneDay = Duration.ofDays(1)
   private val oneWeek = Duration.ofDays(7)
@@ -77,4 +80,23 @@ class StyleExprSuite extends AnyFunSuite {
   check("hex,:decode,%,_25,:s", "one!_25&?")
   check("hex,:decode,%,_25,:s,hex,:decode", "one!%&?")
   check("none,:decode,%,_25,:s,hex,:decode", "one!%&?")
+
+  private def eval(str: String): StyleExpr = {
+    interpreter.execute(str).stack match {
+      case ModelExtractors.PresentationType(t) :: Nil => t
+      case _                                          => throw new MatchError(str)
+    }
+  }
+
+  test("alpha and color are preserved with exprString") {
+    val expr = eval(":true,ff0000,:color,40,:alpha")
+    val result = eval(expr.toString)
+    assert(expr.settings == result.settings)
+  }
+
+  test("alpha and palette are preserved with exprString") {
+    val expr = eval(":true,reds,:palette,40,:alpha")
+    val result = eval(expr.toString)
+    assert(expr.settings == result.settings)
+  }
 }


### PR DESCRIPTION
When processing operators that modify colors the later
operations will override and win. The expression string
generated for StyleExpr was sorting which means that
`:alpha` would be output before `:palette` even if the
user did them in the reverse order. Since `:palette`
will override a previously set alpha this caused the
setting to get ignored. For now change the sort order
to be descending which should always preserve the user
intent with the current set of style operations.