### PR TITLE
avoid allocation for computing size

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
@@ -488,6 +488,12 @@ final class SmallHashMap[K <: Any, V <: Any] private (val data: Array[Any], data
           }
         }
       }
+
+      /**
+        * Overridden for efficiency to avoid need to allocate entry set iterator with default
+        * implementation.
+        */
+      override def size(): Int = self.size
     }
   }
 }


### PR DESCRIPTION
The Java Map view for SmallHashMap was using the default
implementation of `size` that calls `entrySet().size()`.
This change overrides the size to avoid creating the
entry set unnecessarily.