### PR TITLE
update access logger to record sizes

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/AccessLogger.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/AccessLogger.scala
@@ -108,10 +108,14 @@ object AccessLogger {
       .withHttpMethod(request.method.name)
       .withUri(request.uri.toString(), request.uri.path.toString())
     request.headers.foreach(h => entry.addRequestHeader(h.name, h.value))
+    entry.addRequestHeader("Content-Type", request.entity.contentType.value)
+    request.entity.contentLengthOption.foreach(entry.withRequestContentLength)
   }
 
   private def addResponseInfo(entry: IpcLogEntry, response: HttpResponse): Unit = {
     entry.withHttpStatus(response.status.intValue)
     response.headers.foreach(h => entry.addResponseHeader(h.name, h.value))
+    entry.addResponseHeader("Content-Type", response.entity.contentType.value)
+    response.entity.contentLengthOption.foreach(entry.withResponseContentLength)
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
     val log4j      = "2.14.1"
     val scala      = "2.13.6"
     val slf4j      = "1.7.32"
-    val spectator  = "0.135.0"
+    val spectator  = "1.0.1"
 
     val crossScala = Seq(scala)
   }


### PR DESCRIPTION
Record the request/response entity sizes to the ipc
logger when it is known.