### PR TITLE
reduce overhead of expressions etag check

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/FastGzipOutputStream.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/FastGzipOutputStream.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import java.io.OutputStream
+import java.util.zip.Deflater
+import java.util.zip.GZIPOutputStream
+
+/** Wrap GZIPOutputStream to set the best speed compression level. */
+final class FastGzipOutputStream(out: OutputStream) extends GZIPOutputStream(out) {
+  `def`.setLevel(Deflater.BEST_SPEED)
+}


### PR DESCRIPTION
Before it would compute the etag by computing a sha1 hash
of a string representation of the sorted expression list.
With 100k+ expressions that is quite expensive both in
terms of the memory use and CPU.

This change introduces a cache for the encoded entity so
it can be returned directly if there are frequent calls
within a short period. The ETag is computed over the
encoded and compressed response using CRC32. This reduces
the memory and CPU overhead considerably.