### PR TITLE
auto rollup or drop tags based on cardinality limits

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/limiter/CardinalityLimiter.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/limiter/CardinalityLimiter.scala
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.limiter
+
+import com.netflix.atlas.core.model.Query
+import com.netflix.atlas.core.model.TaggedItem
+import com.netflix.atlas.core.limiter.CardinalityLimiter._
+import com.netflix.atlas.core.util.BoundedPriorityBuffer
+import com.netflix.atlas.core.util.CardinalityEstimator
+import com.typesafe.config.Config
+
+import java.util.concurrent.ConcurrentHashMap
+import scala.jdk.CollectionConverters._
+
+/**
+  * A structure that tracks cardinality based on tag keys, and drop or rollup tags based on given
+  * configuration.
+  */
+abstract class CardinalityLimiter(val limiterConfig: LimiterConfig) {
+
+  protected val totalEstimator: CardinalityEstimator = CardinalityEstimator.newSyncEstimator()
+
+  /**
+    * Update cardinality stats for the given tags.
+    * @param tags
+    *   tags to track
+    * @param id
+    *   id that represents the tags
+    * @return
+    *   - null if it should be dropped
+    *   - updated tags if tag roll up happened
+    *   - same object with input tags otherwise
+    */
+  def update(tags: Map[String, String], id: AnyRef): Map[String, String]
+
+  /**
+    * Default to [[TaggedItem.computeId]] to compute id.
+    */
+  def update(tags: Map[String, String]): Map[String, String] = {
+    update(tags, TaggedItem.computeId(tags))
+  }
+
+  /** Get total cardinality for total tags ever seen. */
+  def cardinality: Long = totalEstimator.cardinality
+
+  /**
+    * Get cardinality for a given list of values of prefix keys.
+    */
+  def cardinalityBy(values: List[String]): Long
+
+  /**
+    * Get cardinality for a given list of values of prefix keys and a specific tag key.
+    */
+  def cardinalityBy(values: List[String], tagKey: String): Long
+
+  /**
+    * Check if a query can be served based on the cardinality stats and defined limits.
+    */
+  def canServe(query: Query): Boolean = canServe(QueryInfo(query, limiterConfig))
+
+  private[limiter] def canServe(queryInfo: QueryInfo): Boolean
+
+  /**
+    * A convenient way get topk keys by cardinality at all levels, mainly used for debug/inspect.
+    */
+  def topk(k: Int): AnyRef
+}
+
+/**
+  * Non-leaf node of the tree, tracks stats by prefix keys.
+  */
+private[limiter] class CardinalityLimiterInner(
+  override val limiterConfig: LimiterConfig,
+  val level: Int
+) extends CardinalityLimiter(limiterConfig) {
+  private val children = new ConcurrentHashMap[String, CardinalityLimiter]
+  // Note: For now a dropped value should not be added even if a slot gets freed up, because data
+  // may be incomplete.
+  private val droppedValues: java.util.Set[String] = ConcurrentHashMap.newKeySet()
+
+  override def update(
+    tags: Map[String, String],
+    id: AnyRef
+  ): Map[String, String] = {
+    val key = limiterConfig.prefixKeys(level)
+    val value = tags.getOrElse(key, MissingKey)
+    val conf = limiterConfig.getPrefixConfig(level)
+
+    def reachLimit: Boolean = {
+      conf.totalLimit > 0 && (cardinality >= conf.totalLimit || children.size() >= conf.valueLimit)
+    }
+
+    val newTags = {
+      if (droppedValues.contains(value)) {
+        null
+      } else if (!children.containsKey(value) && reachLimit) {
+        // Don't drop for existing value even if limit is hit - it can be an existing time series
+        droppedValues.add(value)
+        null
+      } else {
+        children.computeIfAbsent(value, _ => createChildNode()).update(tags, id)
+      }
+    }
+    totalEstimator.update(id)
+
+    newTags
+  }
+
+  private def createChildNode() = {
+    if (level == limiterConfig.prefixKeys.length - 1) {
+      new CardinalityLimiterLeaf(limiterConfig)
+    } else {
+      new CardinalityLimiterInner(limiterConfig, level + 1)
+    }
+  }
+
+  override def cardinalityBy(values: List[String]): Long = {
+    require(values != null, "Values can not be null")
+    val maxNumValues = limiterConfig.prefixKeys.length - level
+    require(
+      values.length <= maxNumValues,
+      s"number of values can not exceed $maxNumValues for level $level"
+    )
+
+    values match {
+      case Nil => cardinality
+      case value :: rest =>
+        val child = children.get(value)
+        if (child == null) {
+          0
+        } else {
+          child.cardinalityBy(rest)
+        }
+    }
+  }
+
+  override def cardinalityBy(values: List[String], tagKey: String): Long = {
+    require(tagKey != null, "tag can not be null")
+    val numValues = limiterConfig.prefixKeys.length - level
+    require(
+      values != null && values.length == numValues,
+      s"number of values must be $numValues for level $level"
+    )
+
+    val limiter: CardinalityLimiter = children.get(values.head)
+
+    if (limiter == null) {
+      0
+    } else {
+      limiter.cardinalityBy(values.drop(1), tagKey)
+    }
+  }
+
+  override def topk(k: Int): AnyRef = {
+    val buffer = new BoundedPriorityBuffer[java.util.Map.Entry[String, CardinalityLimiter]](
+      k,
+      Ordering.by(_.getValue.cardinality)
+    )
+    children.entrySet().forEach(buffer.add)
+    val key = limiterConfig.getPrefixConfig(level).key
+    val list = buffer.toOrderedList
+      .map(e => (s"$key: ${e.getKey}", e.getValue.topk(k)))
+    Map("total_ts" -> cardinality, s"num_of_$key" -> children.size(), s"top_$k" -> list)
+  }
+
+  // Not in dropped set, and then check next level
+  override def canServe(queryInfo: QueryInfo): Boolean = {
+    val value = queryInfo.prefixValues(level)
+    if (droppedValues.contains(value)) {
+      false
+    } else {
+      val child = children.get(value)
+      // OK if a value is never seen - it means no drop or rollup either
+      child == null || child.canServe(queryInfo)
+    }
+  }
+}
+
+/**
+  * Leaf-node of the tree, tracks stats for tags belongs to a specific value of last level of prefix
+  * keys: total cardinality and value cardinality for non-prefix tag keys.
+  */
+private[limiter] class CardinalityLimiterLeaf(override val limiterConfig: LimiterConfig)
+    extends CardinalityLimiter(limiterConfig) {
+
+  private val tagCardinality = new ConcurrentHashMap[String, CardinalityEstimator]
+
+  override def update(tags: Map[String, String], id: AnyRef): Map[String, String] = {
+    val rollupKeys = checkRollup(tags)
+    val newTags =
+      if (rollupKeys == Nil) {
+        // Only update if no rollup - it's a different time series after rollup
+        tags
+      } else {
+        rollup(tags, rollupKeys)
+      }
+    updateCardinalityStats(tags, id)
+    newTags
+  }
+
+  private def checkRollup(tags: Map[String, String]): List[String] = {
+    var result: List[String] = Nil
+    tags.foreachEntry { (key, _) =>
+      if (!limiterConfig.isPrefixKey(key) && reachLimit(key)) {
+        result = key :: result
+      }
+    }
+    result
+  }
+
+  private def reachLimit(key: String): Boolean = {
+    val estimator = tagCardinality.get(key)
+    estimator != null && estimator.cardinality >= limiterConfig.tagValueLimit
+  }
+
+  private def updateCardinalityStats(tags: Map[String, String], id: AnyRef): Unit = {
+    totalEstimator.update(id)
+    tags.foreachEntry { (key, value) =>
+      // Size of defined prefix keys should be small, so array contains is efficient
+      if (!limiterConfig.isPrefixKey(key)) {
+        tagCardinality
+          .computeIfAbsent(key, _ => CardinalityEstimator.newSyncEstimator())
+          .update(value)
+      }
+    }
+  }
+
+  private def rollup(tags: Map[String, String], rollupKeys: Seq[String]): Map[String, String] = {
+    tags.map {
+      case (k, v) =>
+        if (rollupKeys.contains(k))
+          (k, RollupValue)
+        else
+          (k, v)
+    }
+  }
+
+  override def cardinalityBy(values: List[String]): Long = cardinality
+
+  override def cardinalityBy(values: List[String], tagKey: String): Long = {
+    require(tagKey != null, "tag can not be null")
+    val estimator = tagCardinality.get(tagKey)
+    if (estimator == null) 0 else estimator.cardinality
+  }
+
+  override def topk(k: Int): AnyRef = {
+    val topTags = tagCardinality.asScala
+      .map(t => (t._1, t._2.cardinality))
+      .toList
+      .sortBy(-_._2)
+      .take(k)
+      .mkString(",")
+
+    s"total: $cardinality, tags: $topTags"
+  }
+
+  override private[limiter] def canServe(queryInfo: QueryInfo): Boolean = {
+    queryInfo.queryKeys.forall { !reachLimit(_) }
+  }
+}
+
+object CardinalityLimiter {
+
+  /**
+    * Create a new instance of CardinalityLimiter.
+    */
+  def newInstance(config: Config): CardinalityLimiter = {
+    new CardinalityLimiterInner(load(config), 0)
+  }
+
+  private def load(config: Config): LimiterConfig = {
+    val conf = config.getConfig("atlas.auto-rollup")
+    val configs = {
+      conf
+        .getConfigList("prefix")
+        .asScala
+        .map(c => {
+          PrefixConfig(
+            c.getString("key"),
+            c.getInt("value-limit"),
+            c.getInt("total-limit")
+          )
+        })
+    }.toArray
+
+    LimiterConfig(configs, conf.getInt("tag-value-limit"))
+  }
+
+  val RollupValue = "_auto-rollup_"
+  val MissingKey = "_missing-key_"
+}
+
+case class QueryInfo(query: Query, limiterConfig: LimiterConfig) {
+  private var _queryKeys: Set[String] = _
+  val prefixValues: Array[String] = genSearchPath()
+
+  // Not needed if drop found early in search path, so generate lazily
+  def queryKeys: Set[String] = {
+    if (_queryKeys eq null) {
+      _queryKeys = Query.allKeys(query) -- limiterConfig.prefixKeys
+    }
+    _queryKeys
+  }
+
+  // Find the values of prefix keys to search through the tree, use default value if missing.
+  private[limiter] def genSearchPath(): Array[String] = {
+    val cnfList = Query.cnfList(query)
+    val prefixKeys = limiterConfig.prefixKeys
+    val path = Array.fill[String](prefixKeys.length)(MissingKey)
+    cnfList.foreach {
+      case Query.Equal(k, v) =>
+        for (i <- prefixKeys.indices) {
+          if (k == prefixKeys(i)) {
+            path(i) = v
+          }
+        }
+      case _ => // do nothing
+    }
+    path
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/limiter/LimiterConifg.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/limiter/LimiterConifg.scala
@@ -15,18 +15,21 @@
  */
 package com.netflix.atlas.core.limiter
 
+import scala.collection.immutable.ArraySeq
+
 /**
   * The configuration for [[CardinalityLimiter]].
+  *
   * @param prefixConfigs list of config with prefix key and associated limits
   * @param tagValueLimit max number of values per non prefix key
   */
-case class LimiterConfig(prefixConfigs: Array[PrefixConfig], tagValueLimit: Int) {
+case class LimiterConfig(prefixConfigs: ArraySeq[PrefixConfig], tagValueLimit: Int) {
   require(prefixConfigs.length > 0)
 
   /**
     * All the prefix keys.
     */
-  val prefixKeys: Array[String] = prefixConfigs.map(_.key)
+  val prefixKeys: ArraySeq[String] = prefixConfigs.map(_.key)
 
   /**
     * get PrefixConfig by level.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/limiter/LimiterConifg.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/limiter/LimiterConifg.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.limiter
+
+/**
+  * The configuration for [[CardinalityLimiter]].
+  * @param prefixConfigs list of config with prefix key and associated limits
+  * @param tagValueLimit max number of values per non prefix key
+  */
+case class LimiterConfig(prefixConfigs: Array[PrefixConfig], tagValueLimit: Int) {
+  require(prefixConfigs.length > 0)
+
+  /**
+    * All the prefix keys.
+    */
+  val prefixKeys: Array[String] = prefixConfigs.map(_.key)
+
+  /**
+    * get PrefixConfig by level.
+    */
+  def getPrefixConfig(level: Int): PrefixConfig = {
+    prefixConfigs(level)
+  }
+
+  /**
+    * Check if a key is one of the prefix keys.
+    */
+  def isPrefixKey(key: String): Boolean = {
+    // Linear array search, number of prefix keys is usually small
+    prefixKeys.contains(key)
+  }
+}
+
+/**
+  * Configuration for a prefix key.
+  * @param key name of the key
+  * @param valueLimit max number of values for this tag key
+  * @param totalLimit max number of items cross all values
+  */
+case class PrefixConfig(key: String, valueLimit: Int, totalLimit: Int)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/BoundedPriorityBuffer.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/BoundedPriorityBuffer.scala
@@ -81,4 +81,13 @@ class BoundedPriorityBuffer[T <: AnyRef](maxSize: Int, comparator: Comparator[T]
     }
     builder.result()
   }
+
+  /** Return a list containing all of the items in the buffer - preserving order by priority. */
+  def toOrderedList: List[T] = {
+    val builder = List.newBuilder[T]
+    while (!queue.isEmpty) {
+      builder += queue.poll()
+    }
+    builder.result()
+  }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/BoundedPriorityBuffer.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/BoundedPriorityBuffer.scala
@@ -82,8 +82,8 @@ class BoundedPriorityBuffer[T <: AnyRef](maxSize: Int, comparator: Comparator[T]
     builder.result()
   }
 
-  /** Return a list containing all of the items in the buffer - preserving order by priority. */
-  def toOrderedList: List[T] = {
+  /** Drain elements to a list that is ordered by priority. */
+  def drainToOrderedList(): List[T] = {
     val builder = List.newBuilder[T]
     while (!queue.isEmpty) {
       builder += queue.poll()

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/CardinalityEstimator.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/CardinalityEstimator.scala
@@ -39,8 +39,7 @@ trait CardinalityEstimator {
 object CardinalityEstimator {
 
   /**
-    * Create a new estimator instance using the [CPC] algorithm. This created estimator is NOT
-    * thread safe, use {@link newSyncEstimator} to create a thread-safe estimator.
+    * Create a new estimator instance using the [CPC] algorithm.
     *
     * [CPC]: https://datasketches.apache.org/docs/CPC/CPC.html
     *
@@ -53,22 +52,8 @@ object CardinalityEstimator {
     new CpcEstimator(lgK)
   }
 
-  /** Create a thread-safe estimator. */
-  def newSyncEstimator(lgK: Int = 9): CardinalityEstimator = {
-    new SyncCpcEstimator(lgK)
-  }
-
+  // It's expected to be updated by a single thread, while reading cardinality is thread-safe.
   private class CpcEstimator(val lgK: Int) extends CardinalityEstimator {
-    private val sketch = new CpcSketch(lgK)
-
-    override def update(obj: AnyRef): Unit = {
-      sketch.update(obj.hashCode())
-    }
-
-    override def cardinality: Long = sketch.getEstimate.longValue()
-  }
-
-  private class SyncCpcEstimator(val lgK: Int) extends CardinalityEstimator {
     private val sketch = new CpcSketch(lgK)
     private val _cardinality = new AtomicLong()
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/limiter/CardinalityLimiterSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/limiter/CardinalityLimiterSuite.scala
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.limiter
+
+import com.netflix.atlas.core.model.Query
+import com.typesafe.config.ConfigFactory
+import org.scalatest.funsuite.AnyFunSuite
+
+class CardinalityLimiterSuite extends AnyFunSuite {
+
+  test("cardinality stats") {
+    val ts = Seq(
+      Map("app" -> "app1", "name" -> "name1", "node" -> "node1"),
+      Map("app" -> "app1", "name" -> "name1", "node" -> "node2"),
+      Map("app" -> "app1", "name" -> "name1", "node" -> "node3"),
+      Map("app" -> "app1", "name" -> "name1", "node" -> "node4", "cluster" -> "c2"),
+      Map("app" -> "app1", "name" -> "name1", "node" -> "node5", "cluster" -> "c1"),
+      //
+      Map("app" -> "app1", "name" -> "name1", "cluster" -> "c1"),
+      Map("app" -> "app1", "name" -> "name1", "cluster" -> "c2"),
+      //
+      Map("app" -> "app1", "name" -> "name2", "node" -> "node1"),
+      Map("app" -> "app1", "name" -> "name2", "node" -> "node2"),
+      Map("app" -> "app1", "name" -> "name2", "node" -> "node3"),
+      Map("app" -> "app1", "name" -> "name2", "node" -> "node4"),
+      Map("app" -> "app1", "name" -> "name2", "node" -> "node5"),
+      //
+      Map("app" -> "app2", "name" -> "name1", "node" -> "node1"),
+      Map("app" -> "app2", "name" -> "name1", "node" -> "node1"),
+      Map("app" -> "app2", "name" -> "name1", "node" -> "node2"),
+      Map("app" -> "app2", "name" -> "name1", "node" -> "node2"),
+      Map("app" -> "app2", "name" -> "name1", "node" -> "node3")
+    )
+
+    val config = ConfigFactory.parseString(
+      """
+        |atlas.auto-rollup = {
+        |  prefix = [
+        |    {
+        |      key = "app",
+        |      value-limit = 100,
+        |      total-limit = 100,
+        |    },
+        |    {
+        |      key = "name",
+        |      value-limit = 100,
+        |      total-limit = 100,
+        |    }
+        |  ],
+        |  tag-value-limit = 100
+        |}
+    """.stripMargin
+    )
+
+    val limiter = CardinalityLimiter.newInstance(config)
+    ts.foreach(limiter.update)
+
+    val app1 = limiter.cardinalityBy(List("app1"))
+    assert(app1 >= 10 && app1 <= 14) // actual is 12
+
+    val app1Name2 = limiter.cardinalityBy(List("app1", "name2"))
+    assert(app1Name2 >= 4 && app1Name2 <= 6) // actual is 5
+
+    val app2Name1Tag = limiter.cardinalityBy(List("app2", "name1"), "node")
+    assert(app2Name1Tag >= 2 && app2Name1Tag <= 4) // actual is 3
+
+    val query1 = Query.Equal("app", "app1").and(Query.Equal("name", "name1"))
+    assert(limiter.canServe(query1))
+
+  }
+
+  test("rollup") {
+    val config = ConfigFactory.parseString(
+      """
+        |atlas.auto-rollup = {
+        |  prefix = [
+        |    {
+        |      key = "app",
+        |      value-limit = 100,
+        |      total-limit = 100,
+        |    },
+        |    {
+        |      key = "name",
+        |      value-limit = 100,
+        |      total-limit = 100,
+        |    }
+        |  ],
+        |  tag-value-limit = 2
+        |}
+    """.stripMargin
+    )
+
+    val limiter = CardinalityLimiter.newInstance(config)
+
+    val ts = Array(
+      Map("app" -> "app1", "name" -> "name1", "node" -> "node0"),
+      Map("app" -> "app1", "name" -> "name1", "node" -> "node1"),
+      Map("app" -> "app1", "name" -> "name1", "node" -> "node2")
+    )
+
+    val queryAppName = Query.Equal("app", "app1").and(Query.Equal("name", "name1"))
+    val queryAppNameNode = queryAppName.and(Query.Equal("node", "1"))
+    for (i <- ts.indices) {
+      val result = limiter.update(ts(i))
+
+      if (i == 0) {
+        assert(result eq ts(i), "should be same tags object without hitting limit")
+        assert(limiter.canServe(queryAppName))
+        assert(limiter.canServe(queryAppNameNode))
+      }
+
+      if (i == 1) {
+        assert(result eq ts(i), "should be same tags object without hitting limit")
+        assert(limiter.canServe(queryAppName))
+        // reach tag limit 2
+        assert(!limiter.canServe(queryAppNameNode))
+      }
+
+      if (i == 2) {
+        assert(
+          result.getOrElse("node", "*") == CardinalityLimiter.RollupValue,
+          "should rollup node after hitting tag limit"
+        )
+        assert(limiter.canServe(queryAppName))
+        // exceed tag limit 2
+        assert(!limiter.canServe(queryAppNameNode))
+      }
+
+    }
+  }
+
+  test("drop") {
+    val config = ConfigFactory.parseString(
+      """
+        |atlas.auto-rollup = {
+        |  prefix = [
+        |    {
+        |      key = "app",
+        |      value-limit = 100,
+        |      total-limit = 0,
+        |    },
+        |    {
+        |      key = "name",
+        |      value-limit = 2,
+        |      total-limit = 3,
+        |    }
+        |  ],
+        |  tag-value-limit = 100
+        |}
+    """.stripMargin
+    )
+
+    val limiter = CardinalityLimiter.newInstance(config)
+
+    val ts = Array(
+      Map("app" -> "app1", "name" -> "name1", "node" -> "node1"),
+      Map("app" -> "app1", "name" -> "name2", "node" -> "node2"),
+      Map("app" -> "app1", "name" -> "name3", "node" -> "node3"),
+      Map("app" -> "app1", "name" -> "name1", "node" -> "node4"),
+      Map("app" -> "app1", "name" -> "name4", "node" -> "node5")
+    )
+
+    val queryName1 = Query.Equal("app", "app1").and(Query.Equal("name", "name1"))
+    val queryName3 = Query.Equal("app", "app1").and(Query.Equal("name", "name3"))
+
+    for (i <- ts.indices) {
+      val result = limiter.update(ts(i))
+      if (i < 2) {
+        assert(result eq ts(i), "should be same tags object - no limit hit")
+        assert(limiter.canServe(queryName1))
+        assert(limiter.canServe(queryName3))
+      }
+
+      if (i == 2) {
+        assert(result == null, "should drop -  number of names reaches 2")
+        assert(limiter.canServe(queryName1))
+        assert(!limiter.canServe(queryName3)) //name3 dropped
+      }
+
+      if (i == 3) {
+        assert(result eq ts(i), "should be same tags object - no limit hit")
+      }
+
+      if (i == 4) {
+        assert(result == null, "should drop -  app1 ts reaches 3 and sees new name")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Automatically rollup or drop tags based on cardinality limit configuration, also provide an api to check if a query can be served based on the limiter stats. 

It tracks cardinality by a list of pre-defined keys and associated limits, and build out a tree structure level by level based on that, also tracks cardinality for other tag keys at leaf level.

Given below example configuration:
`atlas.auto-rollup = {
  prefix = `[`
    {
      key = "app",
      value-limit = 20,
      total-limit = 1000,
    },
    {
      key = "name",
      value-limit = 30,
      total-limit = 50,
    }
  ],
  tag-value-limit = 40
}`

- Level 1: track cardinality by "app", max number of apps allowed is 20, max number of tags across all apps is 1000; drop new apps if either limit is reached.

- Level 2: for a specific app, track cardinality by "name", max number of names is 30, max number of tags across all names is 50; drop new names if limit reached; drop new names if either limit is reached.

- Level 3: for a specific app and name, tracks number of unique values per non prefix tag keys, max number of values is 40; rollup if the limit is reached.

