### PR TITLE
optimize validation when using SortedTagMap

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/HasKeyRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/HasKeyRule.scala
@@ -17,6 +17,7 @@ package com.netflix.atlas.core.validation
 
 import com.netflix.atlas.core.util.IdMap
 import com.netflix.atlas.core.util.SmallHashMap
+import com.netflix.atlas.core.util.SortedTagMap
 import com.netflix.spectator.api.Id
 import com.typesafe.config.Config
 
@@ -30,6 +31,13 @@ import com.typesafe.config.Config
 case class HasKeyRule(key: String) extends Rule {
 
   override def validate(tags: SmallHashMap[String, String]): ValidationResult = {
+    if (tags.contains(key))
+      ValidationResult.Pass
+    else
+      failure(s"missing key '$key'", tags)
+  }
+
+  override def validate(tags: SortedTagMap): ValidationResult = {
     if (tags.contains(key))
       ValidationResult.Pass
     else

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/MaxUserTagsRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/MaxUserTagsRule.scala
@@ -18,6 +18,7 @@ package com.netflix.atlas.core.validation
 import com.netflix.atlas.core.model.TagKey
 import com.netflix.atlas.core.util.IdMap
 import com.netflix.atlas.core.util.SmallHashMap
+import com.netflix.atlas.core.util.SortedTagMap
 import com.netflix.spectator.api.Id
 import com.typesafe.config.Config
 
@@ -36,6 +37,20 @@ case class MaxUserTagsRule(limit: Int) extends Rule {
     while (iter.hasNext) {
       if (!TagKey.isRestricted(iter.key)) count += 1
       iter.nextEntry()
+    }
+    if (count <= limit) ValidationResult.Pass
+    else {
+      failure(s"too many user tags: $count > $limit", tags)
+    }
+  }
+
+  override def validate(tags: SortedTagMap): ValidationResult = {
+    val size = tags.size
+    var i = 0
+    var count = 0
+    while (i < size) {
+      if (!TagKey.isRestricted(tags.key(i))) count += 1
+      i += 1
     }
     if (count <= limit) ValidationResult.Pass
     else {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/NameValueLengthRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/NameValueLengthRule.scala
@@ -33,7 +33,8 @@ import com.typesafe.config.Config
   * }
   * ```
   */
-case class NameValueLengthRule(nameRule: TagRule, valueRule: TagRule) extends TagRule {
+case class NameValueLengthRule(nameRule: ValueLengthRule, valueRule: ValueLengthRule)
+    extends TagRule {
 
   override def validate(k: String, v: String): String = {
     if (k == "name") nameRule.validate(k, v) else valueRule.validate(k, v)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/validation/TagRule.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/validation/TagRule.scala
@@ -17,6 +17,7 @@ package com.netflix.atlas.core.validation
 
 import com.netflix.atlas.core.util.IdMap
 import com.netflix.atlas.core.util.SmallHashMap
+import com.netflix.atlas.core.util.SortedTagMap
 import com.netflix.spectator.api.Id
 
 /**
@@ -30,6 +31,17 @@ trait TagRule extends Rule {
       val result = validate(iter.key, iter.value)
       if (result != TagRule.Pass) return failure(result, tags)
       iter.nextEntry()
+    }
+    ValidationResult.Pass
+  }
+
+  override def validate(tags: SortedTagMap): ValidationResult = {
+    val size = tags.size
+    var i = 0
+    while (i < size) {
+      val result = validate(tags.key(i), tags.value(i))
+      if (result != TagRule.Pass) return failure(result, tags)
+      i += 1
     }
     ValidationResult.Pass
   }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/HasKeyRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/HasKeyRuleSuite.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.core.validation
 
+import com.netflix.atlas.core.util.SortedTagMap
 import com.netflix.spectator.api.Id
 import com.typesafe.config.ConfigFactory
 import org.scalatest.funsuite.AnyFunSuite
@@ -30,6 +31,15 @@ class HasKeyRuleSuite extends AnyFunSuite {
 
   test("missing key") {
     val res = rule.validate(Map("cluster" -> "foo"))
+    assert(res.isFailure)
+  }
+
+  test("sorted: has key") {
+    assert(rule.validate(SortedTagMap("name" -> "foo")) === ValidationResult.Pass)
+  }
+
+  test("sorted: missing key") {
+    val res = rule.validate(SortedTagMap("cluster" -> "foo"))
     assert(res.isFailure)
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/RuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/RuleSuite.scala
@@ -65,6 +65,11 @@ class RuleSuite extends AnyFunSuite {
 
   test("load") {
     val rules = Rule.load(config.getConfigList("rules"))
+    assert(rules.size === 9)
+  }
+
+  test("load, useComposite") {
+    val rules = Rule.load(config.getConfigList("rules"), true)
     assert(rules.size === 3)
     assert(rules.head.isInstanceOf[CompositeTagRule])
     assert(rules.head.asInstanceOf[CompositeTagRule].tagRules.size === 7)


### PR DESCRIPTION
Add validate variant that allows checking this type without
first converting to SmallHashMap.

Benchmark was updated and fixed so that validation would pass
which is the most common case in actual use. Before it would
fail due to the reserved key check. That made the benchmark
results misleading as the composite check seemed faster since
it was able to short-circuit earlier. For the successful case
it was actually slower. Also adds a flag that can be used to
choose whether or not to group simple tag rules into a
composite. By default it will not as that seems to generally
be faster.