### PR TITLE
ignore entity if present on pre-flight check

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/CustomDirectives.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/CustomDirectives.scala
@@ -231,7 +231,9 @@ object CustomDirectives {
         respondWithCorsHeaders(hosts) {
           // Ignore request body if present
           val future = ctx.request.discardEntityBytes(ctx.materializer).future()
-          onComplete(future) { _ => complete(response) }
+          onComplete(future) { _ =>
+            complete(response)
+          }
         }
       }
     }


### PR DESCRIPTION
Some clients send OPTIONS requests with an empty chunked
payload. This would result in warnings in the log because
the response was sent before consuming the request entity.