### PR TITLE
add timeout for ec2 cloudwatch metrics

### DIFF
--- a/atlas-poller-cloudwatch/src/main/resources/ec2.conf
+++ b/atlas-poller-cloudwatch/src/main/resources/ec2.conf
@@ -8,6 +8,7 @@ atlas {
       period = 5m
       end-period-offset = 1
       period-count = 4
+      timeout = 20m
 
       dimensions = [
         "AutoScalingGroupName"
@@ -146,6 +147,7 @@ atlas {
       period = 5m
       end-period-offset = 1
       period-count = 4
+      timeout = 20m
 
       dimensions = [
         "AutoScalingGroupName"
@@ -166,6 +168,7 @@ atlas {
       period = 5m
       end-period-offset = 1
       period-count = 4
+      timeout = 20m
 
       dimensions = [
         "AutoScalingGroupName"
@@ -191,6 +194,7 @@ atlas {
       period = 1m
       end-period-offset = 1
       period-count = 4
+      timeout = 20m
 
       dimensions = [
         "Action"


### PR DESCRIPTION
Ensures that they will stop getting published after an
ASG goes away. Otherwise they will stick around until
the poller service is redeployed.