### PR TITLE
reduce usage of Manifest

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndex.scala
@@ -17,11 +17,11 @@ package com.netflix.atlas.core.index
 
 import java.util
 import java.util.Comparator
-
 import com.netflix.atlas.core.model.ItemId
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.Tag
 import com.netflix.atlas.core.model.TaggedItem
+import com.netflix.atlas.core.util.ArrayHelper
 import com.netflix.atlas.core.util.IntIntHashMap
 import com.netflix.atlas.core.util.IntRefHashMap
 import com.netflix.atlas.core.util.LongHashSet
@@ -493,8 +493,8 @@ class RoaringTagIndex[T <: TaggedItem](items: Array[T], stats: IndexStats) exten
 object RoaringTagIndex {
   private val logger = LoggerFactory.getLogger(getClass)
 
-  def empty[T <: TaggedItem: Manifest]: RoaringTagIndex[T] = {
-    new RoaringTagIndex(new Array[T](0), new IndexStats())
+  def empty[T <: TaggedItem]: RoaringTagIndex[T] = {
+    new RoaringTagIndex(ArrayHelper.newInstance[T](0), new IndexStats())
   }
 
   private[index] def hasNonEmptyIntersection(b1: RoaringBitmap, b2: RoaringBitmap): Boolean = {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/ArrayHelper.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/ArrayHelper.scala
@@ -95,10 +95,10 @@ object ArrayHelper {
     * @return
     *     Object that can be used to merge the arrays.
     */
-  def merger[T <: Comparable[T] : ClassTag](limit: Int): Merger[T] = new Merger[T](limit)
+  def merger[T <: Comparable[T]: ClassTag](limit: Int): Merger[T] = new Merger[T](limit)
 
   /** Helper for merging sorted arrays and lists. */
-  class Merger[T <: Comparable[T] : ClassTag] private[util] (limit: Int) {
+  class Merger[T <: Comparable[T]: ClassTag] private[util] (limit: Int) {
     // Arrays used for storing the merged result. The `src` array will contain the
     // current merged dataset. During a merge operation, the data will be written
     // into the destination array. It is pre-allocated so it can be reused across

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/ArrayHelper.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/ArrayHelper.scala
@@ -15,6 +15,8 @@
  */
 package com.netflix.atlas.core.util
 
+import scala.reflect.ClassTag
+
 object ArrayHelper {
 
   import java.util.{Arrays => JArrays}
@@ -93,10 +95,10 @@ object ArrayHelper {
     * @return
     *     Object that can be used to merge the arrays.
     */
-  def merger[T <: Comparable[T]: Manifest](limit: Int): Merger[T] = new Merger[T](limit)
+  def merger[T <: Comparable[T] : ClassTag](limit: Int): Merger[T] = new Merger[T](limit)
 
   /** Helper for merging sorted arrays and lists. */
-  class Merger[T <: Comparable[T]: Manifest] private[util] (limit: Int) {
+  class Merger[T <: Comparable[T] : ClassTag] private[util] (limit: Int) {
     // Arrays used for storing the merged result. The `src` array will contain the
     // current merged dataset. During a merge operation, the data will be written
     // into the destination array. It is pre-allocated so it can be reused across

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntRefHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntRefHashMap.scala
@@ -23,7 +23,7 @@ package com.netflix.atlas.core.util
   *     Initial capacity guideline. The actual size of the underlying buffer
   *     will be the next prime >= `capacity`. Default is 10.
   */
-class IntRefHashMap[T <: AnyRef: Manifest](noData: Int, capacity: Int = 10) {
+class IntRefHashMap[T <: AnyRef](noData: Int, capacity: Int = 10) {
 
   private[this] var keys = newArray(capacity)
   private[this] var values = ArrayHelper.newInstance[T](keys.length)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/InternMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/InternMap.scala
@@ -21,7 +21,7 @@ import com.netflix.spectator.api.Clock
 
 object InternMap {
 
-  def concurrent[K <: AnyRef: Manifest](
+  def concurrent[K <: AnyRef](
     initialCapacity: Int,
     clock: Clock = Clock.SYSTEM,
     concurrencyLevel: Int = 16
@@ -40,10 +40,10 @@ trait InternMap[K <: AnyRef] extends Interner[K] {
   def size: Int
 }
 
-class OpenHashInternMap[K <: AnyRef: Manifest](initialCapacity: Int, clock: Clock = Clock.SYSTEM)
+class OpenHashInternMap[K <: AnyRef](initialCapacity: Int, clock: Clock = Clock.SYSTEM)
     extends InternMap[K] {
   private val primeCapacity = nextCapacity(initialCapacity)
-  private var data = new Array[K](primeCapacity)
+  private var data = ArrayHelper.newInstance[K](primeCapacity)
   private var timestamps = new Array[Long](primeCapacity)
   private var currentSize = 0
 
@@ -57,11 +57,13 @@ class OpenHashInternMap[K <: AnyRef: Manifest](initialCapacity: Int, clock: Cloc
     val oldTimestamps = timestamps
 
     currentSize = 0
-    data = new Array[K](newCapacity)
+    data = ArrayHelper.newInstance[K](newCapacity)
     timestamps = new Array[Long](newCapacity)
     var i = 0
     while (i < oldData.length) {
-      if (oldData(i) != null && keep(oldTimestamps(i))) intern(oldData(i), oldTimestamps(i))
+      if (oldData(i) != null && keep(oldTimestamps(i))) {
+        intern(oldData(i), oldTimestamps(i))
+      }
       i += 1
     }
   }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/ListHelper.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/ListHelper.scala
@@ -15,6 +15,8 @@
  */
 package com.netflix.atlas.core.util
 
+import scala.reflect.ClassTag
+
 /**
   * Helper functions for working with lists.
   */
@@ -73,7 +75,7 @@ object ListHelper {
     * @return
     *     Sorted list with a max size of `limit`.
     */
-  def merge[T <: Comparable[T]: Manifest](limit: Int, vs: List[List[T]]): List[T] = {
+  def merge[T <: Comparable[T] : ClassTag](limit: Int, vs: List[List[T]]): List[T] = {
     val merged = vs.foldLeft(ArrayHelper.merger[T](limit)) { (m, vs) =>
       m.merge(vs)
     }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/ListHelper.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/ListHelper.scala
@@ -75,7 +75,7 @@ object ListHelper {
     * @return
     *     Sorted list with a max size of `limit`.
     */
-  def merge[T <: Comparable[T] : ClassTag](limit: Int, vs: List[List[T]]): List[T] = {
+  def merge[T <: Comparable[T]: ClassTag](limit: Int, vs: List[List[T]]): List[T] = {
     val merged = vs.foldLeft(ArrayHelper.merger[T](limit)) { (m, vs) =>
       m.merge(vs)
     }


### PR DESCRIPTION
Manifest is not supported in scala 3. Removes the
usage of Manifest for everything but JSON type
detection.