### PR TITLE
eval: reduce parsing of data exprs

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcDataExpr.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcDataExpr.scala
@@ -38,7 +38,7 @@ import com.netflix.atlas.core.stacklang.Interpreter
 case class LwcDataExpr(id: String, expression: String, @JsonAlias(Array("frequency")) step: Long) {
 
   @JsonIgnore
-  val expr: DataExpr = LwcDataExpr.parseExpr(expression)
+  lazy val expr: DataExpr = LwcDataExpr.parseExpr(expression)
 }
 
 object LwcDataExpr {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapoint.scala
@@ -45,7 +45,7 @@ private[stream] class LwcToAggrDatapoint(context: StreamContext)
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
     new GraphStageLogic(shape) with InHandler with OutHandler {
 
-      private[this] var state: Map[String, LwcDataExpr] = Map.empty
+      private[this] val state = scala.collection.mutable.AnyRefMap.empty[String, LwcDataExpr]
 
       // HACK: needed until we can plumb the actual source through the system
       private var nextSource: Int = 0
@@ -61,7 +61,11 @@ private[stream] class LwcToAggrDatapoint(context: StreamContext)
       }
 
       private def updateState(sub: LwcSubscription): Unit = {
-        state ++= sub.metrics.map(m => m.id -> m).toMap
+        sub.metrics.foreach { m =>
+          if (!state.contains(m.id)) {
+            state.put(m.id, m)
+          }
+        }
         pull(in)
       }
 


### PR DESCRIPTION
Make the parsed expression a lazy val and reuse the first
instance for a given id to minimize the number of times
a data expression needs to be fully processed. Before it
occur for each expression from each server.