### PR TITLE
add directive to force connection close

### DIFF
--- a/atlas-akka/src/main/resources/reference.conf
+++ b/atlas-akka/src/main/resources/reference.conf
@@ -46,6 +46,10 @@ atlas.akka {
 
     # Should access logging be enabled?
     access-log = true
+
+    # Probability for adding connection close header to response. A value of 0.0
+    # means it will never be added, 1.0 means it will always be added.
+    close-probability = 0.0
   }
 
   # Settings for the StaticPages API

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerNoCompressionSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerNoCompressionSuite.scala
@@ -46,6 +46,7 @@ class RequestHandlerNoCompressionsSuite extends AnyFunSuite with ScalatestRouteT
       |atlas.akka.request-handler {
       |  compression = false
       |  access-log = false
+      |  close-probability = 0.0
       |}
     """.stripMargin
   )

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerSuite.scala
@@ -51,6 +51,7 @@ class RequestHandlerSuite extends AnyFunSuite with ScalatestRouteTest {
       |atlas.akka.request-handler {
       |  compression = true
       |  access-log = true
+      |  close-probability = 0.0
       |}
     """.stripMargin
   )


### PR DESCRIPTION
For load balancers that work at the TCP level there can
be an imbalance in traffic if clients reuse connections.
The `closeConnection` directive can be used to mitigate
this by adding an explicit `Connection: close` header to
the responses.

In order to allow some reuse, a probability can be set
to tune how frequently the header is applied. This also
avoids the need to track details like the number of
requests per connection for more complex policies.