### PR TITLE
fix block size calculation

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Block.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Block.scala
@@ -496,7 +496,7 @@ final case class CompressedArrayBlock(start: Long, size: Int) extends MutableBlo
   }
 
   private def byteCount(data: Array[Long]): Int = {
-    2 + sizeOf(buffer)
+    2 + sizeOf(data)
   }
 
   override def update(pos: Int, value: Double): Unit = {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/BlockStats.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/BlockStats.scala
@@ -127,4 +127,8 @@ object BlockStats {
   def overallCount: Int = {
     countGauges.values().stream().mapToInt(_.get().toInt).sum()
   }
+
+  def overallBytes: Long = {
+    byteGauges.values().stream().mapToLong(_.get()).sum()
+  }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/BlockStatsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/BlockStatsSuite.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class BlockStatsSuite extends AnyFunSuite {
+
+  test("resize") {
+    BlockStats.clear()
+    val block = CompressedArrayBlock(0L, 60)
+
+    BlockStats.inc(block)
+    assert(BlockStats.overallCount === 1)
+    assert(BlockStats.overallBytes === 22)
+
+    // Resize the block for a single value
+    block.update(0, 2.0)
+    assert(BlockStats.overallCount === 1)
+    assert(BlockStats.overallBytes === 46)
+
+    // Resize the block for up to 4 values
+    block.update(1, 3.0)
+    assert(BlockStats.overallCount === 1)
+    assert(BlockStats.overallBytes === 70)
+
+    // Resize the block for up to 12 values, 2 already used
+    (0 until 10).foreach { i =>
+      block.update(i, i + 4.0)
+    }
+    assert(BlockStats.overallCount === 1)
+    assert(BlockStats.overallBytes === 134)
+
+    // Resize to full array
+    block.update(1, 14.0)
+    assert(BlockStats.overallCount === 1)
+    assert(BlockStats.overallBytes === 486)
+
+    BlockStats.dec(block)
+    assert(BlockStats.overallCount === 0)
+    assert(BlockStats.overallBytes === 0)
+  }
+}


### PR DESCRIPTION
The compressed array block was always using buffer
member rather than the passed in array. This caused
resizes to be ignored since the delta would always
be 0.