### PR TITLE
improve performance for findValues

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndex.scala
@@ -400,55 +400,6 @@ class RoaringTagIndex[T <: TaggedItem](items: Array[T], stats: IndexStats) exten
     }
   }
 
-  def findValuesOld(query: TagQuery): List[String] = {
-    require(query.key.isDefined)
-    val k = query.key.get
-    val kp = keyMap.get(k, -1)
-    if (kp < 0) return Nil
-
-    val has = Query.HasKey(k)
-    val q = query.query.fold[Query](has)(q => q.and(has))
-    val itemSet = findImpl(q, 0)
-    val offset = findOffset(values, query.offset)
-
-    val results = new util.BitSet(values.length)
-
-    // If there are many items with the same value for a key, then we can prune the item set
-    // by doing an AND NOT operation with set for that key and value. This will perform worse
-    // if there aren't a lot of items with the same value. We estimate the chances by comparing
-    // the cardinality of the key with the number of items. For less than 5% it is assumed that
-    // pruning is the better option.
-    val keyCardinality = itemIndex.get(kp).size
-    val attemptPruning = (100.0 * keyCardinality / items.length) < 5.0
-
-    // Find all matching values by looking up the key for each matching item
-    var iter = itemSet.getIntIterator
-    while (iter.hasNext) {
-      val i = iter.next()
-      val tags = itemTags(i)
-      val v = tags.get(kp, -1)
-      if (v >= offset && !results.get(v)) {
-        results.set(v)
-      } else if (v >= 0 && attemptPruning) {
-        // If the value is repeated, then lookup the set of all items with the given value
-        // for the key and removing those from the item set
-        itemSet.andNot(equal(kp, v))
-        iter = itemSet.getIntIterator
-      }
-    }
-
-    createResultList(values, results, query.limit)
-  }
-
-  private def equal(k: Int, v: Int): RoaringBitmap = {
-    val vidx = itemIndex.get(k)
-    if (vidx == null) new RoaringBitmap()
-    else {
-      val matchSet = vidx.get(v)
-      if (matchSet == null) new RoaringBitmap() else matchSet
-    }
-  }
-
   def findValues(query: TagQuery): List[String] = {
     require(query.key.isDefined)
     val k = query.key.get

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntRefHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntRefHashMap.scala
@@ -112,6 +112,16 @@ class IntRefHashMap[T <: AnyRef: Manifest](noData: Int, capacity: Int = 10) {
     }
   }
 
+  /** Execute `f` for each key in the map. */
+  def foreachKey(f: Int => Unit): Unit = {
+    var i = 0
+    while (i < keys.length) {
+      val k = keys(i)
+      if (k != noData) f(k)
+      i += 1
+    }
+  }
+
   /** Return the number of items in the set. This is a constant time operation. */
   def size: Int = used
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/RoaringTagIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/RoaringTagIndexSuite.scala
@@ -16,10 +16,42 @@
 package com.netflix.atlas.core.index
 
 import com.netflix.atlas.core.model.TimeSeries
+import org.roaringbitmap.RoaringBitmap
 
 class RoaringTagIndexSuite extends TagIndexSuite {
 
   val index: TagIndex[TimeSeries] = {
     new RoaringTagIndex(TagIndexSuite.dataset.toArray, new IndexStats())
+  }
+
+  test("hasNonEmptyIntersection: empty, empty") {
+    val b1 = new RoaringBitmap()
+    val b2 = new RoaringBitmap()
+    assert(!RoaringTagIndex.hasNonEmptyIntersection(b1, b2))
+  }
+
+  test("hasNonEmptyIntersection: equal") {
+    val b1 = new RoaringBitmap()
+    b1.add(10)
+    val b2 = new RoaringBitmap()
+    b2.add(10)
+    assert(RoaringTagIndex.hasNonEmptyIntersection(b1, b2))
+  }
+
+  test("hasNonEmptyIntersection: no match") {
+    val b1 = new RoaringBitmap()
+    (0 until 20 by 2).foreach(b1.add)
+    val b2 = new RoaringBitmap()
+    (1 until 21 by 2).foreach(b2.add)
+    assert(!RoaringTagIndex.hasNonEmptyIntersection(b1, b2))
+  }
+
+  test("hasNonEmptyIntersection: last match") {
+    val b1 = new RoaringBitmap()
+    (0 until 22 by 2).foreach(b1.add)
+    val b2 = new RoaringBitmap()
+    (1 until 21 by 2).foreach(b2.add)
+    b2.add(20)
+    assert(RoaringTagIndex.hasNonEmptyIntersection(b1, b2))
   }
 }


### PR DESCRIPTION
Updates the RoaringTagIndex.findValues method to loop
over the set of values for a key rather than the set
of matching items in some cases. Depending on the number
of matches, this can often be much faster.

Performance difference was tested using the data from
one of the large prod clusters. The first is just dumping
all values for a given key with no query restriction.
This is the ideal case for this change as before it would
require analyzing all items in the index with that key.

The second test was to dump all values for a key in a
given region. For some values, like the region key it can
be close to the worst case for looping across the values
because keys like region, zone, asg, and node are specific
to a region. The worst case for `hasNonEmptyIntersection`
is when both bitmaps have a lot of values and the result
is empty. While those cases do get a bit worse with this
change, overall it seems worthwhile for improvements to
more common cases.

**Results**

`/api/v1/tags/$key`

|             key | before (ms) |  after (ms) |
|-----------------|-------------|-------------|
|          nf.app |       34.34 |        0.32 |
|      nf.cluster |       89.36 |        0.50 |
|          nf.asg |       96.59 |        0.74 |
|         nf.node |       97.88 |        8.91 |
|      nf.account |        0.96 |        0.01 |
|       nf.region |        0.11 |        0.01 |
|         nf.zone |        0.84 |        0.01 |
|            name |       76.66 |        0.29 |

`/api/v1/tags/$key?q=nf.region,us-east-1,:eq`

|             key | before (ms) |  after (ms) |
|-----------------|-------------|-------------|
|          nf.app |       18.44 |        2.90 |
|      nf.cluster |       46.78 |        9.79 |
|          nf.asg |       47.12 |       57.23 |
|         nf.node |       70.41 |       78.08 |
|      nf.account |        0.84 |        0.19 |
|       nf.region |        0.16 |       15.94 |
|         nf.zone |        0.24 |       31.48 |
|            name |       53.75 |        2.03 |