### PR TITLE
add SortedTagMap implementation

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/ArrayHelper.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/ArrayHelper.scala
@@ -237,4 +237,54 @@ object ArrayHelper {
       builder.result()
     }
   }
+
+  /**
+    * Sort a string array that consists of tag key/value pairs by key. The array will be
+    * sorted in-place. The pair arrays are supposed to be fairly small, typically less than 20
+    * tags. With the small size a simple insertion sort works well.
+    */
+  def sortPairs[T <: Comparable[T]](data: Array[T]): Unit = {
+    sortPairs(data, data.length)
+  }
+
+  /**
+    * Sort a string array that consists of tag key/value pairs by key. The array will be
+    * sorted in-place. The pair arrays are supposed to be fairly small, typically less than 20
+    * tags. With the small size a simple insertion sort works well.
+    */
+  def sortPairs[T <: Comparable[T]](data: Array[T], length: Int): Unit = {
+    require(length % 2 == 0, "array must have even number of elements")
+    if (length == 4) {
+      // Two key/value pairs, swap if needed
+      if (data(0).compareTo(data(2)) > 0) {
+        // Swap key
+        var tmp = data(0)
+        data(0) = data(2)
+        data(2) = tmp
+        // Swap value
+        tmp = data(1)
+        data(1) = data(3)
+        data(3) = tmp
+      }
+    } else if (length > 4) {
+      // One entry is already sorted. Two entries handled above, for larger arrays
+      // use insertion sort.
+      var i = 2
+      while (i < length) {
+        val k = data(i)
+        val v = data(i + 1)
+        var j = i - 2
+
+        while (j >= 0 && data(j).compareTo(k) > 0) {
+          data(j + 2) = data(j)
+          data(j + 3) = data(j + 1)
+          j -= 2
+        }
+        data(j + 2) = k
+        data(j + 3) = v
+
+        i += 2
+      }
+    }
+  }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/SortedTagMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/SortedTagMap.scala
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+/**
+  * Immutable map implementation for tag maps using a sorted array as the underlying storage.
+  */
+final class SortedTagMap private (data: Array[String], length: Int)
+    extends scala.collection.immutable.Map[String, String]
+    with Comparable[SortedTagMap] {
+
+  private def find(key: String): Int = {
+    if (length == 0) {
+      -2
+    } else {
+      var left = 0
+      var right = length / 2 - 1
+      while (left <= right) {
+        val mid = (left + right) / 2
+        val cmp = data(mid * 2).compareTo(key)
+        if (cmp == 0) {
+          // equal, return position
+          return mid * 2
+        } else if (cmp > 0) {
+          // key is in left half
+          right = mid - 1
+        } else {
+          // key is in right half
+          left = mid + 1
+        }
+      }
+      // key is not present, return position for insertion
+      -(left * 2) - 2
+    }
+  }
+
+  override def removed(key: String): Map[String, String] = {
+    val pos = find(key)
+    if (pos < 0) this
+    else {
+      val copy = new Array[String](length - 2)
+      System.arraycopy(data, 0, copy, 0, pos)
+      System.arraycopy(data, pos + 2, copy, pos, length - pos - 2)
+      new SortedTagMap(copy, copy.length)
+    }
+  }
+
+  override def updated[V1 >: String](key: String, value: V1): Map[String, V1] = {
+    val pos = find(key)
+    if (pos < 0) {
+      val insertPos = -(pos + 2)
+      val copy = new Array[String](length + 2)
+      System.arraycopy(data, 0, copy, 0, insertPos)
+      copy(insertPos) = key
+      copy(insertPos + 1) = value.asInstanceOf[String]
+      System.arraycopy(data, insertPos, copy, insertPos + 2, length - insertPos)
+      new SortedTagMap(copy, copy.length)
+    } else {
+      val copy = new Array[String](length)
+      System.arraycopy(data, 0, copy, 0, length)
+      copy(pos + 1) = value.asInstanceOf[String]
+      new SortedTagMap(copy, copy.length)
+    }
+  }
+
+  /** Return the key in the given position. */
+  def key(i: Int): String = {
+    data(i * 2)
+  }
+
+  /** Return the value in the given position. */
+  def value(i: Int): String = {
+    data(i * 2 + 1)
+  }
+
+  /**
+    * Return the value associated with a key or null if it is not present. This method can be
+    * useful to avoid the allocation of a tuple instance when using `get(key)`.
+    */
+  def getOrNull(key: String): String = {
+    val pos = find(key)
+    if (pos < 0) null else data(pos + 1)
+  }
+
+  override def get(key: String): Option[String] = {
+    Option(getOrNull(key))
+  }
+
+  override def iterator: Iterator[(String, String)] = {
+    val n = length
+    new Iterator[(String, String)] {
+      private var i = 0
+
+      override def hasNext: Boolean = i < n
+
+      override def next(): (String, String) = {
+        val tuple = data(i) -> data(i + 1)
+        i += 2
+        tuple
+      }
+    }
+  }
+
+  override def foreachEntry[U](f: (String, String) => U): Unit = {
+    var i = 0
+    while (i < length) {
+      f(data(i), data(i + 1))
+      i += 2
+    }
+  }
+
+  override def size: Int = {
+    length / 2
+  }
+
+  override def compareTo(other: SortedTagMap): Int = {
+    if (this eq other) {
+      0
+    } else {
+      val n = math.min(size, other.size)
+      var i = 0
+      while (i < n) {
+        var cmp = key(i).compareTo(other.key(i))
+        if (cmp != 0)
+          return cmp
+
+        cmp = value(i).compareTo(other.value(i))
+        if (cmp != 0)
+          return cmp
+        i += 1
+      }
+      // If they are equal up to this point, then remaining items in one list should
+      // put it after the other
+      size - other.size
+    }
+  }
+}
+
+/** Helper functions for working with sorted tag maps. */
+object SortedTagMap {
+
+  /** Instance of empty tag map that can be reused. */
+  val empty: SortedTagMap = new SortedTagMap(new Array[String](0), 0)
+
+  /**
+    * Create a new instance based on an array of paired strings. The array that is passed
+    * in will not be modified and is not used internally so it is safe to reuse.
+    */
+  def apply(data: Array[String]): SortedTagMap = {
+    val array = java.util.Arrays.copyOf(data, data.length)
+    ArrayHelper.sortPairs(array)
+    new SortedTagMap(array, array.length)
+  }
+
+  /**
+    * Create a new instance based on a collection of tuples.
+    */
+  def apply(data: IterableOnce[(String, String)]): SortedTagMap = {
+    data match {
+      case m: SortedTagMap => m
+      case m: Map[String, String] =>
+        builder(m.size).addAll(m).result()
+      case _ =>
+        val size = data.knownSize
+        builder(if (size >= 0) size else 10).addAll(data).result()
+    }
+  }
+
+  /**
+    * Create a new instance from an already sorted array. The array will be reused and should
+    * not be modified.
+    */
+  def createUnsafe(data: Array[String], length: Int): SortedTagMap = {
+    new SortedTagMap(data, length)
+  }
+
+  /**
+    * Builder for constructing a new instance of a sorted tag map. The builder instance
+    * cannot be used after the result is computed.
+    *
+    * @param initialSize
+    *     Size to use for the buffer where added elements are placed. Setting this appropriately
+    *     can improve efficiency by avoiding resizes of the buffer.
+    * @return
+    *     Instance of the builder.
+    */
+  def builder(initialSize: Int = 10): Builder = {
+    new Builder(initialSize)
+  }
+
+  /** Builder for constructing a new instance of a sorted tag map. */
+  class Builder(initialSize: Int) {
+
+    private var buf = new Array[String](initialSize * 2)
+    private var pos = 0
+
+    private def resize(): Unit = {
+      val tmp = new Array[String](buf.length + initialSize * 2)
+      System.arraycopy(buf, 0, tmp, 0, pos)
+      buf = tmp
+    }
+
+    /** Add a tuple into the tag map. */
+    def +=(pair: (String, String)): Unit = add(pair._1, pair._2)
+
+    /** Add a key/value pair into the tag map. */
+    def add(key: String, value: String): Builder = {
+      if (pos >= buf.length) {
+        resize()
+      }
+      buf(pos) = key
+      buf(pos + 1) = value
+      pos += 2
+      this
+    }
+
+    /** Add all entries from the map into the tag map. */
+    def addAll(m: Map[String, String]): Builder = {
+      m.foreachEntry(add)
+      this
+    }
+
+    /** Add all tuples from the collection into the tag map. */
+    def addAll(data: IterableOnce[(String, String)]): Builder = {
+      val it = data.iterator
+      while (it.hasNext) {
+        this += it.next()
+      }
+      this
+    }
+
+    /**
+      * Compute result and clear the internal buffer. The builder instance cannot be used again
+      * after calling.
+      */
+    def result(): SortedTagMap = {
+      ArrayHelper.sortPairs(buf, pos)
+      val map = createUnsafe(buf, pos)
+      buf = null
+      map
+    }
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/ArrayHelperSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/ArrayHelperSuite.scala
@@ -17,6 +17,8 @@ package com.netflix.atlas.core.util
 
 import org.scalatest.funsuite.AnyFunSuite
 
+import java.util.UUID
+
 class ArrayHelperSuite extends AnyFunSuite {
 
   test("merge arrays, limit 1: empty, one") {
@@ -129,5 +131,32 @@ class ArrayHelperSuite extends AnyFunSuite {
     val v2 = List("a", "d")
     val actual = ArrayHelper.merger[String](2).merge(v1).merge(v2).toList
     assert(actual === List("a", "b"))
+  }
+
+  test("sortPairs, empty") {
+    val data = Array.empty[String]
+    ArrayHelper.sortPairs(data)
+  }
+
+  test("sortPairs, single pair") {
+    val data = Array("b", "1")
+    ArrayHelper.sortPairs(data)
+    val expected = Array("b", "1")
+    assert(expected.toList === data.toList)
+  }
+
+  test("sortPairs, two pairs") {
+    val data = Array("b", "1", "a", "2")
+    ArrayHelper.sortPairs(data)
+    val expected = Array("a", "2", "b", "1")
+    assert(expected.toList === data.toList)
+  }
+
+  test("sortPairs, random") {
+    val input = (0 until 50).map(i => UUID.randomUUID().toString -> i.toString)
+    val data = input.flatMap(t => List(t._1, t._2)).toArray
+    ArrayHelper.sortPairs(data)
+    val expected = input.toList.sortWith(_._1 < _._1).flatMap(t => List(t._1, t._2))
+    assert(expected === data.toList)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/SortedTagMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/SortedTagMapSuite.scala
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class SortedTagMapSuite extends AnyFunSuite {
+
+  test("empty") {
+    val m = SortedTagMap.empty
+    assert(m.isEmpty)
+    assert(m.size == 0)
+    assert(m.get("a").isEmpty)
+    assert(m.toList === List.empty)
+  }
+
+  test("single pair") {
+    val m = SortedTagMap(Array("a", "1"))
+    assert(m.nonEmpty)
+    assert(m.size == 1)
+    assert(m.get("a").contains("1"))
+    assert(m.toList === List("a" -> "1"))
+  }
+
+  test("four pairs") {
+    val m = SortedTagMap(Array("c", "2", "a", "0", "d", "3", "b", "1"))
+    assert(m.nonEmpty)
+    assert(m.size == 4)
+    (0 until 4).foreach { i =>
+      val k = s"${('a' + i).asInstanceOf[Char]}"
+      assert(m.get(k).contains(i.toString))
+    }
+    assert(m.toList === List("a" -> "0", "b" -> "1", "c" -> "2", "d" -> "3"))
+  }
+
+  private def pairs: List[(String, String)] = {
+    (' ' to '~').toList.map { i =>
+      val k = s"${('a' + i).asInstanceOf[Char]}"
+      k -> i.toString
+    }
+  }
+
+  test("many pairs") {
+    val input = scala.util.Random.shuffle(pairs)
+    val m = SortedTagMap(input)
+    assert(m.nonEmpty)
+    assert(m.size == input.size)
+    input.foreach { t =>
+      assert(m.get(t._1).contains(t._2))
+    }
+    assert(m.toList === pairs)
+  }
+
+  test("updates: adding new keys") {
+    val input = scala.util.Random.shuffle(pairs)
+    val actual = input.foldLeft[Map[String, String]](SortedTagMap.empty) { (acc, t) =>
+      acc + t
+    }
+    val expected = SortedTagMap(input)
+    assert(actual === expected)
+    assert(actual.isInstanceOf[SortedTagMap])
+  }
+
+  test("updates: overwriting keys") {
+    val input = scala.util.Random.shuffle(pairs)
+    val base = SortedTagMap(input.map(t => t._1 -> "default"))
+    val actual = input.foldLeft[Map[String, String]](base) { (acc, t) =>
+      acc + t
+    }
+    val expected = SortedTagMap(input)
+    assert(actual === expected)
+    assert(actual.isInstanceOf[SortedTagMap])
+  }
+
+  @scala.annotation.tailrec
+  private def removalTest(input: List[(String, String)]): Unit = {
+    if (input.nonEmpty) {
+      // remove key that exists
+      val actual = SortedTagMap(input) - input.head._1
+      val expected = SortedTagMap(input.tail)
+      assert(actual === expected)
+
+      // remove key that is missing
+      assert(actual - input.head._1 === expected)
+
+      // check type
+      assert(actual.isInstanceOf[SortedTagMap])
+      removalTest(input.tail)
+    }
+  }
+
+  test("removals") {
+    val input = scala.util.Random.shuffle(pairs)
+    removalTest(input)
+  }
+
+  test("foreachEntry") {
+    val actual = List.newBuilder[(String, String)]
+    SortedTagMap(pairs).foreachEntry { (k, v) =>
+      actual += k -> v
+    }
+    val expected = pairs
+    assert(actual.result() === expected)
+  }
+
+  test("create from SortedTagMap") {
+    val a = SortedTagMap(pairs)
+    val b = SortedTagMap(a)
+    assert(a eq b)
+  }
+
+  test("create from Map[String, String]") {
+    val map = pairs.toMap
+    val actual = SortedTagMap(map)
+    val expected = SortedTagMap(pairs)
+    assert(actual === expected)
+  }
+
+  test("create from IterableOnce") {
+    val map = pairs.toMap.view
+    val actual = SortedTagMap(map)
+    val expected = SortedTagMap(pairs)
+    assert(actual === expected)
+  }
+
+  test("create uneven size") {
+    intercept[IllegalArgumentException] {
+      SortedTagMap(Array("a", "b", "c"))
+    }
+  }
+
+  test("compareTo: empty") {
+    val a = SortedTagMap.empty
+    val b = SortedTagMap(List.empty)
+    assert(a.compareTo(b) === 0)
+    assert(b.compareTo(a) === 0)
+  }
+
+  test("compareTo: self") {
+    val a = SortedTagMap(Array("a", "1", "b", "2"))
+    assert(a.compareTo(a) === 0)
+  }
+
+  test("compareTo: different keys") {
+    val a = SortedTagMap(Array("a", "1", "b", "2"))
+    val b = SortedTagMap(Array("a", "1", "c", "2"))
+    assert(a.compareTo(b) < 0)
+    assert(b.compareTo(a) > 0)
+  }
+
+  test("compareTo: different values") {
+    val a = SortedTagMap(Array("a", "1", "b", "2"))
+    val b = SortedTagMap(Array("a", "2", "b", "2"))
+    assert(a.compareTo(b) < 0)
+    assert(b.compareTo(a) > 0)
+  }
+
+  test("compareTo: different sizes") {
+    val a = SortedTagMap(Array("a", "1", "b", "2"))
+    val b = SortedTagMap(Array("a", "1", "b", "2", "c", "3"))
+    assert(a.compareTo(b) < 0)
+    assert(b.compareTo(a) > 0)
+  }
+}


### PR DESCRIPTION
For some of the storage experiments it is useful to be
able to receive and maintain the tags sorted by the keys.
This change adds an implementation of Map that is based
on a sorted string array. The memory overhead and general
performance is similar to SmallHashMap, though lookups for
an individual key can be slower, logarithmic rather than
typically constant, compared to a non-compact small hash
map instance.