### PR TITLE
add alias for cloudwatch dimension "DBClusterIdentifier"

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/reference.conf
@@ -195,6 +195,10 @@ atlas {
           alias = "aws.node"
         },
         {
+          name = "DBClusterIdentifier"
+          alias = "aws.dbcluster"
+        },
+        {
           name = "DbClusterIdentifier"
           alias = "aws.dbcluster"
         },


### PR DESCRIPTION
Add alias for Cloudwatch dimension "DBClusterIdentifier".
The behavior of this dimension is inconsistent across AWS services, can be "DbClusterIdentifier" or "DBClusterIdentifier", and in some services its cases insensitive(like RDS uses either for different clusters), some are(like Neptune use the latter).