### PR TITLE
add stream wrappers for nio buffers

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/ByteBufferInputStream.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/ByteBufferInputStream.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import java.io.InputStream
+import java.nio.ByteBuffer
+
+/**
+  * Wraps a ByteBuffer so it can be used with interfaces that require an InputStream. The
+  * buffer should not be modified outside of the reader until reading is complete.
+  */
+class ByteBufferInputStream(buffer: ByteBuffer) extends InputStream {
+
+  override def read(): Int = {
+    if (buffer.hasRemaining) buffer.get() else -1
+  }
+
+  override def read(buf: Array[Byte], offset: Int, length: Int): Int = {
+    if (buffer.hasRemaining) {
+      val readLength = math.min(buffer.remaining(), length)
+      buffer.get(buf, offset, readLength)
+      readLength
+    } else {
+      -1
+    }
+  }
+
+  override def available(): Int = {
+    buffer.remaining()
+  }
+
+  override def skip(n: Long): Long = {
+    val skipAmount = math.min(buffer.remaining(), n).toInt
+    buffer.position(buffer.position() + skipAmount)
+    skipAmount
+  }
+
+  override def markSupported(): Boolean = true
+
+  override def mark(readlimit: Int): Unit = {
+    buffer.mark()
+  }
+
+  override def reset(): Unit = {
+    buffer.reset()
+  }
+
+  override def close(): Unit = {
+    buffer.flip()
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/CharBufferReader.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/CharBufferReader.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import java.io.Reader
+import java.nio.CharBuffer
+
+/**
+  * Wraps a CharBuffer so it can be used with interfaces that require a Reader. The buffer
+  * should not be modified outside of the reader until reading is complete.
+  */
+class CharBufferReader(buffer: CharBuffer) extends Reader {
+
+  override def read(cbuf: Array[Char], offset: Int, length: Int): Int = {
+    if (buffer.hasRemaining) {
+      val readLength = math.min(buffer.remaining(), length)
+      buffer.get(cbuf, offset, readLength)
+      readLength
+    } else {
+      -1
+    }
+  }
+
+  override def read(): Int = {
+    if (buffer.hasRemaining) buffer.get() else -1
+  }
+
+  override def ready(): Boolean = true
+
+  override def skip(n: Long): Long = {
+    val skipAmount = math.min(buffer.remaining(), n).toInt
+    buffer.position(buffer.position() + skipAmount)
+    skipAmount
+  }
+
+  override def markSupported(): Boolean = true
+
+  override def mark(readAheadLimit: Int): Unit = {
+    buffer.mark()
+  }
+
+  override def reset(): Unit = {
+    buffer.reset()
+  }
+
+  override def close(): Unit = {
+    buffer.flip()
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/ByteBufferInputStreamSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/ByteBufferInputStreamSuite.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import scala.util.Using
+
+class ByteBufferInputStreamSuite extends AnyFunSuite {
+
+  private def wrap(str: String): ByteBuffer = {
+    ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_8))
+  }
+
+  test("read()") {
+    val buffer = wrap("abc")
+    val in = new ByteBufferInputStream(buffer)
+    assert(in.read() === 'a')
+    assert(in.read() === 'b')
+    assert(in.read() === 'c')
+    assert(in.read() === -1)
+  }
+
+  test("read(buf)") {
+    val buffer = wrap("abc")
+    val in = new ByteBufferInputStream(buffer)
+    val array = new Array[Byte](2)
+    assert(in.read(array) === 2)
+    assert(array === Array('a', 'b'))
+    assert(in.read(array) === 1)
+    assert(array === Array('c', 'b')) // b left over from previous
+    assert(in.read(array) === -1)
+  }
+
+  test("read(buf, offset, length)") {
+    val buffer = wrap("abc")
+    val in = new ByteBufferInputStream(buffer)
+    val array = new Array[Byte](5)
+    assert(in.read(array, 2, 3) === 3)
+    assert(array === Array('\u0000', '\u0000', 'a', 'b', 'c'))
+    assert(in.read(array) === -1)
+  }
+
+  test("available()") {
+    val buffer = wrap("abc")
+    val in = new ByteBufferInputStream(buffer)
+    assert(in.available() === 3)
+    assert(in.skip(2) === 2)
+    assert(in.available() === 1)
+    assert(in.read() === 'c')
+    assert(in.available() === 0)
+  }
+
+  test("skip()") {
+    val buffer = wrap("abc")
+    val in = new ByteBufferInputStream(buffer)
+    assert(in.skip(2) === 2)
+    assert(in.read() === 'c')
+    assert(in.read() === -1)
+    assert(in.skip(2) === 0)
+  }
+
+  test("mark() and reset()") {
+    val buffer = wrap("abc")
+    val in = new ByteBufferInputStream(buffer)
+    assert(in.markSupported())
+    assert(in.read() === 'a')
+
+    in.mark(5)
+    assert(in.read() === 'b')
+    assert(in.read() === 'c')
+
+    in.reset()
+    assert(in.read() === 'b')
+
+    in.reset()
+    assert(in.read() === 'b')
+  }
+
+  test("close()") {
+    val buffer = wrap("abc")
+    val in = new ByteBufferInputStream(buffer)
+    (0 until 10).foreach { _ =>
+      Using.resource(in) { r =>
+        assert(r.read() === 'a')
+        r.skip(100)
+        assert(r.read() === -1)
+      }
+    }
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/CharBufferReaderSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/CharBufferReaderSuite.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.nio.CharBuffer
+import scala.util.Using
+
+class CharBufferReaderSuite extends AnyFunSuite {
+
+  test("read()") {
+    val buffer = CharBuffer.wrap("abc")
+    val reader = new CharBufferReader(buffer)
+    assert(reader.read() === 'a')
+    assert(reader.read() === 'b')
+    assert(reader.read() === 'c')
+    assert(reader.read() === -1)
+  }
+
+  test("read(cbuf)") {
+    val buffer = CharBuffer.wrap("abc")
+    val reader = new CharBufferReader(buffer)
+    val array = new Array[Char](2)
+    assert(reader.read(array) === 2)
+    assert(array === Array('a', 'b'))
+    assert(reader.read(array) === 1)
+    assert(array === Array('c', 'b')) // b left over from previous
+    assert(reader.read(array) === -1)
+  }
+
+  test("read(cbuf, offset, length)") {
+    val buffer = CharBuffer.wrap("abc")
+    val reader = new CharBufferReader(buffer)
+    val array = new Array[Char](5)
+    assert(reader.read(array, 2, 3) === 3)
+    assert(array === Array('\u0000', '\u0000', 'a', 'b', 'c'))
+    assert(reader.read(array) === -1)
+  }
+
+  test("ready()") {
+    val buffer = CharBuffer.wrap("abc")
+    val reader = new CharBufferReader(buffer)
+    assert(reader.ready())
+  }
+
+  test("skip()") {
+    val buffer = CharBuffer.wrap("abc")
+    val reader = new CharBufferReader(buffer)
+    assert(reader.skip(2) === 2)
+    assert(reader.read() === 'c')
+    assert(reader.read() === -1)
+    assert(reader.skip(2) === 0)
+  }
+
+  test("mark() and reset()") {
+    val buffer = CharBuffer.wrap("abc")
+    val reader = new CharBufferReader(buffer)
+    assert(reader.markSupported())
+    assert(reader.read() === 'a')
+
+    reader.mark(5)
+    assert(reader.read() === 'b')
+    assert(reader.read() === 'c')
+
+    reader.reset()
+    assert(reader.read() === 'b')
+
+    reader.reset()
+    assert(reader.read() === 'b')
+  }
+
+  test("close()") {
+    val buffer = CharBuffer.wrap("abc")
+    val reader = new CharBufferReader(buffer)
+    (0 until 10).foreach { _ =>
+      Using.resource(reader) { r =>
+        assert(r.read() === 'a')
+        r.skip(100)
+        assert(r.read() === -1)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add simple InputStream and Reader wrappers for use with
ByteBuffer and CharBuffer respectively. Useful for cases
where we have data in a NIO buffer, but need to pass it
to something that expects an InputStream or Reader.