### PR TITLE
fix build deprecation warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val atlas = project.in(file("."))
     `atlas-standalone`,
     `atlas-webapi`,
     `atlas-wiki`)
-  .settings(skip in publish := true)
+  .settings(publish / skip := true)
 
 lazy val `atlas-akka` = project
   .configure(BuildSettings.profile)

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -42,10 +42,10 @@ object BuildSettings {
     externalResolvers := BuildSettings.resolvers,
     // Evictions: https://github.com/sbt/sbt/issues/1636
     // Linting: https://github.com/sbt/sbt/pull/5153
-    (evictionWarningOptions in update).withRank(KeyRanks.Invisible) := EvictionWarningOptions.empty,
+    (update / evictionWarningOptions).withRank(KeyRanks.Invisible) := EvictionWarningOptions.empty,
     checkLicenseHeaders := License.checkLicenseHeaders(streams.value.log, sourceDirectory.value),
     formatLicenseHeaders := License.formatLicenseHeaders(streams.value.log, sourceDirectory.value),
-    packageOptions in (Compile, packageBin) += Package.ManifestAttributes(
+    packageBin / packageOptions += Package.ManifestAttributes(
       "Build-Date"   -> java.time.Instant.now().toString,
       "Build-Number" -> sys.env.getOrElse("GITHUB_RUN_ID", "unknown"),
       "Commit"       -> sys.env.getOrElse("GITHUB_SHA", "unknown")


### PR DESCRIPTION
Replace in with [slash syntax].

[slash syntax]: https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash