### PR TITLE
add cloudwatch mapping for RDS DBLoad metrics

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/rds.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/rds.conf
@@ -24,6 +24,28 @@ atlas {
           conversion = "max"
         },
         {
+          name = "DBLoadCPU"
+          alias = "aws.rds.numActiveSessions"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "cpu"
+            }
+          ]
+        },
+        {
+          name = "DBLoadNonCPU"
+          alias = "aws.rds.numActiveSessions"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "nonCpu"
+            }
+          ]
+        },
+        {
           name = "FreeableMemory"
           alias = "aws.rds.memoryFree"
           conversion = "max"


### PR DESCRIPTION
Add cloudwatch mapping for RDS DBLoad metrics. 
Note that Performance Insights needs to enabled for a db instance for these metrics to be available: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.Enabling.html
