### PR TITLE
remove coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ WIKI_OUTPUT_DIR := $(shell pwd)/target/atlas.wiki
 
 LAUNCHER_JAR_URL := https://jcenter.bintray.com/com/netflix/iep/iep-launcher/2.1.9/iep-launcher-2.1.9.jar
 
-.PHONY: build snapshot release clean coverage format update-wiki publish-wiki
+.PHONY: build snapshot release clean format update-wiki publish-wiki
 
 build:
 	$(SBT) clean test checkLicenseHeaders scalafmtCheckAll
@@ -39,10 +39,6 @@ release:
 
 clean:
 	$(SBT) clean
-
-coverage:
-	$(SBT) clean coverage test coverageReport
-	$(SBT) coverageAggregate
 
 format:
 	$(SBT) formatLicenseHeaders scalafmtAll


### PR DESCRIPTION
The plugin for SBT was removed a long time ago. Remove
the target from the makefile since it doesn't work.