### PR TITLE
add compressed mutable block type

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/BlockStore.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/BlockStore.scala
@@ -17,7 +17,6 @@ package com.netflix.atlas.core.db
 
 import com.netflix.atlas.core.model._
 import com.netflix.atlas.core.util.ArrayHelper
-import com.netflix.spectator.api.Spectator
 
 trait BlockStore {
 
@@ -45,11 +44,8 @@ trait BlockStore {
 }
 
 object MemoryBlockStore {
-  private val registry = Spectator.globalRegistry
-  private val allocs = registry.counter("atlas.block.creationCount", "id", "alloc")
 
   def newArrayBlock(start: Long, size: Int): MutableBlock = {
-    allocs.increment()
     CompressedArrayBlock(start, size)
   }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
@@ -135,6 +135,7 @@ class MemoryDatabase(registry: Registry, config: Config) extends Database {
     index.update(BlockStoreItem.create(dp.tags, blkStore))
   }
 
+  @scala.annotation.tailrec
   private def blockAggr(expr: DataExpr): Int = expr match {
     case by: DataExpr.GroupBy          => blockAggr(by.af)
     case _: DataExpr.All               => Block.Sum

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/BlockStats.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/BlockStats.scala
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.spectator.api.Spectator
+import com.netflix.spectator.api.Utils
+import com.netflix.spectator.api.patterns.PolledMeter
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+  * Helper for tracking the number and amount of memory block data is using.
+  */
+object BlockStats {
+
+  private val registry = Spectator.globalRegistry
+
+  private val blocksCreated = registry.counter("atlas.blocksCreated")
+  private val blocksDeleted = registry.counter("atlas.blocksDeleted")
+  private val blocksResized = registry.counter("atlas.blocksResized")
+
+  private val countGauges = new ConcurrentHashMap[String, AtomicLong]()
+
+  private val byteGauges = new ConcurrentHashMap[String, AtomicLong]()
+
+  private def getCountGauge(blockType: String): AtomicLong = {
+    Utils.computeIfAbsent[String, AtomicLong](
+      countGauges,
+      blockType,
+      k =>
+        PolledMeter
+          .using(registry)
+          .withName("atlas.blockCount")
+          .withTag("id", k)
+          .monitorValue(new AtomicLong(0L))
+    )
+  }
+
+  private def getBytesGauge(blockType: String): AtomicLong = {
+    Utils.computeIfAbsent[String, AtomicLong](
+      byteGauges,
+      blockType,
+      k =>
+        PolledMeter
+          .using(registry)
+          .withName("atlas.blockBytes")
+          .withTag("id", k)
+          .monitorValue(new AtomicLong(0L))
+    )
+  }
+
+  private def inc(block: Block, blockType: String): Unit = {
+    getCountGauge(blockType).incrementAndGet()
+    getBytesGauge(blockType).addAndGet(block.byteCount)
+  }
+
+  /** Increment stats when a new block is created. */
+  def inc(block: Block): Unit = {
+    blocksCreated.increment()
+    block match {
+      case _: ArrayBlock           => inc(block, "array")
+      case _: FloatArrayBlock      => inc(block, "arrayFloat")
+      case _: CompressedArrayBlock => inc(block, "arrayCompressed")
+      case _: SparseBlock          => inc(block, "sparse")
+      case _: ConstantBlock        => inc(block, "constant")
+      case b: RollupBlock          => b.blocks.foreach(inc)
+      case _                       =>
+    }
+  }
+
+  private def dec(block: Block, blockType: String): Unit = {
+    getCountGauge(blockType).decrementAndGet()
+    getBytesGauge(blockType).addAndGet(-block.byteCount)
+  }
+
+  /** Decrement stats when a block is deleted and no longer being used. */
+  def dec(block: Block): Unit = {
+    blocksDeleted.increment()
+    block match {
+      case _: ArrayBlock           => dec(block, "array")
+      case _: FloatArrayBlock      => dec(block, "arrayFloat")
+      case _: CompressedArrayBlock => dec(block, "arrayCompressed")
+      case _: SparseBlock          => dec(block, "sparse")
+      case _: ConstantBlock        => dec(block, "constant")
+      case b: RollupBlock          => b.blocks.foreach(dec)
+      case _                       =>
+    }
+  }
+
+  private def resize(blockType: String, before: Long, after: Long): Unit = {
+    getBytesGauge(blockType).addAndGet(-before + after)
+  }
+
+  /** Decrement stats when a block is deleted and no longer being used. */
+  def resize(block: Block, before: Long, after: Long): Unit = {
+    blocksResized.increment()
+    block match {
+      case _: ArrayBlock           => resize("array", before, after)
+      case _: FloatArrayBlock      => resize("arrayFloat", before, after)
+      case _: CompressedArrayBlock => resize("arrayCompressed", before, after)
+      case _: SparseBlock          => resize("sparse", before, after)
+      case _: ConstantBlock        => resize("constant", before, after)
+      case r: RollupBlock          => r.blocks.foreach(b => resize(b, before, after))
+      case _                       =>
+    }
+  }
+
+  def clear(): Unit = {
+    countGauges.values().forEach(_.set(0L))
+    byteGauges.values().forEach(_.set(0L))
+  }
+
+  def overallCount: Int = {
+    countGauges.values().stream().mapToInt(_.get().toInt).sum()
+  }
+}


### PR DESCRIPTION
Adds a new block type that is mutable, allows random access,
and tries to compress data as it is coming in. This should
reduce the overhead for the data that is filling in and help
avoid issue for out of order updates since the historical
blocks will not be compressed to an immutable type.