### PR TITLE
batch messages going to evaluation queue

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/QueueHandler.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/QueueHandler.scala
@@ -28,12 +28,17 @@ import com.typesafe.scalalogging.StrictLogging
   * @param queue
   *     Underlying queue that will receive the messsages.
   */
-class QueueHandler(id: String, queue: StreamOps.SourceQueue[JsonSupport]) extends StrictLogging {
+class QueueHandler(id: String, queue: StreamOps.SourceQueue[Seq[JsonSupport]])
+    extends StrictLogging {
 
-  def offer(msg: JsonSupport): Unit = {
-    logger.trace(s"enqueuing message for $id: ${msg.toJson}")
-    if (!queue.offer(msg))
-      logger.debug(s"failed to enqueue message for $id: ${msg.toJson}")
+  private def toJson(msgs: Seq[JsonSupport]): String = {
+    msgs.map(_.toJson).mkString("[", ",", "]")
+  }
+
+  def offer(msgs: Seq[JsonSupport]): Unit = {
+    logger.trace(s"enqueuing message for $id: ${toJson(msgs)}")
+    if (!queue.offer(msgs))
+      logger.debug(s"failed to enqueue message for $id: ${toJson(msgs)}")
   }
 
   def complete(): Unit = {

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
@@ -44,7 +44,7 @@ class ExpressionApiSuite extends AnyFunSuite with ScalatestRouteTest {
   private val queue = new QueueHandler(
     "test",
     StreamOps
-      .blockingQueue[JsonSupport](new NoopRegistry, "test", 1)
+      .blockingQueue[Seq[JsonSupport]](new NoopRegistry, "test", 1)
       .toMat(Sink.ignore)(Keep.left)
       .run()
   )

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
@@ -86,7 +86,7 @@ class SubscribeApiSuite extends AnyFunSuite with BeforeAndAfter with ScalatestRo
         val datapoint = LwcDatapoint(60000, m.id, tags, 42.0)
         val handlers = sm.handlersForSubscription(m.id)
         assert(handlers.size === 1)
-        handlers.head.offer(datapoint)
+        handlers.head.offer(Seq(datapoint))
 
         assert(parse(client.expectMessage()) === datapoint)
       }
@@ -125,7 +125,7 @@ class SubscribeApiSuite extends AnyFunSuite with BeforeAndAfter with ScalatestRo
         val datapoint = LwcDatapoint(60000, m.id, tags, 42.0)
         val handlers = sm.handlersForSubscription(m.id)
         assert(handlers.size === 1)
-        handlers.head.offer(datapoint)
+        handlers.head.offer(Seq(datapoint))
 
         assert(parseBatch(client.expectMessage()) === List(datapoint))
       }

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/WebSocketSessionManagerSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/WebSocketSessionManagerSuite.scala
@@ -94,7 +94,7 @@ class WebSocketSessionManagerSuite extends AnyFunSuite {
 
   private def createNoopRegisterFunc(): String => (QueueHandler, Source[JsonSupport, Unit]) = {
     val noopQueueHandler = new QueueHandler("", null) {
-      override def offer(msg: JsonSupport): Unit = ()
+      override def offer(msgs: Seq[JsonSupport]): Unit = ()
       override def complete(): Unit = ()
     }
     val noopSource = Source.empty[JsonSupport].mapMaterializedValue(_ => ())


### PR DESCRIPTION
There is some synchronization needed to offer an item
to the source queue. With a high throughput this can
add up to a lot of contention across threads. Batch
the incoming datapoints to reduce the number of items
that have to be offered to the queue.