### PR TITLE
move flatMap to after the broadcast hub

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
@@ -152,7 +152,6 @@ class SubscribeApi @Inject() (
     // Create queue to allow messages coming into /evaluate to be passed to this stream
     val (queue, queueSrc) = StreamOps
       .blockingQueue[Seq[JsonSupport]](registry, "SubscribeApi", queueSize)
-      .flatMapConcat(Source.apply)
       .toMat(BroadcastHub.sink(1))(Keep.both)
       .run()
 
@@ -178,6 +177,7 @@ class SubscribeApi @Inject() (
       }
 
     val source = queueSrc
+      .flatMapConcat(Source.apply)
       .merge(heartbeatSrc)
       .via(StreamOps.monitorFlow(registry, "StreamApi"))
       .watchTermination() { (_, f) =>


### PR DESCRIPTION
Doing it before results in a lot more message passing. By
moving it after fusing happens and it is fairly cheap.