### PR TITLE
update CI builds to use jdk16

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        java: [15]
+        java: [11, 16]
         scala: [2.13.5]
     steps:
       - uses: actions/checkout@v2
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 15
+      - name: Set up JDK 16
         uses: actions/setup-java@v1
         with:
-          java-version: 15
+          java-version: 16
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 15
+          java-version: 11
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 15
+          java-version: 11
       - uses: actions/cache@v2
         with:
           path: |

--- a/build.sbt
+++ b/build.sbt
@@ -94,18 +94,14 @@ lazy val `atlas-lwcapi` = project
 lazy val `atlas-module-akka` = project
   .configure(BuildSettings.profile)
   .dependsOn(`atlas-akka`)
-  .settings(libraryDependencies ++= Seq(
-    Dependencies.guiceCore,
-    Dependencies.guiceMulti,
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++ Seq(
     Dependencies.iepGuice
   ))
 
 lazy val `atlas-module-cloudwatch` = project
   .configure(BuildSettings.profile)
   .dependsOn(`atlas-module-akka`, `atlas-poller-cloudwatch`)
-  .settings(libraryDependencies ++= Seq(
-    Dependencies.guiceCore,
-    Dependencies.guiceMulti,
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++ Seq(
     Dependencies.iepGuice,
     Dependencies.iepModuleAws
   ))
@@ -157,11 +153,9 @@ lazy val `atlas-poller-cloudwatch` = project
 lazy val `atlas-standalone` = project
   .configure(BuildSettings.profile)
   .dependsOn(`atlas-module-akka`, `atlas-module-lwcapi`, `atlas-module-webapi`)
-  .settings(libraryDependencies ++= Seq(
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++ Seq(
     Dependencies.iepGuice,
     Dependencies.iepModuleAtlas,
-    Dependencies.guiceCore,
-    Dependencies.guiceMulti,
     Dependencies.log4jApi,
     Dependencies.log4jCore,
     Dependencies.log4jSlf4j,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,4 +1,5 @@
 import sbt._
+import sbt.librarymanagement.DependencyBuilders.OrganizationArtifactName
 
 // format: off
 
@@ -8,7 +9,7 @@ object Dependencies {
     val akkaHttpV  = "10.2.4"
     val aws        = "2.16.45"
     val iep        = "2.6.9"
-    val guice      = "4.1.0"
+    val guice      = "5.0.1"
     val jackson    = "2.12.3"
     val log4j      = "2.14.1"
     val scala      = "2.13.5"
@@ -33,8 +34,8 @@ object Dependencies {
   val datasketches      = "org.apache.datasketches" % "datasketches-java" % "2.0.0"
   val equalsVerifier    = "nl.jqno.equalsverifier" % "equalsverifier" % "3.6"
   val frigga            = "com.netflix.frigga" % "frigga" % "0.25.0"
-  val guiceCore         = "com.google.inject" % "guice" % guice
-  val guiceMulti        = "com.google.inject.extensions" % "guice-multibindings" % guice
+  val guiceCoreBase     = "com.google.inject" % "guice"
+  val guiceMultiBase    = "com.google.inject.extensions" % "guice-multibindings"
   val iepGuice          = "com.netflix.iep" % "iep-guice" % iep
   val iepLeaderApi      = "com.netflix.iep" % "iep-leader-api" % iep
   val iepLeaderDynamoDb = "com.netflix.iep" % "iep-leader-dynamodb" % iep
@@ -74,6 +75,23 @@ object Dependencies {
   val spectatorLog4j    = "com.netflix.spectator" % "spectator-ext-log4j2" % spectator
   val spectatorM2       = "com.netflix.spectator" % "spectator-reg-metrics2" % spectator
   val typesafeConfig    = "com.typesafe" % "config" % "1.4.1"
+
+  def isBeforeJava16: Boolean = {
+    System.getProperty("java.specification.version").toDouble < 16
+  }
+
+  private def guiceDep(base: OrganizationArtifactName): ModuleID = {
+    base % (if (isBeforeJava16) "4.1.0" else guice)
+  }
+
+  def guiceCore: ModuleID = guiceDep(guiceCoreBase)
+
+  def guiceCoreAndMulti: Seq[ModuleID] = {
+    if (isBeforeJava16)
+      Seq(guiceDep(guiceCoreBase), guiceDep(guiceMultiBase))
+    else
+      Seq(guiceDep(guiceCoreBase))
+  }
 }
 
 // format: on


### PR DESCRIPTION
Jdk16 strongly encapsulates the internals by default
causing problems for older versions of Guice. When
running on a newer JDK, have the build use Guice 5.
For the published library still need to use 4.1.0
to avoid creating problems internally for other
users stuck on old versions.