### PR TITLE
add base interface to customize SSLContext

### DIFF
--- a/atlas-akka/src/main/resources/reference.conf
+++ b/atlas-akka/src/main/resources/reference.conf
@@ -83,6 +83,7 @@ atlas.akka {
     #{
     #  port = 7102
     #  secure = true
+    #  context-factory = "com.netflix.atlas.akka.ConfigConnectionContextFactory"
     #  ssl-config {
     #    // See https://lightbend.github.io/ssl-config/KeyStores.html
     #  }

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/ConfigConnectionContextFactory.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/ConfigConnectionContextFactory.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.akka
+
+import akka.http.scaladsl.ConnectionContext
+import akka.http.scaladsl.HttpsConnectionContext
+import com.typesafe.config.Config
+import com.typesafe.sslconfig.ssl.ClientAuth
+import com.typesafe.sslconfig.ssl.ConfigSSLContextBuilder
+import com.typesafe.sslconfig.ssl.DefaultKeyManagerFactoryWrapper
+import com.typesafe.sslconfig.ssl.DefaultTrustManagerFactoryWrapper
+import com.typesafe.sslconfig.ssl.SSLConfigFactory
+import com.typesafe.sslconfig.util.LoggerFactory
+import com.typesafe.sslconfig.util.NoDepsLogger
+import org.slf4j.Logger
+
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLEngine
+
+/**
+  * Context factory based on ssl-config library.
+  *
+  * @param config
+  *     See https://lightbend.github.io/ssl-config/KeyStores.html.
+  */
+class ConfigConnectionContextFactory(config: Config) extends ConnectionContextFactory {
+
+  import ConfigConnectionContextFactory._
+
+  private val sslConfig = SSLConfigFactory.parse(config)
+
+  override val sslContext: SSLContext = {
+    val keyManager = new DefaultKeyManagerFactoryWrapper(sslConfig.keyManagerConfig.algorithm)
+    val trustManager = new DefaultTrustManagerFactoryWrapper(
+      sslConfig.trustManagerConfig.algorithm
+    )
+    new ConfigSSLContextBuilder(SslLoggerFactory, sslConfig, keyManager, trustManager).build()
+  }
+
+  override def sslEngine: SSLEngine = {
+    val sslEngine = sslContext.createSSLEngine()
+    sslEngine.setUseClientMode(false)
+    sslConfig.sslParametersConfig.clientAuth match {
+      case ClientAuth.Default => sslEngine.setNeedClientAuth(true)
+      case ClientAuth.None    =>
+      case ClientAuth.Need    => sslEngine.setNeedClientAuth(true)
+      case ClientAuth.Want    => sslEngine.setWantClientAuth(true)
+    }
+    sslEngine
+  }
+
+  override def httpsConnectionContext: HttpsConnectionContext = {
+    ConnectionContext.httpsServer(() => sslEngine)
+  }
+}
+
+object ConfigConnectionContextFactory {
+
+  /**
+    * The sslconfig library has its own logging interface to avoid dependencies. Map it
+    * to slf4j.
+    */
+  private object SslLoggerFactory extends LoggerFactory {
+
+    override def apply(clazz: Class[_]): NoDepsLogger = {
+      apply(clazz.getName)
+    }
+
+    override def apply(name: String): NoDepsLogger = {
+      val logger = org.slf4j.LoggerFactory.getLogger(name)
+      new SslLogger(logger)
+    }
+  }
+
+  private class SslLogger(logger: Logger) extends NoDepsLogger {
+
+    override def isDebugEnabled: Boolean = logger.isDebugEnabled
+
+    override def debug(msg: String): Unit = logger.debug(msg)
+
+    override def info(msg: String): Unit = logger.info(msg)
+
+    override def warn(msg: String): Unit = logger.warn(msg)
+
+    override def error(msg: String): Unit = logger.error(msg)
+
+    override def error(msg: String, throwable: Throwable): Unit = logger.error(msg, throwable)
+  }
+}

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/ConnectionContextFactory.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/ConnectionContextFactory.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.akka
+
+import akka.http.scaladsl.HttpsConnectionContext
+import com.typesafe.config.Config
+
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLEngine
+
+/**
+  * Base interface for setting up the connection context of an HTTPS server binding. A custom
+  * implementation can be used for full control. Implementations must have a constructor that
+  * takes a Config object or that is empty.
+  */
+trait ConnectionContextFactory {
+
+  def sslContext: SSLContext
+
+  def sslEngine: SSLEngine
+
+  def httpsConnectionContext: HttpsConnectionContext
+}
+
+object ConnectionContextFactory {
+
+  def apply(config: Config): ConnectionContextFactory = {
+    val contextFactoryClass = {
+      if (config.hasPath("context-factory")) {
+        loadClass(config.getString("context-factory"))
+      } else
+        classOf[ConfigConnectionContextFactory]
+    }
+
+    try {
+      // Look for constructor that takes a config object
+      val ctor = contextFactoryClass.getConstructor(classOf[Config])
+      ctor.newInstance(config.getConfig("ssl-config"))
+    } catch {
+      case _: NoSuchMethodException =>
+        // Use an empty constructor
+        val ctor = contextFactoryClass.getConstructor()
+        ctor.newInstance()
+    }
+  }
+
+  private def loadClass(className: String): Class[ConnectionContextFactory] = {
+    Class.forName(className).asInstanceOf[Class[ConnectionContextFactory]]
+  }
+}

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/ConnectionContextFactorySuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/ConnectionContextFactorySuite.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.akka
+
+import akka.http.scaladsl.HttpsConnectionContext
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.funsuite.AnyFunSuite
+
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLEngine
+
+class ConnectionContextFactorySuite extends AnyFunSuite {
+
+  import ConnectionContextFactorySuite._
+
+  test("factory not set") {
+    val config = ConfigFactory.load()
+    val contextFactory = ConnectionContextFactory(config)
+    assert(contextFactory.isInstanceOf[ConfigConnectionContextFactory])
+  }
+
+  test("empty constructor") {
+    val config = ConfigFactory.parseString(s"""
+        |context-factory = "${classOf[EmptyConstructorFactory].getName}"
+        |""".stripMargin)
+    val contextFactory = ConnectionContextFactory(config)
+    assert(contextFactory.isInstanceOf[EmptyConstructorFactory])
+  }
+
+  test("config constructor") {
+    val config = ConfigFactory.parseString(s"""
+         |context-factory = "${classOf[ConfigConstructorFactory].getName}"
+         |ssl-config {
+         |  correct-subconfig = true
+         |}
+         |""".stripMargin)
+    val contextFactory = ConnectionContextFactory(config)
+    assert(contextFactory.isInstanceOf[ConfigConstructorFactory])
+  }
+}
+
+object ConnectionContextFactorySuite {
+
+  class EmptyConstructorFactory extends ConnectionContextFactory {
+    override def sslContext: SSLContext = null
+
+    override def sslEngine: SSLEngine = null
+
+    override def httpsConnectionContext: HttpsConnectionContext = null
+  }
+
+  class ConfigConstructorFactory(config: Config) extends ConnectionContextFactory {
+    require(config.getBoolean("correct-subconfig"))
+
+    override def sslContext: SSLContext = null
+
+    override def sslEngine: SSLEngine = null
+
+    override def httpsConnectionContext: HttpsConnectionContext = null
+  }
+}


### PR DESCRIPTION
Updates the config for setting up the SSL config to allow
a custom implementation to be used. This gives more complete
control to tuning how it is setup. The default uses the same
approach as before.