### PR TITLE
allow out of order updates for normalization

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/norm/RollingValueBuffer.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/norm/RollingValueBuffer.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.norm
+
+import com.netflix.atlas.core.util.Math
+
+/**
+  * Buffer used to track the last `n` values over time for a given normalization
+  * function. This is typically to allow for use-cases where data may be reported
+  * on many nodes and thus some data is received out of order.
+  *
+  * @param step
+  *     Step size between successive values.
+  * @param size
+  *     Size of the buffer.
+  */
+class RollingValueBuffer(step: Long, size: Int) {
+
+  private val values = Array.fill[Double](size)(Double.NaN)
+  private var lastUpdateTime = -1L
+
+  private def index(timestamp: Long): Int = {
+    val t = timestamp / step
+    val minTime = lastUpdateTime - step * size
+    if (t <= minTime) {
+      -1
+    } else if (t > lastUpdateTime) {
+      lastUpdateTime = t
+      val i = (t % size).toInt
+      values(i) = Double.NaN
+      i
+    } else {
+      (t % size).toInt
+    }
+  }
+
+  def set(timestamp: Long, value: Double): Double = {
+    val i = index(timestamp)
+    if (i >= 0) {
+      values(i) = value
+      value
+    } else {
+      Double.NaN
+    }
+  }
+
+  def add(timestamp: Long, value: Double): Double = {
+    val i = index(timestamp)
+    if (i >= 0) {
+      values(i) = Math.addNaN(values(i), value)
+      values(i)
+    } else {
+      Double.NaN
+    }
+  }
+
+  def max(timestamp: Long, value: Double): Double = {
+    val i = index(timestamp)
+    if (i >= 0) {
+      values(i) = Math.maxNaN(values(i), value)
+      values(i)
+    } else {
+      Double.NaN
+    }
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/norm/SumValueFunction.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/norm/SumValueFunction.scala
@@ -15,8 +15,6 @@
  */
 package com.netflix.atlas.core.norm
 
-import com.netflix.atlas.core.util.Math
-
 /**
   * Normalizes values by truncating the timestamp to the previous step boundary and accumulating
   * all values for a given time. All values will be passed through to the `next` function.
@@ -30,22 +28,15 @@ class SumValueFunction(step: Long, next: ValueFunction) extends ValueFunction {
 
   require(step >= 1, "step must be >= 1")
 
-  /**
-    * The last time an update was received. Used to ensure that we move forward and do not pass
-    * through older measurements that arrived at this function at a later time.
-    */
-  private var lastUpdateTime: Long = -1L
-
-  private var lastStepBoundary: Long = -1L
-  private var value: Double = Double.NaN
+  // For now use a fixed two interval buffer as other components assume recent data. Might
+  // be revisited later.
+  private val values = new RollingValueBuffer(step, 2)
 
   private def update(stepBoundary: Long, current: Double): Unit = {
-    if (stepBoundary > lastStepBoundary) {
-      lastStepBoundary = stepBoundary
-      value = Double.NaN
+    val value = values.add(stepBoundary, current)
+    if (!value.isNaN) {
+      next(stepBoundary, value)
     }
-    value = Math.addNaN(value, current)
-    next(stepBoundary, value)
   }
 
   /**
@@ -53,17 +44,14 @@ class SumValueFunction(step: Long, next: ValueFunction) extends ValueFunction {
     * actual timestamp on the measurement is newer than the last timestamp seen by this function.
     */
   def apply(timestamp: Long, value: Double): Unit = {
-    if (timestamp >= lastUpdateTime) {
-      lastUpdateTime = timestamp
-      val stepBoundary = timestamp / step * step
-      if (timestamp == stepBoundary)
-        update(stepBoundary, value)
-      else
-        update(stepBoundary + step, value)
-    }
+    val stepBoundary = timestamp / step * step
+    if (timestamp == stepBoundary)
+      update(stepBoundary, value)
+    else
+      update(stepBoundary + step, value)
   }
 
   override def toString: String = {
-    s"${getClass.getSimpleName}(step=$step, lastUpdateTime=$lastUpdateTime)"
+    s"${getClass.getSimpleName}(step=$step)"
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/norm/LastValueFunctionSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/norm/LastValueFunctionSuite.scala
@@ -106,11 +106,11 @@ class LastValueFunctionSuite extends AnyFunSuite {
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000, 120000)
     assert(n.update(t(1, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(1, 12), 1.0) === Nil)
+    assert(n.update(t(1, 12), 1.0) === List(t(2, 0) -> 1.0))
     assert(n.update(t(2, 13), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(2, 10), 1.0) === Nil)
+    assert(n.update(t(2, 10), 1.0) === List(t(3, 0) -> 1.0))
     assert(n.update(t(3, 13), 1.0) === List(t(4, 0) -> 1.0))
-    assert(n.update(t(3, 11), 1.0) === Nil)
+    assert(n.update(t(3, 11), 1.0) === List(t(4, 0) -> 1.0))
   }
 
   test("random offset, dual reporting") {
@@ -118,11 +118,11 @@ class LastValueFunctionSuite extends AnyFunSuite {
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000, 120000)
     assert(n.update(t(1, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(1, 13), 1.0) === Nil)
+    assert(n.update(t(1, 13), 1.0) === List(t(2, 0) -> 1.0))
     assert(n.update(t(2, 13), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(2, 13), 1.0) === Nil)
+    assert(n.update(t(2, 13), 1.0) === List(t(3, 0) -> 1.0))
     assert(n.update(t(3, 13), 1.0) === List(t(4, 0) -> 1.0))
-    assert(n.update(t(3, 13), 1.0) === Nil)
+    assert(n.update(t(3, 13), 1.0) === List(t(4, 0) -> 1.0))
   }
 
   test("init, 17") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/norm/MaxValueFunctionSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/norm/MaxValueFunctionSuite.scala
@@ -106,11 +106,11 @@ class MaxValueFunctionSuite extends AnyFunSuite {
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000, 120000)
     assert(n.update(t(1, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(1, 12), 1.0) === Nil)
-    assert(n.update(t(2, 13), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(2, 10), 1.0) === Nil)
+    assert(n.update(t(1, 12), 1.0) === List(t(2, 0) -> 1.0))
+    assert(n.update(t(2, 13), 2.0) === List(t(3, 0) -> 2.0))
+    assert(n.update(t(2, 10), 1.0) === List(t(3, 0) -> 2.0))
     assert(n.update(t(3, 13), 1.0) === List(t(4, 0) -> 1.0))
-    assert(n.update(t(3, 11), 1.0) === Nil)
+    assert(n.update(t(3, 11), 2.0) === List(t(4, 0) -> 2.0))
   }
 
   test("random offset, dual reporting") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/norm/RollingValueBufferSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/norm/RollingValueBufferSuite.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.norm
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class RollingValueBufferSuite extends AnyFunSuite {
+
+  test("values received in order") {
+    val buffer = new RollingValueBuffer(1L, 2)
+    (0 until 20).foreach { i =>
+      val v = buffer.set(i, i)
+      assert(v === i)
+    }
+  }
+
+  test("set: values received out of order") {
+    val buffer = new RollingValueBuffer(1L, 2)
+    assert(1.0 === buffer.set(1, 1.0))
+    assert(2.0 === buffer.set(2, 2.0))
+    assert(0.5 === buffer.set(1, 0.5))
+    assert(3.0 === buffer.set(3, 3.0))
+    assert(buffer.set(1, 0.0).isNaN) // too old
+  }
+
+  test("add: values received out of order") {
+    val buffer = new RollingValueBuffer(1L, 2)
+    assert(1.0 === buffer.add(1, 1.0))
+    assert(2.0 === buffer.add(2, 2.0))
+    assert(1.5 === buffer.add(1, 0.5))
+    assert(3.0 === buffer.add(3, 3.0))
+    assert(buffer.add(1, 0.0).isNaN) // too old
+  }
+
+  test("max: values received out of order") {
+    val buffer = new RollingValueBuffer(1L, 2)
+    assert(1.0 === buffer.max(1, 1.0))
+    assert(2.0 === buffer.max(2, 2.0))
+    assert(1.0 === buffer.max(1, 0.5))
+    assert(3.0 === buffer.max(3, 3.0))
+    assert(buffer.max(1, 0.0).isNaN) // too old
+  }
+}


### PR DESCRIPTION
Updates the normalization functions for last, max, and sum
modes to allow out of order updates within a small window
of time. The use-case is inline aggregation where updates
can come from many nodes. If a node is shutting down, then
it will force data for the current interval to get sent out
earlier than it normally would. Without this change that
flush could cause data from an earlier interval on other
nodes to get dropped resulting in an incorrect aggregate.