### PR TITLE
tune id calculation when using sorted map

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/ItemIdCalculator.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/ItemIdCalculator.scala
@@ -18,6 +18,7 @@ package com.netflix.atlas.core.model
 import com.netflix.atlas.core.util.ArrayHelper
 import com.netflix.atlas.core.util.Hash
 import com.netflix.atlas.core.util.SmallHashMap
+import com.netflix.atlas.core.util.SortedTagMap
 
 import java.nio.ByteBuffer
 import java.nio.CharBuffer
@@ -58,6 +59,8 @@ class ItemIdCalculator {
     }
 
     tags match {
+      case ts: SortedTagMap =>
+        ts.copyToArray(pairs)
       case ts: SmallHashMap[String, String] =>
         var pos = 0
         val iter = ts.entriesIterator

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/SortedTagMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/SortedTagMap.scala
@@ -147,6 +147,14 @@ final class SortedTagMap private (data: Array[String], length: Int)
       size - other.size
     }
   }
+
+  /**
+    * Copy internal data for the map into a string array. The passed in buffer must have
+    * a length of at least twice the size of this map.
+    */
+  def copyToArray(buffer: Array[String]): Unit = {
+    System.arraycopy(data, 0, buffer, 0, length)
+  }
 }
 
 /** Helper functions for working with sorted tag maps. */
@@ -163,6 +171,14 @@ object SortedTagMap {
     val array = java.util.Arrays.copyOf(data, data.length)
     ArrayHelper.sortPairs(array)
     new SortedTagMap(array, array.length)
+  }
+
+  /**
+    * Create a new instance from varargs tuples.
+    */
+  def apply(data: (String, String)*): SortedTagMap = {
+    val size = data.knownSize
+    builder(if (size >= 0) size else 10).addAll(data).result()
   }
 
   /**

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TaggedItemSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TaggedItemSuite.scala
@@ -17,6 +17,7 @@ package com.netflix.atlas.core.model
 
 import com.netflix.atlas.core.util.Hash
 import com.netflix.atlas.core.util.SmallHashMap
+import com.netflix.atlas.core.util.SortedTagMap
 import org.scalatest.funsuite.AnyFunSuite
 
 import java.util.UUID
@@ -56,6 +57,14 @@ class TaggedItemSuite extends AnyFunSuite {
   test("computeId, small hash map") {
     val t1 = SmallHashMap("name" -> "foo", "cluster" -> "abc", "app" -> "a", "zone" -> "1")
     val t2 = SmallHashMap("name" -> "foo", "cluster" -> "abc", "app" -> "a", "zone" -> "2")
+    assert(TaggedItem.computeId(t1) === expectedId(t1))
+    assert(TaggedItem.computeId(t2) === expectedId(t2))
+    assert(TaggedItem.computeId(t1) != TaggedItem.computeId(t2))
+  }
+
+  test("computeId, sorted tag map") {
+    val t1 = SortedTagMap("name" -> "foo", "cluster" -> "abc", "app" -> "a", "zone" -> "1")
+    val t2 = SortedTagMap("name" -> "foo", "cluster" -> "abc", "app" -> "a", "zone" -> "2")
     assert(TaggedItem.computeId(t1) === expectedId(t1))
     assert(TaggedItem.computeId(t2) === expectedId(t2))
     assert(TaggedItem.computeId(t1) != TaggedItem.computeId(t2))


### PR DESCRIPTION
Avoid the duplicate sort and support a direct copy
into the buffer array.