### PR TITLE
avoid option allocation for contains

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
@@ -186,7 +186,11 @@ final class SmallHashMap[K <: Any, V <: Any] private (val data: Array[Any], data
     }
   }
 
-  def get(key: K): Option[V] = Option(getOrNull(key))
+  override def get(key: K): Option[V] = Option(getOrNull(key))
+
+  override def contains(key: K): Boolean = {
+    getOrNull(key) != null
+  }
 
   override def foreach[U](f: ((K, V)) => U): Unit = {
     var i = 0

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/SortedTagMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/SortedTagMap.scala
@@ -99,6 +99,10 @@ final class SortedTagMap private (data: Array[String], length: Int)
     Option(getOrNull(key))
   }
 
+  override def contains(key: String): Boolean = {
+    getOrNull(key) != null
+  }
+
   override def iterator: Iterator[(String, String)] = {
     val n = length
     new Iterator[(String, String)] {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/SmallHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/SmallHashMapSuite.scala
@@ -208,7 +208,9 @@ class SmallHashMapSuite extends AnyFunSuite {
     assert(m2.size === 2)
 
     assert(m1("k1") === "v1")
+    assert(m1.contains("k1"))
     intercept[NoSuchElementException] { m1("k2") }
+    assert(!m1.contains("k2"))
     assert(m2("k1") === "v1")
     assert(m2("k2") === "v2")
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/SortedTagMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/SortedTagMapSuite.scala
@@ -24,6 +24,7 @@ class SortedTagMapSuite extends AnyFunSuite {
     assert(m.isEmpty)
     assert(m.size == 0)
     assert(m.get("a").isEmpty)
+    assert(!m.contains("a"))
     assert(m.toList === List.empty)
   }
 
@@ -32,6 +33,7 @@ class SortedTagMapSuite extends AnyFunSuite {
     assert(m.nonEmpty)
     assert(m.size == 1)
     assert(m.get("a").contains("1"))
+    assert(m.contains("a"))
     assert(m.toList === List("a" -> "1"))
   }
 


### PR DESCRIPTION
Update SmallHashMap and SortedTagMap to override the
contains method and reduce the overhead.