### PR TITLE
support validating Id objects

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/IdMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/IdMap.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.Utils
+
+/**
+  * Wraps a Spectator Id so it can be used as Scala Map. Modifications will result
+  * in a different map type being returned.
+  */
+final case class IdMap(id: Id) extends scala.collection.immutable.Map[String, String] {
+
+  override def removed(key: String): Map[String, String] = {
+    SmallHashMap(this).removed(key)
+  }
+
+  override def updated[V1 >: String](key: String, value: V1): Map[String, V1] = {
+    SmallHashMap(this).updated(key, value)
+  }
+
+  override def get(key: String): Option[String] = {
+    if (key == "name")
+      Some(id.name())
+    else
+      Option(Utils.getTagValue(id, key))
+  }
+
+  override def iterator: Iterator[(String, String)] = {
+    new Iterator[(String, String)] {
+      private var i = 0
+
+      override def hasNext: Boolean = i < id.size()
+
+      override def next(): (String, String) = {
+        val tuple = id.getKey(i) -> id.getValue(i)
+        i += 1
+        tuple
+      }
+    }
+  }
+
+  override def foreachEntry[U](f: (String, String) => U): Unit = {
+    val size = id.size()
+    var i = 0
+    while (i < size) {
+      f(id.getKey(i), id.getValue(i))
+      i += 1
+    }
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/MaxUserTagsRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/MaxUserTagsRule.scala
@@ -16,7 +16,9 @@
 package com.netflix.atlas.core.validation
 
 import com.netflix.atlas.core.model.TagKey
+import com.netflix.atlas.core.util.IdMap
 import com.netflix.atlas.core.util.SmallHashMap
+import com.netflix.spectator.api.Id
 import com.typesafe.config.Config
 
 /**
@@ -38,6 +40,20 @@ case class MaxUserTagsRule(limit: Int) extends Rule {
     if (count <= limit) ValidationResult.Pass
     else {
       failure(s"too many user tags: $count > $limit", tags)
+    }
+  }
+
+  override def validate(id: Id): ValidationResult = {
+    val size = id.size()
+    var i = 1 // skip name
+    var count = 1 // name is counted
+    while (i < size) {
+      if (!TagKey.isRestricted(id.getKey(i))) count += 1
+      i += 1
+    }
+    if (count <= limit) ValidationResult.Pass
+    else {
+      failure(s"too many user tags: $count > $limit", IdMap(id))
     }
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/Rule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/Rule.scala
@@ -16,6 +16,7 @@
 package com.netflix.atlas.core.validation
 
 import com.netflix.atlas.core.util.SmallHashMap
+import com.netflix.spectator.api.Id
 import com.typesafe.config.Config
 
 import scala.reflect.runtime.universe
@@ -42,6 +43,11 @@ trait Rule {
     * Validates that the tag map matches the rule.
     */
   def validate(tags: SmallHashMap[String, String]): ValidationResult
+
+  /**
+    * Validates that the id matches the rule.
+    */
+  def validate(id: Id): ValidationResult
 
   /**
     * Helper for generating the failure response.

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/IdMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/IdMapSuite.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import com.netflix.spectator.api.Id
+import org.scalatest.funsuite.AnyFunSuite
+
+class IdMapSuite extends AnyFunSuite {
+
+  test("basic map") {
+    assert(IdMap(Id.create("foo")) === Map("name" -> "foo"))
+  }
+
+  test("removed") {
+    val id = Id.create("foo").withTags("a", "1", "b", "2")
+    assert(IdMap(id).removed("name") === Map("a" -> "1", "b"   -> "2"))
+    assert(IdMap(id).removed("a") === Map("name" -> "foo", "b" -> "2"))
+  }
+
+  test("updated") {
+    val id = Id.create("foo").withTags("a", "1")
+    assert(IdMap(id).updated("b", "2") === Map("name" -> "foo", "a" -> "1", "b" -> "2"))
+  }
+
+  test("get") {
+    val id = Id.create("foo").withTags("a", "1", "b", "2")
+    assert(IdMap(id).get("name") === Some("foo"))
+    assert(IdMap(id).get("a") === Some("1"))
+    assert(IdMap(id).get("b") === Some("2"))
+    assert(IdMap(id).get("c") === None)
+  }
+
+  test("iterator") {
+    val id = Id.create("foo").withTags("a", "1", "b", "2")
+    val expected = List(
+      "name" -> "foo",
+      "a"    -> "1",
+      "b"    -> "2"
+    )
+    assert(IdMap(id).iterator.toList === expected)
+  }
+
+  test("foreachEntry") {
+    val id = Id.create("foo").withTags("a", "1", "b", "2")
+    val builder = List.newBuilder[(String, String)]
+    IdMap(id).foreachEntry { (k, v) =>
+      builder += k -> v
+    }
+    val actual = builder.result()
+    val expected = List(
+      "name" -> "foo",
+      "a"    -> "1",
+      "b"    -> "2"
+    )
+    assert(actual === expected)
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/HasKeyRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/HasKeyRuleSuite.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.core.validation
 
+import com.netflix.spectator.api.Id
 import com.typesafe.config.ConfigFactory
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -30,5 +31,19 @@ class HasKeyRuleSuite extends AnyFunSuite {
   test("missing key") {
     val res = rule.validate(Map("cluster" -> "foo"))
     assert(res.isFailure)
+  }
+
+  test("id: has key name") {
+    assert(rule.validate(Id.create("foo")) === ValidationResult.Pass)
+  }
+
+  test("id: has key other") {
+    val id = Id.create("foo").withTag("a", "1")
+    assert(HasKeyRule("a").validate(id) === ValidationResult.Pass)
+  }
+
+  test("id: missing key other") {
+    val id = Id.create("foo").withTag("a", "1")
+    assert(HasKeyRule("b").validate(id).isFailure)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/NameValueLengthRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/NameValueLengthRuleSuite.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.core.validation
 
+import com.netflix.spectator.api.Id
 import com.typesafe.config.ConfigFactory
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -35,6 +36,7 @@ class NameValueLengthRuleSuite extends AnyFunSuite {
 
   private def validate(k: String, v: String): ValidationResult = {
     rule.validate(Map(k -> v))
+    rule.validate(if (k == "name") Id.create(v) else Id.create("foo").withTag(k, v))
   }
 
   test("name valid") {


### PR DESCRIPTION
Updates the validation rules so that Spectator Id
objects can be validated directly. This can help
avoid conversions for some use-cases where validation
is on the hot path.