### PR TITLE
delay heartbeat timestamp

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
@@ -142,7 +142,9 @@ class SubscribeApi @Inject() (
           .map(_.metadata.frequency)
           .distinct
           .map { step =>
-            TextMessage(LwcHeartbeat(stepAlignedTime(step), step).toJson)
+            // To account for some delays for data coming from real systems, the heartbeat
+            // timestamp is delayed by one interval
+            TextMessage(LwcHeartbeat(stepAlignedTime(step) - step, step).toJson)
           }
         Source(steps)
       }


### PR DESCRIPTION
Update the heartbeat timestamp to be one interval
behind the current time. This gives more time for
data flowing in from real systems to arrive when
using a small number of buffers on the eval client.