### PR TITLE
eval: properly handle non-strict messages

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -481,11 +481,11 @@ private[stream] abstract class EvaluatorImpl(
         case TextMessage.Strict(str) =>
           parseMessage(str)
         case msg: TextMessage =>
-          msg.textStream.fold("")(_ + _).map(parseMessage)
+          msg.textStream.fold("")(_ + _).flatMapConcat(parseMessage)
         case BinaryMessage.Strict(str) =>
           parseBatch(str)
         case msg: BinaryMessage =>
-          msg.dataStream.fold(ByteString.empty)(_ ++ _).map(parseBatch)
+          msg.dataStream.fold(ByteString.empty)(_ ++ _).flatMapConcat(parseBatch)
       }
       .mapMaterializedValue(_ => NotUsed)
   }


### PR DESCRIPTION
In cases where the message from the websocket was not
strict, the source from the parsed batch wasn't getting
flattend properly and the batch would get ignored later
because it wasn't a recognized message type.