### PR TITLE
extract all keys from Query and DataExpr

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
@@ -112,6 +112,10 @@ object DataExpr {
     builder.toString
   }
 
+  def allKeys(dataExpr: DataExpr): Set[String] = {
+    Query.allKeys(dataExpr.query) ++ dataExpr.finalGrouping
+  }
+
   case class All(query: Query, offset: Duration = Duration.ZERO) extends DataExpr {
 
     def cf: ConsolidationFunction = ConsolidationFunction.Sum

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
@@ -76,6 +76,19 @@ object Query {
   }
 
   /**
+    * Return the set of keys referenced by in the query.
+    */
+  def allKeys(query: Query): Set[String] = {
+    query match {
+      case And(q1, q2) => allKeys(q1) ++ allKeys(q2)
+      case Or(q1, q2)  => allKeys(q1) ++ allKeys(q2)
+      case Not(q)      => allKeys(q)
+      case q: KeyQuery => Set(q.k)
+      case _           => Set.empty
+    }
+  }
+
+  /**
     * Extract a set of tags for the query based on the `:eq` clauses.
     */
   def tags(query: Query): Map[String, String] = {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataExprSuite.scala
@@ -23,4 +23,14 @@ class DataExprSuite extends AnyFunSuite {
     val tags = Map("name" -> "foo")
     assert(expr.groupByKey(tags) === None)
   }
+
+  test("allKeys") {
+    val expr = DataExpr.Sum(Query.Equal("k1", "v1"))
+    assert(DataExpr.allKeys(expr) === Set("k1"))
+  }
+
+  test("allKeys with GroupBy") {
+    val expr = DataExpr.GroupBy(DataExpr.Sum(Query.Equal("k1", "v1")), List("k1", "k2"))
+    assert(DataExpr.allKeys(expr) === Set("k1", "k2"))
+  }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
@@ -394,6 +394,48 @@ class QuerySuite extends AnyFunSuite {
     assert(Query.exactKeys(q) === Set.empty)
   }
 
+  test("allKeys no key") {
+    val q1 = Query.False
+    assert(Query.allKeys(q1) === Set.empty)
+    val q2 = Query.True
+    assert(Query.allKeys(q2) === Set.empty)
+  }
+
+  test("allKeys ignore not") {
+    val q = Query.Not(Equal("k", "v"))
+    assert(Query.allKeys(q) === Set("k"))
+  }
+
+  test("allKeys eq") {
+    val q = Equal("k", "v")
+    assert(Query.allKeys(q) === Set("k"))
+  }
+
+  test("allKeys and eq") {
+    val q = And(Equal("k", "v"), Equal("p", "q"))
+    assert(Query.allKeys(q) === Set("k", "p"))
+  }
+
+  test("allKeys and hasKey") {
+    val q = Query.And(a, b)
+    assert(Query.allKeys(q) === Set("A", "B"))
+  }
+
+  test("allKeys or") {
+    val q = Or(Equal("k", "v"), Equal("p", "q"))
+    assert(Query.allKeys(q) === Set("k", "p"))
+  }
+
+  test("allKeys or - same key") {
+    val q = Or(Equal("k", "v"), Equal("k", "q"))
+    assert(Query.allKeys(q) === Set("k"))
+  }
+
+  test("allKeys or - one side no key") {
+    val q = Or(Equal("k", "v"), True)
+    assert(Query.allKeys(q) === Set("k"))
+  }
+
   test("cnfList (a)") {
     val q = a
     assert(Query.cnfList(q) === List(q))


### PR DESCRIPTION
Add api to extract all keys from Query and DataExpr. 
This is preparing for auto rollup, to check if any key has been dropped or rolled up for a given DataExpr.