### PR TITLE
reduce array allocations for encoding batch

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcMessages.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcMessages.scala
@@ -224,7 +224,7 @@ object LwcMessages {
     } finally {
       gen.close()
     }
-    ByteString(baos.toByteArray)
+    ByteString.fromArrayUnsafe(baos.toByteArray)
   }
 
   /**

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import sbt.librarymanagement.DependencyBuilders.OrganizationArtifactName
 
 object Dependencies {
   object Versions {
-    val akka       = "2.6.14"
+    val akka       = "2.6.15"
     val akkaHttpV  = "10.2.4"
     val aws        = "2.16.78"
     val iep        = "3.0.0"


### PR DESCRIPTION
Use `fromArrayUnsafe` to avoid copying the byte array used
by the ByteString object.