### PR TITLE
re-enable doc artifacts

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/CustomVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/CustomVocabulary.scala
@@ -48,7 +48,7 @@ import com.typesafe.config.Config
   *     The supported fields are:
   *
   *     - `name`: operation name, when the user calls the operation they will use
-  *       `:$name`.
+  *       `:\$name`.
   *     - `body`: expression that is executed for this operation.
   *     - `examples`: set of example stacks that can be used as input to the operator
   *       to show how it works.
@@ -75,7 +75,7 @@ import com.typesafe.config.Config
   *     The supported fields are:
   *
   *     - `name`: operation name, when the user calls the operation they will use
-  *       `:$name`.
+  *       `:\$name`.
   *     - `base-query`: query for the denominator.
   *     - `keys`: tag keys that are available for use on the denominator.
   */

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -930,7 +930,7 @@ object MathExpr {
     * @param context
     *     Evaluation context for the initial creation time. This context is used to
     *     re-evaluate the rewrite using the original context if the overall expression
-    *     is rewritten ([[Expr.rewrite()]]) later.
+    *     is rewritten (`Expr.rewrite()`) later.
     */
   case class NamedRewrite(
     name: String,

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Shards.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Shards.scala
@@ -59,7 +59,7 @@ object Shards {
   /**
     * Creates a mapper used to route data to the appropriate instance. This form is typically
     * used as data is flowing into the system when replicas are not a concern. If replication
-    * is needed, then see [[replicaMapper()]] instead.
+    * is needed, then see `replicaMapper` instead.
     *
     * @param group
     *     Single group that makes up the complete data set.
@@ -71,7 +71,7 @@ object Shards {
   /**
     * Creates a mapper used to route data to the appropriate instance. This form is typically
     * used as data is flowing into the system when replicas are not a concern. If replication
-    * is needed, then see [[replicaMapper()]] instead.
+    * is needed, then see `replicaMapper` instead.
     *
     * @param groups
     *     Set of groups that makes up the complete data set.

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeGroup.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeGroup.scala
@@ -19,7 +19,7 @@ import com.netflix.atlas.core.model.DataExpr
 
 /**
   * A group of values for the same timestamp. This type is typically created as the result
-  * of using the [[com.netflix.atlas.eval.stream.TimeGrouped]] operator on the stream.
+  * of using the `com.netflix.atlas.eval.stream.TimeGrouped` operator on the stream.
   *
   * The values map should always be non-empty and have datapoints for all entries. Empty
   * entries should be omitted.

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/Evaluator.java
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/Evaluator.java
@@ -101,9 +101,9 @@ public final class Evaluator extends EvaluatorImpl {
    * the backend producing the data.
    *
    * It takes a stream of data sources as an input and returns the output of evaluating
-   * those streams. Each {@link DataSources} object should be the complete set of
+   * those streams. Each {@code DataSources} object should be the complete set of
    * sources that should be evaluated at a given time. The output messages can be
-   * correlated with a particular data source using the id on the {@link MessageEnvelope}.
+   * correlated with a particular data source using the id on the {@code MessageEnvelope}.
    */
   public Processor<DataSources, MessageEnvelope> createStreamsProcessor() {
     return createStreamsProcessorImpl();

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/util/HostRewriter.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/util/HostRewriter.scala
@@ -34,7 +34,7 @@ import com.typesafe.config.Config
   * ```
   *
   * This config would extract the second portion of the host name and use it as a region
-  * restriction (`region,$1,:eq`). The first group will be used as the value for the restriction
+  * restriction (`region,\$1,:eq`). The first group will be used as the value for the restriction
   * query.
   */
 class HostRewriter(config: Config) {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/util/SmallHashMapDeserializer.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/util/SmallHashMapDeserializer.scala
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer
 import com.netflix.atlas.core.util.SmallHashMap
 
 /**
-  * Custom deserializer for tag maps to go directly to [[SmallHashMap]] type. It is assumed
+  * Custom deserializer for tag maps to go directly to `SmallHashMap` type. It is assumed
   * that each tag map should have a relatively small number of entries.
   */
 class SmallHashMapDeserializer extends JsonDeserializer[SmallHashMap[String, String]] {

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
@@ -102,7 +102,7 @@ class SubscriptionManager[T] extends StrictLogging {
 
   /**
     * Register a new stream with the provided id. The `handler` is used by the caller to
-    * interact with the stream. The caller can use [[handlersForSubscription()]] to get a
+    * interact with the stream. The caller can use `handlersForSubscription()` to get a
     * list of handlers that should be called for a given subscription.
     *
     * Returns true if it is a new registration.

--- a/atlas-module-akka/src/main/scala/com/netflix/atlas/akka/AkkaModule.scala
+++ b/atlas-module-akka/src/main/scala/com/netflix/atlas/akka/AkkaModule.scala
@@ -34,7 +34,7 @@ import scala.concurrent.duration.Duration
 
 /**
   * Configures the actor system and web server. This module expects that bindings
-  * are available for [[com.typesafe.config.Config]] and [[com.netflix.spectator.api.Registry]].
+  * are available for `com.typesafe.config.Config` and `com.netflix.spectator.api.Registry`.
   */
 final class AkkaModule extends AbstractModule {
 

--- a/atlas-module-eval/src/main/scala/com/netflix/atlas/eval/EvalModule.scala
+++ b/atlas-module-eval/src/main/scala/com/netflix/atlas/eval/EvalModule.scala
@@ -29,7 +29,7 @@ import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
 
 /**
-  * Configures a binding for an [[Evaluator]] instance.
+  * Configures a binding for an `Evaluator` instance.
   */
 final class EvalModule extends AbstractModule {
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -49,11 +49,7 @@ object BuildSettings {
       "Build-Date"   -> java.time.Instant.now().toString,
       "Build-Number" -> sys.env.getOrElse("GITHUB_RUN_ID", "unknown"),
       "Commit"       -> sys.env.getOrElse("GITHUB_SHA", "unknown")
-    ),
-    // scaladoc crashes on jdk11 using `-release 8` with assertion failure:
-    // type AnyRef in java.lang
-    // https://github.com/scala/community-builds/issues/796#issuecomment-423395500
-    publishArtifact in (Compile, packageDoc) := false
+    )
   )
 
   val commonDeps = Seq(


### PR DESCRIPTION
They were disabled due to a bug, but looks like it
has been fixed. Fixed a number of scaladoc errors
to get the build clean.

Error from publishing attempt without docs:

```
Failed: javadoc-staging, failureMessage:Missing: no javadoc
  jar found in folder
  '/com/netflix/atlas_v1/atlas-module-lwcapi_2.13/1.7.0-rc.14'
```