### PR TITLE
avoid fold for strict messages

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -475,8 +475,12 @@ private[stream] abstract class EvaluatorImpl(
       .map(dss => TextMessage(Json.encode(toExprSet(dss, context.interpreter))))
       .via(webSocketFlowOrigin)
       .flatMapConcat {
+        case TextMessage.Strict(str) =>
+          Source.single(ByteString(str))
         case msg: TextMessage =>
           msg.textStream.fold("")(_ + _).map(ByteString(_))
+        case BinaryMessage.Strict(str) =>
+          Source.single(str)
         case msg: BinaryMessage =>
           msg.dataStream.fold(ByteString.empty)(_ ++ _)
       }

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
@@ -105,8 +105,12 @@ class SubscribeApi @Inject() (
 
     Flow[Message]
       .flatMapConcat {
+        case TextMessage.Strict(str) =>
+          Source.single(str)
         case msg: TextMessage =>
           msg.textStream.fold("")(_ + _)
+        case BinaryMessage.Strict(str) =>
+          Source.single(str.decodeString(StandardCharsets.UTF_8))
         case msg: BinaryMessage =>
           msg.dataStream.fold(ByteString.empty)(_ ++ _).map(_.decodeString(StandardCharsets.UTF_8))
       }


### PR DESCRIPTION
When there are many small strict messages the fold
step adds a significant overhead.