### PR TITLE
update to akka-http 10.2.4

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import sbt._
 object Dependencies {
   object Versions {
     val akka       = "2.6.12"
-    val akkaHttpV  = "10.2.3"
+    val akkaHttpV  = "10.2.4"
     val aws        = "1.11.946"
     val iep        = "2.6.5"
     val guice      = "4.1.0"


### PR DESCRIPTION
Pull in security fix for CVE-2021-23339:

https://doc.akka.io/docs/akka-http/10.2/release-notes/10.2.x.html#10-2-4