### PR TITLE
move tests to MUnit

### DIFF
--- a/atlas-akka-testkit/src/main/scala/com/netflix/atlas/akka/testkit/MUnitRouteSuite.scala
+++ b/atlas-akka-testkit/src/main/scala/com/netflix/atlas/akka/testkit/MUnitRouteSuite.scala
@@ -13,24 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.atlas.core.util
+package com.netflix.atlas.akka.testkit
 
-import org.scalatest.Assertions
+import akka.http.scaladsl.server.ExceptionHandler
+import akka.http.scaladsl.testkit.RouteTest
+import akka.http.scaladsl.testkit.TestFrameworkInterface
+import munit.FunSuite
 
-object Assert extends Assertions {
+abstract class MUnitRouteSuite extends FunSuite with RouteTest with TestFrameworkInterface {
 
-  def assertEquals(v1: Double, v2: Double, delta: Double): Unit = {
-    val diff = scala.math.abs(v1 - v2)
-    if (diff > delta) {
-      throw new AssertionError("%f != %f".format(v1, v2))
-    }
+  override def failTest(msg: String): Nothing = {
+    fail(msg)
   }
 
-  def assertEquals(v1: Double, v2: Double, delta: Double, msg: String): Unit = {
-    val diff = scala.math.abs(v1 - v2)
-    if (diff > delta) {
-      throw new AssertionError("%f != %f, %s".format(v1, v2, msg))
-    }
+  override def testExceptionHandler: ExceptionHandler = ExceptionHandler {
+    case e: Exception      => throw e
+    case e: AssertionError => throw e
   }
-
 }

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/ActorServiceSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/ActorServiceSuite.scala
@@ -20,11 +20,11 @@ import akka.actor.ActorSystem
 import akka.util.Timeout
 import com.netflix.iep.service.DefaultClassFactory
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.concurrent.Await
 
-class ActorServiceSuite extends AnyFunSuite {
+class ActorServiceSuite extends FunSuite {
 
   import scala.concurrent.duration._
   implicit val timeout = Timeout(5.seconds)
@@ -45,7 +45,7 @@ class ActorServiceSuite extends AnyFunSuite {
     try {
       val ref = system.actorSelection("/user/test")
       val v = Await.result(akka.pattern.ask(ref, "ping"), Duration.Inf)
-      assert(v === "ping")
+      assertEquals(v, "ping")
     } finally {
       service.stop()
       Await.ready(system.terminate(), Duration.Inf)
@@ -75,7 +75,7 @@ class ActorServiceSuite extends AnyFunSuite {
     try {
       val ref = system.actorSelection("/user/test")
       val v = Await.result(akka.pattern.ask(ref, "ping"), Duration.Inf)
-      assert(v === "ping")
+      assertEquals(v, "ping")
     } finally {
       service.stop()
       Await.ready(system.terminate(), Duration.Inf)

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/ByteStringInputStreamSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/ByteStringInputStreamSuite.scala
@@ -20,9 +20,9 @@ import java.security.MessageDigest
 import java.util.Random
 
 import akka.util.ByteString
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class ByteStringInputStreamSuite extends AnyFunSuite {
+class ByteStringInputStreamSuite extends FunSuite {
 
   private def singleRead(name: String, data: ByteString): Unit = {
     test(s"$name: read() and available()") {
@@ -31,15 +31,15 @@ class ByteStringInputStreamSuite extends AnyFunSuite {
 
       data.indices.foreach { i =>
         if (data.isCompact) {
-          assert(bais.available() === data.length - i)
-          assert(bsis.available() === data.length - i)
+          assertEquals(bais.available(), data.length - i)
+          assertEquals(bsis.available(), data.length - i)
         } else {
           assert(bsis.available() > 0)
         }
-        assert(bais.read() === bsis.read())
+        assertEquals(bais.read(), bsis.read())
       }
 
-      assert(bais.read() === bsis.read())
+      assertEquals(bais.read(), bsis.read())
     }
   }
 
@@ -58,16 +58,16 @@ class ByteStringInputStreamSuite extends AnyFunSuite {
         val len1 = bais.read(b1)
         val len2 = bsis.read(b2)
         if (data.isCompact) {
-          assert(len1 === len2)
-          assert(b1 === b2)
+          assertEquals(len1, len2)
+          assertEquals(b1.toSeq, b2.toSeq)
         }
         if (len1 > 0) h1.update(b1, 0, len1)
         if (len2 > 0) h2.update(b2, 0, len2)
         i += len2
       }
 
-      assert(bais.read(b1) === bsis.read(b2))
-      assert(h1.digest() === h2.digest())
+      assertEquals(bais.read(b1), bsis.read(b2))
+      assertEquals(h1.digest().toSeq, h2.digest().toSeq)
     }
   }
 

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/ClusterOpsSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/ClusterOpsSuite.scala
@@ -19,12 +19,12 @@ import akka.actor.ActorSystem
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class ClusterOpsSuite extends AnyFunSuite {
+class ClusterOpsSuite extends FunSuite {
 
   private implicit val system = ActorSystem(getClass.getSimpleName)
 
@@ -72,7 +72,7 @@ class ClusterOpsSuite extends AnyFunSuite {
       .via(ClusterOps.groupBy(context))
       .runWith(Sink.seq[Int])
     val seq = Await.result(future, Duration.Inf)
-    assert(seq === Seq(1, 2, 3))
+    assertEquals(seq, Seq(1, 2, 3))
   }
 
   test("groupBy: add and remove member") {
@@ -98,7 +98,7 @@ class ClusterOpsSuite extends AnyFunSuite {
       .via(ClusterOps.groupBy(context))
       .runWith(Sink.seq[Int])
     val seq = Await.result(future, Duration.Inf)
-    assert(seq.sortWith(_ < _) === Seq(1, 2, 3, 7, 8, 9))
+    assertEquals(seq.sortWith(_ < _), Seq(1, 2, 3, 7, 8, 9))
   }
 
   test("groupBy: multiple members") {
@@ -116,8 +116,8 @@ class ClusterOpsSuite extends AnyFunSuite {
       .via(ClusterOps.groupBy(context))
       .runWith(Sink.seq[(String, Int)])
     val seq = Await.result(future, Duration.Inf)
-    assert(seq.filter(_._1 == "a").map(_._2) === Seq(1, 3, 5))
-    assert(seq.filter(_._1 == "b").map(_._2) === Seq(2, 4, 6))
+    assertEquals(seq.filter(_._1 == "a").map(_._2), Seq(1, 3, 5))
+    assertEquals(seq.filter(_._1 == "b").map(_._2), Seq(2, 4, 6))
   }
 
   test("groupBy: failed substream") {
@@ -139,7 +139,7 @@ class ClusterOpsSuite extends AnyFunSuite {
       .via(ClusterOps.groupBy(context))
       .runWith(Sink.seq[(String, Int)])
     val seq = Await.result(future, Duration.Inf)
-    assert(seq.filter(_._1 == "a").map(_._2) === Seq(1, 5))
-    assert(seq.filter(_._1 == "b").map(_._2) === Seq(2, 4, 6))
+    assertEquals(seq.filter(_._1 == "a").map(_._2), Seq(1, 5))
+    assertEquals(seq.filter(_._1 == "b").map(_._2), Seq(2, 4, 6))
   }
 }

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/ConfigApiSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/ConfigApiSuite.scala
@@ -17,15 +17,13 @@ package com.netflix.atlas.akka
 
 import java.io.StringReader
 import java.util.Properties
-
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.testkit.RouteTestTimeout
-import akka.http.scaladsl.testkit.ScalatestRouteTest
+import com.netflix.atlas.akka.testkit.MUnitRouteSuite
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
 
-class ConfigApiSuite extends AnyFunSuite with ScalatestRouteTest {
+class ConfigApiSuite extends MUnitRouteSuite {
 
   import scala.concurrent.duration._
 
@@ -37,21 +35,21 @@ class ConfigApiSuite extends AnyFunSuite with ScalatestRouteTest {
   test("/config") {
     Get("/api/v2/config") ~> endpoint.routes ~> check {
       val config = ConfigFactory.parseString(responseAs[String])
-      assert(sysConfig === config)
+      assertEquals(sysConfig, config)
     }
   }
 
   test("/config/") {
     Get("/api/v2/config/") ~> endpoint.routes ~> check {
       val config = ConfigFactory.parseString(responseAs[String])
-      assert(sysConfig === config)
+      assertEquals(sysConfig, config)
     }
   }
 
   test("/config/java") {
     Get("/api/v2/config/java") ~> endpoint.routes ~> check {
       val config = ConfigFactory.parseString(responseAs[String])
-      assert(sysConfig.getConfig("java") === config)
+      assertEquals(sysConfig.getConfig("java"), config)
     }
   }
 
@@ -61,21 +59,21 @@ class ConfigApiSuite extends AnyFunSuite with ScalatestRouteTest {
       val config = ConfigFactory.parseString(responseAs[String])
       val v = sysConfig.getString("os.arch")
       val expected = ConfigFactory.parseMap(Map("value" -> v).asJava)
-      assert(expected === config)
+      assertEquals(expected, config)
     }
   }
 
   test("/config format hocon") {
     Get("/api/v2/config?format=hocon") ~> endpoint.routes ~> check {
       val config = ConfigFactory.parseString(responseAs[String])
-      assert(sysConfig === config)
+      assertEquals(sysConfig, config)
     }
   }
 
   test("/config format json") {
     Get("/api/v2/config?format=json") ~> endpoint.routes ~> check {
       val config = ConfigFactory.parseString(responseAs[String])
-      assert(sysConfig === config)
+      assertEquals(sysConfig, config)
     }
   }
 
@@ -98,19 +96,19 @@ class ConfigApiSuite extends AnyFunSuite with ScalatestRouteTest {
 
       val expected = normalize(sysConfig)
       val actual = normalize(config)
-      assert(expected === actual)
+      assertEquals(expected, actual)
     }
   }
 
   test("/config bad format") {
     Get("/api/v2/config?format=foo") ~> endpoint.routes ~> check {
-      assert(response.status === BadRequest)
+      assertEquals(response.status, BadRequest)
     }
   }
 
   test("/config/foo") {
     Get("/api/v2/config/foo") ~> endpoint.routes ~> check {
-      assert(response.status === NotFound)
+      assertEquals(response.status, NotFound)
     }
   }
 

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/ConnectionContextFactorySuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/ConnectionContextFactorySuite.scala
@@ -18,12 +18,12 @@ package com.netflix.atlas.akka
 import akka.http.scaladsl.HttpsConnectionContext
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLEngine
 
-class ConnectionContextFactorySuite extends AnyFunSuite {
+class ConnectionContextFactorySuite extends FunSuite {
 
   import ConnectionContextFactorySuite._
 

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/DeadLetterStatsActorSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/DeadLetterStatsActorSuite.scala
@@ -24,17 +24,14 @@ import akka.actor.Props
 import akka.actor.SuppressedDeadLetter
 import akka.testkit.ImplicitSender
 import akka.testkit.TestActorRef
-import akka.testkit.TestKit
+import akka.testkit.TestKitBase
 import com.netflix.spectator.api.DefaultRegistry
 import com.typesafe.config.ConfigFactory
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.funsuite.AnyFunSuiteLike
+import munit.FunSuite
 
-class DeadLetterStatsActorSuite
-    extends TestKit(ActorSystem())
-    with ImplicitSender
-    with AnyFunSuiteLike
-    with BeforeAndAfterAll {
+class DeadLetterStatsActorSuite extends FunSuite with TestKitBase with ImplicitSender {
+
+  override implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)
 
   private val config = ConfigFactory.parseString(
     """
@@ -70,9 +67,9 @@ class DeadLetterStatsActorSuite
       .withTag("sender", "from")
       .withTag("recipient", "to")
 
-    assert(0 === registry.counter(id).count())
+    assertEquals(registry.counter(id).count(), 0L)
     ref ! DeadLetter("foo", sender, recipient)
-    assert(1 === registry.counter(id).count())
+    assertEquals(registry.counter(id).count(), 1L)
   }
 
   test("SuppressedDeadLetter") {
@@ -82,8 +79,8 @@ class DeadLetterStatsActorSuite
       .withTag("sender", "from")
       .withTag("recipient", "to")
 
-    assert(0 === registry.counter(id).count())
+    assertEquals(registry.counter(id).count(), 0L)
     ref ! SuppressedDeadLetter(PoisonPill, sender, recipient)
-    assert(1 === registry.counter(id).count())
+    assertEquals(registry.counter(id).count(), 1L)
   }
 }

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/HealthcheckApiSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/HealthcheckApiSuite.scala
@@ -17,17 +17,15 @@ package com.netflix.atlas.akka
 
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Provider
-
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.RouteTestTimeout
-import akka.http.scaladsl.testkit.ScalatestRouteTest
+import com.netflix.atlas.akka.testkit.MUnitRouteSuite
 import com.netflix.atlas.json.Json
 import com.netflix.iep.service.Service
 import com.netflix.iep.service.ServiceManager
 import com.netflix.iep.service.State
-import org.scalatest.funsuite.AnyFunSuite
 
-class HealthcheckApiSuite extends AnyFunSuite with ScalatestRouteTest {
+class HealthcheckApiSuite extends MUnitRouteSuite {
 
   import scala.concurrent.duration._
 
@@ -56,7 +54,7 @@ class HealthcheckApiSuite extends AnyFunSuite with ScalatestRouteTest {
   test("/healthcheck pre-start") {
     serviceHealth.set(false)
     Get("/healthcheck") ~> endpoint.routes ~> check {
-      assert(response.status === StatusCodes.InternalServerError)
+      assertEquals(response.status, StatusCodes.InternalServerError)
       val data = Json.decode[Map[String, Boolean]](responseAs[String])
       assert(!data("test"))
     }
@@ -65,7 +63,7 @@ class HealthcheckApiSuite extends AnyFunSuite with ScalatestRouteTest {
   test("/healthcheck post-start") {
     serviceHealth.set(true)
     Get("/healthcheck") ~> endpoint.routes ~> check {
-      assert(response.status === StatusCodes.OK)
+      assertEquals(response.status, StatusCodes.OK)
       val data = Json.decode[Map[String, Boolean]](responseAs[String])
       assert(data("test"))
     }

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/OpportunisticECSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/OpportunisticECSuite.scala
@@ -15,18 +15,18 @@
  */
 package com.netflix.atlas.akka
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 
-class OpportunisticECSuite extends AnyFunSuite {
+class OpportunisticECSuite extends FunSuite {
 
   test("implicit ec available") {
     import OpportunisticEC._
     val future = Future(1).map(_ + 1)
     val result = Await.result(future, Duration.Inf)
-    assert(result === 2)
+    assertEquals(result, 2)
   }
 }

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/PathsSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/PathsSuite.scala
@@ -17,10 +17,10 @@ package com.netflix.atlas.akka
 
 import akka.actor.ActorPath
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 /** Sanity check the default pattern for extracting an id from the path. */
-class PathsSuite extends AnyFunSuite {
+class PathsSuite extends FunSuite {
 
   private val mapper = Paths.createMapper(ConfigFactory.load().getConfig("atlas.akka"))
 
@@ -28,21 +28,21 @@ class PathsSuite extends AnyFunSuite {
 
   test("contains dashes") {
     val id = mapper(path("akka://test/system/IO-TCP/$123"))
-    assert("IO-TCP" === id)
+    assertEquals("IO-TCP", id)
   }
 
   test("path with child") {
     val id = mapper(path("akka://test/user/foo/$123"))
-    assert("foo" === id)
+    assertEquals("foo", id)
   }
 
   test("temporary actor") {
     val id = mapper(path("akka://test/user/$123"))
-    assert("uncategorized" === id)
+    assertEquals("uncategorized", id)
   }
 
   test("stream supervisor") {
     val id = mapper(path("akka://test/user/StreamSupervisor-99961"))
-    assert("StreamSupervisor-" === id)
+    assertEquals("StreamSupervisor-", id)
   }
 }

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerNoCompressionSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerNoCompressionSuite.scala
@@ -23,15 +23,14 @@ import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.testkit.RouteTestTimeout
-import akka.http.scaladsl.testkit.ScalatestRouteTest
+import com.netflix.atlas.akka.testkit.MUnitRouteSuite
 import com.netflix.atlas.json.Json
 import com.netflix.iep.service.DefaultClassFactory
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
 
 import java.lang.reflect.Type
 
-class RequestHandlerNoCompressionsSuite extends AnyFunSuite with ScalatestRouteTest {
+class RequestHandlerNoCompressionSuite extends MUnitRouteSuite {
 
   import scala.concurrent.duration._
   implicit val routeTestTimeout = RouteTestTimeout(5.second)
@@ -74,8 +73,8 @@ class RequestHandlerNoCompressionsSuite extends AnyFunSuite with ScalatestRouteT
 
   test("/jsonparse") {
     Post("/jsonparse", "\"foo\"") ~> routes ~> check {
-      assert(response.status === StatusCodes.OK)
-      assert(responseAs[String] === "foo")
+      assertEquals(response.status, StatusCodes.OK)
+      assertEquals(responseAs[String], "foo")
     }
   }
 
@@ -85,23 +84,23 @@ class RequestHandlerNoCompressionsSuite extends AnyFunSuite with ScalatestRouteT
       Json.smileEncode("foo")
     )
     Post("/jsonparse", content) ~> routes ~> check {
-      assert(response.status === StatusCodes.OK)
-      assert(responseAs[String] === "foo")
+      assertEquals(response.status, StatusCodes.OK)
+      assertEquals(responseAs[String], "foo")
     }
   }
 
   test("/jsonparse with smile but wrong content-type") {
     val content = HttpEntity(Json.smileEncode("foo"))
     Post("/jsonparse", content) ~> routes ~> check {
-      assert(response.status === StatusCodes.BadRequest)
+      assertEquals(response.status, StatusCodes.BadRequest)
     }
   }
 
   test("/jsonparse with gzipped request") {
     val content = HttpEntity(gzip("\"foo\""))
     Post("/jsonparse", content).addHeader(gzipHeader) ~> routes ~> check {
-      assert(response.status === StatusCodes.OK)
-      assert(responseAs[String] === "foo")
+      assertEquals(response.status, StatusCodes.OK)
+      assertEquals(responseAs[String], "foo")
     }
   }
 
@@ -111,8 +110,8 @@ class RequestHandlerNoCompressionsSuite extends AnyFunSuite with ScalatestRouteT
       gzip(Json.smileEncode("foo"))
     )
     Post("/jsonparse", content).addHeader(gzipHeader) ~> routes ~> check {
-      assert(response.status === StatusCodes.OK)
-      assert(responseAs[String] === "foo")
+      assertEquals(response.status, StatusCodes.OK)
+      assertEquals(responseAs[String], "foo")
     }
   }
 }

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/StaticPagesSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/StaticPagesSuite.scala
@@ -16,52 +16,51 @@
 package com.netflix.atlas.akka
 
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.testkit.ScalatestRouteTest
+import com.netflix.atlas.akka.testkit.MUnitRouteSuite
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
 
-class StaticPagesSuite extends AnyFunSuite with ScalatestRouteTest {
+class StaticPagesSuite extends MUnitRouteSuite {
 
   val endpoint = new StaticPages(ConfigFactory.load())
 
   test("/static/test") {
     Get("/static/test") ~> endpoint.routes ~> check {
-      assert(responseAs[String] === "test text file\n")
+      assertEquals(responseAs[String], "test text file\n")
     }
   }
 
   test("/static") {
     Get("/static") ~> endpoint.routes ~> check {
-      assert(response.status === StatusCodes.OK)
+      assertEquals(response.status, StatusCodes.OK)
       assert(responseAs[String].contains("Index Page"))
     }
   }
 
   test("/static/") {
     Get("/static/") ~> endpoint.routes ~> check {
-      assert(response.status === StatusCodes.OK)
+      assertEquals(response.status, StatusCodes.OK)
       assert(responseAs[String].contains("Index Page"))
     }
   }
 
   test("/") {
     Get("/") ~> endpoint.routes ~> check {
-      assert(response.status === StatusCodes.MovedPermanently)
+      assertEquals(response.status, StatusCodes.MovedPermanently)
       val loc = response.headers.find(_.is("location")).map(_.value)
-      assert(loc === Some("/ui"))
+      assertEquals(loc, Some("/ui"))
     }
   }
 
   test("/ui") {
     Get("/ui") ~> endpoint.routes ~> check {
-      assert(response.status === StatusCodes.OK)
+      assertEquals(response.status, StatusCodes.OK)
       assert(responseAs[String].contains("Index Page"))
     }
   }
 
   test("/ui/foo/bar") {
     Get("/ui/foo/bar") ~> endpoint.routes ~> check {
-      assert(response.status === StatusCodes.OK)
+      assertEquals(response.status, StatusCodes.OK)
       assert(responseAs[String].contains("Index Page"))
     }
   }

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
@@ -29,7 +29,7 @@ import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spectator.api.ManualClock
 import com.netflix.spectator.api.Registry
 import com.netflix.spectator.api.Utils
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.Future
@@ -37,7 +37,7 @@ import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.util.Success
 
-class StreamOpsSuite extends AnyFunSuite {
+class StreamOpsSuite extends FunSuite {
 
   import OpportunisticEC._
 
@@ -53,7 +53,7 @@ class StreamOpsSuite extends AnyFunSuite {
       .filter(m => m.id().name().equals("akka.stream.offeredToQueue"))
       .foreach { m =>
         val result = Utils.getTagValue(m.id(), "result")
-        assert(m.value() === expected.getOrElse(result, 0.0), result)
+        assertEquals(m.value(), expected.getOrElse(result, 0.0), result)
       }
   }
 
@@ -172,7 +172,7 @@ class StreamOpsSuite extends AnyFunSuite {
       .foreach { m =>
         val value = Utils.getTagValue(m.id(), "statistic")
         val stat = if (value == null) "count" else value
-        assert(m.value() === expected.getOrElse(stat, 0.0), stat)
+        assertEquals(m.value(), expected.getOrElse(stat, 0.0), stat)
       }
   }
 
@@ -250,7 +250,7 @@ class StreamOpsSuite extends AnyFunSuite {
     Await.ready(future, Duration.Inf)
 
     val c = registry.counter("akka.stream.exceptions", "error", "ArithmeticException")
-    assert(c.count() === 1)
+    assertEquals(c.count(), 1L)
   }
 
   test("unique") {
@@ -259,7 +259,7 @@ class StreamOpsSuite extends AnyFunSuite {
       .runWith(Sink.seq[Int])
     val vs = Await.result(future, Duration.Inf)
     // Only consecutive repeated values are filtered out, so the final 1 should get repeated
-    assert(vs === List(1, 2, 3, 4, 5, 6, 7, 1))
+    assertEquals(vs, List(1, 2, 3, 4, 5, 6, 7, 1))
   }
 
   test("unique timeout") {
@@ -277,6 +277,6 @@ class StreamOpsSuite extends AnyFunSuite {
       .via(StreamOps.unique(1, clock))
       .runWith(Sink.seq[Int])
     val vs = Await.result(future, Duration.Inf)
-    assert(vs === List(1, 1, 2, 2))
+    assertEquals(vs, List(1, 1, 2, 2))
   }
 }

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/TestApiSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/TestApiSuite.scala
@@ -16,10 +16,9 @@
 package com.netflix.atlas.akka
 
 import akka.http.scaladsl.testkit.RouteTestTimeout
-import akka.http.scaladsl.testkit.ScalatestRouteTest
-import org.scalatest.funsuite.AnyFunSuite
+import com.netflix.atlas.akka.testkit.MUnitRouteSuite
 
-class TestApiSuite extends AnyFunSuite with ScalatestRouteTest {
+class TestApiSuite extends MUnitRouteSuite {
 
   import scala.concurrent.duration._
 
@@ -30,20 +29,20 @@ class TestApiSuite extends AnyFunSuite with ScalatestRouteTest {
 
   test("/query-parsing-directive") {
     Get("/query-parsing-directive?regex=a|b|c") ~> routes ~> check {
-      assert(responseAs[String] === "a|b|c")
+      assertEquals(responseAs[String], "a|b|c")
     }
   }
 
   test("/query-parsing-explicit") {
     Get("/query-parsing-explicit?regex=a|b|c") ~> routes ~> check {
-      assert(responseAs[String] === "a|b|c")
+      assertEquals(responseAs[String], "a|b|c")
     }
   }
 
   test("/chunked") {
     Get("/chunked") ~> routes ~> check {
-      assert(response.status.intValue === 200)
-      assert(chunks.size === 42)
+      assertEquals(response.status.intValue, 200)
+      assertEquals(chunks.size, 42)
     }
   }
 

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/UriParsingSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/UriParsingSuite.scala
@@ -17,21 +17,21 @@ package com.netflix.atlas.akka
 
 import akka.http.scaladsl.model.IllegalUriException
 import akka.http.scaladsl.model.Uri
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class UriParsingSuite extends AnyFunSuite {
+class UriParsingSuite extends FunSuite {
 
   private def query(mode: Uri.ParsingMode): String = {
     Uri("/foo?regex=a|b|c", mode).query().get("regex").get
   }
 
   test("relaxed: regex with |") {
-    assert(query(Uri.ParsingMode.Relaxed) === "a|b|c")
+    assertEquals(query(Uri.ParsingMode.Relaxed), "a|b|c")
   }
 
   test("strict: regex with |") {
     intercept[IllegalUriException] {
-      assert(query(Uri.ParsingMode.Strict) === "a|b|c")
+      assertEquals(query(Uri.ParsingMode.Strict), "a|b|c")
     }
   }
 }

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/ColorsSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/ColorsSuite.scala
@@ -17,13 +17,13 @@ package com.netflix.atlas.chart
 
 import java.awt.Color
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class ColorsSuite extends AnyFunSuite {
+class ColorsSuite extends FunSuite {
 
   test("load") {
     val expected = List(Color.RED, Color.GREEN)
     val actual = Colors.load("palettes/epic_palette.txt").take(2)
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 }

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/JsonGraphEngineSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/JsonGraphEngineSuite.scala
@@ -25,9 +25,9 @@ import com.netflix.atlas.core.model.DsType
 import com.netflix.atlas.core.model.FunctionTimeSeq
 import com.netflix.atlas.core.model.TimeSeries
 import com.netflix.atlas.core.util.Streams
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class JsonGraphEngineSuite extends AnyFunSuite {
+class JsonGraphEngineSuite extends FunSuite {
 
   val step = 60000
 
@@ -58,7 +58,7 @@ class JsonGraphEngineSuite extends AnyFunSuite {
       engine.write(graphDef, out)
     }
     val json = new String(bytes, "UTF-8")
-    assert(json === strip(expected))
+    assertEquals(json, strip(expected))
   }
 
   test("json") {

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/PngGraphEngineSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/PngGraphEngineSuite.scala
@@ -36,14 +36,13 @@ import com.netflix.atlas.core.model.FunctionTimeSeq
 import com.netflix.atlas.core.model.TimeSeries
 import com.netflix.atlas.core.util.Streams
 import com.netflix.atlas.json.Json
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.util.Failure
 import scala.util.Try
 import scala.util.Using
 
-abstract class PngGraphEngineSuite extends AnyFunSuite with BeforeAndAfterAll {
+abstract class PngGraphEngineSuite extends FunSuite {
 
   private val dataDir = s"graphengine/data"
 
@@ -51,7 +50,9 @@ abstract class PngGraphEngineSuite extends AnyFunSuite with BeforeAndAfterAll {
   private val baseDir = SrcPath.forProject("atlas-chart")
   private val goldenDir = s"$baseDir/src/test/resources/graphengine/${getClass.getSimpleName}"
   private val targetDir = s"$baseDir/target/${getClass.getSimpleName}"
-  private val graphAssertions = new GraphAssertions(goldenDir, targetDir, (a, b) => assert(a === b))
+
+  private val graphAssertions =
+    new GraphAssertions(goldenDir, targetDir, (a, b) => assertEquals(a, b))
 
   val bless = false
 
@@ -151,7 +152,7 @@ abstract class PngGraphEngineSuite extends AnyFunSuite with BeforeAndAfterAll {
 
   def checkImpl(name: String, graphDef: GraphDef): Unit = {
     val json = JsonCodec.encode(graphDef)
-    assert(graphDef.normalize === JsonCodec.decode(json).normalize)
+    assertEquals(graphDef.normalize, JsonCodec.decode(json).normalize)
 
     val image = PngImage(graphEngine.createImage(graphDef), Map.empty)
     graphAssertions.assertEquals(image, name, bless)

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/graphics/ScalesSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/graphics/ScalesSuite.scala
@@ -15,85 +15,85 @@
  */
 package com.netflix.atlas.chart.graphics
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class ScalesSuite extends AnyFunSuite {
+class ScalesSuite extends FunSuite {
 
   test("linear") {
     val scale = Scales.linear(0.0, 100.0, 0, 100)
-    assert(scale(0.0) === 0)
-    assert(scale(10.0) === 10)
-    assert(scale(20.0) === 20)
-    assert(scale(30.0) === 30)
-    assert(scale(40.0) === 40)
-    assert(scale(50.0) === 50)
-    assert(scale(60.0) === 60)
-    assert(scale(70.0) === 70)
-    assert(scale(80.0) === 80)
-    assert(scale(90.0) === 90)
-    assert(scale(100.0) === 100)
+    assertEquals(scale(0.0), 0)
+    assertEquals(scale(10.0), 10)
+    assertEquals(scale(20.0), 20)
+    assertEquals(scale(30.0), 30)
+    assertEquals(scale(40.0), 40)
+    assertEquals(scale(50.0), 50)
+    assertEquals(scale(60.0), 60)
+    assertEquals(scale(70.0), 70)
+    assertEquals(scale(80.0), 80)
+    assertEquals(scale(90.0), 90)
+    assertEquals(scale(100.0), 100)
   }
 
   test("ylinear_l1_u2_h300") {
     val scale = Scales.yscale(Scales.linear)(1.0, 2.0, 0, 300)
-    assert(scale(1.0) === 300)
-    assert(scale(2.0) === 0)
+    assertEquals(scale(1.0), 300)
+    assertEquals(scale(2.0), 0)
   }
 
   test("logarithmic") {
     val scale = Scales.logarithmic(0.0, 100.0, 0, 100)
-    assert(scale(0.0) === 0)
-    assert(scale(10.0) === 51)
-    assert(scale(20.0) === 65)
-    assert(scale(30.0) === 74)
-    assert(scale(40.0) === 80)
-    assert(scale(50.0) === 85)
-    assert(scale(60.0) === 89)
-    assert(scale(70.0) === 92)
-    assert(scale(80.0) === 95)
-    assert(scale(90.0) === 97)
-    assert(scale(100.0) === 100)
+    assertEquals(scale(0.0), 0)
+    assertEquals(scale(10.0), 51)
+    assertEquals(scale(20.0), 65)
+    assertEquals(scale(30.0), 74)
+    assertEquals(scale(40.0), 80)
+    assertEquals(scale(50.0), 85)
+    assertEquals(scale(60.0), 89)
+    assertEquals(scale(70.0), 92)
+    assertEquals(scale(80.0), 95)
+    assertEquals(scale(90.0), 97)
+    assertEquals(scale(100.0), 100)
   }
 
   test("logarithmic negative") {
     val scale = Scales.logarithmic(-100.0, 0.0, 0, 100)
-    assert(scale(0.0) === 100)
-    assert(scale(-10.0) === 48)
-    assert(scale(-20.0) === 34)
-    assert(scale(-30.0) === 25)
-    assert(scale(-40.0) === 19)
-    assert(scale(-50.0) === 14)
-    assert(scale(-60.0) === 10)
-    assert(scale(-70.0) === 7)
-    assert(scale(-80.0) === 4)
-    assert(scale(-90.0) === 2)
-    assert(scale(-100.0) === 0)
+    assertEquals(scale(0.0), 100)
+    assertEquals(scale(-10.0), 48)
+    assertEquals(scale(-20.0), 34)
+    assertEquals(scale(-30.0), 25)
+    assertEquals(scale(-40.0), 19)
+    assertEquals(scale(-50.0), 14)
+    assertEquals(scale(-60.0), 10)
+    assertEquals(scale(-70.0), 7)
+    assertEquals(scale(-80.0), 4)
+    assertEquals(scale(-90.0), 2)
+    assertEquals(scale(-100.0), 0)
   }
 
   test("logarithmic positive and negative") {
     val scale = Scales.logarithmic(-100.0, 100.0, 0, 100)
-    assert(scale(100.0) === 100)
-    assert(scale(50.0) === 92)
-    assert(scale(10.0) === 75)
-    assert(scale(0.0) === 50)
-    assert(scale(-10.0) === 24)
-    assert(scale(-50.0) === 7)
-    assert(scale(-100.0) === 0)
+    assertEquals(scale(100.0), 100)
+    assertEquals(scale(50.0), 92)
+    assertEquals(scale(10.0), 75)
+    assertEquals(scale(0.0), 50)
+    assertEquals(scale(-10.0), 24)
+    assertEquals(scale(-50.0), 7)
+    assertEquals(scale(-100.0), 0)
   }
 
   test("logarithmic less than lower bound") {
     val scale = Scales.logarithmic(15.0, 100.0, 0, 100)
-    assert(scale(0.0) === -150)
-    assert(scale(10.0) === -20)
-    assert(scale(20.0) === 14)
-    assert(scale(30.0) === 35)
-    assert(scale(40.0) === 51)
-    assert(scale(50.0) === 62)
-    assert(scale(60.0) === 72)
-    assert(scale(70.0) === 80)
-    assert(scale(80.0) === 88)
-    assert(scale(90.0) === 94)
-    assert(scale(100.0) === 100)
+    assertEquals(scale(0.0), -150)
+    assertEquals(scale(10.0), -20)
+    assertEquals(scale(20.0), 14)
+    assertEquals(scale(30.0), 35)
+    assertEquals(scale(40.0), 51)
+    assertEquals(scale(50.0), 62)
+    assertEquals(scale(60.0), 72)
+    assertEquals(scale(70.0), 80)
+    assertEquals(scale(80.0), 88)
+    assertEquals(scale(90.0), 94)
+    assertEquals(scale(100.0), 100)
   }
 
 }

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/graphics/TicksSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/graphics/TicksSuite.scala
@@ -17,15 +17,15 @@ package com.netflix.atlas.chart.graphics
 
 import java.time.ZoneOffset
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.util.Random
 
-class TicksSuite extends AnyFunSuite {
+class TicksSuite extends FunSuite {
 
   private def checkForDuplicates(ticks: List[ValueTick]): Unit = {
     val duplicates = ticks.filter(_.major).map(_.label).groupBy(v => v).filter(_._2.size > 1)
-    assert(duplicates === Map.empty, "duplicate tick labels")
+    assertEquals(duplicates, Map.empty[String, List[String]], "duplicate tick labels")
   }
 
   private def sanityCheck(ticks: List[ValueTick]): Unit = {
@@ -35,191 +35,191 @@ class TicksSuite extends AnyFunSuite {
   test("values [0.0, 100.0]") {
     val ticks = Ticks.value(0.0, 100.0, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 21)
-    assert(ticks.count(_.major) === 6)
-    assert(ticks.head.offset === 0.0)
-    assert(ticks.head.label === "0.0")
-    assert(ticks.last.label === "100.0")
+    assertEquals(ticks.size, 21)
+    assertEquals(ticks.count(_.major), 6)
+    assertEquals(ticks.head.offset, 0.0)
+    assertEquals(ticks.head.label, "0.0")
+    assertEquals(ticks.last.label, "100.0")
   }
 
   test("values [1.0, 2.0], 7 ticks") {
     val ticks = Ticks.value(1.0, 2.0, 7)
     sanityCheck(ticks)
-    assert(ticks.size === 21)
-    assert(ticks.count(_.major) === 6)
+    assertEquals(ticks.size, 21)
+    assertEquals(ticks.count(_.major), 6)
   }
 
   test("values [0.0, 10.0]") {
     val ticks = Ticks.value(0.0, 10.0, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 21)
-    assert(ticks.count(_.major) === 6)
-    assert(ticks.head.offset === 0.0)
-    assert(ticks.head.label === "0.0")
-    assert(ticks.last.label === "10.0")
+    assertEquals(ticks.size, 21)
+    assertEquals(ticks.count(_.major), 6)
+    assertEquals(ticks.head.offset, 0.0)
+    assertEquals(ticks.head.label, "0.0")
+    assertEquals(ticks.last.label, "10.0")
   }
 
   test("values [0.0, 8.0]") {
     val ticks = Ticks.value(0.0, 8.0, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 17)
-    assert(ticks.count(_.major) === 5)
-    assert(ticks.head.offset === 0.0)
-    assert(ticks.head.label === "0.0")
-    assert(ticks.last.label === "8.0")
+    assertEquals(ticks.size, 17)
+    assertEquals(ticks.count(_.major), 5)
+    assertEquals(ticks.head.offset, 0.0)
+    assertEquals(ticks.head.label, "0.0")
+    assertEquals(ticks.last.label, "8.0")
   }
 
   test("values [0.0, 7.0]") {
     val ticks = Ticks.value(0.0, 7.0, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 15)
-    assert(ticks.count(_.major) === 4)
-    assert(ticks.head.offset === 0.0)
-    assert(ticks.filter(_.major).map(_.label).mkString(",") === "0.0,2.0,4.0,6.0")
+    assertEquals(ticks.size, 15)
+    assertEquals(ticks.count(_.major), 4)
+    assertEquals(ticks.head.offset, 0.0)
+    assertEquals(ticks.filter(_.major).map(_.label).mkString(","), "0.0,2.0,4.0,6.0")
   }
 
   test("values [0.96, 1.0]") {
     val ticks = Ticks.value(0.96, 1.0, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 21)
-    assert(ticks.count(_.major) === 5)
-    assert(ticks.head.offset === 0.0)
-    assert(ticks.head.label === "0.96")
-    assert(ticks.last.label === "1.00")
+    assertEquals(ticks.size, 21)
+    assertEquals(ticks.count(_.major), 5)
+    assertEquals(ticks.head.offset, 0.0)
+    assertEquals(ticks.head.label, "0.96")
+    assertEquals(ticks.last.label, "1.00")
   }
 
   test("values [835, 1068]") {
     val ticks = Ticks.value(835.0, 1068, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 23)
-    assert(ticks.count(_.major) === 5)
-    assert(ticks.head.offset === 0.0)
-    //assert(ticks.filter(_.major).head.label === "0.85k")
-    assert(ticks.filter(_.major).last.label === "1.05k")
+    assertEquals(ticks.size, 23)
+    assertEquals(ticks.count(_.major), 5)
+    assertEquals(ticks.head.offset, 0.0)
+    //assertEquals(ticks.filter(_.major).head.label, "0.85k")
+    assertEquals(ticks.filter(_.major).last.label, "1.05k")
   }
 
   test("values [2026, 2027]") {
     val ticks = Ticks.value(2026.0, 2027.0, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 21)
-    assert(ticks.count(_.major) === 6)
-    assert(ticks.head.offset === 2026.0)
-    assert(ticks.head.label === "0.0")
-    assert(ticks.last.label === "1.0")
+    assertEquals(ticks.size, 21)
+    assertEquals(ticks.count(_.major), 6)
+    assertEquals(ticks.head.offset, 2026.0)
+    assertEquals(ticks.head.label, "0.0")
+    assertEquals(ticks.last.label, "1.0")
   }
 
   test("values [200026, 200027]") {
     val ticks = Ticks.value(200026.0, 200027.0, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 21)
-    assert(ticks.count(_.major) === 6)
-    assert(ticks.head.offset === 200026.0)
-    assert(ticks.head.label === "0.0")
-    assert(ticks.last.label === "1.0")
+    assertEquals(ticks.size, 21)
+    assertEquals(ticks.count(_.major), 6)
+    assertEquals(ticks.head.offset, 200026.0)
+    assertEquals(ticks.head.label, "0.0")
+    assertEquals(ticks.last.label, "1.0")
   }
 
   test("values [200026.23, 200026.2371654]") {
     val ticks = Ticks.value(200026.23, 200026.2371654, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 15)
-    assert(ticks.count(_.major) === 4)
-    assert(ticks.head.offset === 200026.23)
-    assert(ticks.head.label === "0.0")
-    assert(ticks.last.label === "7.0m")
+    assertEquals(ticks.size, 15)
+    assertEquals(ticks.count(_.major), 4)
+    assertEquals(ticks.head.offset, 200026.23)
+    assertEquals(ticks.head.label, "0.0")
+    assertEquals(ticks.last.label, "7.0m")
   }
 
   test("values [2026, 2047]") {
     val ticks = Ticks.value(2026.0, 2047.0, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 22)
-    assert(ticks.count(_.major) === 4)
-    assert(ticks.head.offset === 0.0)
-    assert(ticks.filter(_.major).head.label === "2.030k")
-    assert(ticks.filter(_.major).last.label === "2.045k")
+    assertEquals(ticks.size, 22)
+    assertEquals(ticks.count(_.major), 4)
+    assertEquals(ticks.head.offset, 0.0)
+    assertEquals(ticks.filter(_.major).head.label, "2.030k")
+    assertEquals(ticks.filter(_.major).last.label, "2.045k")
   }
 
   test("values [20, 21.8]") {
     val ticks = Ticks.value(20.0, 21.8, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 19)
-    assert(ticks.count(_.major) === 5)
-    assert(ticks.head.offset === 0.0)
-    assert(ticks.head.label === "20.0")
-    assert(ticks.last.label === "21.8")
+    assertEquals(ticks.size, 19)
+    assertEquals(ticks.count(_.major), 5)
+    assertEquals(ticks.head.offset, 0.0)
+    assertEquals(ticks.head.label, "20.0")
+    assertEquals(ticks.last.label, "21.8")
   }
 
   test("values [-21.8, -20]") {
     val ticks = Ticks.value(-21.8, -20.0, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 19)
-    assert(ticks.count(_.major) === 5)
-    assert(ticks.head.offset === 0.0)
-    assert(ticks.head.label === "-21.8")
-    assert(ticks.last.label === "-20.0")
+    assertEquals(ticks.size, 19)
+    assertEquals(ticks.count(_.major), 5)
+    assertEquals(ticks.head.offset, 0.0)
+    assertEquals(ticks.head.label, "-21.8")
+    assertEquals(ticks.last.label, "-20.0")
   }
 
   test("values [-2027, -2046]") {
     val ticks = Ticks.value(-2027.0, -2026.0, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 21)
-    assert(ticks.count(_.major) === 6)
-    assert(ticks.head.offset === -2027.0)
-    assert(ticks.filter(_.major).head.label === "0.0")
-    assert(ticks.filter(_.major).last.label === "1.0")
+    assertEquals(ticks.size, 21)
+    assertEquals(ticks.count(_.major), 6)
+    assertEquals(ticks.head.offset, -2027.0)
+    assertEquals(ticks.filter(_.major).head.label, "0.0")
+    assertEquals(ticks.filter(_.major).last.label, "1.0")
   }
 
   test("values [42.0, 8.123456e12]") {
     val ticks = Ticks.value(42.0, 8.123456e12, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 16)
-    assert(ticks.count(_.major) === 4)
-    assert(ticks.head.offset === 0.0)
-    assert(ticks.head.label === "0.5T")
-    assert(ticks.last.label === "8.0T")
+    assertEquals(ticks.size, 16)
+    assertEquals(ticks.count(_.major), 4)
+    assertEquals(ticks.head.offset, 0.0)
+    assertEquals(ticks.head.label, "0.5T")
+    assertEquals(ticks.last.label, "8.0T")
   }
 
   test("values [2126.4044472658984, 2128.626188548245], 9 ticks") {
     val ticks = Ticks.value(2126.4044472658984, 2128.626188548245, 9)
     sanityCheck(ticks)
-    assert(ticks.size === 22)
-    assert(ticks.count(_.major) === 7)
-    assert(ticks.head.offset === 2126.4)
-    assert(ticks.head.label === "100.0m")
-    assert(ticks.last.label === "2.2")
+    assertEquals(ticks.size, 22)
+    assertEquals(ticks.count(_.major), 7)
+    assertEquals(ticks.head.offset, 2126.4)
+    assertEquals(ticks.head.label, "100.0m")
+    assertEquals(ticks.last.label, "2.2")
   }
 
   test("values [0.0, 1.468m]") {
     val ticks = Ticks.value(0.0, 1.468e-3, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 15)
-    assert(ticks.count(_.major) === 5)
-    assert(ticks.head.offset === 0.0)
-    assert(ticks.filter(_.major).head.label === "0.0m")
-    assert(ticks.filter(_.major).last.label === "1.2m")
+    assertEquals(ticks.size, 15)
+    assertEquals(ticks.count(_.major), 5)
+    assertEquals(ticks.head.offset, 0.0)
+    assertEquals(ticks.filter(_.major).head.label, "0.0m")
+    assertEquals(ticks.filter(_.major).last.label, "1.2m")
   }
 
   test("values [4560.0, 4569.9]") {
     val ticks = Ticks.value(4559.9, 4569.9, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 20)
-    assert(ticks.count(_.major) === 5)
-    assert(ticks.head.offset === 0.0)
-    assert(ticks.head.label === "4.560k")
-    assert(ticks.last.label === "4.570k")
+    assertEquals(ticks.size, 20)
+    assertEquals(ticks.count(_.major), 5)
+    assertEquals(ticks.head.offset, 0.0)
+    assertEquals(ticks.head.label, "4.560k")
+    assertEquals(ticks.last.label, "4.570k")
   }
 
   test("values [0.0, Infinity]") {
     val t = intercept[IllegalArgumentException] {
       Ticks.value(0.0, Double.PositiveInfinity, 5)
     }
-    assert(t.getMessage === "requirement failed: upper bound must be finite")
+    assertEquals(t.getMessage, "requirement failed: upper bound must be finite")
   }
 
   test("values [-Infinity, 0.0]") {
     val t = intercept[IllegalArgumentException] {
       Ticks.value(Double.NegativeInfinity, 0.0, 5)
     }
-    assert(t.getMessage === "requirement failed: lower bound must be finite")
+    assertEquals(t.getMessage, "requirement failed: lower bound must be finite")
   }
 
   test("values [0.0, MaxValue]") {
@@ -256,121 +256,121 @@ class TicksSuite extends AnyFunSuite {
   test("binary [0, 1024]") {
     val ticks = Ticks.binary(0.0, 1024, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 11)
-    assert(ticks.count(_.major) === 4)
-    assert(ticks.head.offset === 0.0)
-    assert(ticks.head.label === "0")
-    assert(ticks.last.label === "1000")
+    assertEquals(ticks.size, 11)
+    assertEquals(ticks.count(_.major), 4)
+    assertEquals(ticks.head.offset, 0.0)
+    assertEquals(ticks.head.label, "0")
+    assertEquals(ticks.last.label, "1000")
   }
 
   test("binary [0, 1258]") {
     val ticks = Ticks.binary(0.0, 1258, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 13)
-    assert(ticks.count(_.major) === 5)
-    assert(ticks.head.offset === 0.0)
-    assert(ticks.head.label === "0")
-    assert(ticks.last.label === "1200")
+    assertEquals(ticks.size, 13)
+    assertEquals(ticks.count(_.major), 5)
+    assertEquals(ticks.head.offset, 0.0)
+    assertEquals(ticks.head.label, "0")
+    assertEquals(ticks.last.label, "1200")
   }
 
   test("binary [0, 7258]") {
     val ticks = Ticks.binary(0.0, 7258, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 15)
-    assert(ticks.count(_.major) === 4)
-    assert(ticks.head.offset === 0.0)
-    assert(ticks.head.label === "0")
-    assert(ticks.last.label === "7168")
+    assertEquals(ticks.size, 15)
+    assertEquals(ticks.count(_.major), 4)
+    assertEquals(ticks.head.offset, 0.0)
+    assertEquals(ticks.head.label, "0")
+    assertEquals(ticks.last.label, "7168")
   }
 
   test("binary [0, 10k]") {
     val ticks = Ticks.binary(0.0, 10e3, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 20)
-    assert(ticks.count(_.major) === 5)
-    assert(ticks.head.offset === 0.0)
-    assert(ticks.head.label === "0Ki")
-    assert(ticks.last.label === "10Ki")
+    assertEquals(ticks.size, 20)
+    assertEquals(ticks.count(_.major), 5)
+    assertEquals(ticks.head.offset, 0.0)
+    assertEquals(ticks.head.label, "0Ki")
+    assertEquals(ticks.last.label, "10Ki")
   }
 
   test("binary [8k, 10k]") {
     val ticks = Ticks.binary(8e3, 10e3, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 21)
-    assert(ticks.count(_.major) === 6)
-    assert(ticks.head.offset === 0.0)
-    assert(ticks.head.label === "7.8Ki")
-    assert(ticks.last.label === "9.8Ki")
+    assertEquals(ticks.size, 21)
+    assertEquals(ticks.count(_.major), 6)
+    assertEquals(ticks.head.offset, 0.0)
+    assertEquals(ticks.head.label, "7.8Ki")
+    assertEquals(ticks.last.label, "9.8Ki")
   }
 
   test("binary [8k, 10M]") {
     val ticks = Ticks.binary(8e3, 10e6, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 19)
-    assert(ticks.count(_.major) === 4)
-    assert(ticks.head.offset === 0.0)
-    assert(ticks.head.label === "512Ki")
-    assert(ticks.last.label === "9728Ki")
+    assertEquals(ticks.size, 19)
+    assertEquals(ticks.count(_.major), 4)
+    assertEquals(ticks.head.offset, 0.0)
+    assertEquals(ticks.head.label, "512Ki")
+    assertEquals(ticks.last.label, "9728Ki")
   }
 
   test("binary [8k, 10T]") {
     val ticks = Ticks.binary(8e3, 10e12, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 18)
-    assert(ticks.count(_.major) === 4)
-    assert(ticks.head.offset === 0.0)
-    assert(ticks.head.label === "512Gi")
-    assert(ticks.last.label === "9216Gi")
+    assertEquals(ticks.size, 18)
+    assertEquals(ticks.count(_.major), 4)
+    assertEquals(ticks.head.offset, 0.0)
+    assertEquals(ticks.head.label, "512Gi")
+    assertEquals(ticks.last.label, "9216Gi")
   }
 
   test("binary [9993, 10079]") {
     val ticks = Ticks.binary(9993, 10079, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 17)
-    assert(ticks.count(_.major) === 4)
-    assert(ticks.head.offset === 9980.0)
-    assert(ticks.head.label === "15")
-    assert(ticks.last.label === "95")
+    assertEquals(ticks.size, 17)
+    assertEquals(ticks.count(_.major), 4)
+    assertEquals(ticks.head.offset, 9980.0)
+    assertEquals(ticks.head.label, "15")
+    assertEquals(ticks.last.label, "95")
   }
 
   test("binary [9991234563, 9991234567]") {
     val ticks = Ticks.binary(9991234563.0, 9991234567.0, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 21)
-    assert(ticks.count(_.major) === 5)
-    assert(ticks.head.offset === 9.991234563e9)
-    assert(ticks.head.label === "0")
-    assert(ticks.last.label === "4")
+    assertEquals(ticks.size, 21)
+    assertEquals(ticks.count(_.major), 5)
+    assertEquals(ticks.head.offset, 9.991234563e9)
+    assertEquals(ticks.head.label, "0")
+    assertEquals(ticks.last.label, "4")
   }
 
   test("binary [99912000000, 9991800000]") {
     val ticks = Ticks.binary(99912000000.0, 99918000000.0, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 11)
-    assert(ticks.count(_.major) === 3)
-    assert(ticks.head.offset === 9.9910418432e10)
-    assert(ticks.head.label === "2048Ki")
-    assert(ticks.last.label === "7168Ki")
+    assertEquals(ticks.size, 11)
+    assertEquals(ticks.count(_.major), 3)
+    assertEquals(ticks.head.offset, 9.9910418432e10)
+    assertEquals(ticks.head.label, "2048Ki")
+    assertEquals(ticks.last.label, "7168Ki")
   }
 
   test("binary [339.86152734763687, 339.87716933873867]") {
     val ticks = Ticks.binary(339.86152734763687, 339.87716933873867, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 2)
-    assert(ticks.count(_.major) === 2)
-    assert(ticks.head.offset === 339.86152734763687)
-    assert(ticks.head.label === "0.0")
-    assert(ticks.last.label === "15.6m")
+    assertEquals(ticks.size, 2)
+    assertEquals(ticks.count(_.major), 2)
+    assertEquals(ticks.head.offset, 339.86152734763687)
+    assertEquals(ticks.head.label, "0.0")
+    assertEquals(ticks.last.label, "15.6m")
   }
 
   test("binary [1e12, 1e12 + 5e6]") {
     val ticks = Ticks.binary(1e12, 1e12 + 5e6, 5)
     sanityCheck(ticks)
-    assert(ticks.size === 19)
-    assert(ticks.count(_.major) === 5)
-    assert(ticks.head.offset === 9.99999668224e11)
-    assert(ticks.head.label === "512Ki")
-    assert(ticks.last.label === "5120Ki")
+    assertEquals(ticks.size, 19)
+    assertEquals(ticks.count(_.major), 5)
+    assertEquals(ticks.head.offset, 9.99999668224e11)
+    assertEquals(ticks.head.label, "512Ki")
+    assertEquals(ticks.last.label, "5120Ki")
   }
 
   test("binary sanity check, 0 to y") {
@@ -404,36 +404,36 @@ class TicksSuite extends AnyFunSuite {
     val s = 0L
     val e = 1498751868000L
     val ticks = Ticks.time(s, e, ZoneOffset.UTC, 5)
-    assert(ticks.size === 6)
+    assertEquals(ticks.size, 6)
   }
 
   test("issue-948: [6.667e-3, 0.01]") {
     val ticks = Ticks.value(6.667e-3, 0.01, 7)
     sanityCheck(ticks)
-    assert(ticks.size === 34)
-    assert(ticks.count(_.major) === 7)
-    assert(ticks.head.offset === 0.0)
-    assert(ticks.head.label === "6.7m")
-    assert(ticks.last.label === "10.0m")
+    assertEquals(ticks.size, 34)
+    assertEquals(ticks.count(_.major), 7)
+    assertEquals(ticks.head.offset, 0.0)
+    assertEquals(ticks.head.label, "6.7m")
+    assertEquals(ticks.last.label, "10.0m")
   }
 
   test("issue-991: [99.938845, 100]") {
     val ticks = Ticks.value(99.938845, 100, 7)
     sanityCheck(ticks)
-    assert(ticks.size === 31)
-    assert(ticks.count(_.major) === 7)
-    assert(ticks.head.offset === 0.0)
-    assert(ticks.head.label === "99.94")
-    assert(ticks.last.label === "100.00")
+    assertEquals(ticks.size, 31)
+    assertEquals(ticks.count(_.major), 7)
+    assertEquals(ticks.head.offset, 0.0)
+    assertEquals(ticks.head.label, "99.94")
+    assertEquals(ticks.last.label, "100.00")
   }
 
   test("issue-991: [99.9, 100]") {
     val ticks = Ticks.value(99.9, 100, 7)
     sanityCheck(ticks)
-    assert(ticks.size === 21)
-    assert(ticks.count(_.major) === 6)
-    assert(ticks.head.offset === 0.0)
-    assert(ticks.head.label === "99.90")
-    assert(ticks.last.label === "100.00")
+    assertEquals(ticks.size, 21)
+    assertEquals(ticks.count(_.major), 6)
+    assertEquals(ticks.head.offset, 0.0)
+    assertEquals(ticks.head.label, "99.90")
+    assertEquals(ticks.last.label, "100.00")
   }
 }

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/model/GraphDefSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/model/GraphDefSuite.scala
@@ -18,9 +18,9 @@ package com.netflix.atlas.chart.model
 import com.netflix.atlas.core.model.DsType
 import com.netflix.atlas.core.model.FunctionTimeSeq
 import com.netflix.atlas.core.model.TimeSeries
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class GraphDefSuite extends AnyFunSuite {
+class GraphDefSuite extends FunSuite {
 
   val step = 60000
 

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/model/PaletteSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/model/PaletteSuite.scala
@@ -17,9 +17,9 @@ package com.netflix.atlas.chart.model
 
 import java.awt.Color
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class PaletteSuite extends AnyFunSuite {
+class PaletteSuite extends FunSuite {
 
   test("colors:") {
     intercept[IllegalArgumentException] {
@@ -35,20 +35,20 @@ class PaletteSuite extends AnyFunSuite {
 
   test("colors:f00") {
     val p = Palette.create("colors:f00")
-    assert(p.colors(0) === Color.RED)
+    assertEquals(p.colors(0), Color.RED)
   }
 
   test("colors:f00,00ff00") {
     val p = Palette.create("colors:f00,00ff00")
-    assert(p.colors(0) === Color.RED)
-    assert(p.colors(1) === Color.GREEN)
+    assertEquals(p.colors(0), Color.RED)
+    assertEquals(p.colors(1), Color.GREEN)
   }
 
   test("colors:f00,00ff00,ff0000ff") {
     val p = Palette.create("colors:f00,00ff00,ff0000ff")
-    assert(p.colors(0) === Color.RED)
-    assert(p.colors(1) === Color.GREEN)
-    assert(p.colors(2) === Color.BLUE)
+    assertEquals(p.colors(0), Color.RED)
+    assertEquals(p.colors(1), Color.GREEN)
+    assertEquals(p.colors(2), Color.BLUE)
   }
 
   test("(,)") {
@@ -65,25 +65,25 @@ class PaletteSuite extends AnyFunSuite {
 
   test("(,f00,)") {
     val p = Palette.create("(,f00,)")
-    assert(p.colors(0) === Color.RED)
+    assertEquals(p.colors(0), Color.RED)
   }
 
   test("(,f00,00ff00,)") {
     val p = Palette.create("(,f00,00ff00,)")
-    assert(p.colors(0) === Color.RED)
-    assert(p.colors(1) === Color.GREEN)
+    assertEquals(p.colors(0), Color.RED)
+    assertEquals(p.colors(1), Color.GREEN)
   }
 
   test("(,f00,00ff00,ff0000ff,)") {
     val p = Palette.create("(,f00,00ff00,ff0000ff,)")
-    assert(p.colors(0) === Color.RED)
-    assert(p.colors(1) === Color.GREEN)
-    assert(p.colors(2) === Color.BLUE)
+    assertEquals(p.colors(0), Color.RED)
+    assertEquals(p.colors(1), Color.GREEN)
+    assertEquals(p.colors(2), Color.BLUE)
   }
 
   test("armytage") {
     val p = Palette.create("armytage")
-    assert(p.colors(0) === new Color(0, 117, 220))
+    assertEquals(p.colors(0), new Color(0, 117, 220))
   }
 
   test("foo") {

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/model/PlotDefSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/model/PlotDefSuite.scala
@@ -21,9 +21,9 @@ import com.netflix.atlas.chart.model.PlotBound.Explicit
 import com.netflix.atlas.core.model.ArrayTimeSeq
 import com.netflix.atlas.core.model.DsType
 import com.netflix.atlas.core.model.TimeSeries
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class PlotDefSuite extends AnyFunSuite {
+class PlotDefSuite extends FunSuite {
 
   test("lower >= upper") {
     intercept[IllegalArgumentException] {
@@ -33,102 +33,102 @@ class PlotDefSuite extends AnyFunSuite {
 
   test("finalBounds explicit") {
     val plotDef = PlotDef(Nil, lower = Explicit(1.0), upper = Explicit(42.0))
-    assert(plotDef.finalBounds(false, 0.0, 43.0) === 1.0 -> 42.0)
+    assertEquals(plotDef.finalBounds(false, 0.0, 43.0), 1.0 -> 42.0)
   }
 
   test("finalBounds explicit lower, auto upper") {
     val plotDef = PlotDef(Nil, lower = Explicit(1.0), upper = AutoStyle)
-    assert(plotDef.finalBounds(false, 0.0, 43.0) === 1.0 -> 43.0)
+    assertEquals(plotDef.finalBounds(false, 0.0, 43.0), 1.0 -> 43.0)
   }
 
   test("finalBounds auto lower, explict upper") {
     val plotDef = PlotDef(Nil, lower = AutoStyle, upper = Explicit(42.0))
-    assert(plotDef.finalBounds(false, 0.0, 43.0) === 0.0 -> 42.0)
+    assertEquals(plotDef.finalBounds(false, 0.0, 43.0), 0.0 -> 42.0)
   }
 
   test("finalBounds auto") {
     val plotDef = PlotDef(Nil, lower = AutoStyle, upper = AutoStyle)
-    assert(plotDef.finalBounds(false, 0.0, 43.0) === 0.0 -> 43.0)
+    assertEquals(plotDef.finalBounds(false, 0.0, 43.0), 0.0 -> 43.0)
   }
 
   test("finalBounds constant, auto") {
     val plotDef = PlotDef(Nil, lower = AutoStyle, upper = AutoStyle)
-    assert(plotDef.finalBounds(false, 0.0, 0.0) === 0.0 -> 1.0)
+    assertEquals(plotDef.finalBounds(false, 0.0, 0.0), 0.0 -> 1.0)
   }
 
   test("finalBounds constant, explicit lower") {
     val plotDef = PlotDef(Nil, lower = Explicit(0.0), upper = AutoStyle)
-    assert(plotDef.finalBounds(false, 0.0, 0.0) === 0.0 -> 1.0)
+    assertEquals(plotDef.finalBounds(false, 0.0, 0.0), 0.0 -> 1.0)
   }
 
   test("finalBounds constant, explicit lower > auto upper") {
     val plotDef = PlotDef(Nil, lower = Explicit(1.0), upper = AutoStyle)
-    assert(plotDef.finalBounds(false, 0.0, 0.0) === 1.0 -> 2.0)
+    assertEquals(plotDef.finalBounds(false, 0.0, 0.0), 1.0 -> 2.0)
   }
 
   test("finalBounds constant, explicit upper") {
     val plotDef = PlotDef(Nil, lower = AutoStyle, upper = Explicit(42.0))
-    assert(plotDef.finalBounds(false, 0.0, 0.0) === 0.0 -> 42.0)
+    assertEquals(plotDef.finalBounds(false, 0.0, 0.0), 0.0 -> 42.0)
   }
 
   test("finalBounds constant, explicit upper == auto lower") {
     val plotDef = PlotDef(Nil, lower = AutoStyle, upper = Explicit(0.0))
-    assert(plotDef.finalBounds(false, 0.0, 0.0) === -1.0 -> 0.0)
+    assertEquals(plotDef.finalBounds(false, 0.0, 0.0), -1.0 -> 0.0)
   }
 
   test("finalBounds constant, explicit upper < auto lower") {
     val plotDef = PlotDef(Nil, lower = AutoStyle, upper = Explicit(-1.0))
-    assert(plotDef.finalBounds(false, 0.0, 0.0) === -2.0 -> -1.0)
+    assertEquals(plotDef.finalBounds(false, 0.0, 0.0), -2.0 -> -1.0)
   }
 
   test("finalBounds area, auto") {
     val plotDef = PlotDef(Nil, lower = AutoStyle, upper = AutoStyle)
-    assert(plotDef.finalBounds(true, 2.0, 2.0) === 0.0 -> 2.0)
+    assertEquals(plotDef.finalBounds(true, 2.0, 2.0), 0.0 -> 2.0)
   }
 
   test("finalBounds area, auto spans 0") {
     val plotDef = PlotDef(Nil, lower = AutoStyle, upper = AutoStyle)
-    assert(plotDef.finalBounds(true, -42.0, 42.0) === -42.0 -> 42.0)
+    assertEquals(plotDef.finalBounds(true, -42.0, 42.0), -42.0 -> 42.0)
   }
 
   test("finalBounds area, auto lower > 0") {
     val plotDef = PlotDef(Nil, lower = AutoStyle, upper = AutoStyle)
-    assert(plotDef.finalBounds(true, 50.0, 55.0) === 0.0 -> 55.0)
+    assertEquals(plotDef.finalBounds(true, 50.0, 55.0), 0.0 -> 55.0)
   }
 
   test("finalBounds area, auto upper < 0") {
     val plotDef = PlotDef(Nil, lower = AutoStyle, upper = AutoStyle)
-    assert(plotDef.finalBounds(true, -50.0, -45.0) === -50.0 -> 0.0)
+    assertEquals(plotDef.finalBounds(true, -50.0, -45.0), -50.0 -> 0.0)
   }
 
   test("finalBounds area, explicit lower > 0") {
     val plotDef = PlotDef(Nil, lower = Explicit(1.0), upper = AutoStyle)
-    assert(plotDef.finalBounds(true, 2.0, 2.0) === 1.0 -> 2.0)
+    assertEquals(plotDef.finalBounds(true, 2.0, 2.0), 1.0 -> 2.0)
   }
 
   test("finalBounds area, explicit upper < 0") {
     val plotDef = PlotDef(Nil, lower = AutoStyle, upper = Explicit(-42.0))
-    assert(plotDef.finalBounds(true, -50.0, -45.0) === -50.0 -> -42.0)
+    assertEquals(plotDef.finalBounds(true, -50.0, -45.0), -50.0 -> -42.0)
   }
 
   test("finalBounds area, auto-data") {
     val plotDef = PlotDef(Nil, lower = AutoData, upper = AutoData)
-    assert(plotDef.finalBounds(true, 2.0, 2.0) === 2.0 -> 3.0)
+    assertEquals(plotDef.finalBounds(true, 2.0, 2.0), 2.0 -> 3.0)
   }
 
   test("finalBounds area, auto-data spans 0") {
     val plotDef = PlotDef(Nil, lower = AutoStyle, upper = AutoStyle)
-    assert(plotDef.finalBounds(true, -42.0, 42.0) === -42.0 -> 42.0)
+    assertEquals(plotDef.finalBounds(true, -42.0, 42.0), -42.0 -> 42.0)
   }
 
   test("finalBounds area, auto-data lower > 0") {
     val plotDef = PlotDef(Nil, lower = AutoData, upper = AutoStyle)
-    assert(plotDef.finalBounds(true, 50.0, 55.0) === 50.0 -> 55.0)
+    assertEquals(plotDef.finalBounds(true, 50.0, 55.0), 50.0 -> 55.0)
   }
 
   test("finalBounds area, auto-data upper < 0") {
     val plotDef = PlotDef(Nil, lower = AutoStyle, upper = AutoData)
-    assert(plotDef.finalBounds(true, -50.0, -45.0) === -50.0 -> -45.0)
+    assertEquals(plotDef.finalBounds(true, -50.0, -45.0), -50.0 -> -45.0)
   }
 
   test("bounds infinity") {
@@ -137,8 +137,8 @@ class PlotDefSuite extends AnyFunSuite {
     val plotDef = PlotDef(List(LineDef(ts)))
 
     val (min, max) = plotDef.bounds(0L, 1L)
-    assert(min === 0.0)
-    assert(max === 1.0)
+    assertEquals(min, 0.0)
+    assertEquals(max, 1.0)
   }
 
   test("bounds infinity, stack") {
@@ -147,7 +147,7 @@ class PlotDefSuite extends AnyFunSuite {
     val plotDef = PlotDef(List(LineDef(ts, lineStyle = LineStyle.STACK)))
 
     val (min, max) = plotDef.bounds(0L, 1L)
-    assert(min === 0.0)
-    assert(max === 1.0)
+    assertEquals(min, 0.0)
+    assertEquals(max, 1.0)
   }
 }

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/util/PngImageSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/util/PngImageSuite.scala
@@ -18,15 +18,17 @@ package com.netflix.atlas.chart.util
 import java.io.InputStream
 
 import com.netflix.atlas.core.util.Streams
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class PngImageSuite extends AnyFunSuite {
+class PngImageSuite extends FunSuite {
 
   // SBT working directory gets updated with fork to be the dir for the project
   private val baseDir = SrcPath.forProject("atlas-chart")
   private val goldenDir = s"$baseDir/src/test/resources/pngimage"
   private val targetDir = s"$baseDir/target/pngimage"
-  private val graphAssertions = new GraphAssertions(goldenDir, targetDir, (a, b) => assert(a === b))
+
+  private val graphAssertions =
+    new GraphAssertions(goldenDir, targetDir, (a, b) => assertEquals(a, b))
 
   private val bless = false
 
@@ -58,25 +60,25 @@ class PngImageSuite extends AnyFunSuite {
 
   test("load image") {
     val image = getImage("test.png")
-    assert(image.metadata.size === 2)
-    assert(image.metadata("identical") === "false")
-    assert(image.metadata("diff-pixel-count") === "48302")
+    assertEquals(image.metadata.size, 2)
+    assertEquals(image.metadata("identical"), "false")
+    assertEquals(image.metadata("diff-pixel-count"), "48302")
   }
 
   test("diff image, identical") {
     val i1 = PngImage.error("", 800, 100)
     val i2 = PngImage.error("", 800, 100)
     val diff = PngImage.diff(i1.data, i2.data)
-    assert(diff.metadata("identical") === "true")
-    assert(diff.metadata("diff-pixel-count") === "0")
+    assertEquals(diff.metadata("identical"), "true")
+    assertEquals(diff.metadata("diff-pixel-count"), "0")
   }
 
   test("diff image, with delta") {
     val i1 = PngImage.error("", 800, 100)
     val i2 = PngImage.error("", 801, 121)
     val diff = PngImage.diff(i1.data, i2.data)
-    assert(diff.metadata("identical") === "false")
-    assert(diff.metadata("diff-pixel-count") === "16921")
+    assertEquals(diff.metadata("identical"), "false")
+    assertEquals(diff.metadata("diff-pixel-count"), "16921")
   }
 
   test("error image, 400x300") {
@@ -111,8 +113,8 @@ class PngImageSuite extends AnyFunSuite {
     val systemErrorImage = PngImage.systemError("", 800, 100)
     val diff = PngImage.diff(userErrorImage.data, systemErrorImage.data)
 
-    assert(diff.metadata("identical") === "false")
-    assert(diff.metadata("diff-pixel-count") === "80000")
+    assertEquals(diff.metadata("identical"), "false")
+    assertEquals(diff.metadata("diff-pixel-count"), "80000")
   }
 
   test("image metadata") {
@@ -126,6 +128,6 @@ class PngImageSuite extends AnyFunSuite {
     val bytes = img.toByteArray
     val decoded = PngImage(bytes)
 
-    assert(metadata === decoded.metadata)
+    assertEquals(metadata, decoded.metadata)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/BaseOnlineAlgorithmSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/BaseOnlineAlgorithmSuite.scala
@@ -15,10 +15,9 @@
  */
 package com.netflix.atlas.core.algorithm
 
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers._
+import munit.FunSuite
 
-abstract class BaseOnlineAlgorithmSuite extends AnyFunSuite {
+abstract class BaseOnlineAlgorithmSuite extends FunSuite {
 
   protected def newInstance: OnlineAlgorithm
 
@@ -35,7 +34,7 @@ abstract class BaseOnlineAlgorithmSuite extends AnyFunSuite {
       if (expected.isNaN) {
         assert(actual.isNaN, s"$actual != $expected")
       } else {
-        assert(actual === expected +- 1e-12)
+        assertEqualsDouble(actual, expected, 1e-12)
       }
       if (i % n == 0) {
         restoredAlgo = OnlineAlgorithm(algo.state)

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineAlgorithmSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineAlgorithmSuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.core.algorithm
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class OnlineAlgorithmSuite extends AnyFunSuite {
+class OnlineAlgorithmSuite extends FunSuite {
 
   test("restore unknown type") {
     intercept[IllegalArgumentException] {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineDelaySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineDelaySuite.scala
@@ -22,9 +22,9 @@ class OnlineDelaySuite extends BaseOnlineAlgorithmSuite {
   test("n = 1") {
     val algo = OnlineDelay(1)
     assert(algo.next(0.0).isNaN)
-    assert(algo.next(1.0) === 0.0)
-    assert(algo.next(2.0) === 1.0)
-    assert(algo.next(Double.NaN) === 2.0)
+    assertEquals(algo.next(1.0), 0.0)
+    assertEquals(algo.next(2.0), 1.0)
+    assertEquals(algo.next(Double.NaN), 2.0)
     assert(algo.isEmpty)
     assert(algo.next(Double.NaN).isNaN)
   }
@@ -32,20 +32,20 @@ class OnlineDelaySuite extends BaseOnlineAlgorithmSuite {
   test("n = 1, reset") {
     val algo = OnlineDelay(1)
     assert(algo.next(0.0).isNaN)
-    assert(algo.next(1.0) === 0.0)
+    assertEquals(algo.next(1.0), 0.0)
     algo.reset()
     assert(algo.next(2.0).isNaN)
-    assert(algo.next(3.0) === 2.0)
+    assertEquals(algo.next(3.0), 2.0)
   }
 
   test("n = 2") {
     val algo = OnlineDelay(2)
     assert(algo.next(0.0).isNaN)
     assert(algo.next(1.0).isNaN)
-    assert(algo.next(2.0) === 0.0)
-    assert(algo.next(Double.NaN) === 1.0)
+    assertEquals(algo.next(2.0), 0.0)
+    assertEquals(algo.next(Double.NaN), 1.0)
     assert(!algo.isEmpty)
-    assert(algo.next(Double.NaN) === 2.0)
+    assertEquals(algo.next(Double.NaN), 2.0)
     assert(algo.isEmpty)
     assert(algo.next(Double.NaN).isNaN)
     assert(algo.isEmpty)

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineDerivativeSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineDerivativeSuite.scala
@@ -22,42 +22,42 @@ class OnlineDerivativeSuite extends BaseOnlineAlgorithmSuite {
   test("init") {
     val algo = OnlineDerivative(Double.NaN)
     assert(algo.next(1.0).isNaN)
-    assert(algo.next(1.0) === 0.0)
+    assertEquals(algo.next(1.0), 0.0)
   }
 
   test("NaN values") {
     val algo = OnlineDerivative(Double.NaN)
     assert(algo.next(1.0).isNaN)
-    assert(algo.next(1.0) === 0.0)
+    assertEquals(algo.next(1.0), 0.0)
     assert(algo.next(Double.NaN).isNaN)
     assert(algo.next(1.0).isNaN)
-    assert(algo.next(1.0) === 0.0)
+    assertEquals(algo.next(1.0), 0.0)
   }
 
   test("increase") {
     val algo = OnlineDerivative(Double.NaN)
     assert(algo.next(1.0).isNaN)
-    assert(algo.next(2.0) === 1.0)
-    assert(algo.next(3.0) === 1.0)
-    assert(algo.next(7.0) === 4.0)
+    assertEquals(algo.next(2.0), 1.0)
+    assertEquals(algo.next(3.0), 1.0)
+    assertEquals(algo.next(7.0), 4.0)
   }
 
   test("decrease") {
     val algo = OnlineDerivative(Double.NaN)
     assert(algo.next(10.0).isNaN)
-    assert(algo.next(9.0) === -1.0)
-    assert(algo.next(8.0) === -1.0)
-    assert(algo.next(4.0) === -4.0)
+    assertEquals(algo.next(9.0), -1.0)
+    assertEquals(algo.next(8.0), -1.0)
+    assertEquals(algo.next(4.0), -4.0)
   }
 
   test("reset") {
     val algo = OnlineDerivative(Double.NaN)
     assert(algo.next(1.0).isNaN)
     assert(!algo.isEmpty)
-    assert(algo.next(2.0) === 1.0)
+    assertEquals(algo.next(2.0), 1.0)
     algo.reset()
     assert(algo.isEmpty)
     assert(algo.next(3.0).isNaN)
-    assert(algo.next(7.0) === 4.0)
+    assertEquals(algo.next(7.0), 4.0)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineIgnoreNSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineIgnoreNSuite.scala
@@ -22,25 +22,25 @@ class OnlineIgnoreNSuite extends BaseOnlineAlgorithmSuite {
   test("n = 1") {
     val algo = OnlineIgnoreN(1)
     assert(algo.next(0.0).isNaN)
-    assert(algo.next(1.0) === 1.0)
-    assert(algo.next(2.0) === 2.0)
+    assertEquals(algo.next(1.0), 1.0)
+    assertEquals(algo.next(2.0), 2.0)
     assert(algo.next(Double.NaN).isNaN)
   }
 
   test("n = 1, reset") {
     val algo = OnlineIgnoreN(1)
     assert(algo.next(0.0).isNaN)
-    assert(algo.next(1.0) === 1.0)
+    assertEquals(algo.next(1.0), 1.0)
     algo.reset()
     assert(algo.next(2.0).isNaN)
-    assert(algo.next(3.0) === 3.0)
+    assertEquals(algo.next(3.0), 3.0)
   }
 
   test("n = 2") {
     val algo = OnlineIgnoreN(2)
     assert(algo.next(0.0).isNaN)
     assert(algo.next(1.0).isNaN)
-    assert(algo.next(2.0) === 2.0)
+    assertEquals(algo.next(2.0), 2.0)
     assert(algo.next(Double.NaN).isNaN)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineIntegralSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineIntegralSuite.scala
@@ -21,41 +21,41 @@ class OnlineIntegralSuite extends BaseOnlineAlgorithmSuite {
 
   test("init") {
     val algo = OnlineIntegral(Double.NaN)
-    assert(algo.next(1.0) === 1.0)
-    assert(algo.next(1.0) === 2.0)
+    assertEquals(algo.next(1.0), 1.0)
+    assertEquals(algo.next(1.0), 2.0)
   }
 
   test("NaN values") {
     val algo = OnlineIntegral(Double.NaN)
-    assert(algo.next(1.0) === 1.0)
-    assert(algo.next(1.0) === 2.0)
-    assert(algo.next(Double.NaN) === 2.0)
-    assert(algo.next(1.0) === 3.0)
-    assert(algo.next(1.0) === 4.0)
+    assertEquals(algo.next(1.0), 1.0)
+    assertEquals(algo.next(1.0), 2.0)
+    assertEquals(algo.next(Double.NaN), 2.0)
+    assertEquals(algo.next(1.0), 3.0)
+    assertEquals(algo.next(1.0), 4.0)
   }
 
   test("increase") {
     val algo = OnlineIntegral(Double.NaN)
-    assert(algo.next(1.0) === 1.0)
-    assert(algo.next(2.0) === 3.0)
-    assert(algo.next(3.0) === 6.0)
-    assert(algo.next(7.0) === 13.0)
+    assertEquals(algo.next(1.0), 1.0)
+    assertEquals(algo.next(2.0), 3.0)
+    assertEquals(algo.next(3.0), 6.0)
+    assertEquals(algo.next(7.0), 13.0)
   }
 
   test("decrease") {
     val algo = OnlineIntegral(Double.NaN)
-    assert(algo.next(10.0) === 10.0)
-    assert(algo.next(9.0) === 19.0)
-    assert(algo.next(8.0) === 27.0)
-    assert(algo.next(4.0) === 31.0)
+    assertEquals(algo.next(10.0), 10.0)
+    assertEquals(algo.next(9.0), 19.0)
+    assertEquals(algo.next(8.0), 27.0)
+    assertEquals(algo.next(4.0), 31.0)
   }
 
   test("reset") {
     val algo = OnlineIntegral(Double.NaN)
-    assert(algo.next(1.0) === 1.0)
-    assert(algo.next(2.0) === 3.0)
+    assertEquals(algo.next(1.0), 1.0)
+    assertEquals(algo.next(2.0), 3.0)
     algo.reset()
-    assert(algo.next(3.0) === 3.0)
-    assert(algo.next(7.0) === 10.0)
+    assertEquals(algo.next(3.0), 3.0)
+    assertEquals(algo.next(7.0), 10.0)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingCountSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingCountSuite.scala
@@ -21,39 +21,39 @@ class OnlineRollingCountSuite extends BaseOnlineAlgorithmSuite {
 
   test("n = 1") {
     val algo = OnlineRollingCount(1)
-    assert(algo.next(0.0) === 0.0)
-    assert(algo.next(1.0) === 1.0)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(1.0), 1.0)
   }
 
   test("n = 2") {
     val algo = OnlineRollingCount(2)
-    assert(algo.next(0.0) === 0.0)
-    assert(algo.next(1.0) === 1.0)
-    assert(algo.next(2.0) === 2.0)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(1.0), 1.0)
+    assertEquals(algo.next(2.0), 2.0)
   }
 
   test("n = 2, decreasing") {
     val algo = OnlineRollingCount(2)
-    assert(algo.next(2.0) === 1.0)
-    assert(algo.next(1.0) === 2.0)
-    assert(algo.next(0.0) === 1.0)
+    assertEquals(algo.next(2.0), 1.0)
+    assertEquals(algo.next(1.0), 2.0)
+    assertEquals(algo.next(0.0), 1.0)
   }
 
   test("n = 2, NaNs") {
     val algo = OnlineRollingCount(2)
-    assert(algo.next(0.0) === 0.0)
-    assert(algo.next(1.0) === 1.0)
-    assert(algo.next(2.0) === 2.0)
-    assert(algo.next(Double.NaN) === 1.0)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(1.0), 1.0)
+    assertEquals(algo.next(2.0), 2.0)
+    assertEquals(algo.next(Double.NaN), 1.0)
     assert(!algo.isEmpty)
-    assert(algo.next(Double.NaN) === 0.0)
+    assertEquals(algo.next(Double.NaN), 0.0)
     assert(algo.isEmpty)
   }
 
   test("n = 2, reset") {
     val algo = OnlineRollingCount(2)
-    assert(algo.next(1.0) === 1.0)
+    assertEquals(algo.next(1.0), 1.0)
     algo.reset()
-    assert(algo.next(1.0) === 1.0)
+    assertEquals(algo.next(1.0), 1.0)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMaxSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMaxSuite.scala
@@ -21,30 +21,30 @@ class OnlineRollingMaxSuite extends BaseOnlineAlgorithmSuite {
 
   test("n = 1") {
     val algo = OnlineRollingMax(1)
-    assert(algo.next(0.0) === 0.0)
-    assert(algo.next(1.0) === 1.0)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(1.0), 1.0)
   }
 
   test("n = 2") {
     val algo = OnlineRollingMax(2)
-    assert(algo.next(0.0) === 0.0)
-    assert(algo.next(1.0) === 1.0)
-    assert(algo.next(2.0) === 2.0)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(1.0), 1.0)
+    assertEquals(algo.next(2.0), 2.0)
   }
 
   test("n = 2, decreasing") {
     val algo = OnlineRollingMax(2)
-    assert(algo.next(2.0) === 2.0)
-    assert(algo.next(1.0) === 2.0)
-    assert(algo.next(0.0) === 1.0)
+    assertEquals(algo.next(2.0), 2.0)
+    assertEquals(algo.next(1.0), 2.0)
+    assertEquals(algo.next(0.0), 1.0)
   }
 
   test("n = 2, NaNs") {
     val algo = OnlineRollingMax(2)
-    assert(algo.next(0.0) === 0.0)
-    assert(algo.next(1.0) === 1.0)
-    assert(algo.next(2.0) === 2.0)
-    assert(algo.next(Double.NaN) === 2.0)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(1.0), 1.0)
+    assertEquals(algo.next(2.0), 2.0)
+    assertEquals(algo.next(Double.NaN), 2.0)
     assert(!algo.isEmpty)
     assert(algo.next(Double.NaN).isNaN)
     assert(algo.isEmpty)
@@ -52,8 +52,8 @@ class OnlineRollingMaxSuite extends BaseOnlineAlgorithmSuite {
 
   test("n = 2, reset") {
     val algo = OnlineRollingMax(2)
-    assert(algo.next(1.0) === 1.0)
+    assertEquals(algo.next(1.0), 1.0)
     algo.reset()
-    assert(algo.next(0.0) === 0.0)
+    assertEquals(algo.next(0.0), 0.0)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMeanSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMeanSuite.scala
@@ -21,37 +21,37 @@ class OnlineRollingMeanSuite extends BaseOnlineAlgorithmSuite {
 
   test("n = 1, min = 1") {
     val algo = OnlineRollingMean(1, 1)
-    assert(algo.next(0.0) === 0.0)
-    assert(algo.next(1.0) === 1.0)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(1.0), 1.0)
   }
 
   test("n = 2, min = 1") {
     val algo = OnlineRollingMean(2, 1)
-    assert(algo.next(0.0) === 0.0)
-    assert(algo.next(1.0) === 0.5)
-    assert(algo.next(2.0) === 1.5)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(1.0), 0.5)
+    assertEquals(algo.next(2.0), 1.5)
   }
 
   test("n = 2, min = 2") {
     val algo = OnlineRollingMean(2, 2)
     assert(algo.next(0.0).isNaN)
-    assert(algo.next(1.0) === 0.5)
-    assert(algo.next(2.0) === 1.5)
+    assertEquals(algo.next(1.0), 0.5)
+    assertEquals(algo.next(2.0), 1.5)
   }
 
   test("n = 2, min = 1, decreasing") {
     val algo = OnlineRollingMean(2, 1)
-    assert(algo.next(2.0) === 2.0)
-    assert(algo.next(1.0) === 1.5)
-    assert(algo.next(0.0) === 0.5)
+    assertEquals(algo.next(2.0), 2.0)
+    assertEquals(algo.next(1.0), 1.5)
+    assertEquals(algo.next(0.0), 0.5)
   }
 
   test("n = 2, min = 1, NaNs") {
     val algo = OnlineRollingMean(2, 1)
-    assert(algo.next(0.0) === 0.0)
-    assert(algo.next(1.0) === 0.5)
-    assert(algo.next(2.0) === 1.5)
-    assert(algo.next(Double.NaN) === 2.0)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(1.0), 0.5)
+    assertEquals(algo.next(2.0), 1.5)
+    assertEquals(algo.next(Double.NaN), 2.0)
     assert(!algo.isEmpty)
     assert(algo.next(Double.NaN).isNaN)
     assert(algo.isEmpty)
@@ -59,9 +59,9 @@ class OnlineRollingMeanSuite extends BaseOnlineAlgorithmSuite {
 
   test("n = 2, min = 1, reset") {
     val algo = OnlineRollingMean(2, 1)
-    assert(algo.next(1.0) === 1.0)
+    assertEquals(algo.next(1.0), 1.0)
     algo.reset()
-    assert(algo.next(5.0) === 5.0)
+    assertEquals(algo.next(5.0), 5.0)
   }
 
   test("min < n") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMinSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMinSuite.scala
@@ -21,30 +21,30 @@ class OnlineRollingMinSuite extends BaseOnlineAlgorithmSuite {
 
   test("n = 1") {
     val algo = OnlineRollingMin(1)
-    assert(algo.next(0.0) === 0.0)
-    assert(algo.next(1.0) === 1.0)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(1.0), 1.0)
   }
 
   test("n = 2") {
     val algo = OnlineRollingMin(2)
-    assert(algo.next(0.0) === 0.0)
-    assert(algo.next(1.0) === 0.0)
-    assert(algo.next(2.0) === 1.0)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(1.0), 0.0)
+    assertEquals(algo.next(2.0), 1.0)
   }
 
   test("n = 2, decreasing") {
     val algo = OnlineRollingMin(2)
-    assert(algo.next(2.0) === 2.0)
-    assert(algo.next(1.0) === 1.0)
-    assert(algo.next(0.0) === 0.0)
+    assertEquals(algo.next(2.0), 2.0)
+    assertEquals(algo.next(1.0), 1.0)
+    assertEquals(algo.next(0.0), 0.0)
   }
 
   test("n = 2, NaNs") {
     val algo = OnlineRollingMin(2)
-    assert(algo.next(0.0) === 0.0)
-    assert(algo.next(1.0) === 0.0)
-    assert(algo.next(2.0) === 1.0)
-    assert(algo.next(Double.NaN) === 2.0)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(1.0), 0.0)
+    assertEquals(algo.next(2.0), 1.0)
+    assertEquals(algo.next(Double.NaN), 2.0)
     assert(!algo.isEmpty)
     assert(algo.next(Double.NaN).isNaN)
     assert(algo.isEmpty)
@@ -52,8 +52,8 @@ class OnlineRollingMinSuite extends BaseOnlineAlgorithmSuite {
 
   test("n = 2, reset") {
     val algo = OnlineRollingMin(2)
-    assert(algo.next(0.0) === 0.0)
+    assertEquals(algo.next(0.0), 0.0)
     algo.reset()
-    assert(algo.next(1.0) === 1.0)
+    assertEquals(algo.next(1.0), 1.0)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingSumSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingSumSuite.scala
@@ -21,42 +21,42 @@ class OnlineRollingSumSuite extends BaseOnlineAlgorithmSuite {
 
   test("n = 1") {
     val algo = OnlineRollingSum(1)
-    assert(algo.next(0.0) === 0.0)
-    assert(algo.next(1.0) === 1.0)
-    assert(algo.next(2.0) === 2.0)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(1.0), 1.0)
+    assertEquals(algo.next(2.0), 2.0)
   }
 
   test("n = 2") {
     val algo = OnlineRollingSum(2)
-    assert(algo.next(0.0) === 0.0)
-    assert(algo.next(1.0) === 1.0)
-    assert(algo.next(2.0) === 3.0)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(1.0), 1.0)
+    assertEquals(algo.next(2.0), 3.0)
   }
 
   test("n = 3 - up and down") {
     val algo = OnlineRollingSum(3)
-    assert(algo.next(0.0) === 0.0)
-    assert(algo.next(1.0) === 1.0)
-    assert(algo.next(-1.0) === 0.0)
-    assert(algo.next(Double.NaN) === 0.0)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(1.0), 1.0)
+    assertEquals(algo.next(-1.0), 0.0)
+    assertEquals(algo.next(Double.NaN), 0.0)
     assert(!algo.isEmpty)
-    assert(algo.next(Double.NaN) === -1.0)
+    assertEquals(algo.next(Double.NaN), -1.0)
     assert(!algo.isEmpty)
     assert(algo.next(Double.NaN).isNaN)
     assert(algo.isEmpty)
-    assert(algo.next(0.0) === 0.0)
-    assert(algo.next(1.0) === 1.0)
-    assert(algo.next(1.0) === 2.0)
-    assert(algo.next(1.0) === 3.0)
-    assert(algo.next(0.0) === 2.0)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(1.0), 1.0)
+    assertEquals(algo.next(1.0), 2.0)
+    assertEquals(algo.next(1.0), 3.0)
+    assertEquals(algo.next(0.0), 2.0)
   }
 
   test("n = 2, NaNs") {
     val algo = OnlineRollingSum(2)
-    assert(algo.next(0.0) === 0.0)
-    assert(algo.next(1.0) === 1.0)
-    assert(algo.next(2.0) === 3.0)
-    assert(algo.next(Double.NaN) === 2.0)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(1.0), 1.0)
+    assertEquals(algo.next(2.0), 3.0)
+    assertEquals(algo.next(Double.NaN), 2.0)
     assert(!algo.isEmpty)
     assert(algo.next(Double.NaN).isNaN)
     assert(algo.isEmpty)
@@ -64,8 +64,8 @@ class OnlineRollingSumSuite extends BaseOnlineAlgorithmSuite {
 
   test("n = 2, reset") {
     val algo = OnlineRollingSum(2)
-    assert(algo.next(1.0) === 1.0)
+    assertEquals(algo.next(1.0), 1.0)
     algo.reset()
-    assert(algo.next(5.0) === 5.0)
+    assertEquals(algo.next(5.0), 5.0)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineTrendSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineTrendSuite.scala
@@ -21,30 +21,30 @@ class OnlineTrendSuite extends BaseOnlineAlgorithmSuite {
 
   test("n = 1") {
     val algo = OnlineTrend(1)
-    assert(algo.next(0.0) === 0.0)
-    assert(algo.next(1.0) === 1.0)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(1.0), 1.0)
   }
 
   test("n = 2") {
     val algo = OnlineTrend(2)
     assert(algo.next(0.0).isNaN)
-    assert(algo.next(1.0) === 0.5)
-    assert(algo.next(2.0) === 1.5)
+    assertEquals(algo.next(1.0), 0.5)
+    assertEquals(algo.next(2.0), 1.5)
   }
 
   test("n = 2, decreasing") {
     val algo = OnlineTrend(2)
     assert(algo.next(2.0).isNaN)
-    assert(algo.next(1.0) === 1.5)
-    assert(algo.next(0.0) === 0.5)
+    assertEquals(algo.next(1.0), 1.5)
+    assertEquals(algo.next(0.0), 0.5)
   }
 
   test("n = 2, NaNs") {
     val algo = OnlineTrend(2)
     assert(algo.next(0.0).isNaN)
-    assert(algo.next(1.0) === 0.5)
-    assert(algo.next(2.0) === 1.5)
-    assert(algo.next(Double.NaN) === 1.0)
+    assertEquals(algo.next(1.0), 0.5)
+    assertEquals(algo.next(2.0), 1.5)
+    assertEquals(algo.next(Double.NaN), 1.0)
     assert(!algo.isEmpty)
     assert(algo.next(Double.NaN).isNaN)
     assert(algo.isEmpty)

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/PipelineSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/PipelineSuite.scala
@@ -26,28 +26,28 @@ class PipelineSuite extends BaseOnlineAlgorithmSuite {
   test("n = 1") {
     val algo = ignoreMax(1)
     assert(algo.next(0.0).isNaN)
-    assert(algo.next(2.0) === 2.0)
-    assert(algo.next(1.0) === 1.0)
+    assertEquals(algo.next(2.0), 2.0)
+    assertEquals(algo.next(1.0), 1.0)
     assert(algo.next(Double.NaN).isNaN)
   }
 
   test("n = 1, reset") {
     val algo = ignoreMax(1)
     assert(algo.next(0.0).isNaN)
-    assert(algo.next(1.0) === 1.0)
+    assertEquals(algo.next(1.0), 1.0)
     algo.reset()
     assert(algo.next(2.0).isNaN)
-    assert(algo.next(3.0) === 3.0)
+    assertEquals(algo.next(3.0), 3.0)
   }
 
   test("n = 2") {
     val algo = ignoreMax(2)
     assert(algo.next(0.0).isNaN)
     assert(algo.next(1.0).isNaN)
-    assert(algo.next(2.0) === 2.0)
-    assert(algo.next(3.0) === 3.0)
-    assert(algo.next(0.0) === 3.0)
-    assert(algo.next(Double.NaN) === 0.0)
+    assertEquals(algo.next(2.0), 2.0)
+    assertEquals(algo.next(3.0), 3.0)
+    assertEquals(algo.next(0.0), 3.0)
+    assertEquals(algo.next(Double.NaN), 0.0)
     assert(algo.next(Double.NaN).isNaN)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/RollingBufferSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/RollingBufferSuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.core.algorithm
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class RollingBufferSuite extends AnyFunSuite {
+class RollingBufferSuite extends FunSuite {
 
   test("n = 0") {
     intercept[IllegalArgumentException] {
@@ -28,29 +28,29 @@ class RollingBufferSuite extends AnyFunSuite {
   test("n = 1, add") {
     val buf = RollingBuffer(1)
     assert(buf.add(0.0).isNaN)
-    assert(buf.add(1.0) === 0.0)
-    assert(buf.add(2.0) === 1.0)
+    assertEquals(buf.add(1.0), 0.0)
+    assertEquals(buf.add(2.0), 1.0)
   }
 
   test("n = 2, add") {
     val buf = RollingBuffer(2)
     assert(buf.add(0.0).isNaN)
     assert(buf.add(1.0).isNaN)
-    assert(buf.add(2.0) === 0.0)
-    assert(buf.add(3.0) === 1.0)
-    assert(buf.add(4.0) === 2.0)
-    assert(buf.add(5.0) === 3.0)
-    assert(buf.add(6.0) === 4.0)
+    assertEquals(buf.add(2.0), 0.0)
+    assertEquals(buf.add(3.0), 1.0)
+    assertEquals(buf.add(4.0), 2.0)
+    assertEquals(buf.add(5.0), 3.0)
+    assertEquals(buf.add(6.0), 4.0)
   }
 
   test("n = 2, add NaNs") {
     val buf = RollingBuffer(2)
     assert(buf.add(0.0).isNaN)
     assert(buf.add(1.0).isNaN)
-    assert(buf.add(2.0) === 0.0)
-    assert(buf.add(3.0) === 1.0)
-    assert(buf.add(Double.NaN) === 2.0)
-    assert(buf.add(5.0) === 3.0)
+    assertEquals(buf.add(2.0), 0.0)
+    assertEquals(buf.add(3.0), 1.0)
+    assertEquals(buf.add(Double.NaN), 2.0)
+    assertEquals(buf.add(5.0), 3.0)
     assert(buf.add(6.0).isNaN)
   }
 
@@ -138,13 +138,13 @@ class RollingBufferSuite extends AnyFunSuite {
     val buf = RollingBuffer(2)
     buf.add(0.0)
     val cfg = buf.state
-    assert(cfg.getInt("pos") === 1)
+    assertEquals(cfg.getInt("pos"), 1)
     val actual = cfg.getDoubleArray("values")
     val expected = List(0.0, Double.NaN)
-    assert(actual.size === 2)
+    assertEquals(actual.size, 2)
     actual.zip(expected).foreach {
       // Used Double.compare to handle NaN properly
-      case (v1, v2) => assert(java.lang.Double.compare(v1, v2) === 0, s"$v1 != $v2")
+      case (v1, v2) => assertEquals(java.lang.Double.compare(v1, v2), 0, s"$v1 != $v2")
     }
   }
 
@@ -158,7 +158,7 @@ class RollingBufferSuite extends AnyFunSuite {
       val v = if (random.nextDouble() < 0.01) Double.NaN else random.nextDouble()
       val expected = buf.add(v)
       val actual = restoredBuf.add(v)
-      assert(java.lang.Double.compare(actual, expected) === 0, s"$actual != $expected")
+      assertEquals(java.lang.Double.compare(actual, expected), 0, s"$actual != $expected")
       if (i % n == 0) {
         restoredBuf = RollingBuffer(buf.state)
       }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/AggregateCollectorSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/AggregateCollectorSuite.scala
@@ -20,9 +20,9 @@ import com.netflix.atlas.core.model.CollectorStats
 import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.DsType
 import com.netflix.atlas.core.model.Query
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class AggregateCollectorSuite extends AnyFunSuite {
+class AggregateCollectorSuite extends FunSuite {
 
   private def newBuffer(v: Double, start: Long = 0L) = {
     new TimeSeriesBuffer(Map.empty, new ArrayTimeSeq(DsType.Gauge, start, 60000, Array.fill(1)(v)))
@@ -34,44 +34,44 @@ class AggregateCollectorSuite extends AnyFunSuite {
 
   test("sum collector") {
     val c = new SumAggregateCollector
-    assert(c.result === Nil)
+    assertEquals(c.result, Nil)
     c.add(newBuffer(1.0))
     c.add(newBuffer(1.0))
     c.add(newBuffer(1.0))
     c.add(newBuffer(1.0))
-    assert(c.result === List(newBuffer(4.0)))
-    assert(c.stats === CollectorStats(4, 4, 1, 1))
+    assertEquals(c.result, List(newBuffer(4.0)))
+    assertEquals(c.stats, CollectorStats(4, 4, 1, 1))
   }
 
   test("min collector") {
     val c = new MinAggregateCollector
-    assert(c.result === Nil)
+    assertEquals(c.result, Nil)
     c.add(newBuffer(3.0))
     c.add(newBuffer(1.0))
     c.add(newBuffer(2.0))
     c.add(newBuffer(5.0))
-    assert(c.result === List(newBuffer(1.0)))
-    assert(c.stats === CollectorStats(4, 4, 1, 1))
+    assertEquals(c.result, List(newBuffer(1.0)))
+    assertEquals(c.stats, CollectorStats(4, 4, 1, 1))
   }
 
   test("max collector") {
     val c = new MaxAggregateCollector
-    assert(c.result === Nil)
+    assertEquals(c.result, Nil)
     c.add(newBuffer(3.0))
     c.add(newBuffer(1.0))
     c.add(newBuffer(2.0))
     c.add(newBuffer(5.0))
-    assert(c.result === List(newBuffer(5.0)))
-    assert(c.stats === CollectorStats(4, 4, 1, 1))
+    assertEquals(c.result, List(newBuffer(5.0)))
+    assertEquals(c.stats, CollectorStats(4, 4, 1, 1))
   }
 
   test("all collector") {
     val expected = List(newBuffer(3.0), newBuffer(1.0), newBuffer(2.0), newBuffer(5.0))
     val c = new AllAggregateCollector
-    assert(c.result === Nil)
+    assertEquals(c.result, Nil)
     expected.foreach(c.add)
-    assert(c.result === expected)
-    assert(c.stats === CollectorStats(4, 4, 4, 4))
+    assertEquals(c.result, expected)
+    assertEquals(c.stats, CollectorStats(4, 4, 4, 4))
   }
 
   test("by collector -- all") {
@@ -83,10 +83,10 @@ class AggregateCollectorSuite extends AnyFunSuite {
     )
     val by = DataExpr.GroupBy(DataExpr.Sum(Query.False), List("a"))
     val c = new GroupByAggregateCollector(by)
-    assert(c.result === Nil)
+    assertEquals(c.result, Nil)
     expected.foreach(c.add)
-    assert(c.result.toSet === expected.toSet)
-    assert(c.stats === CollectorStats(4, 4, 4, 4))
+    assertEquals(c.result.toSet, expected.toSet)
+    assertEquals(c.stats, CollectorStats(4, 4, 4, 4))
   }
 
   test("by collector -- grp") {
@@ -102,10 +102,10 @@ class AggregateCollectorSuite extends AnyFunSuite {
     )
     val by = DataExpr.GroupBy(DataExpr.Sum(Query.False), List("b"))
     val c = new GroupByAggregateCollector(by)
-    assert(c.result === Nil)
+    assertEquals(c.result, Nil)
     input.foreach(c.add)
-    assert(c.result.toSet === expected.toSet)
-    assert(c.stats === CollectorStats(4, 4, 2, 2))
+    assertEquals(c.result.toSet, expected.toSet)
+    assertEquals(c.stats, CollectorStats(4, 4, 2, 2))
   }
 
   test("by collector -- missing key") {
@@ -118,9 +118,9 @@ class AggregateCollectorSuite extends AnyFunSuite {
     val expected = List(newTaggedBuffer(Map("a" -> "4", "b" -> "2", "c" -> "7"), 5.0))
     val by = DataExpr.GroupBy(DataExpr.Sum(Query.False), List("b", "c"))
     val c = new GroupByAggregateCollector(by)
-    assert(c.result === Nil)
+    assertEquals(c.result, Nil)
     input.foreach(c.add)
-    assert(c.result.toSet === expected.toSet)
-    assert(c.stats === CollectorStats(1, 1, 1, 1))
+    assertEquals(c.result.toSet, expected.toSet)
+    assertEquals(c.stats, CollectorStats(1, 1, 1, 1))
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryBlockStoreSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryBlockStoreSuite.scala
@@ -18,37 +18,37 @@ package com.netflix.atlas.core.db
 import com.netflix.atlas.core.model.Block
 import com.netflix.atlas.core.model.BlockStats
 import com.netflix.atlas.core.model.CompressedArrayBlock
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class MemoryBlockStoreSuite extends AnyFunSuite {
+class MemoryBlockStoreSuite extends FunSuite {
 
   test("update, new") {
     val bs = new MemoryBlockStore(1, 60, 1)
     bs.update(0, List(1.0, 2.0, 3.0))
-    assert(bs.fetch(0, 2, Block.Sum).toList === List(1.0, 2.0, 3.0))
-    assert(bs.fetch(2, 2, Block.Sum).toList === List(3.0))
+    assertEquals(bs.fetch(0, 2, Block.Sum).toList, List(1.0, 2.0, 3.0))
+    assertEquals(bs.fetch(2, 2, Block.Sum).toList, List(3.0))
   }
 
   test("update, 1m step") {
     val bs = new MemoryBlockStore(60000L, 60, 1)
     bs.update(0, List(1.0, 2.0, 3.0))
-    assert(bs.fetch(0L, 2 * 60000L, Block.Sum).toList === List(1.0, 2.0, 3.0))
-    assert(bs.fetch(2 * 60000L, 2 * 60000L, Block.Sum).toList === List(3.0))
+    assertEquals(bs.fetch(0L, 2 * 60000L, Block.Sum).toList, List(1.0, 2.0, 3.0))
+    assertEquals(bs.fetch(2 * 60000L, 2 * 60000L, Block.Sum).toList, List(3.0))
   }
 
   test("update, many blocks") {
     val bs = new MemoryBlockStore(1, 1, 4)
     bs.update(0, List(1.0, 2.0, 3.0))
-    assert(bs.fetch(0, 2, Block.Sum).toList === List(1.0, 2.0, 3.0))
-    assert(bs.fetch(2, 2, Block.Sum).toList === List(3.0))
+    assertEquals(bs.fetch(0, 2, Block.Sum).toList, List(1.0, 2.0, 3.0))
+    assertEquals(bs.fetch(2, 2, Block.Sum).toList, List(3.0))
   }
 
   test("update, gap in updates") {
     val bs = new MemoryBlockStore(1, 1, 40)
     bs.update(0, List(1.0, 2.0, 3.0))
     bs.update(10, List(4.0, 5.0, 6.0))
-    assert(bs.fetch(0, 2, Block.Sum).toList === List(1.0, 2.0, 3.0))
-    assert(bs.fetch(10, 12, Block.Sum).toList === List(4.0, 5.0, 6.0))
+    assertEquals(bs.fetch(0, 2, Block.Sum).toList, List(1.0, 2.0, 3.0))
+    assertEquals(bs.fetch(10, 12, Block.Sum).toList, List(4.0, 5.0, 6.0))
     val exp = List(
       1.0,
       2.0,
@@ -66,15 +66,15 @@ class MemoryBlockStoreSuite extends AnyFunSuite {
     )
     exp
       .zip(bs.fetch(0, 12, Block.Sum))
-      .foreach(t => assert(java.lang.Double.compare(t._1, t._2) === 0))
+      .foreach(t => assertEquals(java.lang.Double.compare(t._1, t._2), 0))
   }
 
   test("update, gap in updates misalign") {
     val bs = new MemoryBlockStore(1, 4, 40)
     bs.update(0, List(1.0, 2.0, 3.0))
     bs.update(10, List(4.0, 5.0, 6.0))
-    assert(bs.fetch(0, 2, Block.Sum).toList === List(1.0, 2.0, 3.0))
-    assert(bs.fetch(10, 12, Block.Sum).toList === List(4.0, 5.0, 6.0))
+    assertEquals(bs.fetch(0, 2, Block.Sum).toList, List(1.0, 2.0, 3.0))
+    assertEquals(bs.fetch(10, 12, Block.Sum).toList, List(4.0, 5.0, 6.0))
     val exp = List(
       1.0,
       2.0,
@@ -92,7 +92,7 @@ class MemoryBlockStoreSuite extends AnyFunSuite {
     )
     exp
       .zip(bs.fetch(0, 12, Block.Sum))
-      .foreach(t => assert(java.lang.Double.compare(t._1, t._2) === 0))
+      .foreach(t => assertEquals(java.lang.Double.compare(t._1, t._2), 0))
   }
 
   test("update, old data") {
@@ -100,33 +100,33 @@ class MemoryBlockStoreSuite extends AnyFunSuite {
     bs.update(0, List(1.0, 2.0, 3.0))
     bs.update(0, List(4.0, 5.0))
     // previous block can still be updated, but older updates will be ignored
-    assert(bs.fetch(0, 2, Block.Sum).toList === List(1.0, 5.0, 3.0))
+    assertEquals(bs.fetch(0, 2, Block.Sum).toList, List(1.0, 5.0, 3.0))
   }
 
   test("update, old data hour transition") {
     val bs = new MemoryBlockStore(1, 60, 3)
     val input = (0 to 61).map(_.toDouble).toList
     bs.update(0, input)
-    assert(bs.fetch(0, 61, Block.Sum).toList === input)
+    assertEquals(bs.fetch(0, 61, Block.Sum).toList, input)
 
     bs.update(58, 60.0)
     bs.update(59, 60.0)
-    assert(bs.fetch(58, 61, Block.Sum).toList === List(60.0, 60.0, 60.0, 61.0))
+    assertEquals(bs.fetch(58, 61, Block.Sum).toList, List(60.0, 60.0, 60.0, 61.0))
   }
 
   test("update, overwrite") {
     val bs = new MemoryBlockStore(1, 60, 40)
     bs.update(0, List(1.0, 2.0, 3.0))
     bs.update(1, List(4.0, 5.0))
-    assert(bs.fetch(0, 2, Block.Sum).toList === List(1.0, 4.0, 5.0))
+    assertEquals(bs.fetch(0, 2, Block.Sum).toList, List(1.0, 4.0, 5.0))
   }
 
   test("update, skip some") {
     val bs = new MemoryBlockStore(1, 10, 40)
     bs.update(0, List(1.0, 2.0, 3.0))
     bs.update(8, List(4.0, 5.0, 6.0))
-    assert(bs.fetch(0, 2, Block.Sum).toList === List(1.0, 2.0, 3.0))
-    assert(bs.fetch(8, 10, Block.Sum).toList === List(4.0, 5.0, 6.0))
+    assertEquals(bs.fetch(0, 2, Block.Sum).toList, List(1.0, 2.0, 3.0))
+    assertEquals(bs.fetch(8, 10, Block.Sum).toList, List(4.0, 5.0, 6.0))
     assert(bs.fetch(3, 7, Block.Sum).forall(_.isNaN))
   }
 
@@ -144,18 +144,18 @@ class MemoryBlockStoreSuite extends AnyFunSuite {
     val bs = new MemoryBlockStore(1, 7, 3)
     bs.update(5, List(1.0, 2.0, 3.0))
     assert(bs.fetch(0, 4, Block.Sum).forall(_.isNaN))
-    assert(bs.fetch(5, 7, Block.Sum).toList === List(1.0, 2.0, 3.0))
+    assertEquals(bs.fetch(5, 7, Block.Sum).toList, List(1.0, 2.0, 3.0))
     assert(bs.fetch(8, 13, Block.Sum).forall(_.isNaN))
-    assert(bs.blocks(0) === null)
-    assert(bs.blocks(1).start === 0)
-    assert(bs.blocks(2).start === 7)
+    assertEquals(bs.blocks(0), null)
+    assertEquals(bs.blocks(1).start, 0L)
+    assertEquals(bs.blocks(2).start, 7L)
   }
 
   test("update, overwrite oldest blocks") {
     val bs = new MemoryBlockStore(1, 2, 3)
     bs.update(0, List(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0))
     assert(bs.fetch(0, 1, Block.Sum).forall(_.isNaN))
-    assert(bs.fetch(2, 6, Block.Sum).toList === List(3.0, 4.0, 5.0, 6.0, 7.0))
+    assertEquals(bs.fetch(2, 6, Block.Sum).toList, List(3.0, 4.0, 5.0, 6.0, 7.0))
     bs.fetch(7, 10, Block.Sum).foreach(println)
     assert(bs.fetch(7, 10, Block.Sum).forall(_.isNaN))
   }
@@ -165,30 +165,30 @@ class MemoryBlockStoreSuite extends AnyFunSuite {
     (0 until 10).foreach { i =>
       bs.update(i, 2.0)
     }
-    assert(bs.currentBlock !== null)
+    assert(bs.currentBlock != null)
     bs.update(0)
-    assert(bs.currentBlock === null)
+    assertEquals(bs.currentBlock, null)
     val expected = CompressedArrayBlock(0, 10)
     (0 until 10).foreach { i =>
       expected.update(i, 2.0)
     }
-    assert(bs.blockList === List(expected))
+    assertEquals(bs.blockList, List(expected))
   }
 
   test("cleanup, nothing to do") {
     val bs = new MemoryBlockStore(1, 60, 1)
     assert(!bs.hasData)
     bs.update(0, List(1.0, 2.0, 3.0))
-    assert(bs.fetch(0, 2, Block.Sum).toList === List(1.0, 2.0, 3.0))
+    assertEquals(bs.fetch(0, 2, Block.Sum).toList, List(1.0, 2.0, 3.0))
     bs.cleanup(0)
     assert(bs.hasData)
-    assert(bs.fetch(0, 2, Block.Sum).toList === List(1.0, 2.0, 3.0))
+    assertEquals(bs.fetch(0, 2, Block.Sum).toList, List(1.0, 2.0, 3.0))
   }
 
   test("cleanup, all") {
     val bs = new MemoryBlockStore(1, 60, 1)
     bs.update(0, List(1.0, 2.0, 3.0))
-    assert(bs.fetch(0, 2, Block.Sum).toList === List(1.0, 2.0, 3.0))
+    assertEquals(bs.fetch(0, 2, Block.Sum).toList, List(1.0, 2.0, 3.0))
     bs.cleanup(10)
     assert(!bs.hasData)
   }
@@ -197,12 +197,12 @@ class MemoryBlockStoreSuite extends AnyFunSuite {
     val bs = new MemoryBlockStore(1, 1, 60)
     bs.update(0, List(1.0, 2.0, 3.0))
     bs.update(120, List(4.0, 5.0, 6.0))
-    assert(bs.fetch(0, 2, Block.Sum).toList === List(1.0, 2.0, 3.0))
-    assert(bs.fetch(120, 122, Block.Sum).toList === List(4.0, 5.0, 6.0))
+    assertEquals(bs.fetch(0, 2, Block.Sum).toList, List(1.0, 2.0, 3.0))
+    assertEquals(bs.fetch(120, 122, Block.Sum).toList, List(4.0, 5.0, 6.0))
     bs.cleanup(10)
     assert(bs.hasData)
     assert(bs.fetch(0, 2, Block.Sum).forall(_.isNaN))
-    assert(bs.fetch(120, 122, Block.Sum).toList === List(4.0, 5.0, 6.0))
+    assertEquals(bs.fetch(120, 122, Block.Sum).toList, List(4.0, 5.0, 6.0))
   }
 
   test("cleanup, flush data") {
@@ -227,7 +227,7 @@ class MemoryBlockStoreSuite extends AnyFunSuite {
     val start = end - windowSize + step
     val data = blockStore.fetch(start, end, Block.Sum)
     data.indices.foreach { i =>
-      assert(data(i) === 1080.0 + i)
+      assertEquals(data(i), 1080.0 + i)
     }
   }
 
@@ -238,10 +238,10 @@ class MemoryBlockStoreSuite extends AnyFunSuite {
     bs.update(0, List(1.0, 2.0, 3.0))
     bs.update(60, List(1.0, 2.0, 3.0))
     bs.update(120, List(1.0, 2.0, 3.0))
-    assert(BlockStats.overallCount === 3)
+    assertEquals(BlockStats.overallCount, 3)
 
     bs.update(180, List(1.0, 2.0, 3.0))
-    assert(BlockStats.overallCount === 3)
+    assertEquals(BlockStats.overallCount, 3)
   }
 
   test("block counts update correctly on update(ts)") {
@@ -249,10 +249,10 @@ class MemoryBlockStoreSuite extends AnyFunSuite {
 
     val bs = new MemoryBlockStore(1, 60, 3)
     bs.update(0, List(1.0, 2.0, 3.0))
-    assert(BlockStats.overallCount === 1)
+    assertEquals(BlockStats.overallCount, 1)
 
     bs.update(0)
-    assert(BlockStats.overallCount === 1)
+    assertEquals(BlockStats.overallCount, 1)
   }
 
   test("block counts update correctly on cleanup(ts)") {
@@ -260,10 +260,10 @@ class MemoryBlockStoreSuite extends AnyFunSuite {
 
     val bs = new MemoryBlockStore(1, 60, 3)
     bs.update(0, List(1.0, 2.0, 3.0))
-    assert(BlockStats.overallCount === 1)
+    assertEquals(BlockStats.overallCount, 1)
 
     bs.cleanup(60)
-    assert(BlockStats.overallCount === 0)
+    assertEquals(BlockStats.overallCount, 0)
   }
 
   test("block counts update for update with gap") {
@@ -272,6 +272,6 @@ class MemoryBlockStoreSuite extends AnyFunSuite {
     val bs = new MemoryBlockStore(1, 60, 3)
     bs.update(0, List(1.0, 2.0, 3.0))
     bs.update(62, List(1.0))
-    assert(BlockStats.overallCount === 2)
+    assertEquals(BlockStats.overallCount, 2)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
@@ -20,9 +20,9 @@ import com.netflix.atlas.core.stacklang.Interpreter
 import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spectator.api.ManualClock
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class MemoryDatabaseSuite extends AnyFunSuite {
+class MemoryDatabaseSuite extends FunSuite {
 
   private val interpreter = new Interpreter(DataVocabulary.allWords)
 
@@ -103,44 +103,45 @@ class MemoryDatabaseSuite extends AnyFunSuite {
 
   test(":eq query") {
     val result = exec("name,a,:eq")
-    assert(result.map(_.tags) === List(Map("name" -> "a")))
-    assert(result === List(expTS("a", "sum(name=a)", 1, 1.0, 2.0, 3.0)))
+    assertEquals(result.map(_.tags), List(Map("name" -> "a")))
+    assertEquals(result, List(expTS("a", "sum(name=a)", 1, 1.0, 2.0, 3.0)))
   }
 
   test(":in query") {
-    assert(exec("name,(,a,b,),:in") === List(ts("sum(name in (a,b))", 1, 4.0, 4.0, 4.0)))
+    assertEquals(exec("name,(,a,b,),:in"), List(ts("sum(name in (a,b))", 1, 4.0, 4.0, 4.0)))
   }
 
   test(":re query") {
-    assert(exec("name,[ab]$,:re") === List(ts("sum(name~/^[ab]$/)", 1, 4.0, 4.0, 4.0)))
+    assertEquals(exec("name,[ab]$,:re"), List(ts("sum(name~/^[ab]$/)", 1, 4.0, 4.0, 4.0)))
   }
 
   test(":has query") {
-    assert(exec("name,:has") === List(ts("sum(has(name))", 1, 19.0, 22.0, 25.0)))
+    assertEquals(exec("name,:has"), List(ts("sum(has(name))", 1, 19.0, 22.0, 25.0)))
   }
 
   test(":offset expr") {
-    assert(
-      exec(":true,:sum,1m,:offset") === List(
-          ts("sum(true) (offset=1m)", 1, Double.NaN, 19.0, 22.0)
-        )
+    assertEquals(
+      exec(":true,:sum,1m,:offset"),
+      List(
+        ts("sum(true) (offset=1m)", 1, Double.NaN, 19.0, 22.0)
+      )
     )
   }
 
   test(":sum expr") {
-    assert(exec(":true,:sum") === List(ts("sum(true)", 1, 19.0, 22.0, 25.0)))
+    assertEquals(exec(":true,:sum"), List(ts("sum(true)", 1, 19.0, 22.0, 25.0)))
   }
 
   test(":count expr") {
-    assert(exec(":true,:count") === List(ts("count(true)", 1, 5.0, 5.0, 5.0)))
+    assertEquals(exec(":true,:count"), List(ts("count(true)", 1, 5.0, 5.0, 5.0)))
   }
 
   test(":min expr") {
-    assert(exec(":true,:min") === List(ts("min(true)", 1, 1.0, 2.0, 1.0)))
+    assertEquals(exec(":true,:min"), List(ts("min(true)", 1, 1.0, 2.0, 1.0)))
   }
 
   test(":max expr") {
-    assert(exec(":true,:max") === List(ts("max(true)", 1, 6.0, 7.0, 8.0)))
+    assertEquals(exec(":true,:max"), List(ts("max(true)", 1, 6.0, 7.0, 8.0)))
   }
 
   test(":by expr") {
@@ -149,7 +150,7 @@ class MemoryDatabaseSuite extends AnyFunSuite {
       expTS("b", "(name=b)", 1, 3.0, 2.0, 1.0),
       expTS("c", "(name=c)", 1, 15.0, 18.0, 21.0)
     )
-    assert(exec(":true,(,name,),:by") === expected)
+    assertEquals(exec(":true,(,name,),:by"), expected)
   }
 
   test(":all expr") {
@@ -158,39 +159,39 @@ class MemoryDatabaseSuite extends AnyFunSuite {
       expTS("b", "name=b", 1, 3.0, 2.0, 1.0),
       expTS("c", "name=c", 1, 15.0, 18.0, 21.0)
     )
-    assert(exec(":true,:all") === expected)
+    assertEquals(exec(":true,:all"), expected)
   }
 
   test(":sum expr, c=3") {
-    assert(exec(":true,:sum", 3 * step) === List(ts("sum(true)", 3, 22.0)))
+    assertEquals(exec(":true,:sum", 3 * step), List(ts("sum(true)", 3, 22.0)))
   }
 
   test(":sum expr, c=3, cf=sum") {
-    assert(exec(":true,:sum,:cf-sum", 3 * step) === List(ts("sum(true)", 3, 66.0)))
+    assertEquals(exec(":true,:sum,:cf-sum", 3 * step), List(ts("sum(true)", 3, 66.0)))
   }
 
   test(":sum expr, c=3, cf=max") {
-    assert(exec(":true,:sum,:cf-max", 3 * step) === List(ts("sum(true)", 3, 27.0)))
+    assertEquals(exec(":true,:sum,:cf-max", 3 * step), List(ts("sum(true)", 3, 27.0)))
   }
 
   test(":count expr, c=3") {
-    assert(exec(":true,:count", 3 * step) === List(ts("count(true)", 3, 5.0)))
+    assertEquals(exec(":true,:count", 3 * step), List(ts("count(true)", 3, 5.0)))
   }
 
   test(":count expr, c=3, cf=sum") {
-    assert(exec(":true,:count,:cf-sum", 3 * step) === List(ts("count(true)", 3, 15.0)))
+    assertEquals(exec(":true,:count,:cf-sum", 3 * step), List(ts("count(true)", 3, 15.0)))
   }
 
   test(":count expr, c=3, cf=max") {
-    assert(exec(":true,:count,:cf-max", 3 * step) === List(ts("count(true)", 3, 5.0)))
+    assertEquals(exec(":true,:count,:cf-max", 3 * step), List(ts("count(true)", 3, 5.0)))
   }
 
   test(":min expr, c=3") {
-    assert(exec(":true,:min", 3 * step) === List(ts("min(true)", 3, 1.0)))
+    assertEquals(exec(":true,:min", 3 * step), List(ts("min(true)", 3, 1.0)))
   }
 
   test(":max expr, c=3") {
-    assert(exec(":true,:max", 3 * step) === List(ts("max(true)", 3, 8.0)))
+    assertEquals(exec(":true,:max", 3 * step), List(ts("max(true)", 3, 8.0)))
   }
 
   test(":by expr, c=3") {
@@ -199,7 +200,7 @@ class MemoryDatabaseSuite extends AnyFunSuite {
       expTS("b", "(name=b)", 3, 2.0),
       expTS("c", "(name=c)", 3, 18.0)
     )
-    assert(exec(":true,(,name,),:by", 3 * step) === expected)
+    assertEquals(exec(":true,(,name,),:by", 3 * step), expected)
   }
 
   test(":all expr, c=3") {
@@ -208,6 +209,6 @@ class MemoryDatabaseSuite extends AnyFunSuite {
       expTS("b", "name=b", 3, 6.0),
       expTS("c", "name=c", 3, 54.0)
     )
-    assert(exec(":true,:all", 3 * step) === expected)
+    assertEquals(exec(":true,:all", 3 * step), expected)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/TimeSeriesBufferSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/TimeSeriesBufferSuite.scala
@@ -24,9 +24,9 @@ import com.netflix.atlas.core.model.DsType
 import com.netflix.atlas.core.util.Math
 import nl.jqno.equalsverifier.EqualsVerifier
 import nl.jqno.equalsverifier.Warning
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class TimeSeriesBufferSuite extends AnyFunSuite {
+class TimeSeriesBufferSuite extends FunSuite {
 
   import java.lang.{Double => JDouble}
 
@@ -51,8 +51,8 @@ class TimeSeriesBufferSuite extends AnyFunSuite {
 
     val buffer = TimeSeriesBuffer(tags, step, 1 * step, 19 * step, blocks, Block.Sum)
     val m = buffer
-    assert(m.step === step)
-    assert(m.start === step)
+    assertEquals(m.step, step)
+    assertEquals(m.start, step)
     assert(m.values.take(5).forall(_ == 1.0))
     assert(m.values.slice(5, 11).forall(_ == 2.0))
     assert(m.values.slice(11, 17).forall(v => JDouble.isNaN(v)))
@@ -73,8 +73,8 @@ class TimeSeriesBufferSuite extends AnyFunSuite {
       buffer.add(tags, b)
     }
     val m = buffer
-    assert(m.step === step)
-    assert(m.start === step)
+    assertEquals(m.step, step)
+    assertEquals(m.start, step)
     assert(m.values.take(5).forall(_ == 1.0))
     assert(m.values.slice(5, 11).forall(_ == 2.0))
     assert(m.values.slice(11, 17).forall(v => JDouble.isNaN(v)))
@@ -95,8 +95,8 @@ class TimeSeriesBufferSuite extends AnyFunSuite {
       buffer.aggrBlock(tags, b, Block.Sum, ConsolidationFunction.Max, 6, Math.addNaN)
     }
     val m = buffer
-    assert(m.step === 6 * step)
-    assert(m.start === 0L)
+    assertEquals(m.step, 6 * step)
+    assertEquals(m.start, 0L)
     assert(m.values.take(1).forall(_ == 1.0))
     assert(m.values.slice(1, 2).forall(_ == 2.0))
     assert(m.values.slice(2, 3).forall(v => JDouble.isNaN(v)))
@@ -117,12 +117,12 @@ class TimeSeriesBufferSuite extends AnyFunSuite {
       buffer.aggrBlock(tags, b, Block.Sum, ConsolidationFunction.Max, multiple, Math.addNaN)
     }
     val m = buffer
-    assert(m.step === consol)
-    assert(m.start === consol)
+    assertEquals(m.step, consol)
+    assertEquals(m.start, consol)
     assert(m.values.forall(_ == 4.0))
   }
 
-  ignore("cf with start") {
+  test("cf with start".ignore) {
     val tags = emptyTags
     val step = 60000L
     val block = ArrayBlock(0L, 60)
@@ -159,7 +159,7 @@ class TimeSeriesBufferSuite extends AnyFunSuite {
 
         val cfSecond = afFirst.consolidate(6, cf)
         (0 until cfFirst.values.length).foreach { i =>
-          assert(cfSecond.values(i) === (cfFirst.values(i) +- 1e-9), s"position $i")
+          assertEquals(cfSecond.values(i), (cfFirst.values(i) +- 1e-9), s"position $i")
         }
       }
 
@@ -178,7 +178,7 @@ class TimeSeriesBufferSuite extends AnyFunSuite {
 
         val cfSecond = afFirst.consolidate(6, cf)
         (0 until cfFirst.values.length).foreach { i =>
-          assert(cfSecond.values(i) === (cfFirst.values(i) +- 1e-9), s"position $i")
+          assertEquals(cfSecond.values(i), (cfFirst.values(i) +- 1e-9), s"position $i")
         }
       }
   }*/
@@ -190,30 +190,30 @@ class TimeSeriesBufferSuite extends AnyFunSuite {
     val b1 = TimeSeriesBuffer(t1, 60000, 0, Array.fill(1)(0.0))
     val b2 = TimeSeriesBuffer(t2, 60000, 0, Array.fill(1)(0.0))
     b1.add(b2)
-    assert(b1.tags === Map("a" -> "b"))
+    assertEquals(b1.tags, Map("a" -> "b"))
   }
 
   test("add buffer") {
     val b1 = newBuffer(42.0)
     val b2 = newBuffer(42.0)
     b1.add(b2)
-    b1.values.foreach(v => assert(v === 84.0))
-    b2.values.foreach(v => assert(v === 42.0))
+    b1.values.foreach(v => assertEquals(v, 84.0))
+    b2.values.foreach(v => assertEquals(v, 42.0))
   }
 
   test("add buffer, b1=NaN") {
     val b1 = newBuffer(Double.NaN)
     val b2 = newBuffer(42.0)
     b1.add(b2)
-    b1.values.foreach(v => assert(v === 42.0))
-    b2.values.foreach(v => assert(v === 42.0))
+    b1.values.foreach(v => assertEquals(v, 42.0))
+    b2.values.foreach(v => assertEquals(v, 42.0))
   }
 
   test("add buffer, b2=NaN") {
     val b1 = newBuffer(42.0)
     val b2 = newBuffer(Double.NaN)
     b1.add(b2)
-    b1.values.foreach(v => assert(v === 42.0))
+    b1.values.foreach(v => assertEquals(v, 42.0))
     b2.values.foreach(v => assert(v.isNaN))
   }
 
@@ -228,19 +228,19 @@ class TimeSeriesBufferSuite extends AnyFunSuite {
   test("add constant") {
     val b1 = newBuffer(42.0)
     b1.add(42.0)
-    b1.values.foreach(v => assert(v === 84.0))
+    b1.values.foreach(v => assertEquals(v, 84.0))
   }
 
   test("add constant, b1=NaN") {
     val b1 = newBuffer(Double.NaN)
     b1.add(42.0)
-    b1.values.foreach(v => assert(v === 42.0))
+    b1.values.foreach(v => assertEquals(v, 42.0))
   }
 
   test("add constant, v=NaN") {
     val b1 = newBuffer(42.0)
     b1.add(Double.NaN)
-    b1.values.foreach(v => assert(v === 42.0))
+    b1.values.foreach(v => assertEquals(v, 42.0))
   }
 
   test("add buffer, b1=v=NaN") {
@@ -253,73 +253,73 @@ class TimeSeriesBufferSuite extends AnyFunSuite {
     val b1 = newBuffer(84.0)
     val b2 = newBuffer(42.0)
     b1.subtract(b2)
-    b1.values.foreach(v => assert(v === 42.0))
-    b2.values.foreach(v => assert(v === 42.0))
+    b1.values.foreach(v => assertEquals(v, 42.0))
+    b2.values.foreach(v => assertEquals(v, 42.0))
   }
 
   test("subtract constant") {
     val b1 = newBuffer(84.0)
     b1.subtract(42.0)
-    b1.values.foreach(v => assert(v === 42.0))
+    b1.values.foreach(v => assertEquals(v, 42.0))
   }
 
   test("multiply buffer") {
     val b1 = newBuffer(84.0)
     val b2 = newBuffer(2.0)
     b1.multiply(b2)
-    b1.values.foreach(v => assert(v === 168.0))
-    b2.values.foreach(v => assert(v === 2.0))
+    b1.values.foreach(v => assertEquals(v, 168.0))
+    b2.values.foreach(v => assertEquals(v, 2.0))
   }
 
   test("multiply constant") {
     val b1 = newBuffer(84.0)
     b1.multiply(2.0)
-    b1.values.foreach(v => assert(v === 168.0))
+    b1.values.foreach(v => assertEquals(v, 168.0))
   }
 
   test("divide buffer") {
     val b1 = newBuffer(84.0)
     val b2 = newBuffer(2.0)
     b1.divide(b2)
-    b1.values.foreach(v => assert(v === 42.0))
-    b2.values.foreach(v => assert(v === 2.0))
+    b1.values.foreach(v => assertEquals(v, 42.0))
+    b2.values.foreach(v => assertEquals(v, 2.0))
   }
 
   test("divide constant") {
     val b1 = newBuffer(84.0)
     b1.divide(2.0)
-    b1.values.foreach(v => assert(v === 42.0))
+    b1.values.foreach(v => assertEquals(v, 42.0))
   }
 
   test("max buffer, b1 > b2") {
     val b1 = newBuffer(42.0)
     val b2 = newBuffer(21.0)
     b1.max(b2)
-    b1.values.foreach(v => assert(v === 42.0))
-    b2.values.foreach(v => assert(v === 21.0))
+    b1.values.foreach(v => assertEquals(v, 42.0))
+    b2.values.foreach(v => assertEquals(v, 21.0))
   }
 
   test("max buffer, b1 < b2") {
     val b1 = newBuffer(21.0)
     val b2 = newBuffer(42.0)
     b1.max(b2)
-    b1.values.foreach(v => assert(v === 42.0))
-    b2.values.foreach(v => assert(v === 42.0))
+    b1.values.foreach(v => assertEquals(v, 42.0))
+    b2.values.foreach(v => assertEquals(v, 42.0))
   }
 
   test("max buffer, b1=NaN") {
     val b1 = newBuffer(Double.NaN)
     val b2 = newBuffer(42.0)
     b1.max(b2)
-    b1.values.foreach(v => assert(v === 42.0))
-    b2.values.foreach(v => assert(v === 42.0))
+    b1.values.foreach(v => assertEquals(v, 42.0))
+    b2.values.foreach(v => assertEquals(v, 42.0))
   }
 
   test("max buffer, b2=NaN") {
     val b1 = newBuffer(42.0)
     val b2 = newBuffer(Double.NaN)
     b1.max(b2)
-    b1.values.foreach(v => assert(v === 42.0))
+    b1.values.foreach(v => assertEquals(v, 42.0))
     b2.values.foreach(v => assert(v.isNaN))
   }
 
@@ -335,31 +335,31 @@ class TimeSeriesBufferSuite extends AnyFunSuite {
     val b1 = newBuffer(42.0)
     val b2 = newBuffer(21.0)
     b1.min(b2)
-    b1.values.foreach(v => assert(v === 21.0))
-    b2.values.foreach(v => assert(v === 21.0))
+    b1.values.foreach(v => assertEquals(v, 21.0))
+    b2.values.foreach(v => assertEquals(v, 21.0))
   }
 
   test("min buffer, b1 < b2") {
     val b1 = newBuffer(21.0)
     val b2 = newBuffer(42.0)
     b1.min(b2)
-    b1.values.foreach(v => assert(v === 21.0))
-    b2.values.foreach(v => assert(v === 42.0))
+    b1.values.foreach(v => assertEquals(v, 21.0))
+    b2.values.foreach(v => assertEquals(v, 42.0))
   }
 
   test("min buffer, b1=NaN") {
     val b1 = newBuffer(Double.NaN)
     val b2 = newBuffer(42.0)
     b1.min(b2)
-    b1.values.foreach(v => assert(v === 42.0))
-    b2.values.foreach(v => assert(v === 42.0))
+    b1.values.foreach(v => assertEquals(v, 42.0))
+    b2.values.foreach(v => assertEquals(v, 42.0))
   }
 
   test("min buffer, b2=NaN") {
     val b1 = newBuffer(42.0)
     val b2 = newBuffer(Double.NaN)
     b1.min(b2)
-    b1.values.foreach(v => assert(v === 42.0))
+    b1.values.foreach(v => assertEquals(v, 42.0))
     b2.values.foreach(v => assert(v.isNaN))
   }
 
@@ -376,8 +376,8 @@ class TimeSeriesBufferSuite extends AnyFunSuite {
     val b2 = newBuffer(42.0)
     b1.initCount()
     b1.count(b2)
-    b1.values.foreach(v => assert(v === 2.0))
-    b2.values.foreach(v => assert(v === 42.0))
+    b1.values.foreach(v => assertEquals(v, 2.0))
+    b2.values.foreach(v => assertEquals(v, 42.0))
   }
 
   test("count buffer, b1=NaN") {
@@ -385,8 +385,8 @@ class TimeSeriesBufferSuite extends AnyFunSuite {
     val b2 = newBuffer(42.0)
     b1.initCount()
     b1.count(b2)
-    b1.values.foreach(v => assert(v === 1.0))
-    b2.values.foreach(v => assert(v === 42.0))
+    b1.values.foreach(v => assertEquals(v, 1.0))
+    b2.values.foreach(v => assertEquals(v, 42.0))
   }
 
   test("count buffer, b2=NaN") {
@@ -394,7 +394,7 @@ class TimeSeriesBufferSuite extends AnyFunSuite {
     val b2 = newBuffer(Double.NaN)
     b1.initCount()
     b1.count(b2)
-    b1.values.foreach(v => assert(v === 1.0))
+    b1.values.foreach(v => assertEquals(v, 1.0))
     b2.values.foreach(v => assert(v.isNaN))
   }
 
@@ -403,7 +403,7 @@ class TimeSeriesBufferSuite extends AnyFunSuite {
     val b2 = newBuffer(Double.NaN)
     b1.initCount()
     b1.count(b2)
-    b1.values.foreach(v => assert(v === 0.0))
+    b1.values.foreach(v => assertEquals(v, 0.0))
     b2.values.foreach(v => assert(v.isNaN))
   }
 
@@ -419,43 +419,43 @@ class TimeSeriesBufferSuite extends AnyFunSuite {
 
   test("getValue with match") {
     val b1 = newBuffer(42.0, 120000)
-    assert(b1.getValue(129000) === 42.0)
+    assertEquals(b1.getValue(129000), 42.0)
   }
 
   test("sum") {
     val buffers = List(newBuffer(1.0), newBuffer(Double.NaN), newBuffer(2.0))
-    assert(TimeSeriesBuffer.sum(buffers).get.values(0) === 3.0)
+    assertEquals(TimeSeriesBuffer.sum(buffers).get.values(0), 3.0)
   }
 
   test("sum empty") {
-    assert(TimeSeriesBuffer.sum(Nil) === None)
+    assertEquals(TimeSeriesBuffer.sum(Nil), None)
   }
 
   test("max") {
     val buffers = List(newBuffer(1.0), newBuffer(Double.NaN), newBuffer(2.0))
-    assert(TimeSeriesBuffer.max(buffers).get.values(0) === 2.0)
+    assertEquals(TimeSeriesBuffer.max(buffers).get.values(0), 2.0)
   }
 
   test("max empty") {
-    assert(TimeSeriesBuffer.max(Nil) === None)
+    assertEquals(TimeSeriesBuffer.max(Nil), None)
   }
 
   test("min") {
     val buffers = List(newBuffer(1.0), newBuffer(Double.NaN), newBuffer(2.0))
-    assert(TimeSeriesBuffer.min(buffers).get.values(0) === 1.0)
+    assertEquals(TimeSeriesBuffer.min(buffers).get.values(0), 1.0)
   }
 
   test("min empty") {
-    assert(TimeSeriesBuffer.min(Nil) === None)
+    assertEquals(TimeSeriesBuffer.min(Nil), None)
   }
 
   test("count") {
     val buffers = List(newBuffer(1.0), newBuffer(Double.NaN), newBuffer(2.0))
-    assert(TimeSeriesBuffer.count(buffers).get.values(0) === 2.0)
+    assertEquals(TimeSeriesBuffer.count(buffers).get.values(0), 2.0)
   }
 
   test("count empty") {
-    assert(TimeSeriesBuffer.count(Nil) === None)
+    assertEquals(TimeSeriesBuffer.count(Nil), None)
   }
 
   test("merge diff sizes b1.length < b2.length") {
@@ -478,29 +478,29 @@ class TimeSeriesBufferSuite extends AnyFunSuite {
     val b = TimeSeriesBuffer(emptyTags, 60000, start, Array(1.0, 2.0, 3.0, 4.0, 5.0))
 
     val b2 = TimeSeriesBuffer(emptyTags, 120000, start, Array(1.0, 5.0, 9.0))
-    assert(b.consolidate(2, ConsolidationFunction.Sum) === b2)
+    assertEquals(b.consolidate(2, ConsolidationFunction.Sum), b2)
 
     val b3 = TimeSeriesBuffer(emptyTags, 180000, start, Array(3.0, 12.0))
-    assert(b.consolidate(3, ConsolidationFunction.Sum) === b3)
+    assertEquals(b.consolidate(3, ConsolidationFunction.Sum), b3)
 
     val b4 = TimeSeriesBuffer(emptyTags, 240000, start, Array(1.0, 14.0))
-    assert(b.consolidate(4, ConsolidationFunction.Sum) === b4)
+    assertEquals(b.consolidate(4, ConsolidationFunction.Sum), b4)
 
     val b5 = TimeSeriesBuffer(emptyTags, 300000, start, Array(15.0))
-    assert(b.consolidate(5, ConsolidationFunction.Sum) === b5)
+    assertEquals(b.consolidate(5, ConsolidationFunction.Sum), b5)
   }
 
   test("normalize") {
     val start = 1366746900000L
     val b1 = TimeSeriesBuffer(emptyTags, 60000, start, Array(1.0, 2.0, 3.0, 4.0, 5.0))
     val b1e = TimeSeriesBuffer(emptyTags, 120000, start, Array(1.0, 2.5, 4.5))
-    assert(b1.normalize(60000, start, 5) === b1)
-    assert(b1.normalize(120000, start, 3) === b1e)
+    assertEquals(b1.normalize(60000, start, 5), b1)
+    assertEquals(b1.normalize(120000, start, 3), b1e)
 
     val b2 = TimeSeriesBuffer(emptyTags, 120000, start, Array(3.0, 7.0))
     val b2e =
       TimeSeriesBuffer(emptyTags, 60000, start, Array(3.0, 7.0, 7.0, Double.NaN, Double.NaN))
-    assert(b2.normalize(60000, start, 5) === b2e)
+    assertEquals(b2.normalize(60000, start, 5), b2e)
   }
 
   test("bug: consolidated aggr using incorrect block index") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/BatchUpdateTagIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/BatchUpdateTagIndexSuite.scala
@@ -17,9 +17,9 @@ package com.netflix.atlas.core.index
 
 import com.netflix.atlas.core.model.LazyTaggedItem
 import com.netflix.spectator.api.NoopRegistry
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class BatchUpdateTagIndexSuite extends AnyFunSuite {
+class BatchUpdateTagIndexSuite extends FunSuite {
 
   case class Item(tags: Map[String, String], version: Int) extends LazyTaggedItem
 
@@ -29,24 +29,24 @@ class BatchUpdateTagIndexSuite extends AnyFunSuite {
 
   test("update") {
     val idx = newIndex
-    assert(idx.size === 0)
+    assertEquals(idx.size, 0)
 
     val updates = List(Item(Map("a" -> "b"), 0))
     idx.update(updates)
-    assert(idx.size === 0)
+    assertEquals(idx.size, 0)
 
     idx.rebuildIndex()
-    assert(idx.findItems(TagQuery(None)) === updates)
+    assertEquals(idx.findItems(TagQuery(None)), updates)
   }
 
   test("update, new items") {
     val idx = newIndex
-    assert(idx.size === 0)
+    assertEquals(idx.size, 0)
 
     val updates1 = List(Item(Map("a" -> "b"), 0))
     idx.update(updates1)
     idx.rebuildIndex()
-    assert(idx.findItems(TagQuery(None)) === updates1)
+    assertEquals(idx.findItems(TagQuery(None)), updates1)
 
     val updates2 = List(Item(Map("b" -> "c"), 0))
     idx.update(updates2)
@@ -55,21 +55,21 @@ class BatchUpdateTagIndexSuite extends AnyFunSuite {
     val expected = (updates1 ::: updates2).sortWith { (a, b) =>
       a.id.compareTo(b.id) < 0
     }
-    assert(idx.findItems(TagQuery(None)) === expected)
+    assertEquals(idx.findItems(TagQuery(None)), expected)
   }
 
   test("update, prefer older item") {
     val idx = newIndex
-    assert(idx.size === 0)
+    assertEquals(idx.size, 0)
 
     val updates1 = List(Item(Map("a" -> "b"), 0))
     idx.update(updates1)
     idx.rebuildIndex()
-    assert(idx.findItems(TagQuery(None)) === updates1)
+    assertEquals(idx.findItems(TagQuery(None)), updates1)
 
     val updates2 = List(Item(Map("a" -> "b"), 1))
     idx.update(updates2)
     idx.rebuildIndex()
-    assert(idx.findItems(TagQuery(None)) === updates1)
+    assertEquals(idx.findItems(TagQuery(None)), updates1)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/IndexStatsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/IndexStatsSuite.scala
@@ -18,18 +18,17 @@ package com.netflix.atlas.core.index
 import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spectator.api.ManualClock
 import com.netflix.spectator.api.patterns.PolledMeter
-import org.scalatest.BeforeAndAfter
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.util.Random
 
-class IndexStatsSuite extends AnyFunSuite with BeforeAndAfter {
+class IndexStatsSuite extends FunSuite {
 
   private val clock = new ManualClock()
   private var registry = new DefaultRegistry(clock)
   private var stats = new IndexStats(registry)
 
-  before {
+  override def beforeEach(context: BeforeEach): Unit = {
     clock.setWallTime(0)
     registry = new DefaultRegistry(clock)
     stats = new IndexStats(registry)
@@ -46,31 +45,31 @@ class IndexStatsSuite extends AnyFunSuite with BeforeAndAfter {
     // Should have 44 metrics in total:
     // 43 key metrics: 1 num keys, 21 num values, 21 num items
     //  1  db metrics: 1 num metrics
-    assert(registry.gauges().count() === 44)
+    assertEquals(registry.gauges().count(), 44L)
   }
 
   test("top-N value") {
     val numValues = registry.gauge("atlas.index.numberOfValues", "key", "42").value()
-    assert(numValues === 42)
+    assertEquals(numValues, 42.0)
   }
 
   test("top-N item") {
     val numItems = registry.gauge("atlas.index.numberOfItems", "key", "42").value()
-    assert(numItems === 8)
+    assertEquals(numItems, 8.0)
   }
 
   test("aggregation of other values") {
     // Top 20 are selected, others is N * (N - 1) / 2
     val numValues = registry.gauge("atlas.index.numberOfValues", "key", "-others-").value()
-    assert(numValues === 30 * 29 / 2)
+    assertEquals(numValues, 30.0 * 29 / 2)
   }
 
   test("aggregation of other items") {
     // Top 20 by value are selected, items were given reverse counts
     val numItems = registry.gauge("atlas.index.numberOfItems", "key", "-others-").value()
-    val overall = 50 * 51 / 2
+    val overall = 50.0 * 51 / 2
     val top20 = 20 * 21 / 2
-    assert(numItems === overall - top20)
+    assertEquals(numItems, overall - top20)
   }
 
   test("cleanup") {
@@ -96,6 +95,6 @@ class IndexStatsSuite extends AnyFunSuite with BeforeAndAfter {
 
   test("db size is present") {
     val numMetrics = registry.gauge("atlas.db.size").value()
-    assert(numMetrics === 100)
+    assertEquals(numMetrics, 100.0)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/TagIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/TagIndexSuite.scala
@@ -18,22 +18,22 @@ package com.netflix.atlas.core.index
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.Tag
 import com.netflix.atlas.core.model._
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 object TagIndexSuite {
   val dataset: List[TimeSeries] = DataSet.largeStaticSet(10)
 }
 
-abstract class TagIndexSuite extends AnyFunSuite {
+abstract class TagIndexSuite extends FunSuite {
 
   def index: TagIndex[TimeSeries]
 
   test("size") {
-    assert(index.size === 7640)
+    assertEquals(index.size, 7640)
   }
 
   test("findTags all") {
-    assert(index.findTags(TagQuery(None)) === Nil)
+    assertEquals(index.findTags(TagQuery(None)), Nil)
   }
 
   test("findTags all with paging") {
@@ -47,14 +47,14 @@ abstract class TagIndexSuite extends AnyFunSuite {
       tmp = index.findTags(TagQuery(None, offset = last, limit = pageSize)).map(_.copy(count = -1))
     }
     builder ++= tmp
-    assert(expected.size === builder.result().size)
-    assert(expected === builder.result())
+    assertEquals(expected.size, builder.result().size)
+    assertEquals(expected, builder.result())
   }
 
   test("findTags all with key restriction") {
     val result = index.findTags(TagQuery(None, key = Some("nf.cluster"))).map(_.copy(count = -1))
-    assert(result.find(_.value == "nccp-appletv") === Some(Tag("nf.cluster", "nccp-appletv")))
-    assert(result.size === 6)
+    assertEquals(result.find(_.value == "nccp-appletv"), Some(Tag("nf.cluster", "nccp-appletv")))
+    assertEquals(result.size, 6)
   }
 
   test("findTags all with key restriction and paging") {
@@ -71,29 +71,29 @@ abstract class TagIndexSuite extends AnyFunSuite {
         .map(_.copy(count = -1))
     }
     builder ++= tmp
-    assert(expected.size === builder.result().size)
-    assert(expected === builder.result())
+    assertEquals(expected.size, builder.result().size)
+    assertEquals(expected, builder.result())
   }
 
   test("findTags query") {
     val q = Query.Equal("name", "sps_9")
-    assert(index.findTags(TagQuery(Some(q))) === Nil)
+    assertEquals(index.findTags(TagQuery(Some(q))), Nil)
   }
 
   test("findTags query with key restriction") {
     val q = Query.Equal("name", "sps_9")
     val result =
       index.findTags(TagQuery(Some(q), key = Some("nf.cluster"))).map(_.copy(count = -1))
-    assert(result.find(_.value == "nccp-appletv") === Some(Tag("nf.cluster", "nccp-appletv")))
-    assert(result.size === 6)
+    assertEquals(result.find(_.value == "nccp-appletv"), Some(Tag("nf.cluster", "nccp-appletv")))
+    assertEquals(result.size, 6)
   }
 
   test("findTags query with exact regex") {
     val q = Query.Regex("name", "sps_9")
     val result =
       index.findTags(TagQuery(Some(q), key = Some("nf.cluster"))).map(_.copy(count = -1))
-    assert(result.find(_.value == "nccp-appletv") === Some(Tag("nf.cluster", "nccp-appletv")))
-    assert(result.size === 6)
+    assertEquals(result.find(_.value == "nccp-appletv"), Some(Tag("nf.cluster", "nccp-appletv")))
+    assertEquals(result.size, 6)
   }
 
   test("findValues, with no key") {
@@ -104,84 +104,84 @@ abstract class TagIndexSuite extends AnyFunSuite {
 
   test("findValues, with limit") {
     val result = index.findValues(TagQuery(None, key = Some("name"), limit = 3))
-    assert(result === List("sps_0", "sps_1", "sps_2"))
+    assertEquals(result, List("sps_0", "sps_1", "sps_2"))
   }
 
   test("findValues, with offset") {
     val result = index.findValues(TagQuery(None, key = Some("name"), offset = "sps_7"))
-    assert(result === List("sps_8", "sps_9"))
+    assertEquals(result, List("sps_8", "sps_9"))
   }
 
   test("findValues, with offset that is not present") {
     val result = index.findValues(TagQuery(None, key = Some("name"), offset = "sps_77"))
-    assert(result === List("sps_8", "sps_9"))
+    assertEquals(result, List("sps_8", "sps_9"))
   }
 
   test("findValues, with offset and limit") {
     val result = index.findValues(TagQuery(None, key = Some("name"), offset = "sps_7", limit = 1))
-    assert(result === List("sps_8"))
+    assertEquals(result, List("sps_8"))
   }
 
   test("findKeys, with limit") {
     val result = index.findKeys(TagQuery(None, limit = 3))
-    assert(result === List("atlas.legacy", "name", "nf.app"))
+    assertEquals(result, List("atlas.legacy", "name", "nf.app"))
   }
 
   test("findKeys, with offset") {
     val result = index.findKeys(TagQuery(None, offset = "nf.asg"))
-    assert(result === List("nf.cluster", "nf.node", "type", "type2"))
+    assertEquals(result, List("nf.cluster", "nf.node", "type", "type2"))
   }
 
   test("findKeys, with offset that is not present") {
     val result = index.findKeys(TagQuery(None, offset = "nf.asg2"))
-    assert(result === List("nf.cluster", "nf.node", "type", "type2"))
+    assertEquals(result, List("nf.cluster", "nf.node", "type", "type2"))
   }
 
   test("findKeys, with offset and limit") {
     val result = index.findKeys(TagQuery(None, offset = "nf.asg", limit = 2))
-    assert(result === List("nf.cluster", "nf.node"))
+    assertEquals(result, List("nf.cluster", "nf.node"))
   }
 
   test("findKeys, with query and limit") {
     val q = Query.Equal("name", "sps_9")
     val result = index.findKeys(TagQuery(Some(q), limit = 3))
-    assert(result === List("atlas.legacy", "name", "nf.app"))
+    assertEquals(result, List("atlas.legacy", "name", "nf.app"))
   }
 
   test("findKeys, with query and offset") {
     val q = Query.Equal("name", "sps_9")
     val result = index.findKeys(TagQuery(Some(q), offset = "nf.asg"))
-    assert(result === List("nf.cluster", "nf.node", "type", "type2"))
+    assertEquals(result, List("nf.cluster", "nf.node", "type", "type2"))
   }
 
   test("findKeys, with query and offset that is not present") {
     val q = Query.Equal("name", "sps_9")
     val result = index.findKeys(TagQuery(Some(q), offset = "nf.asg2"))
-    assert(result === List("nf.cluster", "nf.node", "type", "type2"))
+    assertEquals(result, List("nf.cluster", "nf.node", "type", "type2"))
   }
 
   test("findKeys, with query, offset, and limit") {
     val q = Query.Equal("name", "sps_9")
     val result = index.findKeys(TagQuery(Some(q), offset = "nf.asg", limit = 2))
-    assert(result === List("nf.cluster", "nf.node"))
+    assertEquals(result, List("nf.cluster", "nf.node"))
   }
 
   test("equal query") {
     val q = Query.Equal("name", "sps_9")
     val result = index.findItems(TagQuery(Some(q)))
     result.foreach { m =>
-      assert(m.tags("name") === "sps_9")
+      assertEquals(m.tags("name"), "sps_9")
     }
-    assert(result.size === 764)
+    assertEquals(result.size, 764)
   }
 
   test("equal query repeat") {
     val q = Query.Equal("name", "sps_9")
     val result = index.findItems(TagQuery(Some(q)))
     result.foreach { m =>
-      assert(m.tags("name") === "sps_9")
+      assertEquals(m.tags("name"), "sps_9")
     }
-    assert(result.size === 764)
+    assertEquals(result.size, 764)
   }
 
   test("equal query with offset") {
@@ -191,7 +191,7 @@ abstract class TagIndexSuite extends AnyFunSuite {
     result.foreach { m =>
       assert(m.idString > offset)
     }
-    assert(result.size === 200)
+    assertEquals(result.size, 200)
   }
 
   test("equal query with offset repeat") {
@@ -201,7 +201,7 @@ abstract class TagIndexSuite extends AnyFunSuite {
     result.foreach { m =>
       assert(m.idString > offset)
     }
-    assert(result.size === 200)
+    assertEquals(result.size, 200)
   }
 
   test("equal query with paging") {
@@ -216,8 +216,8 @@ abstract class TagIndexSuite extends AnyFunSuite {
       tmp = index.findItems(TagQuery(Some(q), offset = last, limit = pageSize))
     }
     builder ++= tmp
-    assert(result.size === builder.result().size)
-    assert(result === builder.result())
+    assertEquals(result.size, builder.result().size)
+    assertEquals(result, builder.result())
   }
 
   test("gt query") {
@@ -226,7 +226,7 @@ abstract class TagIndexSuite extends AnyFunSuite {
     result.foreach { m =>
       assert(m.tags("name") > "sps_4")
     }
-    assert(result.size === 3820)
+    assertEquals(result.size, 3820)
   }
 
   test("ge query") {
@@ -235,7 +235,7 @@ abstract class TagIndexSuite extends AnyFunSuite {
     result.foreach { m =>
       assert(m.tags("name") >= "sps_4")
     }
-    assert(result.size === 4584)
+    assertEquals(result.size, 4584)
   }
 
   test("lt query") {
@@ -244,7 +244,7 @@ abstract class TagIndexSuite extends AnyFunSuite {
     result.foreach { m =>
       assert(m.tags("name") < "sps_5")
     }
-    assert(result.size === 3820)
+    assertEquals(result.size, 3820)
   }
 
   test("le query") {
@@ -253,7 +253,7 @@ abstract class TagIndexSuite extends AnyFunSuite {
     result.foreach { m =>
       assert(m.tags("name") <= "sps_5")
     }
-    assert(result.size === 4584)
+    assertEquals(result.size, 4584)
   }
 
   test("in query") {
@@ -262,40 +262,40 @@ abstract class TagIndexSuite extends AnyFunSuite {
     result.foreach { m =>
       assert(m.tags("name") == "sps_5" || m.tags("name") == "sps_7")
     }
-    assert(result.size === 1528)
+    assertEquals(result.size, 1528)
   }
 
   test("regex query, prefix") {
     val q = Query.Regex("nf.cluster", "^nccp-silver.*")
     val result = index.findItems(TagQuery(Some(q)))
     result.foreach { m =>
-      assert(m.tags("nf.cluster") === "nccp-silverlight")
+      assertEquals(m.tags("nf.cluster"), "nccp-silverlight")
     }
-    assert(result.size === 3000)
+    assertEquals(result.size, 3000)
   }
 
   test("regex query, index of") {
     val q = Query.Regex("nf.cluster", ".*silver.*")
     val result = index.findItems(TagQuery(Some(q)))
     result.foreach { m =>
-      assert(m.tags("nf.cluster") === "nccp-silverlight")
+      assertEquals(m.tags("nf.cluster"), "nccp-silverlight")
     }
-    assert(result.size === 3000)
+    assertEquals(result.size, 3000)
   }
 
   test("regex query, case insensitive index of") {
     val q = Query.RegexIgnoreCase("type2", ".*dea.*")
     val result = index.findItems(TagQuery(Some(q)))
     result.foreach { m =>
-      assert(m.tags("type2") === "IDEAL")
+      assertEquals(m.tags("type2"), "IDEAL")
     }
-    assert(result.size === 7640)
+    assertEquals(result.size, 7640)
   }
 
   test("haskey query") {
     val q = Query.HasKey("nf.cluster")
     val result = index.findItems(TagQuery(Some(q)))
-    assert(result.size === 7640)
+    assertEquals(result.size, 7640)
   }
 
   test("and query") {
@@ -303,10 +303,10 @@ abstract class TagIndexSuite extends AnyFunSuite {
     val q2 = Query.Regex("nf.cluster", "^nccp-silver.*")
     val result = index.findItems(TagQuery(Some(Query.And(q1, q2))))
     result.foreach { m =>
-      assert(m.tags("name") === "sps_9")
-      assert(m.tags("nf.cluster") === "nccp-silverlight")
+      assertEquals(m.tags("name"), "sps_9")
+      assertEquals(m.tags("nf.cluster"), "nccp-silverlight")
     }
-    assert(result.size === 300)
+    assertEquals(result.size, 300)
   }
 
   test("and query: substring") {
@@ -314,10 +314,10 @@ abstract class TagIndexSuite extends AnyFunSuite {
     val q2 = Query.Regex("nf.cluster", ".*silver.*")
     val result = index.findItems(TagQuery(Some(Query.And(q1, q2))))
     result.foreach { m =>
-      assert(m.tags("name") === "sps_9")
-      assert(m.tags("nf.cluster") === "nccp-silverlight")
+      assertEquals(m.tags("name"), "sps_9")
+      assertEquals(m.tags("nf.cluster"), "nccp-silverlight")
     }
-    assert(result.size === 300)
+    assertEquals(result.size, 300)
   }
 
   test("or query") {
@@ -327,7 +327,7 @@ abstract class TagIndexSuite extends AnyFunSuite {
     result.foreach { m =>
       assert(m.tags("name") == "sps_9" || m.tags("nf.cluster") == "nccp-silverlight")
     }
-    assert(result.size === 3464)
+    assertEquals(result.size, 3464)
   }
 
   test("not query") {
@@ -336,7 +336,7 @@ abstract class TagIndexSuite extends AnyFunSuite {
     result.foreach { m =>
       assert(m.tags("nf.cluster") != "nccp-silverlight")
     }
-    assert(result.size === 4640)
+    assertEquals(result.size, 4640)
   }
 
   test("not query: CLDMTA-863") {
@@ -345,6 +345,6 @@ abstract class TagIndexSuite extends AnyFunSuite {
     result.foreach { m =>
       assert(m.tags("nf.cluster") != "nccp-silverlight")
     }
-    assert(result.size === 4640)
+    assertEquals(result.size, 4640)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/TaggedItemIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/TaggedItemIndexSuite.scala
@@ -17,11 +17,11 @@ package com.netflix.atlas.core.index
 
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.TimeSeries
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.collection.immutable.ArraySeq
 
-class TaggedItemIndexSuite extends AnyFunSuite {
+class TaggedItemIndexSuite extends FunSuite {
 
   import TaggedItemIndexSuite._
 
@@ -38,7 +38,7 @@ class TaggedItemIndexSuite extends AnyFunSuite {
 
   test("true query") {
     val result = findItems(Query.True)
-    assert(result.size === dataset.length)
+    assertEquals(result.size, dataset.length)
   }
 
   test("false query") {
@@ -50,18 +50,18 @@ class TaggedItemIndexSuite extends AnyFunSuite {
     val q = Query.Equal("name", "sps_9")
     val result = findItems(q)
     result.foreach { m =>
-      assert(m.tags("name") === "sps_9")
+      assertEquals(m.tags("name"), "sps_9")
     }
-    assert(result.size === 764)
+    assertEquals(result.size, 764)
   }
 
   test("equal query repeat") {
     val q = Query.Equal("name", "sps_9")
     val result = findItems(q)
     result.foreach { m =>
-      assert(m.tags("name") === "sps_9")
+      assertEquals(m.tags("name"), "sps_9")
     }
-    assert(result.size === 764)
+    assertEquals(result.size, 764)
   }
 
   test("equal query with offset") {
@@ -94,8 +94,8 @@ class TaggedItemIndexSuite extends AnyFunSuite {
       tmp = findItems(q, offset).take(pageSize)
     }
     builder ++= tmp
-    assert(result.size === builder.result().size)
-    assert(result === builder.result())
+    assertEquals(result.size, builder.result().size)
+    assertEquals(result, builder.result())
   }
 
   test("gt query") {
@@ -104,7 +104,7 @@ class TaggedItemIndexSuite extends AnyFunSuite {
     result.foreach { m =>
       assert(m.tags("name") > "sps_4")
     }
-    assert(result.size === 3820)
+    assertEquals(result.size, 3820)
   }
 
   test("ge query") {
@@ -113,7 +113,7 @@ class TaggedItemIndexSuite extends AnyFunSuite {
     result.foreach { m =>
       assert(m.tags("name") >= "sps_4")
     }
-    assert(result.size === 4584)
+    assertEquals(result.size, 4584)
   }
 
   test("lt query") {
@@ -122,7 +122,7 @@ class TaggedItemIndexSuite extends AnyFunSuite {
     result.foreach { m =>
       assert(m.tags("name") < "sps_5")
     }
-    assert(result.size === 3820)
+    assertEquals(result.size, 3820)
   }
 
   test("le query") {
@@ -131,7 +131,7 @@ class TaggedItemIndexSuite extends AnyFunSuite {
     result.foreach { m =>
       assert(m.tags("name") <= "sps_5")
     }
-    assert(result.size === 4584)
+    assertEquals(result.size, 4584)
   }
 
   test("in query") {
@@ -140,40 +140,40 @@ class TaggedItemIndexSuite extends AnyFunSuite {
     result.foreach { m =>
       assert(m.tags("name") == "sps_5" || m.tags("name") == "sps_7")
     }
-    assert(result.size === 1528)
+    assertEquals(result.size, 1528)
   }
 
   test("regex query, prefix") {
     val q = Query.Regex("nf.cluster", "^nccp-silver.*")
     val result = findItems(q)
     result.foreach { m =>
-      assert(m.tags("nf.cluster") === "nccp-silverlight")
+      assertEquals(m.tags("nf.cluster"), "nccp-silverlight")
     }
-    assert(result.size === 3000)
+    assertEquals(result.size, 3000)
   }
 
   test("regex query, index of") {
     val q = Query.Regex("nf.cluster", ".*silver.*")
     val result = findItems(q)
     result.foreach { m =>
-      assert(m.tags("nf.cluster") === "nccp-silverlight")
+      assertEquals(m.tags("nf.cluster"), "nccp-silverlight")
     }
-    assert(result.size === 3000)
+    assertEquals(result.size, 3000)
   }
 
   test("regex query, case insensitive index of") {
     val q = Query.RegexIgnoreCase("type2", ".*dea.*")
     val result = findItems(q)
     result.foreach { m =>
-      assert(m.tags("type2") === "IDEAL")
+      assertEquals(m.tags("type2"), "IDEAL")
     }
-    assert(result.size === 7640)
+    assertEquals(result.size, 7640)
   }
 
   test("haskey query") {
     val q = Query.HasKey("nf.cluster")
     val result = findItems(q)
-    assert(result.size === 7640)
+    assertEquals(result.size, 7640)
   }
 
   test("and query") {
@@ -181,10 +181,10 @@ class TaggedItemIndexSuite extends AnyFunSuite {
     val q2 = Query.Regex("nf.cluster", "^nccp-silver.*")
     val result = findItems(Query.And(q1, q2))
     result.foreach { m =>
-      assert(m.tags("name") === "sps_9")
-      assert(m.tags("nf.cluster") === "nccp-silverlight")
+      assertEquals(m.tags("name"), "sps_9")
+      assertEquals(m.tags("nf.cluster"), "nccp-silverlight")
     }
-    assert(result.size === 300)
+    assertEquals(result.size, 300)
   }
 
   test("and query: substring") {
@@ -192,10 +192,10 @@ class TaggedItemIndexSuite extends AnyFunSuite {
     val q2 = Query.Regex("nf.cluster", ".*silver.*")
     val result = findItems(Query.And(q1, q2))
     result.foreach { m =>
-      assert(m.tags("name") === "sps_9")
-      assert(m.tags("nf.cluster") === "nccp-silverlight")
+      assertEquals(m.tags("name"), "sps_9")
+      assertEquals(m.tags("nf.cluster"), "nccp-silverlight")
     }
-    assert(result.size === 300)
+    assertEquals(result.size, 300)
   }
 
   test("or query") {
@@ -205,7 +205,7 @@ class TaggedItemIndexSuite extends AnyFunSuite {
     result.foreach { m =>
       assert(m.tags("name") == "sps_9" || m.tags("nf.cluster") == "nccp-silverlight")
     }
-    assert(result.size === 3464)
+    assertEquals(result.size, 3464)
   }
 
   test("not query") {
@@ -214,7 +214,7 @@ class TaggedItemIndexSuite extends AnyFunSuite {
     result.foreach { m =>
       assert(m.tags("nf.cluster") != "nccp-silverlight")
     }
-    assert(result.size === 4640)
+    assertEquals(result.size, 4640)
   }
 
   test("not query: CLDMTA-863") {
@@ -223,7 +223,7 @@ class TaggedItemIndexSuite extends AnyFunSuite {
     result.foreach { m =>
       assert(m.tags("nf.cluster") != "nccp-silverlight")
     }
-    assert(result.size === 4640)
+    assertEquals(result.size, 4640)
   }
 }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/limiter/CardinalityLimiterSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/limiter/CardinalityLimiterSuite.scala
@@ -17,9 +17,9 @@ package com.netflix.atlas.core.limiter
 
 import com.netflix.atlas.core.model.Query
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class CardinalityLimiterSuite extends AnyFunSuite {
+class CardinalityLimiterSuite extends FunSuite {
 
   test("cardinality stats") {
     val ts = Seq(

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ArrayTimeSeqSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ArrayTimeSeqSuite.scala
@@ -17,9 +17,9 @@ package com.netflix.atlas.core.model
 
 import nl.jqno.equalsverifier.EqualsVerifier
 import nl.jqno.equalsverifier.Warning
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class ArrayTimeSeqSuite extends AnyFunSuite {
+class ArrayTimeSeqSuite extends FunSuite {
 
   test("equals") {
     EqualsVerifier

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/BlockStatsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/BlockStatsSuite.scala
@@ -15,42 +15,42 @@
  */
 package com.netflix.atlas.core.model
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class BlockStatsSuite extends AnyFunSuite {
+class BlockStatsSuite extends FunSuite {
 
   test("resize") {
     BlockStats.clear()
     val block = CompressedArrayBlock(0L, 60)
 
     BlockStats.inc(block)
-    assert(BlockStats.overallCount === 1)
-    assert(BlockStats.overallBytes === 22)
+    assertEquals(BlockStats.overallCount, 1)
+    assertEquals(BlockStats.overallBytes, 22L)
 
     // Resize the block for a single value
     block.update(0, 2.0)
-    assert(BlockStats.overallCount === 1)
-    assert(BlockStats.overallBytes === 46)
+    assertEquals(BlockStats.overallCount, 1)
+    assertEquals(BlockStats.overallBytes, 46L)
 
     // Resize the block for up to 4 values
     block.update(1, 3.0)
-    assert(BlockStats.overallCount === 1)
-    assert(BlockStats.overallBytes === 70)
+    assertEquals(BlockStats.overallCount, 1)
+    assertEquals(BlockStats.overallBytes, 70L)
 
     // Resize the block for up to 12 values, 2 already used
     (0 until 10).foreach { i =>
       block.update(i, i + 4.0)
     }
-    assert(BlockStats.overallCount === 1)
-    assert(BlockStats.overallBytes === 134)
+    assertEquals(BlockStats.overallCount, 1)
+    assertEquals(BlockStats.overallBytes, 134L)
 
     // Resize to full array
     block.update(1, 14.0)
-    assert(BlockStats.overallCount === 1)
-    assert(BlockStats.overallBytes === 486)
+    assertEquals(BlockStats.overallCount, 1)
+    assertEquals(BlockStats.overallBytes, 486L)
 
     BlockStats.dec(block)
-    assert(BlockStats.overallCount === 0)
-    assert(BlockStats.overallBytes === 0)
+    assertEquals(BlockStats.overallCount, 0)
+    assertEquals(BlockStats.overallBytes, 0L)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/BlockSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/BlockSuite.scala
@@ -17,11 +17,11 @@ package com.netflix.atlas.core.model
 
 import nl.jqno.equalsverifier.EqualsVerifier
 import nl.jqno.equalsverifier.Warning
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.util.Random
 
-class BlockSuite extends AnyFunSuite {
+class BlockSuite extends FunSuite {
 
   def rleBlock(start: Long, data: List[(Int, Double)], size: Int = 60): Block = {
     val block = ArrayBlock(start, size)
@@ -93,10 +93,10 @@ class BlockSuite extends AnyFunSuite {
     val b = ArrayBlock(0L, 2)
     b.buffer(0) = 0.0
     b.buffer(1) = Double.NaN
-    assert(b.get(0, Block.Sum) === 0.0)
-    assert(b.get(0, Block.Count) === 1.0)
-    assert(b.get(0, Block.Min) === 0.0)
-    assert(b.get(0, Block.Max) === 0.0)
+    assertEquals(b.get(0, Block.Sum), 0.0)
+    assertEquals(b.get(0, Block.Count), 1.0)
+    assertEquals(b.get(0, Block.Min), 0.0)
+    assertEquals(b.get(0, Block.Max), 0.0)
     assert(JDouble.isNaN(b.get(1, Block.Sum)))
     assert(JDouble.isNaN(b.get(1, Block.Count)))
     assert(JDouble.isNaN(b.get(1, Block.Min)))
@@ -113,10 +113,10 @@ class BlockSuite extends AnyFunSuite {
     val data = List(5 -> 42.0, 37 -> Double.NaN, 59 -> 21.0)
     val b = rleBlock(0L, data)
     val nb = Block.compress(b.toArrayBlock).asInstanceOf[SparseBlock]
-    //assert(nb.byteCount === 84)
-    assert(nb.values.length === 2)
+    //assertEquals(nb.byteCount, 84)
+    assertEquals(nb.values.length, 2)
     (0 until 60).foreach { i =>
-      assert(java.lang.Double.compare(b.get(i), nb.get(i)) === 0)
+      assertEquals(java.lang.Double.compare(b.get(i), nb.get(i)), 0)
     }
   }
 
@@ -124,9 +124,9 @@ class BlockSuite extends AnyFunSuite {
     val data = List(5 -> 2.0, 37 -> Double.NaN, 59 -> 0.0)
     val b = rleBlock(0L, data)
     val nb = Block.compress(b.toArrayBlock).asInstanceOf[SparseBlock]
-    assert(nb.values.length === 1)
+    assertEquals(nb.values.length, 1)
     (0 until 60).foreach { i =>
-      assert(java.lang.Double.compare(b.get(i), nb.get(i)) === 0)
+      assertEquals(java.lang.Double.compare(b.get(i), nb.get(i)), 0)
     }
   }
 
@@ -134,9 +134,9 @@ class BlockSuite extends AnyFunSuite {
     val data = List(5 -> 2.0, 37 -> Double.NaN, 359 -> 0.0)
     val b = rleBlock(0L, data, 360)
     val nb = Block.compress(b.toArrayBlock).asInstanceOf[SparseBlock]
-    assert(nb.values.length === 1)
+    assertEquals(nb.values.length, 1)
     (0 until 360).foreach { i =>
-      assert(java.lang.Double.compare(b.get(i), nb.get(i)) === 0)
+      assertEquals(java.lang.Double.compare(b.get(i), nb.get(i)), 0)
     }
   }
 
@@ -145,7 +145,7 @@ class BlockSuite extends AnyFunSuite {
     val b = rleBlock(0L, data, 360)
     val nb = Block.compress(b.toArrayBlock)
     (0 until 360).foreach { i =>
-      assert(java.lang.Double.compare(b.get(i), nb.get(i)) === 0)
+      assertEquals(java.lang.Double.compare(b.get(i), nb.get(i)), 0)
     }
   }
 
@@ -158,7 +158,7 @@ class BlockSuite extends AnyFunSuite {
   test("lossyCompress, array") {
     val b = ArrayBlock(0L, 60)
     (0 until 60).foreach(i => b.buffer(i) = i)
-    assert(Block.lossyCompress(b) === FloatArrayBlock(b))
+    assertEquals(Block.lossyCompress(b), FloatArrayBlock(b))
   }
 
   test("compress, small block") {
@@ -176,7 +176,7 @@ class BlockSuite extends AnyFunSuite {
     val b3 = Block.merge(b1, b2)
     val expBlock = rleBlock(0L, expected).toArrayBlock
     (0 until 60).foreach { i =>
-      assert(java.lang.Double.compare(b3.get(i), expBlock.get(i)) === 0)
+      assertEquals(java.lang.Double.compare(b3.get(i), expBlock.get(i)), 0)
     }
     assert(b3.isInstanceOf[SparseBlock])
   }
@@ -202,7 +202,7 @@ class BlockSuite extends AnyFunSuite {
       sum = ConstantBlock(0L, 60, 51.0),
       count = ConstantBlock(0L, 60, 3.0)
     )
-    assert(b3 === expected)
+    assertEquals(b3, expected)
   }
 
   test("merge prefer rollup to scalar") {
@@ -213,8 +213,8 @@ class BlockSuite extends AnyFunSuite {
       count = ConstantBlock(0L, 60, 2.0)
     )
     val b2 = ConstantBlock(0L, 60, 2.0)
-    assert(b1 === Block.merge(b1, b2))
-    assert(b1 === Block.merge(b2, b1))
+    assertEquals(Block.merge(b1, b2), b1)
+    assertEquals(Block.merge(b2, b1), b1)
   }
 
   test("rollup") {
@@ -232,26 +232,26 @@ class BlockSuite extends AnyFunSuite {
 
     r.rollup(ConstantBlock(0L, n, 1.0))
     (0 until n).foreach { i =>
-      assert(r.get(i, Block.Sum) === 1.0)
-      assert(r.get(i, Block.Count) === 1.0)
-      assert(r.get(i, Block.Min) === 1.0)
-      assert(r.get(i, Block.Max) === 1.0)
+      assertEquals(r.get(i, Block.Sum), 1.0)
+      assertEquals(r.get(i, Block.Count), 1.0)
+      assertEquals(r.get(i, Block.Min), 1.0)
+      assertEquals(r.get(i, Block.Max), 1.0)
     }
 
     r.rollup(ConstantBlock(0L, n, 3.0))
     (0 until n).foreach { i =>
-      assert(r.get(i, Block.Sum) === 4.0)
-      assert(r.get(i, Block.Count) === 2.0)
-      assert(r.get(i, Block.Min) === 1.0)
-      assert(r.get(i, Block.Max) === 3.0)
+      assertEquals(r.get(i, Block.Sum), 4.0)
+      assertEquals(r.get(i, Block.Count), 2.0)
+      assertEquals(r.get(i, Block.Min), 1.0)
+      assertEquals(r.get(i, Block.Max), 3.0)
     }
 
     r.rollup(ConstantBlock(0L, n, 0.5))
     (0 until n).foreach { i =>
-      assert(r.get(i, Block.Sum) === 4.5)
-      assert(r.get(i, Block.Count) === 3.0)
-      assert(r.get(i, Block.Min) === 0.5)
-      assert(r.get(i, Block.Max) === 3.0)
+      assertEquals(r.get(i, Block.Sum), 4.5)
+      assertEquals(r.get(i, Block.Count), 3.0)
+      assertEquals(r.get(i, Block.Min), 0.5)
+      assertEquals(r.get(i, Block.Max), 3.0)
     }
   }
 
@@ -259,16 +259,16 @@ class BlockSuite extends AnyFunSuite {
     import CompressedArrayBlock._
 
     (0 until 32).foreach { i =>
-      assert(set2(0L, i, 0) === 0L)
-      assert(set2(0L, i, 1) === 1L << (2 * i))
-      assert(set2(0L, i, 2) === 2L << (2 * i))
-      assert(set2(0L, i, 3) === 3L << (2 * i))
+      assertEquals(set2(0L, i, 0), 0L)
+      assertEquals(set2(0L, i, 1), 1L << (2 * i))
+      assertEquals(set2(0L, i, 2), 2L << (2 * i))
+      assertEquals(set2(0L, i, 3), 3L << (2 * i))
 
       (0 until 32).foreach { j =>
-        assert(get2(set2(-1L, i, 0), j) === (if (i == j) 0L else 3L))
-        assert(get2(set2(-1L, i, 1), j) === (if (i == j) 1L else 3L))
-        assert(get2(set2(-1L, i, 2), j) === (if (i == j) 2L else 3L))
-        assert(get2(set2(-1L, i, 3), j) === 3L)
+        assertEquals(get2(set2(-1L, i, 0), j), (if (i == j) 0 else 3))
+        assertEquals(get2(set2(-1L, i, 1), j), (if (i == j) 1 else 3))
+        assertEquals(get2(set2(-1L, i, 2), j), (if (i == j) 2 else 3))
+        assertEquals(get2(set2(-1L, i, 3), j), 3)
       }
     }
   }
@@ -278,12 +278,12 @@ class BlockSuite extends AnyFunSuite {
 
     (0 until 16).foreach { i =>
       (0 until 16).foreach { v =>
-        assert(set4(0L, i, v) === v.toLong << (4 * i))
+        assertEquals(set4(0L, i, v), v.toLong << (4 * i))
       }
 
       (0 until 16).foreach { j =>
         (0 until 16).foreach { v =>
-          assert(get4(set4(-1L, i, v), j) === (if (i == j) v.toLong else 0xFL))
+          assertEquals(get4(set4(-1L, i, v), j), (if (i == j) v else 0xF))
         }
       }
     }
@@ -291,8 +291,8 @@ class BlockSuite extends AnyFunSuite {
 
   test("compressed array: ceiling division") {
     import CompressedArrayBlock._
-    assert(ceilingDivide(8, 2) === 4)
-    assert(ceilingDivide(9, 2) === 5)
+    assertEquals(ceilingDivide(8, 2), 4)
+    assertEquals(ceilingDivide(9, 2), 5)
   }
 
   test("compressed array: empty") {
@@ -306,7 +306,7 @@ class BlockSuite extends AnyFunSuite {
     val block = CompressedArrayBlock(0L, 60)
     (0 until 60).foreach { i =>
       block.update(i, 0.0)
-      assert(block.get(i) === 0.0)
+      assertEquals(block.get(i), 0.0)
     }
     assert(block.byteCount < 25)
   }
@@ -314,10 +314,10 @@ class BlockSuite extends AnyFunSuite {
   test("compressed array: single increment") {
     val block = CompressedArrayBlock(0L, 60)
     block.update(14, 1.0 / 60.0)
-    assert(block.get(14) === 1.0 / 60.0)
+    assertEquals(block.get(14), 1.0 / 60.0)
     (15 until 30).foreach { i =>
       block.update(i, 0.0)
-      assert(block.get(i) === 0.0)
+      assertEquals(block.get(i), 0.0)
     }
     assert(block.byteCount < 25)
   }
@@ -325,10 +325,10 @@ class BlockSuite extends AnyFunSuite {
   test("compressed array: double increment") {
     val block = CompressedArrayBlock(0L, 60)
     block.update(14, 2.0 / 60.0)
-    assert(block.get(14) === 2.0 / 60.0)
+    assertEquals(block.get(14), 2.0 / 60.0)
     (15 until 30).foreach { i =>
       block.update(i, 0.0)
-      assert(block.get(i) === 0.0)
+      assertEquals(block.get(i), 0.0)
     }
     assert(block.byteCount < 50)
   }
@@ -337,7 +337,7 @@ class BlockSuite extends AnyFunSuite {
     val block = CompressedArrayBlock(0L, 60)
     (0 until 60).foreach { i =>
       block.update(i, 2.0)
-      assert(block.get(i) === 2.0)
+      assertEquals(block.get(i), 2.0)
     }
     assert(block.byteCount < 50)
   }
@@ -346,7 +346,7 @@ class BlockSuite extends AnyFunSuite {
     val block = CompressedArrayBlock(0L, 60)
     (0 until 60).foreach { i =>
       block.update(i, i.toDouble)
-      assert(block.get(i) === i.toDouble)
+      assertEquals(block.get(i), i.toDouble)
     }
     assert(block.byteCount < 500)
   }
@@ -357,7 +357,7 @@ class BlockSuite extends AnyFunSuite {
       block.update(i, i.toDouble)
     }
     (0 until 60).foreach { i =>
-      assert(block.get(i) === i.toDouble)
+      assertEquals(block.get(i), i.toDouble)
     }
     assert(block.byteCount < 500)
   }
@@ -367,7 +367,7 @@ class BlockSuite extends AnyFunSuite {
       val block = CompressedArrayBlock(0L, i)
       (0 until i).foreach { j =>
         block.update(j, j.toDouble)
-        assert(block.get(j) === j.toDouble)
+        assertEquals(block.get(j), j.toDouble)
       }
     }
   }
@@ -375,7 +375,7 @@ class BlockSuite extends AnyFunSuite {
   test("compressed array: small") {
     val block = CompressedArrayBlock(0L, 2)
     block.update(0, 1.0)
-    assert(block.get(0) === 1.0)
+    assertEquals(block.get(0), 1.0)
     assert(block.get(1).isNaN)
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ClampSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ClampSuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.core.model
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class ClampSuite extends AnyFunSuite {
+class ClampSuite extends FunSuite {
 
   val step = 60000L
   val dataTags = Map("name" -> "cpu", "node" -> "i-1")
@@ -52,7 +52,7 @@ class ClampSuite extends AnyFunSuite {
     val clamp = MathExpr.ClampMin(DataExpr.Sum(Query.Equal("name", "cpu")), 1.1)
     val actual = clamp.eval(context, List(inputTS)).data.head.data.bounded(s, e).data
     val expected = Array[Double](1.1, 1.5, 1.6, 1.7, 1.4, 1.3, 1.2, 1.1, 1.1, 1.1)
-    assert(actual === expected)
+    assertEquals(actual.toSeq, expected.toSeq)
   }
 
   test("clamp-max") {
@@ -62,7 +62,7 @@ class ClampSuite extends AnyFunSuite {
     val clamp = MathExpr.ClampMax(DataExpr.Sum(Query.Equal("name", "cpu")), 1.1)
     val actual = clamp.eval(context, List(inputTS)).data.head.data.bounded(s, e).data
     val expected = Array[Double](1.0, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.0, 0.0, 0.0)
-    assert(actual === expected)
+    assertEquals(actual.toSeq, expected.toSeq)
   }
 
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/CustomVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/CustomVocabularySuite.scala
@@ -17,9 +17,9 @@ package com.netflix.atlas.core.model
 
 import com.netflix.atlas.core.stacklang.Interpreter
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class CustomVocabularySuite extends AnyFunSuite {
+class CustomVocabularySuite extends FunSuite {
 
   private val cpuUser = "name,cpuUser,:eq"
   private val numInstances = "name,aws.numInstances,:eq"
@@ -58,7 +58,7 @@ class CustomVocabularySuite extends AnyFunSuite {
   test("custom word: square") {
     val expr = eval("2,:square")
     val expected = eval("2,2,:mul")
-    assert(expr === expected)
+    assertEquals(expr, expected)
   }
 
   test("simple average") {
@@ -66,7 +66,7 @@ class CustomVocabularySuite extends AnyFunSuite {
       case MathExpr.NamedRewrite("node-avg", _, e, _, _) => e
     }
     val expected = eval(s"$cpuUser,:sum,$numInstances,:sum,:div")
-    assert(expr === expected)
+    assertEquals(expr, expected)
   }
 
   test("expr with cluster") {
@@ -74,7 +74,7 @@ class CustomVocabularySuite extends AnyFunSuite {
       case MathExpr.NamedRewrite("node-avg", _, e, _, _) => e
     }
     val expected = eval(s"$cpuUser,:sum,$numInstances,:sum,:div,cluster,foo,:eq,:cq")
-    assert(expr === expected)
+    assertEquals(expr, expected)
   }
 
   test("expr with cq using non-infrastructure tags") {
@@ -82,7 +82,7 @@ class CustomVocabularySuite extends AnyFunSuite {
       case MathExpr.NamedRewrite("node-avg", _, e, _, _) => e
     }
     val expected = eval(s"$cpuUser,core,1,:eq,:and,:sum,$numInstances,:sum,:div")
-    assert(expr === expected)
+    assertEquals(expr, expected)
   }
 
   test("expr grouped by infrastructure tags") {
@@ -91,7 +91,7 @@ class CustomVocabularySuite extends AnyFunSuite {
     }
     val expected =
       eval(s"$cpuUser,:sum,(,zone,),:by,$numInstances,:sum,(,zone,),:by,:div,cluster,foo,:eq,:cq")
-    assert(expr === expected)
+    assertEquals(expr, expected)
   }
 
   test("expr grouped by non-infrastructure tags") {
@@ -99,7 +99,7 @@ class CustomVocabularySuite extends AnyFunSuite {
       case MathExpr.NamedRewrite("node-avg", _, e, _, _) => e
     }
     val expected = eval(s"$cpuUser,:sum,(,name,),:by,$numInstances,:sum,:div,cluster,foo,:eq,:cq")
-    assert(expr === expected)
+    assertEquals(expr, expected)
   }
 
   test("expr grouped by non-infrastructure tags with offset") {
@@ -110,22 +110,23 @@ class CustomVocabularySuite extends AnyFunSuite {
     val expected = eval(
       s"$cpuUser,:sum,(,name,),:by,PT1H,:offset,$numInstances,:sum,PT1H,:offset,:div,cluster,foo,:eq,:cq"
     )
-    assert(evalExpr === expected)
-    assert(
-      displayExpr.toString === s"$cpuUser,cluster,foo,:eq,:and,:node-avg,PT1H,:offset,(,name,),:by"
+    assertEquals(evalExpr, expected)
+    assertEquals(
+      displayExpr.toString,
+      s"$cpuUser,cluster,foo,:eq,:and,:node-avg,PT1H,:offset,(,name,),:by"
     )
   }
 
   test("expr with cq") {
     val e1 = eval(s"$cpuUser,cluster,api,:eq,:and,:node-avg")
     val e2 = eval(s"$cpuUser,:node-avg,:list,(,cluster,api,:eq,:cq,),:each")
-    assert(e1 === e2)
+    assertEquals(e1, e2)
   }
 
   test("expr with group by") {
     val e1 = eval("name,(,a,b,c,),:in,app,beacon,:eq,zone,1c,:eq,:and,:and,:node-avg,(,name,),:by")
     val e2 = eval("name,(,a,b,c,),:in,:node-avg,(,name,),:by,app,beacon,:eq,zone,1c,:eq,:and,:cq")
-    assert(e1 === e2)
+    assertEquals(e1, e2)
   }
 
   test("expr with not") {
@@ -134,7 +135,7 @@ class CustomVocabularySuite extends AnyFunSuite {
     }
     val expected =
       eval(s"$cpuUser,foo,bar,:eq,:not,:and,:sum,$numInstances,:sum,:div,cluster,foo,:eq,:cq")
-    assert(expr === expected)
+    assertEquals(expr, expected)
   }
 
   test("group by mixed keys") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataExprSuite.scala
@@ -15,22 +15,22 @@
  */
 package com.netflix.atlas.core.model
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class DataExprSuite extends AnyFunSuite {
+class DataExprSuite extends FunSuite {
   test("groupByKey") {
     val expr = DataExpr.Sum(Query.True)
     val tags = Map("name" -> "foo")
-    assert(expr.groupByKey(tags) === None)
+    assertEquals(expr.groupByKey(tags), None)
   }
 
   test("allKeys") {
     val expr = DataExpr.Sum(Query.Equal("k1", "v1"))
-    assert(DataExpr.allKeys(expr) === Set("k1"))
+    assertEquals(DataExpr.allKeys(expr), Set("k1"))
   }
 
   test("allKeys with GroupBy") {
     val expr = DataExpr.GroupBy(DataExpr.Sum(Query.Equal("k1", "v1")), List("k1", "k2"))
-    assert(DataExpr.allKeys(expr) === Set("k1", "k2"))
+    assertEquals(DataExpr.allKeys(expr), Set("k1", "k2"))
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataGroupBySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataGroupBySuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.core.model
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class DataGroupBySuite extends AnyFunSuite {
+class DataGroupBySuite extends FunSuite {
 
   private val start = 0L
   private val step = 60000L
@@ -46,10 +46,10 @@ class DataGroupBySuite extends AnyFunSuite {
       ts(3)
     )
     val rs = groupBy(input, List("name"))
-    assert(rs.size === 1)
+    assertEquals(rs.size, 1)
 
     val expected = ts(6).withTags(Map("name" -> "test")).withLabel("(name=test)")
-    assert(rs.head === expected)
+    assertEquals(rs.head, expected)
   }
 
   test("(,not_present,),:by") {
@@ -59,7 +59,7 @@ class DataGroupBySuite extends AnyFunSuite {
       ts(3)
     )
     val rs = groupBy(input, List("not_present"))
-    assert(rs.size === 0)
+    assertEquals(rs.size, 0)
   }
 
   test("(,name,not_present,),:by") {
@@ -69,7 +69,7 @@ class DataGroupBySuite extends AnyFunSuite {
       ts(3)
     )
     val rs = groupBy(input, List("name", "not_present"))
-    assert(rs.size === 0)
+    assertEquals(rs.size, 0)
   }
 
   test("(,name,mode,),:by") {
@@ -80,7 +80,7 @@ class DataGroupBySuite extends AnyFunSuite {
       ts(3)
     )
     val rs = groupBy(input, List("name", "mode"))
-    assert(rs.size === 1)
+    assertEquals(rs.size, 1)
   }
 
   def binaryOp(ks1: List[String], ks2: List[String]): List[TimeSeries] = {
@@ -94,12 +94,12 @@ class DataGroupBySuite extends AnyFunSuite {
 
   test("binary ops: both sides match") {
     val rs = binaryOp(List("value"), List("value"))
-    assert(rs.size === 5) // only even values will be on both sides
+    assertEquals(rs.size, 5) // only even values will be on both sides
   }
 
   test("binary ops: both sides match, different orders") {
     val rs = binaryOp(List("name", "value"), List("value", "name"))
-    assert(rs.size === 5) // only even values will be on both sides
+    assertEquals(rs.size, 5) // only even values will be on both sides
   }
 
   test("binary ops: mismatch") {
@@ -113,10 +113,10 @@ class DataGroupBySuite extends AnyFunSuite {
     // LHS: sum of even values < 10 (20)
     // RHS: all values from 0 until 10
     val rs = binaryOp(List("name"), List("name", "value"))
-    assert(rs.size === 10)
+    assertEquals(rs.size, 10)
     rs.foreach { t =>
       val rhsValue = t.tags("value").toDouble
-      assert(t.datapoint(start).value === 20.0 + rhsValue)
+      assertEquals(t.datapoint(start).value, 20.0 + rhsValue)
     }
   }
 
@@ -124,10 +124,10 @@ class DataGroupBySuite extends AnyFunSuite {
     // LHS: even values 0, 2, 4, 6, and 8
     // RHS: sum of 0 to 9 (45)
     val rs = binaryOp(List("name", "value"), List("name"))
-    assert(rs.size === 5)
+    assertEquals(rs.size, 5)
     rs.foreach { t =>
       val lhsValue = t.tags("value").toDouble
-      assert(t.datapoint(start).value === 45.0 + lhsValue)
+      assertEquals(t.datapoint(start).value, 45.0 + lhsValue)
     }
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/DerivativeSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/DerivativeSuite.scala
@@ -16,9 +16,9 @@
 package com.netflix.atlas.core.model
 
 import com.netflix.atlas.core.util.IdentityMap
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class DerivativeSuite extends AnyFunSuite {
+class DerivativeSuite extends FunSuite {
 
   private val start = 0L
   private val step = 60000L
@@ -36,17 +36,17 @@ class DerivativeSuite extends AnyFunSuite {
 
   test("basic") {
     val input = ts(7.0, 8.0, 9.0)
-    assert(eval(input, 3).data === ts(Double.NaN, 1.0, 1.0).data)
+    assertEquals(eval(input, 3).data, ts(Double.NaN, 1.0, 1.0).data)
   }
 
   test("basic with same value and decreasing") {
     val input = ts(7.0, 42.0, 42.0, 43.0, 2.0, 5.0)
-    assert(eval(input, 6).data === ts(Double.NaN, 35.0, 0.0, 1.0, -41.0, 3.0).data)
+    assertEquals(eval(input, 6).data, ts(Double.NaN, 35.0, 0.0, 1.0, -41.0, 3.0).data)
   }
 
   test("basic with NaN values") {
     val input = ts(7.0, 42.0, Double.NaN, 43.0, 2.0, 5.0)
-    assert(eval(input, 6).data === ts(Double.NaN, 35.0, Double.NaN, Double.NaN, -41.0, 3.0).data)
+    assertEquals(eval(input, 6).data, ts(Double.NaN, 35.0, Double.NaN, Double.NaN, -41.0, 3.0).data)
   }
 
   test("state across binary operations") {
@@ -68,7 +68,7 @@ class DerivativeSuite extends AnyFunSuite {
         val actual = result.data.head.data.bounded(s, e)
         val expectedValue = if (i == 0) Double.NaN else 2.0
         val expected = new ArrayTimeSeq(DsType.Gauge, s, step, Array(expectedValue))
-        assert(actual === expected)
+        assertEquals(actual, expected)
     }
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/DesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/DesSuite.scala
@@ -15,10 +15,9 @@
  */
 package com.netflix.atlas.core.model
 
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers._
+import munit.FunSuite
 
-class DesSuite extends AnyFunSuite {
+class DesSuite extends FunSuite {
 
   val step = 60000L
   val dataTags = Map("name" -> "cpu", "node" -> "i-1")
@@ -99,13 +98,13 @@ class DesSuite extends AnyFunSuite {
     val result = eval(des, alignedStream)
     result.zip(expected).zipWithIndex.foreach {
       case ((ts, v), i) =>
-        assert(ts.size === 1)
+        assertEquals(ts.size, 1)
         ts.foreach { t =>
           val r = t.data(i * step)
           if (i <= 1)
             assert(r.isNaN)
           else
-            assert(v === r +- 0.00001)
+            assertEqualsDouble(v, r, 0.00001)
         }
     }
   }
@@ -119,13 +118,13 @@ class DesSuite extends AnyFunSuite {
     val result = eval(sdes, alignedStream)
     result.zip(expected).zipWithIndex.foreach {
       case ((ts, v), i) =>
-        assert(ts.size === 1)
+        assertEquals(ts.size, 1)
         ts.foreach { t =>
           val r = t.data(i * step)
           if (i <= 1)
             assert(r.isNaN)
           else
-            assert(v === r +- 0.00001)
+            assertEqualsDouble(v, r, 0.00001)
         }
     }
   }
@@ -141,13 +140,13 @@ class DesSuite extends AnyFunSuite {
     //println(result.map { case v => v(0).data.asInstanceOf[ArrayTimeSeq].data(0) }.mkString(", "))
     result.zip(expected).zipWithIndex.foreach {
       case ((ts, v), i) =>
-        assert(ts.size === 1)
+        assertEquals(ts.size, 1)
         ts.foreach { t =>
           val r = t.data((i + 1) * step) // offset step by our skipped data
           if (i <= 2)
             assert(r.isNaN)
           else
-            assert(v === r +- 0.00001)
+            assertEqualsDouble(v, r, 0.00001)
         }
     }
   }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/EvalContextSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/EvalContextSuite.scala
@@ -18,9 +18,9 @@ package com.netflix.atlas.core.model
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class EvalContextSuite extends AnyFunSuite {
+class EvalContextSuite extends FunSuite {
 
   // Was throwing:
   // requirement failed: start time must be less than end time (1495052210000 >= 1495051800000)
@@ -30,6 +30,6 @@ class EvalContextSuite extends AnyFunSuite {
     val step = 10000L
     val size = 60 * step
     val partitions = EvalContext(s, e, step).partition(size, ChronoUnit.MILLIS)
-    assert(partitions.size === 3)
+    assertEquals(partitions.size, 3)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ExprRewriteSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ExprRewriteSuite.scala
@@ -16,9 +16,9 @@
 package com.netflix.atlas.core.model
 
 import com.netflix.atlas.core.model.DataExpr.AggregateFunction
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class ExprRewriteSuite extends AnyFunSuite {
+class ExprRewriteSuite extends FunSuite {
 
   test("basic") {
     val avgHashCode = System.identityHashCode(ConsolidationFunction.Avg)
@@ -26,8 +26,8 @@ class ExprRewriteSuite extends AnyFunSuite {
     val result = expr.rewrite {
       case q: Query => Query.False
     }
-    assert(result === DataExpr.Sum(Query.False))
-    assert(System.identityHashCode(result.asInstanceOf[AggregateFunction].cf) === avgHashCode)
+    assertEquals(result, DataExpr.Sum(Query.False))
+    assertEquals(System.identityHashCode(result.asInstanceOf[AggregateFunction].cf), avgHashCode)
     ConsolidationFunction.Avg
   }
 
@@ -39,8 +39,8 @@ class ExprRewriteSuite extends AnyFunSuite {
     val result = expr.rewrite {
       case Query.Not(q) => Query.False
     }
-    assert(result === Query.And(Query.True, Query.False))
-    assert(System.identityHashCode(result.asInstanceOf[Query.And].q1) === trueHashCode)
+    assertEquals(result, Query.And(Query.True, Query.False))
+    assertEquals(System.identityHashCode(result.asInstanceOf[Query.And].q1), trueHashCode)
   }
 
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/FilterSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/FilterSuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.core.model
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class FilterSuite extends AnyFunSuite {
+class FilterSuite extends FunSuite {
 
   private val start = 0L
   private val step = 60000L

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/FinalGroupingSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/FinalGroupingSuite.scala
@@ -16,9 +16,9 @@
 package com.netflix.atlas.core.model
 
 import com.netflix.atlas.core.stacklang.Interpreter
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class FinalGroupingSuite extends AnyFunSuite {
+class FinalGroupingSuite extends FunSuite {
 
   private val interpreter = Interpreter(StyleVocabulary.allWords)
 
@@ -31,42 +31,42 @@ class FinalGroupingSuite extends AnyFunSuite {
   }
 
   test("constant") {
-    assert(eval("42") === Nil)
+    assertEquals(eval("42"), Nil)
   }
 
   test("aggregate") {
-    assert(eval("name,sps,:eq,:sum") === Nil)
+    assertEquals(eval("name,sps,:eq,:sum"), Nil)
   }
 
   test("data group by") {
-    assert(eval("name,sps,:eq,(,cluster,),:by") === List("cluster"))
+    assertEquals(eval("name,sps,:eq,(,cluster,),:by"), List("cluster"))
   }
 
   test("data group by with multiple keys") {
-    assert(eval("name,sps,:eq,(,app,region,device,),:by") === List("app", "region", "device"))
+    assertEquals(eval("name,sps,:eq,(,app,region,device,),:by"), List("app", "region", "device"))
   }
 
   test("data group by with math aggregate") {
     val expr = "name,sps,:eq,(,app,region,device,),:by,:max"
     val expected = Nil
-    assert(eval(expr) === expected)
+    assertEquals(eval(expr), expected)
   }
 
   test("data group by with math group by") {
     val expr = "name,sps,:eq,(,app,region,device,),:by,:max,(,region,device,),:by"
     val expected = List("region", "device")
-    assert(eval(expr) === expected)
+    assertEquals(eval(expr), expected)
   }
 
   test("aggregate with percentiles") {
     val expr = "name,sps,:eq,(,50,),:percentiles"
     val expected = List("percentile")
-    assert(eval(expr) === expected)
+    assertEquals(eval(expr), expected)
   }
 
   test("data group by with percentiles") {
     val expr = "name,sps,:eq,(,app,),:by,(,50,),:percentiles"
     val expected = List("percentile", "app")
-    assert(eval(expr) === expected)
+    assertEquals(eval(expr), expected)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/IntegralSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/IntegralSuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.core.model
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class IntegralSuite extends AnyFunSuite {
+class IntegralSuite extends FunSuite {
 
   private val start = 0L
   private val step = 60000L
@@ -35,16 +35,16 @@ class IntegralSuite extends AnyFunSuite {
 
   test("basic") {
     val input = ts(1.0, 1.0, 1.0)
-    assert(eval(input, 3).data === ts(1.0, 2.0, 3.0).data)
+    assertEquals(eval(input, 3).data, ts(1.0, 2.0, 3.0).data)
   }
 
   test("basic with same value and decreasing") {
     val input = ts(Double.NaN, 35.0, 0.0, 1.0, -41.0, 3.0)
-    assert(eval(input, 6).data === ts(Double.NaN, 35.0, 35.0, 36.0, -5.0, -2.0).data)
+    assertEquals(eval(input, 6).data, ts(Double.NaN, 35.0, 35.0, 36.0, -5.0, -2.0).data)
   }
 
   test("basic with NaN values") {
     val input = ts(Double.NaN, 35.0, Double.NaN, Double.NaN, -41.0, 3.0)
-    assert(eval(input, 6).data === ts(Double.NaN, 35.0, 35.0, 35.0, -6.0, -3.0).data)
+    assertEquals(eval(input, 6).data, ts(Double.NaN, 35.0, 35.0, 35.0, -6.0, -3.0).data)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ItemIdSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ItemIdSuite.scala
@@ -17,53 +17,53 @@ package com.netflix.atlas.core.model
 
 import com.netflix.atlas.core.util.Hash
 import com.netflix.atlas.core.util.Strings
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.util.hashing.MurmurHash3
 
-class ItemIdSuite extends AnyFunSuite {
+class ItemIdSuite extends FunSuite {
 
   test("create from byte array") {
     val bytes = Array(1.toByte, 2.toByte)
     val id = ItemId(bytes)
-    assert(id.hashCode() === MurmurHash3.bytesHash(bytes))
+    assertEquals(id.hashCode(), MurmurHash3.bytesHash(bytes))
   }
 
   test("equals") {
     val id1 = ItemId(Array(1.toByte, 2.toByte))
     val id2 = ItemId(Array(1.toByte, 2.toByte))
-    assert(id1 === id1)
-    assert(id1 === id2)
+    assertEquals(id1, id1)
+    assertEquals(id1, id2)
   }
 
   test("not equals") {
     val id1 = ItemId(Array(1.toByte, 2.toByte))
     val id2 = ItemId(Array(1.toByte, 3.toByte))
-    assert(id1 !== id2)
-    assert(id1.hashCode() !== id2.hashCode())
+    assertNotEquals(id1, id2)
+    assertNotEquals(id1.hashCode(), id2.hashCode())
   }
 
   test("does not equal wrong object type") {
     val id1 = ItemId(Array(1.toByte, 2.toByte))
-    assert(id1 !== "foo")
+    assert(!id1.equals("foo"))
   }
 
   test("does not equal null") {
     val id1 = ItemId(Array(1.toByte, 2.toByte))
-    assert(id1 !== null)
+    assert(id1 != null)
   }
 
   test("toString") {
     val bytes = Array(1.toByte, 2.toByte)
     val id = ItemId(bytes)
-    assert(id.toString === "0102")
+    assertEquals(id.toString, "0102")
   }
 
   test("toString sha1 bytes 0") {
     val bytes = new Array[Byte](20)
     val id = ItemId(bytes)
-    assert(id.toString === "0000000000000000000000000000000000000000")
-    assert(id === ItemId("0000000000000000000000000000000000000000"))
+    assertEquals(id.toString, "0000000000000000000000000000000000000000")
+    assertEquals(id, ItemId("0000000000000000000000000000000000000000"))
   }
 
   test("toString sha1") {
@@ -71,23 +71,23 @@ class ItemIdSuite extends AnyFunSuite {
       val sha1 = Hash.sha1(i.toString)
       val sha1str = Strings.zeroPad(sha1.toString(16), 40)
       val id = ItemId(Hash.sha1bytes(i.toString))
-      assert(id.toString === sha1str)
-      assert(id === ItemId(sha1str))
-      assert(id.compareTo(ItemId(sha1str)) === 0)
-      assert(sha1 === ItemId(sha1str).toBigInteger)
+      assertEquals(id.toString, sha1str)
+      assertEquals(id, ItemId(sha1str))
+      assertEquals(id.compareTo(ItemId(sha1str)), 0)
+      assertEquals(sha1, ItemId(sha1str).toBigInteger)
     }
   }
 
   test("from String lower") {
     val bytes = Array(10.toByte, 11.toByte)
     val id = ItemId(bytes)
-    assert(id === ItemId("0a0b"))
+    assertEquals(id, ItemId("0a0b"))
   }
 
   test("from String upper") {
     val bytes = Array(10.toByte, 11.toByte)
     val id = ItemId(bytes)
-    assert(id === ItemId("0A0B"))
+    assertEquals(id, ItemId("0A0B"))
   }
 
   test("from String invalid") {
@@ -99,8 +99,8 @@ class ItemIdSuite extends AnyFunSuite {
   test("compareTo equals") {
     val id1 = ItemId(Array(1.toByte, 2.toByte))
     val id2 = ItemId(Array(1.toByte, 2.toByte))
-    assert(id1.compareTo(id1) === 0)
-    assert(id1.compareTo(id2) === 0)
+    assertEquals(id1.compareTo(id1), 0)
+    assertEquals(id1.compareTo(id2), 0)
   }
 
   test("compareTo less than/greater than") {
@@ -113,22 +113,22 @@ class ItemIdSuite extends AnyFunSuite {
   test("int value") {
     (0 until 100).foreach { i =>
       val id = ItemId(Hash.sha1bytes(i.toString))
-      assert(id.intValue === id.toBigInteger.intValue())
+      assertEquals(id.intValue, id.toBigInteger.intValue())
     }
   }
 
   test("int value: one byte") {
     val id = ItemId(Array(57.toByte))
-    assert(id.intValue === id.toBigInteger.intValue())
+    assertEquals(id.intValue, id.toBigInteger.intValue())
   }
 
   test("int value: two bytes") {
     val id = ItemId(Array(1.toByte, 2.toByte))
-    assert(id.intValue === id.toBigInteger.intValue())
+    assertEquals(id.intValue, id.toBigInteger.intValue())
   }
 
   test("int value: three bytes") {
     val id = ItemId(Array(1.toByte, 2.toByte, 0xFF.toByte))
-    assert(id.intValue === id.toBigInteger.intValue())
+    assertEquals(id.intValue, id.toBigInteger.intValue())
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/MapStepTimeSeqSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/MapStepTimeSeqSuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.core.model
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class MapStepTimeSeqSuite extends AnyFunSuite {
+class MapStepTimeSeqSuite extends FunSuite {
 
   import ConsolidationFunction._
 
@@ -54,70 +54,70 @@ class MapStepTimeSeqSuite extends AnyFunSuite {
   }
 
   test("consolidate: sum") {
-    assert(map(DsType.Gauge, 1, 2, Sum, 1.0, 2.0) === gauge(start, 2, 3.0))
+    assertEquals(map(DsType.Gauge, 1, 2, Sum, 1.0, 2.0), gauge(start, 2, 3.0))
   }
 
   test("consolidate: sum with partial interval") {
-    assert(map(DsType.Gauge, 1, 2, Sum, 1.0, 2.0, 3.0) === gauge(start, 2, 3.0, 3.0))
+    assertEquals(map(DsType.Gauge, 1, 2, Sum, 1.0, 2.0, 3.0), gauge(start, 2, 3.0, 3.0))
   }
 
   test("consolidate: sum with start time not on step boundary") {
     val step = 7
     val cstart = start / step * step
     val expected = gauge(cstart, step, 6.0, 22.0)
-    assert(map(DsType.Gauge, 1, step, Sum, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0) === expected)
+    assertEquals(map(DsType.Gauge, 1, step, Sum, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), expected)
   }
 
   test("consolidate: sum with NaN") {
-    assert(map(DsType.Gauge, 1, 2, Sum, 1.0, Double.NaN) === gauge(start, 2, 1.0))
+    assertEquals(map(DsType.Gauge, 1, 2, Sum, 1.0, Double.NaN), gauge(start, 2, 1.0))
   }
 
   test("consolidate: sum with all NaN") {
-    assert(map(DsType.Gauge, 1, 2, Sum, Double.NaN, Double.NaN) === gauge(start, 2, Double.NaN))
+    assertEquals(map(DsType.Gauge, 1, 2, Sum, Double.NaN, Double.NaN), gauge(start, 2, Double.NaN))
   }
 
   test("consolidate: avg") {
-    assert(map(DsType.Gauge, 1, 2, Avg, 1.0, 2.0) === gauge(start, 2, 1.5))
+    assertEquals(map(DsType.Gauge, 1, 2, Avg, 1.0, 2.0), gauge(start, 2, 1.5))
   }
 
   test("consolidate: avg with NaN") {
-    assert(map(DsType.Gauge, 1, 2, Avg, 1.0, Double.NaN) === gauge(start, 2, 1.0))
+    assertEquals(map(DsType.Gauge, 1, 2, Avg, 1.0, Double.NaN), gauge(start, 2, 1.0))
   }
 
   test("consolidate: avg rate with NaN") {
-    assert(map(DsType.Rate, 1, 2, Avg, 1.0, Double.NaN) === rate(start, 2, 0.5))
+    assertEquals(map(DsType.Rate, 1, 2, Avg, 1.0, Double.NaN), rate(start, 2, 0.5))
   }
 
   test("consolidate: avg with all NaN") {
-    assert(map(DsType.Gauge, 1, 2, Avg, Double.NaN, Double.NaN) === gauge(start, 2, Double.NaN))
+    assertEquals(map(DsType.Gauge, 1, 2, Avg, Double.NaN, Double.NaN), gauge(start, 2, Double.NaN))
   }
 
   test("consolidate: min") {
-    assert(map(DsType.Gauge, 1, 2, Min, 1.0, 2.0) === gauge(start, 2, 1.0))
+    assertEquals(map(DsType.Gauge, 1, 2, Min, 1.0, 2.0), gauge(start, 2, 1.0))
   }
 
   test("consolidate: min with NaN") {
-    assert(map(DsType.Gauge, 1, 2, Min, 1.0, Double.NaN) === gauge(start, 2, 1.0))
+    assertEquals(map(DsType.Gauge, 1, 2, Min, 1.0, Double.NaN), gauge(start, 2, 1.0))
   }
 
   test("consolidate: min with all NaN") {
-    assert(map(DsType.Gauge, 1, 2, Min, Double.NaN, Double.NaN) === gauge(start, 2, Double.NaN))
+    assertEquals(map(DsType.Gauge, 1, 2, Min, Double.NaN, Double.NaN), gauge(start, 2, Double.NaN))
   }
 
   test("consolidate: max") {
-    assert(map(DsType.Gauge, 1, 2, Max, 1.0, 2.0) === gauge(start, 2, 2.0))
+    assertEquals(map(DsType.Gauge, 1, 2, Max, 1.0, 2.0), gauge(start, 2, 2.0))
   }
 
   test("consolidate: max with NaN") {
-    assert(map(DsType.Gauge, 1, 2, Max, 1.0, Double.NaN) === gauge(start, 2, 1.0))
+    assertEquals(map(DsType.Gauge, 1, 2, Max, 1.0, Double.NaN), gauge(start, 2, 1.0))
   }
 
   test("consolidate: max with all NaN") {
-    assert(map(DsType.Gauge, 1, 2, Max, Double.NaN, Double.NaN) === gauge(start, 2, Double.NaN))
+    assertEquals(map(DsType.Gauge, 1, 2, Max, Double.NaN, Double.NaN), gauge(start, 2, Double.NaN))
   }
 
   test("expand: sum") {
-    assert(map(DsType.Gauge, 2, 1, Sum, 1.0, 2.0) === gauge(start, 1, 1.0, 1.0, 2.0, 2.0))
+    assertEquals(map(DsType.Gauge, 2, 1, Sum, 1.0, 2.0), gauge(start, 1, 1.0, 1.0, 2.0, 2.0))
   }
 
   test("expand: bad step") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathAcrossStyleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathAcrossStyleSuite.scala
@@ -16,7 +16,7 @@
 package com.netflix.atlas.core.model
 
 import com.netflix.atlas.core.stacklang.Interpreter
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 /**
   * Verify that basic math operations can be applied to StyleExprs. For binary operators
@@ -24,7 +24,7 @@ import org.scalatest.funsuite.AnyFunSuite
   *
   * https://github.com/Netflix/atlas/issues/761
   */
-class MathAcrossStyleSuite extends AnyFunSuite {
+class MathAcrossStyleSuite extends FunSuite {
 
   import ModelExtractors._
 
@@ -44,7 +44,7 @@ class MathAcrossStyleSuite extends AnyFunSuite {
       test(s"${w.name}, StyleExpr op") {
         val expected = eval(s"1,:${w.name},abc,:legend")
         val actual = eval(s"1,abc,:legend,:${w.name}")
-        assert(actual === expected)
+        assertEquals(actual, expected)
       }
     }
 
@@ -57,73 +57,73 @@ class MathAcrossStyleSuite extends AnyFunSuite {
       test(s"${w.name}, TimeSeriesExpr op StyleExpr") {
         val expected = eval(s"$a,$b,:${w.name},abc,:legend")
         val actual = eval(s"$a,$b,abc,:legend,:${w.name}")
-        assert(actual === expected)
+        assertEquals(actual, expected)
       }
 
       test(s"${w.name}, StyleExpr op TimeSeriesExpr") {
         val expected = eval(s"$a,$b,:${w.name},abc,:legend")
         val actual = eval(s"$a,abc,:legend,$b,:${w.name}")
-        assert(actual === expected)
+        assertEquals(actual, expected)
       }
     }
 
   test("clamp-min") {
     val expected = eval("a,:has,1,:clamp-min,abc,:legend")
     val actual = eval("a,:has,abc,:legend,1,:clamp-min")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("clamp-max") {
     val expected = eval("a,:has,1,:clamp-max,abc,:legend")
     val actual = eval("a,:has,abc,:legend,1,:clamp-max")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("rolling-count") {
     val expected = eval("a,:has,1,:rolling-count,abc,:legend")
     val actual = eval("a,:has,abc,:legend,1,:rolling-count")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("des") {
     val expected = eval("a,:has,1,0.1,0.2,:des,abc,:legend")
     val actual = eval("a,:has,abc,:legend,1,0.1,0.2,:des")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("sdes") {
     val expected = eval("a,:has,1,0.1,0.2,:sdes,abc,:legend")
     val actual = eval("a,:has,abc,:legend,1,0.1,0.2,:sdes")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("trend") {
     val expected = eval("a,:has,5m,:trend,abc,:legend")
     val actual = eval("a,:has,abc,:legend,5m,:trend")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("integral") {
     val expected = eval("a,:has,:integral,abc,:legend")
     val actual = eval("a,:has,abc,:legend,:integral")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("derivative") {
     val expected = eval("a,:has,:derivative,abc,:legend")
     val actual = eval("a,:has,abc,:legend,:derivative")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("stat") {
     val expected = eval("a,:has,max,:stat,abc,:legend")
     val actual = eval("a,:has,abc,:legend,max,:stat")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("filter") {
     val expected = eval("a,:has,:stat-max,1,:gt,:filter,abc,:legend")
     val actual = eval("a,:has,abc,:legend,:stat-max,1,:gt,:filter")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathExamplesSuite.scala
@@ -24,28 +24,29 @@ class MathExamplesSuite extends BaseExamplesSuite {
 
   test("toString with offsets") {
     val expr = eval("name,test,:eq,:sum,1h,:offset")
-    assert(expr.toString === "name,test,:eq,:sum,PT1H,:offset")
+    assertEquals(expr.toString, "name,test,:eq,:sum,PT1H,:offset")
   }
 
   test("rewrite toString with offsets") {
     val expr = eval("name,test,:eq,:dist-avg,1h,:offset")
-    assert(expr.toString === "name,test,:eq,:dist-avg,PT1H,:offset")
+    assertEquals(expr.toString, "name,test,:eq,:dist-avg,PT1H,:offset")
   }
 
   test("rewrite toString with offsets and cq") {
     val expr = eval("name,test,:eq,:avg,1h,:offset,app,foo,:eq,:cq")
-    assert(expr.toString === "name,test,:eq,app,foo,:eq,:and,:avg,PT1H,:offset")
+    assertEquals(expr.toString, "name,test,:eq,app,foo,:eq,:and,:avg,PT1H,:offset")
   }
 
   test("rewrite group by toString with offsets") {
     val expr = eval("name,test,:eq,:dist-avg,(,cluster,),:by,1h,:offset")
-    assert(expr.toString === "name,test,:eq,:dist-avg,PT1H,:offset,(,cluster,),:by")
+    assertEquals(expr.toString, "name,test,:eq,:dist-avg,PT1H,:offset,(,cluster,),:by")
   }
 
   test("rewrite group by toString with offsets and cq") {
     val expr = eval("name,test,:eq,:dist-avg,(,cluster,),:by,1h,:offset,app,foo,:eq,:cq")
-    assert(
-      expr.toString === "name,test,:eq,app,foo,:eq,:and,:dist-avg,PT1H,:offset,(,cluster,),:by"
+    assertEquals(
+      expr.toString,
+      "name,test,:eq,app,foo,:eq,:and,:dist-avg,PT1H,:offset,(,cluster,),:by"
     )
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
@@ -16,9 +16,9 @@
 package com.netflix.atlas.core.model
 
 import com.netflix.atlas.core.stacklang.Interpreter
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class ModelExtractorsSuite extends AnyFunSuite {
+class ModelExtractorsSuite extends FunSuite {
 
   private val words = StyleVocabulary.allWords
   private val interpreter = Interpreter(words)
@@ -28,7 +28,7 @@ class ModelExtractorsSuite extends AnyFunSuite {
   def completionTest(expr: String, expected: Int): Unit = {
     test(expr) {
       val result = interpreter.execute(expr)
-      assert(candidates.count(_.matches(result.stack)) === expected)
+      assertEquals(candidates.count(_.matches(result.stack)), expected)
     }
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/NamedRewriteSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/NamedRewriteSuite.scala
@@ -19,9 +19,9 @@ import java.time.Duration
 
 import com.netflix.atlas.core.stacklang.Interpreter
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class NamedRewriteSuite extends AnyFunSuite {
+class NamedRewriteSuite extends FunSuite {
 
   private val config = ConfigFactory.parseString("""
       |atlas.core.vocabulary {
@@ -60,31 +60,31 @@ class NamedRewriteSuite extends AnyFunSuite {
   test("avg") {
     val actual = eval("name,a,:eq,:avg")
     val expected = eval("name,a,:eq,:sum,name,a,:eq,:count,:div")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("avg with group by") {
     val actual = eval("name,a,:eq,:avg,(,name,),:by")
     val expected = eval("name,a,:eq,:sum,name,a,:eq,:count,:div,(,name,),:by")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("dist-max") {
     val actual = eval("name,a,:eq,:dist-max")
     val expected = eval("statistic,max,:eq,name,a,:eq,:and,:max")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("dist-max with group by") {
     val actual = eval("name,a,:eq,:dist-max,(,name,),:by")
     val expected = eval("statistic,max,:eq,name,a,:eq,:and,:max,(,name,),:by")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("dist-max with offset") {
     val actual = eval("name,a,:eq,:dist-max,1h,:offset")
     val expected = eval("statistic,max,:eq,name,a,:eq,:and,:max,1h,:offset")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("dist-avg") {
@@ -92,7 +92,7 @@ class NamedRewriteSuite extends AnyFunSuite {
     val expected = eval(
       "statistic,(,totalTime,totalAmount,),:in,:sum,statistic,count,:eq,:sum,:div,name,a,:eq,:cq"
     )
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("dist-avg with group by") {
@@ -100,25 +100,25 @@ class NamedRewriteSuite extends AnyFunSuite {
     val expected = eval(
       "statistic,(,totalTime,totalAmount,),:in,:sum,statistic,count,:eq,:sum,:div,name,a,:eq,:cq,(,name,),:by"
     )
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("avg, group by with offset") {
     val actual = eval("name,a,:eq,:avg,(,b,),:by,1h,:offset")
     val expected = eval("name,a,:eq,:dup,:sum,:swap,:count,:div,(,b,),:by,1h,:offset")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("avg, group by, max with offset") {
     val actual = eval("name,a,:eq,:avg,(,b,),:by,:max,1h,:offset")
     val expected = eval("name,a,:eq,:dup,:sum,:swap,:count,:div,1h,:offset,(,b,),:by,:max")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("node-avg, group by, max with offset") {
     val actual = eval("name,a,:eq,:node-avg,(,app,),:by,:max,1h,:offset")
     val expected = eval("name,a,:eq,name,numNodes,:eq,:div,1h,:offset,(,app,),:by,:max")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("node-avg, offset maintained after query rewrite") {
@@ -134,7 +134,7 @@ class NamedRewriteSuite extends AnyFunSuite {
       }
       .flatten
       .distinct
-    assert(offsets === List(Duration.ofHours(1)))
+    assertEquals(offsets, List(Duration.ofHours(1)))
   }
 
   test("node-avg, group by, offset maintained after query rewrite") {
@@ -150,7 +150,7 @@ class NamedRewriteSuite extends AnyFunSuite {
       }
       .flatten
       .distinct
-    assert(offsets === List(Duration.ofHours(1)))
+    assertEquals(offsets, List(Duration.ofHours(1)))
   }
 
   test("percentiles, offset maintained after query rewrite") {
@@ -166,7 +166,7 @@ class NamedRewriteSuite extends AnyFunSuite {
       }
       .flatten
       .distinct
-    assert(offsets === List(Duration.ofHours(1)))
+    assertEquals(offsets, List(Duration.ofHours(1)))
   }
 
   // https://github.com/Netflix/atlas/issues/809
@@ -178,61 +178,61 @@ class NamedRewriteSuite extends AnyFunSuite {
     }
     val actual = exprs.mkString(",")
     val expected = "name,a,:eq,region,east,:eq,:and,(,99.0,),:percentiles,PT1H,:offset"
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("freeze works with named rewrite, cq") {
     val actual = eval("name,a,:eq,:freeze,name,b,:eq,:avg,:list,(,app,foo,:eq,:cq,),:each")
     val expected = eval("name,a,:eq,name,b,:eq,:avg,app,foo,:eq,:cq")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("freeze works with named rewrite, add") {
     val actual = eval("name,a,:eq,:freeze,name,b,:eq,:avg,:list,(,42,:add,),:each")
     val expected = eval("name,a,:eq,name,b,:eq,:avg,42,:add")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("pct rewrite") {
     val actual = eval("name,a,:eq,(,b,),:by,:pct")
     val expected = eval("name,a,:eq,(,b,),:by,:dup,:sum,:div,100,:mul")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("pct rewrite with cq") {
     val actual = eval("name,a,:eq,(,b,),:by,:pct,c,:has,:cq")
     val expected = eval("name,a,:eq,(,b,),:by,:dup,:sum,:div,100,:mul,c,:has,:cq")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("pct after binary op") {
     val actual = eval("name,a,:eq,(,b,),:by,10,:mul,:pct")
     val expected = eval("name,a,:eq,(,b,),:by,10,:mul,:dup,:sum,:div,100,:mul")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   // https://github.com/Netflix/atlas/issues/791
   test("pct after binary op with cq") {
     val actual = eval("name,a,:eq,(,b,),:by,10,:mul,:pct,c,:has,:cq")
     val expected = eval("name,a,:eq,(,b,),:by,10,:mul,:dup,:sum,:div,100,:mul,c,:has,:cq")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("issue-763: avg with cf-max") {
     val actual = eval("name,a,:eq,:avg,:cf-max")
     val expected = eval("name,a,:eq,:sum,:cf-max,name,a,:eq,:count,:cf-max,:div")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("issue-1021: offset with des macros, af") {
     val actual = eval("name,a,:eq,:des-fast,1w,:offset,foo,bar,:eq,:cq")
     val expected = eval("name,a,:eq,foo,bar,:eq,:and,:des-fast,1w,:offset")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("issue-1021: offset with des macros, math") {
     val actual = eval("name,a,:eq,:sum,:des-fast,1w,:offset,foo,bar,:eq,:cq")
     val expected = eval("name,a,:eq,foo,bar,:eq,:and,:sum,:des-fast,1w,:offset")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/PercentilesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/PercentilesSuite.scala
@@ -24,12 +24,11 @@ import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spectator.api.histogram.PercentileBuckets
 import com.netflix.spectator.api.histogram.PercentileDistributionSummary
 import com.netflix.spectator.api.histogram.PercentileTimer
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers._
+import munit.FunSuite
 
 import scala.language.postfixOps
 
-class PercentilesSuite extends AnyFunSuite {
+class PercentilesSuite extends FunSuite {
 
   private val interpreter = Interpreter(MathVocabulary.allWords)
 
@@ -121,74 +120,74 @@ class PercentilesSuite extends AnyFunSuite {
   test("distribution summary :sum") {
     val data = eval("name,test,:eq,(,9,25,50,90,100,),:percentiles", input100)
 
-    assert(data.size === 5)
+    assertEquals(data.size, 5)
     List(9.0, 25.0, 50.0, 90.0).zip(data).foreach {
       case (p, t) =>
         val estimate = t.data(0L)
-        assert(t.tags === Map("name" -> "test", "percentile" -> f"$p%5.1f"))
-        assert(t.label === f"percentile(name=test, $p%5.1f)")
-        assert(p === (estimate +- 2.0))
+        assertEquals(t.tags, Map("name" -> "test", "percentile" -> f"$p%5.1f"))
+        assertEquals(t.label, f"percentile(name=test, $p%5.1f)")
+        assertEqualsDouble(p, estimate, 2.0)
     }
-    assert(data.last.label === f"percentile(name=test, 100.0)")
+    assertEquals(data.last.label, f"percentile(name=test, 100.0)")
   }
 
   test("distribution summary, bad data") {
     val e = intercept[IllegalArgumentException] {
       eval("name,test,:eq,(,9,25,50,90,100,),:percentiles", input100 ::: inputBad100)
     }
-    assert(e.getMessage === "requirement failed: invalid percentile encoding: [D000A,D000a]")
+    assertEquals(e.getMessage, "requirement failed: invalid percentile encoding: [D000A,D000a]")
   }
 
   test("timer :sum") {
     val data = eval("name,test,:eq,(,25,50,90,),:percentiles", inputTimer100)
 
-    assert(data.size === 3)
+    assertEquals(data.size, 3)
     List(25.0, 50.0, 90.0).zip(data).foreach {
       case (p, t) =>
         val estimate = t.data(0L)
-        assert(t.tags === Map("name" -> "test", "percentile" -> f"$p%5.1f"))
-        assert(t.label === f"percentile(name=test, $p%5.1f)")
-        assert(p / 1e9 === (estimate +- 2.0e-9))
+        assertEquals(t.tags, Map("name" -> "test", "percentile" -> f"$p%5.1f"))
+        assertEquals(t.label, f"percentile(name=test, $p%5.1f)")
+        assertEqualsDouble(p / 1e9, estimate, 2.0e-9)
     }
   }
 
   test("spectator distribution summary :sum") {
     val data = eval("name,test,:eq,(,9,25,50,90,100,),:percentiles", inputSpectatorDistSummary)
 
-    assert(data.size === 5)
+    assertEquals(data.size, 5)
     List(9.0, 25.0, 50.0, 90.0).zip(data).foreach {
       case (p, t) =>
         val estimate = t.data(0L)
-        assert(t.tags === Map("name" -> "test", "percentile" -> f"$p%5.1f"))
-        assert(t.label === f"percentile(name=test, $p%5.1f)")
-        assert(p === (estimate +- 2.0))
+        assertEquals(t.tags, Map("name" -> "test", "percentile" -> f"$p%5.1f"))
+        assertEquals(t.label, f"percentile(name=test, $p%5.1f)")
+        assertEqualsDouble(p, estimate, 2.0)
     }
-    assert(data.last.label === f"percentile(name=test, 100.0)")
+    assertEquals(data.last.label, f"percentile(name=test, 100.0)")
   }
 
   test("spectator timer :sum") {
     val data = eval("name,test,:eq,(,25,50,90,),:percentiles", inputSpectatorTimer)
 
-    assert(data.size === 3)
+    assertEquals(data.size, 3)
     List(25.0, 50.0, 90.0).zip(data).foreach {
       case (p, t) =>
         val estimate = t.data(0L)
-        assert(t.tags === Map("name" -> "test", "percentile" -> f"$p%5.1f"))
-        assert(t.label === f"percentile(name=test, $p%5.1f)")
+        assertEquals(t.tags, Map("name" -> "test", "percentile" -> f"$p%5.1f"))
+        assertEquals(t.label, f"percentile(name=test, $p%5.1f)")
 
         // Values were 0 ot 100 recorded in milliseconds, should be reported in seconds
-        assert(p / 1e3 === (estimate +- 2.0e-3))
+        assertEqualsDouble(p / 1e3, estimate, 2.0e-3)
     }
   }
 
   private def checkPercentile(v: Double, s: String): Unit = {
     val data = eval(s"name,test,:eq,(,$v,),:percentiles", inputSpectatorTimer)
 
-    assert(data.size === 1)
+    assertEquals(data.size, 1)
     List(v).zip(data).foreach {
       case (p, t) =>
-        assert(t.tags === Map("name" -> "test", "percentile" -> s))
-        assert(t.label === f"percentile(name=test, $s)")
+        assertEquals(t.tags, Map("name" -> "test", "percentile" -> s))
+        assertEquals(t.label, f"percentile(name=test, $s)")
     }
   }
 
@@ -207,64 +206,64 @@ class PercentilesSuite extends AnyFunSuite {
   test("distribution summary :max") {
     val data = eval("name,test,:eq,:max,(,25,50,90,),:percentiles", input100)
 
-    assert(data.size === 3)
+    assertEquals(data.size, 3)
     List(25.0, 50.0, 90.0).zip(data).foreach {
       case (p, t) =>
         val estimate = t.data(0L)
-        assert(t.tags === Map("name" -> "test", "percentile" -> f"$p%5.1f"))
-        assert(t.label === f"percentile(name=test, $p%5.1f)")
-        assert(p === (estimate +- 2.0))
+        assertEquals(t.tags, Map("name" -> "test", "percentile" -> f"$p%5.1f"))
+        assertEquals(t.label, f"percentile(name=test, $p%5.1f)")
+        assertEqualsDouble(p, estimate, 2.0)
     }
   }
 
   test("distribution summary :median") {
     val data = eval("name,test,:eq,:median", input100)
 
-    assert(data.size === 1)
+    assertEquals(data.size, 1)
     List(50.0).zip(data).foreach {
       case (p, t) =>
         val estimate = t.data(0L)
-        assert(t.tags === Map("name" -> "test", "percentile" -> f"$p%5.1f"))
-        assert(t.label === f"percentile(name=test, $p%5.1f)")
-        assert(p === (estimate +- 2.0))
+        assertEquals(t.tags, Map("name" -> "test", "percentile" -> f"$p%5.1f"))
+        assertEquals(t.label, f"percentile(name=test, $p%5.1f)")
+        assertEqualsDouble(p, estimate, 2.0)
     }
   }
 
   test("group by empty") {
     val data = eval("name,test,:eq,(,foo,),:by,(,25,50,90,),:percentiles", input100)
-    assert(data.size === 0)
+    assertEquals(data.size, 0)
   }
 
   test("group by with single result") {
     val data = eval("name,test,:eq,(,name,),:by,(,25,50,90,),:percentiles", input100)
 
-    assert(data.size === 3)
+    assertEquals(data.size, 3)
     List(25.0, 50.0, 90.0).zip(data).foreach {
       case (p, t) =>
         val estimate = t.data(0L)
-        assert(t.tags === Map("name" -> "test", "percentile" -> f"$p%5.1f"))
-        assert(t.label === f"percentile((name=test), $p%5.1f)")
-        assert(p === (estimate +- 2.0))
+        assertEquals(t.tags, Map("name" -> "test", "percentile" -> f"$p%5.1f"))
+        assertEquals(t.label, f"percentile((name=test), $p%5.1f)")
+        assertEqualsDouble(p, estimate, 2.0)
     }
   }
 
   test("group by with multiple results") {
     val data = eval("name,test,:eq,(,mode,),:by,(,25,50,90,),:percentiles", input100)
 
-    assert(data.size === 6)
+    assertEquals(data.size, 6)
     List(25.0, 50.0, 90.0).zip(data.filter(_.tags("mode") == "even")).foreach {
       case (p, t) =>
         val estimate = t.data(0L)
-        assert(t.tags === Map("name" -> "test", "mode" -> "even", "percentile" -> f"$p%5.1f"))
-        assert(t.label === f"percentile((mode=even), $p%5.1f)")
-        assert(p === (estimate +- 10.0))
+        assertEquals(t.tags, Map("name" -> "test", "mode" -> "even", "percentile" -> f"$p%5.1f"))
+        assertEquals(t.label, f"percentile((mode=even), $p%5.1f)")
+        assertEqualsDouble(p, estimate, 10.0)
     }
     List(25.0, 50.0, 90.0).zip(data.filter(_.tags("mode") == "odd")).foreach {
       case (p, t) =>
         val estimate = t.data(0L)
-        assert(t.tags === Map("name" -> "test", "mode" -> "odd", "percentile" -> f"$p%5.1f"))
-        assert(t.label === f"percentile((mode=odd), $p%5.1f)")
-        assert(p === (estimate +- 10.0))
+        assertEquals(t.tags, Map("name" -> "test", "mode" -> "odd", "percentile" -> f"$p%5.1f"))
+        assertEquals(t.label, f"percentile((mode=odd), $p%5.1f)")
+        assertEqualsDouble(p, estimate, 10.0)
     }
   }
 
@@ -274,30 +273,30 @@ class PercentilesSuite extends AnyFunSuite {
       input100
     )
 
-    assert(data.size === 3)
+    assertEquals(data.size, 3)
     List(25.0, 50.0, 90.0).zip(data).foreach {
       case (p, t) =>
         val estimate = t.data(0L)
-        assert(t.tags === Map("name" -> "test", "percentile" -> f"$p%5.1f"))
-        assert(t.label === f"(percentile=$p%5.1f)")
-        assert(p === (estimate +- 10.0))
+        assertEquals(t.tags, Map("name" -> "test", "percentile" -> f"$p%5.1f"))
+        assertEquals(t.label, f"(percentile=$p%5.1f)")
+        assertEqualsDouble(p, estimate, 10.0)
     }
   }
 
   test("distribution summary empty") {
     val data = eval(":false,(,25,50,90,),:percentiles", input100)
-    assert(data.size === 0)
+    assertEquals(data.size, 0)
   }
 
   test("distribution summary NaN") {
     val data = eval(":true,(,25,50,90,),:percentiles", inputNaN)
 
-    assert(data.size === 3)
+    assertEquals(data.size, 3)
     List(25.0, 50.0, 90.0).zip(data).foreach {
       case (p, t) =>
         val estimate = t.data(0L)
-        assert(t.tags === Map("percentile" -> f"$p%5.1f"))
-        assert(t.label === f"percentile(true, $p%5.1f)")
+        assertEquals(t.tags, Map("percentile" -> f"$p%5.1f"))
+        assertEquals(t.label, f"percentile(true, $p%5.1f)")
         assert(estimate.isNaN)
     }
   }
@@ -348,8 +347,8 @@ class PercentilesSuite extends AnyFunSuite {
     val expr = MathExpr.Percentiles(by, List(50.0))
     val input = Map[DataExpr, List[TimeSeries]](by -> List(TimeSeries.noData(step)))
     val ts = expr.eval(context, input).data
-    assert(ts.size === 1)
-    assert(ts.head.tags === Map("name" -> "NO_DATA"))
-    assert(ts.head.label === "NO DATA")
+    assertEquals(ts.size, 1)
+    assertEquals(ts.head.tags, Map("name" -> "NO_DATA"))
+    assertEquals(ts.head.label, "NO DATA")
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
@@ -16,27 +16,27 @@
 package com.netflix.atlas.core.model
 
 import com.netflix.atlas.core.util.SmallHashMap
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class QuerySuite extends AnyFunSuite {
+class QuerySuite extends FunSuite {
 
   import com.netflix.atlas.core.model.Query._
 
   def matches(q: Query, tags: Map[String, String]): Boolean = {
     val result = q.matches(tags)
-    assert(result === q.matches(SmallHashMap(tags)))
+    assertEquals(result, q.matches(SmallHashMap(tags)))
     result
   }
 
   def matchesAny(q: Query, tags: Map[String, List[String]]): Boolean = {
     val result = q.matchesAny(tags)
-    assert(result === q.matchesAny(SmallHashMap(tags)))
+    assertEquals(result, q.matchesAny(SmallHashMap(tags)))
     result
   }
 
   def couldMatch(q: Query, tags: Map[String, String]): Boolean = {
     val result = q.couldMatch(tags)
-    assert(result === q.couldMatch(SmallHashMap(tags)))
+    assertEquals(result, q.couldMatch(SmallHashMap(tags)))
     result
   }
 
@@ -371,241 +371,241 @@ class QuerySuite extends AnyFunSuite {
     val output = input.rewrite {
       case And(p, q) => Or(q, p)
     }
-    assert(output === expected)
+    assertEquals(output, expected)
   }
 
   test("exactKeys eq") {
     val q = Equal("k", "v")
-    assert(Query.exactKeys(q) === Set("k"))
+    assertEquals(Query.exactKeys(q), Set("k"))
   }
 
   test("exactKeys and") {
     val q = And(Equal("k", "v"), Equal("p", "q"))
-    assert(Query.exactKeys(q) === Set("k", "p"))
+    assertEquals(Query.exactKeys(q), Set("k", "p"))
   }
 
   test("exactKeys or") {
     val q = Or(Equal("k", "v"), Equal("p", "q"))
-    assert(Query.exactKeys(q) === Set.empty)
+    assertEquals(Query.exactKeys(q), Set.empty[String])
   }
 
   test("exactKeys or same key") {
     val q = Or(Equal("k", "v"), Equal("k", "q"))
-    assert(Query.exactKeys(q) === Set.empty)
+    assertEquals(Query.exactKeys(q), Set.empty[String])
   }
 
   test("allKeys no key") {
     val q1 = Query.False
-    assert(Query.allKeys(q1) === Set.empty)
+    assertEquals(Query.allKeys(q1), Set.empty[String])
     val q2 = Query.True
-    assert(Query.allKeys(q2) === Set.empty)
+    assertEquals(Query.allKeys(q2), Set.empty[String])
   }
 
   test("allKeys ignore not") {
     val q = Query.Not(Equal("k", "v"))
-    assert(Query.allKeys(q) === Set("k"))
+    assertEquals(Query.allKeys(q), Set("k"))
   }
 
   test("allKeys eq") {
     val q = Equal("k", "v")
-    assert(Query.allKeys(q) === Set("k"))
+    assertEquals(Query.allKeys(q), Set("k"))
   }
 
   test("allKeys and eq") {
     val q = And(Equal("k", "v"), Equal("p", "q"))
-    assert(Query.allKeys(q) === Set("k", "p"))
+    assertEquals(Query.allKeys(q), Set("k", "p"))
   }
 
   test("allKeys and hasKey") {
     val q = Query.And(a, b)
-    assert(Query.allKeys(q) === Set("A", "B"))
+    assertEquals(Query.allKeys(q), Set("A", "B"))
   }
 
   test("allKeys or") {
     val q = Or(Equal("k", "v"), Equal("p", "q"))
-    assert(Query.allKeys(q) === Set("k", "p"))
+    assertEquals(Query.allKeys(q), Set("k", "p"))
   }
 
   test("allKeys or - same key") {
     val q = Or(Equal("k", "v"), Equal("k", "q"))
-    assert(Query.allKeys(q) === Set("k"))
+    assertEquals(Query.allKeys(q), Set("k"))
   }
 
   test("allKeys or - one side no key") {
     val q = Or(Equal("k", "v"), True)
-    assert(Query.allKeys(q) === Set("k"))
+    assertEquals(Query.allKeys(q), Set("k"))
   }
 
   test("cnfList (a)") {
     val q = a
-    assert(Query.cnfList(q) === List(q))
-    assert(Query.cnf(q) === q)
+    assertEquals(Query.cnfList(q), List(q))
+    assertEquals(Query.cnf(q), q)
   }
 
   test("cnfList (a or b)") {
     val q = Or(a, b)
-    assert(Query.cnfList(q) === List(q))
-    assert(Query.cnf(q) === q)
+    assertEquals(Query.cnfList(q), List(q))
+    assertEquals(Query.cnf(q), q)
   }
 
   test("cnfList (a and b) or c)") {
     val q = Or(And(a, b), c)
-    assert(Query.cnfList(q) === List(Or(a, c), Or(b, c)))
-    assert(Query.cnf(q) === And(Or(a, c), Or(b, c)))
+    assertEquals(Query.cnfList(q), List(Or(a, c), Or(b, c)))
+    assertEquals(Query.cnf(q), And(Or(a, c), Or(b, c)))
   }
 
   test("cnfList (a and b) or (c and d))") {
     val q = Or(And(a, b), And(c, d))
-    assert(Query.cnfList(q) === List(Or(a, c), Or(a, d), Or(b, c), Or(b, d)))
-    assert(Query.cnf(q) === And(And(And(Or(a, c), Or(a, d)), Or(b, c)), Or(b, d)))
+    assertEquals(Query.cnfList(q), List(Or(a, c), Or(a, d), Or(b, c), Or(b, d)))
+    assertEquals(Query.cnf(q), And(And(And(Or(a, c), Or(a, d)), Or(b, c)), Or(b, d)))
   }
 
   test("cnfList not(a or b)") {
     val q = Not(Or(a, b))
-    assert(Query.cnfList(q) === List(Not(a), Not(b)))
-    assert(Query.cnf(q) === And(Not(a), Not(b)))
+    assertEquals(Query.cnfList(q), List(Not(a), Not(b)))
+    assertEquals(Query.cnf(q), And(Not(a), Not(b)))
   }
 
   test("cnfList not(a and b)") {
     val q = Not(And(a, b))
-    assert(Query.cnfList(q) === List(Or(Not(a), Not(b))))
-    assert(Query.cnf(q) === Or(Not(a), Not(b)))
+    assertEquals(Query.cnfList(q), List(Or(Not(a), Not(b))))
+    assertEquals(Query.cnf(q), Or(Not(a), Not(b)))
   }
 
   test("dnfList (a)") {
     val q = a
-    assert(Query.dnfList(q) === List(q))
-    assert(Query.dnf(q) === q)
+    assertEquals(Query.dnfList(q), List(q))
+    assertEquals(Query.dnf(q), q)
   }
 
   test("dnfList (a and b)") {
     val q = And(a, b)
-    assert(Query.dnfList(q) === List(q))
-    assert(Query.dnf(q) === q)
+    assertEquals(Query.dnfList(q), List(q))
+    assertEquals(Query.dnf(q), q)
   }
 
   test("dnfList (a or b) and c)") {
     val q = And(Or(a, b), c)
-    assert(Query.dnfList(q) === List(And(a, c), And(b, c)))
-    assert(Query.dnf(q) === Or(And(a, c), And(b, c)))
+    assertEquals(Query.dnfList(q), List(And(a, c), And(b, c)))
+    assertEquals(Query.dnf(q), Or(And(a, c), And(b, c)))
   }
 
   test("dnfList (a or b) and (c or d))") {
     val q = And(Or(a, b), Or(c, d))
-    assert(Query.dnfList(q) === List(And(a, c), And(a, d), And(b, c), And(b, d)))
-    assert(Query.dnf(q) === Or(Or(Or(And(a, c), And(a, d)), And(b, c)), And(b, d)))
+    assertEquals(Query.dnfList(q), List(And(a, c), And(a, d), And(b, c), And(b, d)))
+    assertEquals(Query.dnf(q), Or(Or(Or(And(a, c), And(a, d)), And(b, c)), And(b, d)))
   }
 
   test("dnfList not(a or b)") {
     val q = Not(Or(a, b))
-    assert(Query.dnfList(q) === List(And(Not(a), Not(b))))
-    assert(Query.dnf(q) === And(Not(a), Not(b)))
+    assertEquals(Query.dnfList(q), List(And(Not(a), Not(b))))
+    assertEquals(Query.dnf(q), And(Not(a), Not(b)))
   }
 
   test("dnfList not(a and b)") {
     val q = Not(And(a, b))
-    assert(Query.dnfList(q) === List(Not(a), Not(b)))
-    assert(Query.dnf(q) === Or(Not(a), Not(b)))
+    assertEquals(Query.dnfList(q), List(Not(a), Not(b)))
+    assertEquals(Query.dnf(q), Or(Not(a), Not(b)))
   }
 
   test("simplify and(true, eq)") {
     val q = And(True, Equal("a", "b"))
-    assert(Query.simplify(q) === Equal("a", "b"))
+    assertEquals(Query.simplify(q), Equal("a", "b"))
   }
 
   test("simplify and(eq, true)") {
     val q = And(Equal("a", "b"), True)
-    assert(Query.simplify(q) === Equal("a", "b"))
+    assertEquals(Query.simplify(q), Equal("a", "b"))
   }
 
   test("simplify and(false, eq)") {
     val q = And(False, Equal("a", "b"))
-    assert(Query.simplify(q) === False)
+    assertEquals(Query.simplify(q), False)
   }
 
   test("simplify and(eq, false)") {
     val q = And(Equal("a", "b"), False)
-    assert(Query.simplify(q) === False)
+    assertEquals(Query.simplify(q), False)
   }
 
   test("simplify and(eq, eq)") {
     val q = And(Equal("a", "b"), Equal("c", "d"))
-    assert(Query.simplify(q) === q)
+    assertEquals(Query.simplify(q), q)
   }
 
   test("simplify and recursive") {
     val q = And(And(True, Equal("a", "b")), And(Equal("c", "d"), False))
-    assert(Query.simplify(q) === False)
+    assertEquals(Query.simplify(q), False)
   }
 
   test("simplify or(true, eq)") {
     val q = Or(True, Equal("a", "b"))
-    assert(Query.simplify(q) === True)
+    assertEquals(Query.simplify(q), True)
   }
 
   test("simplify or(eq, true)") {
     val q = Or(Equal("a", "b"), True)
-    assert(Query.simplify(q) === True)
+    assertEquals(Query.simplify(q), True)
   }
 
   test("simplify or(false, eq)") {
     val q = Or(False, Equal("a", "b"))
-    assert(Query.simplify(q) === Equal("a", "b"))
+    assertEquals(Query.simplify(q), Equal("a", "b"))
   }
 
   test("simplify or(eq, false)") {
     val q = Or(Equal("a", "b"), False)
-    assert(Query.simplify(q) === Equal("a", "b"))
+    assertEquals(Query.simplify(q), Equal("a", "b"))
   }
 
   test("simplify or(eq, eq)") {
     val q = Or(Equal("a", "b"), Equal("c", "d"))
-    assert(Query.simplify(q) === q)
+    assertEquals(Query.simplify(q), q)
   }
 
   test("simplify or recursive") {
     val q = Or(Or(True, Equal("a", "b")), Or(Equal("c", "d"), False))
-    assert(Query.simplify(q) === True)
+    assertEquals(Query.simplify(q), True)
   }
 
   test("simplify not(true)") {
     val q = Not(True)
-    assert(Query.simplify(q) === False)
+    assertEquals(Query.simplify(q), False)
   }
 
   test("simplify not(true), ignore") {
     val q = Not(True)
-    assert(Query.simplify(q, ignore = true) === True)
+    assertEquals(Query.simplify(q, ignore = true), True)
   }
 
   test("simplify not(false)") {
     val q = Not(False)
-    assert(Query.simplify(q) === True)
+    assertEquals(Query.simplify(q), True)
   }
 
   test("simplify not recursive") {
     val q = Not(And(Not(False), Equal("a", "b")))
-    assert(Query.simplify(q) === Not(Equal("a", "b")))
+    assertEquals(Query.simplify(q), Not(Equal("a", "b")))
   }
 
   test("simplify not recursive ignore") {
     val q = Not(And(Not(True), Equal("a", "b")))
-    assert(Query.simplify(q, ignore = true) === Not(Equal("a", "b")))
+    assertEquals(Query.simplify(q, ignore = true), Not(Equal("a", "b")))
   }
 
   test("simplify not recursive ignore - Or") {
     val q = Or(And(Not(True), Equal("a", "b")), False)
-    assert(Query.simplify(q, ignore = true) === Equal("a", "b"))
+    assertEquals(Query.simplify(q, ignore = true), Equal("a", "b"))
   }
 
   test("expandInClauses, simple query") {
     val q = Equal("a", "b")
-    assert(Query.expandInClauses(q) === List(q))
+    assertEquals(Query.expandInClauses(q), List(q))
   }
 
   test("expandInClauses, in query") {
     val q = In("a", List("b", "c"))
-    assert(Query.expandInClauses(q) === List(Equal("a", "b"), Equal("a", "c")))
+    assertEquals(Query.expandInClauses(q), List(Equal("a", "b"), Equal("a", "c")))
   }
 
   test("expandInClauses, conjunction with in query") {
@@ -615,17 +615,17 @@ class QuerySuite extends AnyFunSuite {
       And(base, Equal("b", "v1")),
       And(base, Equal("b", "v2"))
     )
-    assert(Query.expandInClauses(q) === expected)
+    assertEquals(Query.expandInClauses(q), expected)
   }
 
   test("expandInClauses, number of values exceeds limit") {
     val q = In("a", List("b", "c"))
-    assert(Query.expandInClauses(q, 1) === List(q))
+    assertEquals(Query.expandInClauses(q, 1), List(q))
   }
 
   test("expandInClauses, number of values equals limit") {
     val q = In("a", List("b", "c"))
-    assert(Query.expandInClauses(q, 2) === List(Equal("a", "b"), Equal("a", "c")))
+    assertEquals(Query.expandInClauses(q, 2), List(Equal("a", "b"), Equal("a", "c")))
   }
 
   test("expandInClauses, conjunction with multiple in queries") {
@@ -633,11 +633,11 @@ class QuerySuite extends AnyFunSuite {
     val expected = for (a <- List("a1", "a2"); b <- List("b1", "b2", "b3")) yield {
       And(Equal("a", a), Equal("b", b))
     }
-    assert(Query.expandInClauses(q) === expected)
+    assertEquals(Query.expandInClauses(q), expected)
   }
 
   test("expandInClauses, disjunction") {
     val q = Or(Equal("a", "1"), In("b", List("1", "2")))
-    assert(Query.expandInClauses(q, 1) === List(q))
+    assertEquals(Query.expandInClauses(q, 1), List(q))
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/StatefulExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/StatefulExamplesSuite.scala
@@ -24,6 +24,6 @@ class StatefulExamplesSuite extends BaseExamplesSuite {
 
   test("rewrite toString and cq") {
     val expr = eval("name,test,:eq,:sum,:des-fast,app,foo,:eq,:cq")
-    assert(expr.toString === "name,test,:eq,app,foo,:eq,:and,:sum,:des-fast")
+    assertEquals(expr.toString, "name,test,:eq,app,foo,:eq,:and,:sum,:des-fast")
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/StreamSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/StreamSuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.core.model
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class StreamSuite extends AnyFunSuite {
+class StreamSuite extends FunSuite {
 
   val stream = List(
     List(
@@ -50,9 +50,9 @@ class StreamSuite extends AnyFunSuite {
     val aggr = DataExpr.Sum(Query.Equal("name", "cpu"))
     val result = eval(aggr, stream)
     result.foreach { ts =>
-      assert(ts.size === 1)
+      assertEquals(ts.size, 1)
       ts.foreach { t =>
-        assert(t.tags === Map("name" -> "cpu"))
+        assertEquals(t.tags, Map("name" -> "cpu"))
       }
     }
   }
@@ -61,9 +61,9 @@ class StreamSuite extends AnyFunSuite {
     val aggr = DataExpr.Count(Query.Equal("name", "cpu"))
     val result = eval(aggr, stream)
     result.foreach { ts =>
-      assert(ts.size === 1)
+      assertEquals(ts.size, 1)
       ts.foreach { t =>
-        assert(t.tags === Map("name" -> "cpu"))
+        assertEquals(t.tags, Map("name" -> "cpu"))
       }
     }
   }
@@ -72,9 +72,9 @@ class StreamSuite extends AnyFunSuite {
     val aggr = DataExpr.GroupBy(DataExpr.Sum(Query.Equal("name", "cpu")), List("name"))
     val result = eval(aggr, stream)
     result.foreach { ts =>
-      assert(ts.size === 1)
+      assertEquals(ts.size, 1)
       ts.foreach { t =>
-        assert(t.tags === Map("name" -> "cpu"))
+        assertEquals(t.tags, Map("name" -> "cpu"))
       }
     }
   }
@@ -90,7 +90,7 @@ class StreamSuite extends AnyFunSuite {
           case 2 => (1 to 2).map(i => Map("name" -> "cpu", "node" -> s"i-$i")).toSet
           case 3 => Set(Map("name" -> "cpu", "node" -> "i-2"))
         }
-        assert(expected === ts.map(_.tags).toSet)
+        assertEquals(expected, ts.map(_.tags).toSet)
     }
   }
 
@@ -98,9 +98,9 @@ class StreamSuite extends AnyFunSuite {
     val aggr = DataExpr.GroupBy(DataExpr.Sum(Query.True), List("name"))
     val result = eval(aggr, stream)
     result.foreach { ts =>
-      assert(ts.size === 1)
+      assertEquals(ts.size, 1)
       ts.foreach { t =>
-        assert(t.tags === Map("name" -> "cpu"))
+        assertEquals(t.tags, Map("name" -> "cpu"))
       }
     }
   }
@@ -116,7 +116,7 @@ class StreamSuite extends AnyFunSuite {
           case 2 => (1 to 2).map(i => Map("name" -> "cpu", "node" -> s"i-$i")).toSet
           case 3 => Set(Map("name" -> "cpu", "node" -> "i-2"))
         }
-        assert(expected === ts.map(_.tags).toSet)
+        assertEquals(expected, ts.map(_.tags).toSet)
     }
   }
 
@@ -127,9 +127,9 @@ class StreamSuite extends AnyFunSuite {
     val sum = DataExpr.Sum(Query.True)
     val result = eval(sum, stream)
     result.foreach { ts =>
-      assert(ts.size === 1)
+      assertEquals(ts.size, 1)
       ts.foreach { t =>
-        assert(t.tags === Map("name" -> "unknown"))
+        assertEquals(t.tags, Map("name" -> "unknown"))
       }
     }
   }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleExprSuite.scala
@@ -18,9 +18,9 @@ package com.netflix.atlas.core.model
 import com.netflix.atlas.core.stacklang.Interpreter
 
 import java.time.Duration
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class StyleExprSuite extends AnyFunSuite {
+class StyleExprSuite extends FunSuite {
 
   private val interpreter = Interpreter(StyleVocabulary.allWords)
 
@@ -34,19 +34,19 @@ class StyleExprSuite extends AnyFunSuite {
       StyleExpr(DataExpr.Sum(Query.True).withOffset(oneDay), Map.empty),
       StyleExpr(DataExpr.Sum(Query.True).withOffset(oneWeek), Map.empty)
     )
-    assert(expr.perOffset === expected)
+    assertEquals(expr.perOffset, expected)
   }
 
   test("perOffset empty") {
     val expr = StyleExpr(DataExpr.Sum(Query.True), Map("offset" -> "(,)"))
     val expected = List(expr)
-    assert(expr.perOffset === expected)
+    assertEquals(expr.perOffset, expected)
   }
 
   test("perOffset not specified") {
     val expr = StyleExpr(DataExpr.Sum(Query.True), Map.empty)
     val expected = List(expr)
-    assert(expr.perOffset === expected)
+    assertEquals(expr.perOffset, expected)
   }
 
   private def newExpr(legend: String, sed: String): StyleExpr = {
@@ -61,14 +61,14 @@ class StyleExprSuite extends AnyFunSuite {
   test("decode after substitute") {
     val expr = newExpr(s"$$b", "hex,:decode")
     val ts = newTimeSeries("foo", Map("a" -> "1", "b" -> "one_21_25_26_3F"))
-    assert(expr.legend(ts) === "one!%&?")
+    assertEquals(expr.legend(ts), "one!%&?")
   }
 
   private def check(sed: String, expected: String): Unit = {
     test(sed) {
       val expr = newExpr(s"$$b", sed)
       val ts = newTimeSeries("foo", Map("a" -> "1", "b" -> "one_21_25_26_3F"))
-      assert(expr.legend(ts) === expected)
+      assertEquals(expr.legend(ts), expected)
     }
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleVocabularySuite.scala
@@ -17,9 +17,9 @@ package com.netflix.atlas.core.model
 
 import com.netflix.atlas.core.model.ModelExtractors.PresentationType
 import com.netflix.atlas.core.stacklang.Interpreter
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class StyleVocabularySuite extends AnyFunSuite {
+class StyleVocabularySuite extends FunSuite {
 
   val interpreter = new Interpreter(StyleVocabulary.allWords)
 
@@ -33,30 +33,30 @@ class StyleVocabularySuite extends AnyFunSuite {
   test("no additional style") {
     val expr = eval(":true")
     val expected = StyleExpr(DataExpr.Sum(Query.True), Map.empty)
-    assert(expr === expected)
+    assertEquals(expr, expected)
   }
 
   test("alpha") {
     val expr = eval(":true,40,:alpha")
     val expected = StyleExpr(DataExpr.Sum(Query.True), Map("alpha" -> "40"))
-    assert(expr === expected)
+    assertEquals(expr, expected)
   }
 
   test("color") {
     val expr = eval(":true,f00,:color")
     val expected = StyleExpr(DataExpr.Sum(Query.True), Map("color" -> "f00"))
-    assert(expr === expected)
+    assertEquals(expr, expected)
   }
 
   test("alpha > color") {
     val expr = eval(":true,40,:alpha,f00,:color")
     val expected = StyleExpr(DataExpr.Sum(Query.True), Map("color" -> "f00"))
-    assert(expr === expected)
+    assertEquals(expr, expected)
   }
 
   test("alpha > color > alpha") {
     val expr = eval(":true,40,:alpha,f00,:color,60,:alpha")
     val expected = StyleExpr(DataExpr.Sum(Query.True), Map("color" -> "60ff0000"))
-    assert(expr === expected)
+    assertEquals(expr, expected)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/SummaryStatsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/SummaryStatsSuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.core.model
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class SummaryStatsSuite extends AnyFunSuite {
+class SummaryStatsSuite extends FunSuite {
 
   private val start = 0L
   private val step = 60000L
@@ -30,74 +30,74 @@ class SummaryStatsSuite extends AnyFunSuite {
 
   test("constant") {
     val stats = SummaryStats(ts(1.0, 1.0), start, end)
-    assert(stats.count === 2)
-    assert(stats.min === 1.0)
-    assert(stats.max === 1.0)
-    assert(stats.last === 1.0)
-    assert(stats.total === 2.0)
+    assertEquals(stats.count, 2)
+    assertEquals(stats.min, 1.0)
+    assertEquals(stats.max, 1.0)
+    assertEquals(stats.last, 1.0)
+    assertEquals(stats.total, 2.0)
   }
 
   test("varied") {
     val stats = SummaryStats(ts(1.0, 2.0), start, end)
-    assert(stats.count === 2)
-    assert(stats.min === 1.0)
-    assert(stats.max === 2.0)
-    assert(stats.last === 2.0)
-    assert(stats.total === 3.0)
+    assertEquals(stats.count, 2)
+    assertEquals(stats.min, 1.0)
+    assertEquals(stats.max, 2.0)
+    assertEquals(stats.last, 2.0)
+    assertEquals(stats.total, 3.0)
   }
 
   test("negative") {
     val stats = SummaryStats(ts(-1.0, -2.0), start, end)
-    assert(stats.count === 2)
-    assert(stats.min === -2.0)
-    assert(stats.max === -1.0)
-    assert(stats.last === -2.0)
-    assert(stats.total === -3.0)
+    assertEquals(stats.count, 2)
+    assertEquals(stats.min, -2.0)
+    assertEquals(stats.max, -1.0)
+    assertEquals(stats.last, -2.0)
+    assertEquals(stats.total, -3.0)
   }
 
   test("NaN first") {
     val stats = SummaryStats(ts(Double.NaN, -2.0), start, end)
-    assert(stats.count === 1)
-    assert(stats.min === -2.0)
-    assert(stats.max === -2.0)
-    assert(stats.last === -2.0)
-    assert(stats.total === -2.0)
+    assertEquals(stats.count, 1)
+    assertEquals(stats.min, -2.0)
+    assertEquals(stats.max, -2.0)
+    assertEquals(stats.last, -2.0)
+    assertEquals(stats.total, -2.0)
   }
 
   test("NaN last") {
     val stats = SummaryStats(ts(-1.0, Double.NaN), start, end)
-    assert(stats.count === 1)
-    assert(stats.min === -1.0)
-    assert(stats.max === -1.0)
-    assert(stats.last === -1.0)
-    assert(stats.total === -1.0)
+    assertEquals(stats.count, 1)
+    assertEquals(stats.min, -1.0)
+    assertEquals(stats.max, -1.0)
+    assertEquals(stats.last, -1.0)
+    assertEquals(stats.total, -1.0)
   }
 
   test("Infinity") {
     val stats = SummaryStats(ts(Double.PositiveInfinity, Double.PositiveInfinity), start, end)
-    assert(stats.count === 2)
-    assert(stats.min === Double.PositiveInfinity)
-    assert(stats.max === Double.PositiveInfinity)
-    assert(stats.last === Double.PositiveInfinity)
-    assert(stats.total === Double.PositiveInfinity)
+    assertEquals(stats.count, 2)
+    assertEquals(stats.min, Double.PositiveInfinity)
+    assertEquals(stats.max, Double.PositiveInfinity)
+    assertEquals(stats.last, Double.PositiveInfinity)
+    assertEquals(stats.total, Double.PositiveInfinity)
   }
 
   test("constant, Infinity") {
     val stats = SummaryStats(ts(1.0, Double.PositiveInfinity), start, end)
-    assert(stats.count === 2)
-    assert(stats.min === 1.0)
-    assert(stats.max === Double.PositiveInfinity)
-    assert(stats.last === Double.PositiveInfinity)
-    assert(stats.total === Double.PositiveInfinity)
+    assertEquals(stats.count, 2)
+    assertEquals(stats.min, 1.0)
+    assertEquals(stats.max, Double.PositiveInfinity)
+    assertEquals(stats.last, Double.PositiveInfinity)
+    assertEquals(stats.total, Double.PositiveInfinity)
   }
 
   test("Infinity, constant") {
     val stats = SummaryStats(ts(Double.PositiveInfinity, 1.0), start, end)
-    assert(stats.count === 2)
-    assert(stats.min === 1.0)
-    assert(stats.max === Double.PositiveInfinity)
-    assert(stats.last === 1.0)
-    assert(stats.total === Double.PositiveInfinity)
+    assertEquals(stats.count, 2)
+    assertEquals(stats.min, 1.0)
+    assertEquals(stats.max, Double.PositiveInfinity)
+    assertEquals(stats.last, 1.0)
+    assertEquals(stats.total, Double.PositiveInfinity)
   }
 
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TaggedItemSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TaggedItemSuite.scala
@@ -18,11 +18,11 @@ package com.netflix.atlas.core.model
 import com.netflix.atlas.core.util.Hash
 import com.netflix.atlas.core.util.SmallHashMap
 import com.netflix.atlas.core.util.SortedTagMap
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import java.util.UUID
 
-class TaggedItemSuite extends AnyFunSuite {
+class TaggedItemSuite extends FunSuite {
 
   def expectedId(tags: Map[String, String]): ItemId = {
     ItemId(
@@ -33,40 +33,40 @@ class TaggedItemSuite extends AnyFunSuite {
   test("computeId, name only") {
     val t1 = Map("name" -> "foo")
     val t2 = Map("name" -> "bar")
-    assert(TaggedItem.computeId(t1) === expectedId(t1))
-    assert(TaggedItem.computeId(t2) === expectedId(t2))
+    assertEquals(TaggedItem.computeId(t1), expectedId(t1))
+    assertEquals(TaggedItem.computeId(t2), expectedId(t2))
     assert(TaggedItem.computeId(t1) != TaggedItem.computeId(t2))
   }
 
   test("computeId, two") {
     val t1 = Map("name" -> "foo", "cluster" -> "abc")
     val t2 = Map("name" -> "bar", "cluster" -> "abc")
-    assert(TaggedItem.computeId(t1) === expectedId(t1))
-    assert(TaggedItem.computeId(t2) === expectedId(t2))
+    assertEquals(TaggedItem.computeId(t1), expectedId(t1))
+    assertEquals(TaggedItem.computeId(t2), expectedId(t2))
     assert(TaggedItem.computeId(t1) != TaggedItem.computeId(t2))
   }
 
   test("computeId, multi") {
     val t1 = Map("name" -> "foo", "cluster" -> "abc", "app" -> "a", "zone" -> "1")
     val t2 = Map("name" -> "foo", "cluster" -> "abc", "app" -> "a", "zone" -> "2")
-    assert(TaggedItem.computeId(t1) === expectedId(t1))
-    assert(TaggedItem.computeId(t2) === expectedId(t2))
+    assertEquals(TaggedItem.computeId(t1), expectedId(t1))
+    assertEquals(TaggedItem.computeId(t2), expectedId(t2))
     assert(TaggedItem.computeId(t1) != TaggedItem.computeId(t2))
   }
 
   test("computeId, small hash map") {
     val t1 = SmallHashMap("name" -> "foo", "cluster" -> "abc", "app" -> "a", "zone" -> "1")
     val t2 = SmallHashMap("name" -> "foo", "cluster" -> "abc", "app" -> "a", "zone" -> "2")
-    assert(TaggedItem.computeId(t1) === expectedId(t1))
-    assert(TaggedItem.computeId(t2) === expectedId(t2))
+    assertEquals(TaggedItem.computeId(t1), expectedId(t1))
+    assertEquals(TaggedItem.computeId(t2), expectedId(t2))
     assert(TaggedItem.computeId(t1) != TaggedItem.computeId(t2))
   }
 
   test("computeId, sorted tag map") {
     val t1 = SortedTagMap("name" -> "foo", "cluster" -> "abc", "app" -> "a", "zone" -> "1")
     val t2 = SortedTagMap("name" -> "foo", "cluster" -> "abc", "app" -> "a", "zone" -> "2")
-    assert(TaggedItem.computeId(t1) === expectedId(t1))
-    assert(TaggedItem.computeId(t2) === expectedId(t2))
+    assertEquals(TaggedItem.computeId(t1), expectedId(t1))
+    assertEquals(TaggedItem.computeId(t2), expectedId(t2))
     assert(TaggedItem.computeId(t1) != TaggedItem.computeId(t2))
   }
 
@@ -75,7 +75,7 @@ class TaggedItemSuite extends AnyFunSuite {
     (10 until 10_000 by 1000).foreach { size =>
       val tags = (0 until size).map(i => i.toString -> UUID.randomUUID().toString).toMap
       val smallTags = SmallHashMap(tags)
-      assert(TaggedItem.computeId(smallTags) === expectedId(tags))
+      assertEquals(TaggedItem.computeId(smallTags), expectedId(tags))
     }
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
@@ -19,9 +19,9 @@ import java.time.temporal.ChronoUnit
 
 import com.netflix.atlas.core.stacklang.Interpreter
 import com.netflix.atlas.core.util.Math
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class TimeSeriesExprSuite extends AnyFunSuite {
+class TimeSeriesExprSuite extends FunSuite {
 
   import com.netflix.atlas.core.model.TimeSeriesExprSuite._
 
@@ -227,18 +227,18 @@ class TimeSeriesExprSuite extends AnyFunSuite {
     case (prg, p) =>
       test(s"eval global: $prg") {
         val c = interpreter.execute(prg)
-        assert(c.stack.size === 1)
+        assertEquals(c.stack.size, 1)
         val expr = c.stack.collect { case ModelExtractors.TimeSeriesType(t) => t } head
         val rs = expr.eval(p.ctxt, p.input)
-        assert(rs.expr === expr)
-        assert(bounded(rs.data, p.ctxt) === bounded(p.output, p.ctxt))
+        assertEquals(rs.expr, expr)
+        assertEquals(bounded(rs.data, p.ctxt), bounded(p.output, p.ctxt))
       }
 
       List("1m" -> 60000, "5m" -> 300000).foreach {
         case (label, step) =>
           test(s"eval incremental $label: $prg") {
             val c = interpreter.execute(prg)
-            assert(c.stack.size === 1)
+            assertEquals(c.stack.size, 1)
             val expr = c.stack.collect { case ModelExtractors.TimeSeriesType(t) => t } head
             val rs = expr.eval(p.ctxt, p.input)
             val ctxts = p.ctxt.partition(step, ChronoUnit.MINUTES)
@@ -262,8 +262,8 @@ class TimeSeriesExprSuite extends AnyFunSuite {
                 TimeSeries(t.tags, t.label, seq)
               }
             )
-            assert(incrRS.expr === expr)
-            assert(bounded(incrRS.data, p.ctxt) === bounded(p.output, p.ctxt))
+            assertEquals(incrRS.expr, expr)
+            assertEquals(bounded(incrRS.data, p.ctxt), bounded(p.output, p.ctxt))
           }
       }
   }
@@ -272,11 +272,11 @@ class TimeSeriesExprSuite extends AnyFunSuite {
     case (prg, p) =>
       test(s"eval global: $prg") {
         val c = interpreter.execute(prg)
-        assert(c.stack.size === 1)
+        assertEquals(c.stack.size, 1)
         val expr = c.stack.collect { case ModelExtractors.PresentationType(t) => t } head
         val rs = expr.expr.eval(p.ctxt, p.input)
-        assert(rs.expr === expr.expr)
-        assert(bounded(rs.data, p.ctxt) === bounded(p.output, p.ctxt))
+        assertEquals(rs.expr, expr.expr)
+        assertEquals(bounded(rs.data, p.ctxt), bounded(p.output, p.ctxt))
       }
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSpanSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSpanSuite.scala
@@ -18,9 +18,9 @@ package com.netflix.atlas.core.model
 import java.time.zone.ZoneRulesException
 
 import com.netflix.atlas.core.stacklang.Interpreter
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class TimeSpanSuite extends AnyFunSuite {
+class TimeSpanSuite extends FunSuite {
 
   private val step = 60000L
   private val start = 0L
@@ -33,7 +33,7 @@ class TimeSpanSuite extends AnyFunSuite {
     val results = interpreter.execute(program).stack.collect {
       case ModelExtractors.TimeSeriesType(t) => t
     }
-    assert(results.size === 1)
+    assertEquals(results.size, 1)
     val span = results.head
     span.eval(context, Nil).data.head.data.bounded(start, end).data
   }
@@ -41,66 +41,66 @@ class TimeSpanSuite extends AnyFunSuite {
   test("relative start time") {
     val actual = eval(s"tz,UTC,:set,e-5m,1970-01-01T00:08,:time-span")
     val expected = Array[Double](0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0)
-    assert(actual === expected)
+    assertEquals(actual.toSeq, expected.toSeq)
   }
 
   test("relative end time") {
     val actual = eval(s"tz,UTC,:set,1970-01-01T00:02,s+1m,:time-span")
     val expected = Array[Double](0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
-    assert(actual === expected)
+    assertEquals(actual.toSeq, expected.toSeq)
   }
 
   test("graph relative start time") {
     val actual = eval(s"tz,UTC,:set,gs,s+1m,:time-span")
     val expected = Array[Double](1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
-    assert(actual === expected)
+    assertEquals(actual.toSeq, expected.toSeq)
   }
 
   test("graph relative end time") {
     val actual = eval(s"tz,UTC,:set,e-5m,ge,:time-span")
     val expected = Array[Double](0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0)
-    assert(actual === expected)
+    assertEquals(actual.toSeq, expected.toSeq)
   }
 
   test("invalid time") {
     val e = intercept[IllegalArgumentException] {
       eval(s"tz,UTC,:set,foo42,now,:time-span")
     }
-    assert(e.getMessage === "invalid date foo42")
+    assertEquals(e.getMessage, "invalid date foo42")
   }
 
   test("invalid time zone") {
     val e = intercept[ZoneRulesException] {
       eval(s"tz,foo,:set,e-5m,now,:time-span")
     }
-    assert(e.getMessage === "Unknown time-zone ID: foo")
+    assertEquals(e.getMessage, "Unknown time-zone ID: foo")
   }
 
   test("start is after end") {
     val e = intercept[IllegalArgumentException] {
       eval(s"tz,UTC,:set,42,0,:time-span")
     }
-    assert(e.getMessage === "requirement failed: start must be <= end")
+    assertEquals(e.getMessage, "requirement failed: start must be <= end")
   }
 
   test("start is relative to itself") {
     val e = intercept[IllegalArgumentException] {
       eval(s"tz,UTC,:set,s-5m,now,:time-span")
     }
-    assert(e.getMessage === "start time is relative to itself")
+    assertEquals(e.getMessage, "start time is relative to itself")
   }
 
   test("end is relative to itself") {
     val e = intercept[IllegalArgumentException] {
       eval(s"tz,UTC,:set,gs,e-5m,:time-span")
     }
-    assert(e.getMessage === "end time is relative to itself")
+    assertEquals(e.getMessage, "end time is relative to itself")
   }
 
   test("start/end are relative to each other") {
     val e = intercept[IllegalArgumentException] {
       eval(s"tz,UTC,:set,e-5m,s+5m,:time-span")
     }
-    assert(e.getMessage === "start and end time are relative to each other")
+    assertEquals(e.getMessage, "start and end time are relative to each other")
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TrendSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TrendSuite.scala
@@ -17,10 +17,9 @@ package com.netflix.atlas.core.model
 
 import java.time.Duration
 
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers._
+import munit.FunSuite
 
-class TrendSuite extends AnyFunSuite {
+class TrendSuite extends FunSuite {
 
   val step = 60000L
   val dataTags = Map("name" -> "cpu", "node" -> "i-1")
@@ -77,13 +76,13 @@ class TrendSuite extends AnyFunSuite {
 
     result.zip(expected).zipWithIndex.foreach {
       case ((ts, v), i) =>
-        assert(ts.size === 1)
+        assertEquals(ts.size, 1)
         ts.foreach { t =>
           val r = t.data(i * step)
           if (i <= 1)
             assert(r.isNaN)
           else
-            assert(v === r +- 0.00001)
+            assertEqualsDouble(v, r, 0.00001)
         }
     }
   }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/VocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/VocabularySuite.scala
@@ -15,13 +15,13 @@
  */
 package com.netflix.atlas.core.model
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class VocabularySuite extends AnyFunSuite {
+class VocabularySuite extends FunSuite {
 
   for (vocab <- StyleVocabulary :: StyleVocabulary.dependencies; w <- vocab.words) {
     test(s"${vocab.name}: ${w.name} == self") {
-      assert(w === w)
+      assertEquals(w, w)
     }
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/norm/MaxValueFunctionSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/norm/MaxValueFunctionSuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.core.norm
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class MaxValueFunctionSuite extends AnyFunSuite {
+class MaxValueFunctionSuite extends FunSuite {
 
   private def newFunction(step: Long) = {
     val listVF = new ListValueFunction
@@ -28,120 +28,120 @@ class MaxValueFunctionSuite extends AnyFunSuite {
 
   test("basic") {
     val n = newFunction(10)
-    assert(n.update(5, 1.0) === List(10    -> 1.0))
-    assert(n.update(15, 2.0) === List(20   -> 2.0))
-    assert(n.update(25, 2.0) === List(30   -> 2.0))
-    assert(n.update(35, 1.0) === List(40   -> 1.0))
-    assert(n.update(85, 1.0) === List(90   -> 1.0))
-    assert(n.update(95, 2.0) === List(100  -> 2.0))
-    assert(n.update(105, 2.0) === List(110 -> 2.0))
+    assertEquals(n.update(5, 1.0), List(10L    -> 1.0))
+    assertEquals(n.update(15, 2.0), List(20L   -> 2.0))
+    assertEquals(n.update(25, 2.0), List(30L   -> 2.0))
+    assertEquals(n.update(35, 1.0), List(40L   -> 1.0))
+    assertEquals(n.update(85, 1.0), List(90L   -> 1.0))
+    assertEquals(n.update(95, 2.0), List(100L  -> 2.0))
+    assertEquals(n.update(105, 2.0), List(110L -> 2.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("already normalized updates") {
     val n = newFunction(10)
-    assert(n.update(0, 1.0) === List(0   -> 1.0))
-    assert(n.update(10, 2.0) === List(10 -> 2.0))
-    assert(n.update(20, 3.0) === List(20 -> 3.0))
-    assert(n.update(30, 1.0) === List(30 -> 1.0))
+    assertEquals(n.update(0, 1.0), List(0L   -> 1.0))
+    assertEquals(n.update(10, 2.0), List(10L -> 2.0))
+    assertEquals(n.update(20, 3.0), List(20L -> 3.0))
+    assertEquals(n.update(30, 1.0), List(30L -> 1.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("already normalized updates, skip 1") {
     val n = newFunction(10)
-    assert(n.update(0, 1.0) === List(0   -> 1.0))
-    assert(n.update(10, 1.0) === List(10 -> 1.0))
-    assert(n.update(30, 1.0) === List(30 -> 1.0))
+    assertEquals(n.update(0, 1.0), List(0L   -> 1.0))
+    assertEquals(n.update(10, 1.0), List(10L -> 1.0))
+    assertEquals(n.update(30, 1.0), List(30L -> 1.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("already normalized updates, miss heartbeat") {
     val n = newFunction(10)
-    assert(n.update(0, 1.0) === List(0   -> 1.0))
-    assert(n.update(10, 2.0) === List(10 -> 2.0))
-    assert(n.update(30, 1.0) === List(30 -> 1.0))
-    assert(n.update(60, 4.0) === List(60 -> 4.0))
-    assert(n.update(70, 2.0) === List(70 -> 2.0))
+    assertEquals(n.update(0, 1.0), List(0L   -> 1.0))
+    assertEquals(n.update(10, 2.0), List(10L -> 2.0))
+    assertEquals(n.update(30, 1.0), List(30L -> 1.0))
+    assertEquals(n.update(60, 4.0), List(60L -> 4.0))
+    assertEquals(n.update(70, 2.0), List(70L -> 2.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("random offset") {
 
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000)
-    assert(n.update(t(1, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(2, 13), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(3, 13), 1.0) === List(t(4, 0) -> 1.0))
+    assertEquals(n.update(t(1, 13), 1.0), List(t(2, 0) -> 1.0))
+    assertEquals(n.update(t(2, 13), 1.0), List(t(3, 0) -> 1.0))
+    assertEquals(n.update(t(3, 13), 1.0), List(t(4, 0) -> 1.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("random offset, skip 1") {
 
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000)
-    assert(n.update(t(1, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(2, 13), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(3, 13), 1.0) === List(t(4, 0) -> 1.0))
-    assert(n.update(t(5, 13), 1.0) === List(t(6, 0) -> 1.0))
+    assertEquals(n.update(t(1, 13), 1.0), List(t(2, 0) -> 1.0))
+    assertEquals(n.update(t(2, 13), 1.0), List(t(3, 0) -> 1.0))
+    assertEquals(n.update(t(3, 13), 1.0), List(t(4, 0) -> 1.0))
+    assertEquals(n.update(t(5, 13), 1.0), List(t(6, 0) -> 1.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("random offset, skip 2") {
 
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000)
-    assert(n.update(t(1, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(2, 13), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(3, 13), 1.0) === List(t(4, 0) -> 1.0))
-    assert(n.update(t(6, 13), 1.0) === List(t(7, 0) -> 1.0))
+    assertEquals(n.update(t(1, 13), 1.0), List(t(2, 0) -> 1.0))
+    assertEquals(n.update(t(2, 13), 1.0), List(t(3, 0) -> 1.0))
+    assertEquals(n.update(t(3, 13), 1.0), List(t(4, 0) -> 1.0))
+    assertEquals(n.update(t(6, 13), 1.0), List(t(7, 0) -> 1.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("random offset, skip almost 2") {
 
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000)
-    assert(n.update(t(1, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(2, 13), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(3, 13), 1.0) === List(t(4, 0) -> 1.0))
-    assert(n.update(t(6, 5), 1.0) === List(t(7, 0)  -> 1.0))
+    assertEquals(n.update(t(1, 13), 1.0), List(t(2, 0) -> 1.0))
+    assertEquals(n.update(t(2, 13), 1.0), List(t(3, 0) -> 1.0))
+    assertEquals(n.update(t(3, 13), 1.0), List(t(4, 0) -> 1.0))
+    assertEquals(n.update(t(6, 5), 1.0), List(t(7, 0)  -> 1.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("random offset, out of order") {
 
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000)
-    assert(n.update(t(1, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(1, 12), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(2, 13), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(2, 10), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(3, 13), 1.0) === List(t(4, 0) -> 1.0))
-    assert(n.update(t(3, 11), 1.0) === List(t(4, 0) -> 1.0))
+    assertEquals(n.update(t(1, 13), 1.0), List(t(2, 0) -> 1.0))
+    assertEquals(n.update(t(1, 12), 1.0), List(t(2, 0) -> 1.0))
+    assertEquals(n.update(t(2, 13), 1.0), List(t(3, 0) -> 1.0))
+    assertEquals(n.update(t(2, 10), 1.0), List(t(3, 0) -> 1.0))
+    assertEquals(n.update(t(3, 13), 1.0), List(t(4, 0) -> 1.0))
+    assertEquals(n.update(t(3, 11), 1.0), List(t(4, 0) -> 1.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("random offset, dual reporting") {
 
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000)
-    assert(n.update(t(1, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(1, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(2, 13), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(2, 13), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(3, 13), 1.0) === List(t(4, 0) -> 1.0))
-    assert(n.update(t(3, 13), 1.0) === List(t(4, 0) -> 1.0))
+    assertEquals(n.update(t(1, 13), 1.0), List(t(2, 0) -> 1.0))
+    assertEquals(n.update(t(1, 13), 1.0), List(t(2, 0) -> 1.0))
+    assertEquals(n.update(t(2, 13), 1.0), List(t(3, 0) -> 1.0))
+    assertEquals(n.update(t(2, 13), 1.0), List(t(3, 0) -> 1.0))
+    assertEquals(n.update(t(3, 13), 1.0), List(t(4, 0) -> 1.0))
+    assertEquals(n.update(t(3, 13), 1.0), List(t(4, 0) -> 1.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("init, 17") {
@@ -149,43 +149,43 @@ class MaxValueFunctionSuite extends AnyFunSuite {
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000)
     val v = 1.0 / 60.0
-    assert(n.update(t(8, 17), v) === List(t(9, 0)     -> v))
-    assert(n.update(t(9, 17), 0.0) === List(t(10, 0)  -> 0.0))
-    assert(n.update(t(10, 17), 0.0) === List(t(11, 0) -> 0.0))
+    assertEquals(n.update(t(8, 17), v), List(t(9, 0)     -> v))
+    assertEquals(n.update(t(9, 17), 0.0), List(t(10, 0)  -> 0.0))
+    assertEquals(n.update(t(10, 17), 0.0), List(t(11, 0) -> 0.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("frequent updates") {
     val n = newFunction(10)
-    assert(n.update(0, 1.0) === List(0   -> 1.0))
-    assert(n.update(2, 2.0) === List(10  -> 2.0))
-    assert(n.update(4, 4.0) === List(10  -> 4.0))
-    assert(n.update(8, 8.0) === List(10  -> 8.0))
-    assert(n.update(12, 2.0) === List(20 -> 2.0))
-    assert(n.update(40, 3.0) === List(40 -> 3.0))
+    assertEquals(n.update(0, 1.0), List(0L   -> 1.0))
+    assertEquals(n.update(2, 2.0), List(10L  -> 2.0))
+    assertEquals(n.update(4, 4.0), List(10L  -> 4.0))
+    assertEquals(n.update(8, 8.0), List(10L  -> 8.0))
+    assertEquals(n.update(12, 2.0), List(20L -> 2.0))
+    assertEquals(n.update(40, 3.0), List(40L -> 3.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("multi-node updates") {
     val n = newFunction(10)
 
     // Node 1: if shutting down it can flush an interval early
-    assert(n.update(0, 1.0) === List(0   -> 1.0))
-    assert(n.update(10, 2.0) === List(10 -> 2.0))
+    assertEquals(n.update(0, 1.0), List(0L   -> 1.0))
+    assertEquals(n.update(10, 2.0), List(10L -> 2.0))
 
     // Other nodes: report around the same time. Need to ensure that the flush
     // from the node shutting down doesn't block the updates from the other nodes
-    assert(n.update(0, 3.0) === List(0 -> 3.0))
-    assert(n.update(0, 4.0) === List(0 -> 4.0))
-    assert(n.update(0, 5.0) === List(0 -> 5.0))
+    assertEquals(n.update(0, 3.0), List(0L -> 3.0))
+    assertEquals(n.update(0, 4.0), List(0L -> 4.0))
+    assertEquals(n.update(0, 5.0), List(0L -> 5.0))
 
-    assert(n.update(10, 6.0) === List(10 -> 6.0))
-    assert(n.update(10, 7.0) === List(10 -> 7.0))
-    assert(n.update(10, 8.0) === List(10 -> 8.0))
+    assertEquals(n.update(10, 6.0), List(10L -> 6.0))
+    assertEquals(n.update(10, 7.0), List(10L -> 7.0))
+    assertEquals(n.update(10, 8.0), List(10L -> 8.0))
 
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/norm/NormalizationCacheSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/norm/NormalizationCacheSuite.scala
@@ -17,10 +17,9 @@ package com.netflix.atlas.core.norm
 
 import com.netflix.atlas.core.model.Datapoint
 import com.netflix.spectator.api.ManualClock
-import org.scalatest.BeforeAndAfter
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class NormalizationCacheSuite extends AnyFunSuite with BeforeAndAfter {
+class NormalizationCacheSuite extends FunSuite {
 
   val clock = new ManualClock()
   val buffer = scala.collection.mutable.Buffer.empty[Datapoint]
@@ -28,7 +27,7 @@ class NormalizationCacheSuite extends AnyFunSuite with BeforeAndAfter {
 
   def dp(t: Long, v: Double): Datapoint = Datapoint(Map.empty, t, v)
 
-  before {
+  override def beforeEach(context: BeforeEach): Unit = {
     buffer.clear()
   }
 
@@ -50,7 +49,7 @@ class NormalizationCacheSuite extends AnyFunSuite with BeforeAndAfter {
     )
     val actual = buffer.toList
 
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("update counter on exact interval") {
@@ -71,7 +70,7 @@ class NormalizationCacheSuite extends AnyFunSuite with BeforeAndAfter {
     )
     val actual = buffer.toList
 
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("update gauge on exact interval") {
@@ -92,6 +91,6 @@ class NormalizationCacheSuite extends AnyFunSuite with BeforeAndAfter {
     )
     val actual = buffer.toList
 
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/norm/NormalizeValueFunctionSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/norm/NormalizeValueFunctionSuite.scala
@@ -15,10 +15,9 @@
  */
 package com.netflix.atlas.core.norm
 
-import com.netflix.atlas.core.util.Assert._
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class NormalizeValueFunctionSuite extends AnyFunSuite {
+class NormalizeValueFunctionSuite extends FunSuite {
 
   private def newFunction(step: Long, heartbeat: Long) = {
     val listVF = new ListValueFunction
@@ -29,100 +28,100 @@ class NormalizeValueFunctionSuite extends AnyFunSuite {
 
   test("basic") {
     val n = newFunction(10, 20)
-    assert(n.update(5, 1.0) === List(0     -> 0.5))
-    assert(n.update(15, 2.0) === List(10   -> 1.5))
-    assert(n.update(25, 2.0) === List(20   -> 2.0))
-    assert(n.update(35, 1.0) === List(30   -> 1.5))
-    assert(n.update(85, 1.0) === List(80   -> 0.5))
-    assert(n.update(95, 2.0) === List(90   -> 1.5))
-    assert(n.update(105, 2.0) === List(100 -> 2.0))
+    assertEquals(n.update(5, 1.0), List(0L     -> 0.5))
+    assertEquals(n.update(15, 2.0), List(10L   -> 1.5))
+    assertEquals(n.update(25, 2.0), List(20L   -> 2.0))
+    assertEquals(n.update(35, 1.0), List(30L   -> 1.5))
+    assertEquals(n.update(85, 1.0), List(80L   -> 0.5))
+    assertEquals(n.update(95, 2.0), List(90L   -> 1.5))
+    assertEquals(n.update(105, 2.0), List(100L -> 2.0))
   }
 
   test("already normalized updates") {
     val n = newFunction(10, 20)
-    assert(n.update(0, 1.0) === List(0   -> 1.0))
-    assert(n.update(10, 2.0) === List(10 -> 2.0))
-    assert(n.update(20, 3.0) === List(20 -> 3.0))
-    assert(n.update(30, 1.0) === List(30 -> 1.0))
+    assertEquals(n.update(0, 1.0), List(0L   -> 1.0))
+    assertEquals(n.update(10, 2.0), List(10L -> 2.0))
+    assertEquals(n.update(20, 3.0), List(20L -> 3.0))
+    assertEquals(n.update(30, 1.0), List(30L -> 1.0))
   }
 
   test("already normalized updates, skip 1") {
     val n = newFunction(10, 20)
-    assert(n.update(0, 1.0) === List(0   -> 1.0))
-    assert(n.update(10, 1.0) === List(10 -> 1.0))
-    assert(n.update(30, 1.0) === List(20 -> 1.0, 30 -> 1.0))
+    assertEquals(n.update(0, 1.0), List(0L   -> 1.0))
+    assertEquals(n.update(10, 1.0), List(10L -> 1.0))
+    assertEquals(n.update(30, 1.0), List(20L -> 1.0, 30L -> 1.0))
   }
 
   test("already normalized updates, miss heartbeat") {
     val n = newFunction(10, 20)
-    assert(n.update(0, 1.0) === List(0   -> 1.0))
-    assert(n.update(10, 2.0) === List(10 -> 2.0))
-    assert(n.update(30, 1.0) === List(20 -> 1.0, 30 -> 1.0))
-    assert(n.update(60, 4.0) === List(60 -> 4.0))
-    assert(n.update(70, 2.0) === List(70 -> 2.0))
+    assertEquals(n.update(0, 1.0), List(0L   -> 1.0))
+    assertEquals(n.update(10, 2.0), List(10L -> 2.0))
+    assertEquals(n.update(30, 1.0), List(20L -> 1.0, 30L -> 1.0))
+    assertEquals(n.update(60, 4.0), List(60L -> 4.0))
+    assertEquals(n.update(70, 2.0), List(70L -> 2.0))
   }
 
   test("random offset") {
 
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000, 120000)
-    assert(n.update(t(1, 13), 1.0) === List(t(1, 0) -> 47.0 / 60.0))
-    assert(n.update(t(2, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(3, 13), 1.0) === List(t(3, 0) -> 1.0))
+    assertEquals(n.update(t(1, 13), 1.0), List(t(1, 0) -> 47.0 / 60.0))
+    assertEquals(n.update(t(2, 13), 1.0), List(t(2, 0) -> 1.0))
+    assertEquals(n.update(t(3, 13), 1.0), List(t(3, 0) -> 1.0))
   }
 
   test("random offset, skip 1") {
 
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000, 120000)
-    assert(n.update(t(1, 13), 1.0) === List(t(1, 0) -> 47.0 / 60.0))
-    assert(n.update(t(2, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(3, 13), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(5, 13), 1.0) === List(t(4, 0) -> 1.0, t(5, 0) -> 1.0))
+    assertEquals(n.update(t(1, 13), 1.0), List(t(1, 0) -> 47.0 / 60.0))
+    assertEquals(n.update(t(2, 13), 1.0), List(t(2, 0) -> 1.0))
+    assertEquals(n.update(t(3, 13), 1.0), List(t(3, 0) -> 1.0))
+    assertEquals(n.update(t(5, 13), 1.0), List(t(4, 0) -> 1.0, t(5, 0) -> 1.0))
   }
 
   test("random offset, skip 2") {
 
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000, 120000)
-    assert(n.update(t(1, 13), 1.0) === List(t(1, 0) -> 47.0 / 60.0))
-    assert(n.update(t(2, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(3, 13), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(6, 13), 1.0) === List(t(6, 0) -> 47.0 / 60.0))
+    assertEquals(n.update(t(1, 13), 1.0), List(t(1, 0) -> 47.0 / 60.0))
+    assertEquals(n.update(t(2, 13), 1.0), List(t(2, 0) -> 1.0))
+    assertEquals(n.update(t(3, 13), 1.0), List(t(3, 0) -> 1.0))
+    assertEquals(n.update(t(6, 13), 1.0), List(t(6, 0) -> 47.0 / 60.0))
   }
 
   test("random offset, skip almost 2") {
 
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000, 120000)
-    assert(n.update(t(1, 13), 1.0) === List(t(1, 0) -> 47.0 / 60.0))
-    assert(n.update(t(2, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(3, 13), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(6, 5), 1.0) === List(t(6, 0)  -> 55.0 / 60.0))
+    assertEquals(n.update(t(1, 13), 1.0), List(t(1, 0) -> 47.0 / 60.0))
+    assertEquals(n.update(t(2, 13), 1.0), List(t(2, 0) -> 1.0))
+    assertEquals(n.update(t(3, 13), 1.0), List(t(3, 0) -> 1.0))
+    assertEquals(n.update(t(6, 5), 1.0), List(t(6, 0)  -> 55.0 / 60.0))
   }
 
   test("random offset, out of order") {
 
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000, 120000)
-    assert(n.update(t(1, 13), 1.0) === List(t(1, 0) -> 47.0 / 60.0))
-    assert(n.update(t(1, 12), 1.0) === Nil)
-    assert(n.update(t(2, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(2, 10), 1.0) === Nil)
-    assert(n.update(t(3, 13), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(3, 11), 1.0) === Nil)
+    assertEquals(n.update(t(1, 13), 1.0), List(t(1, 0) -> 47.0 / 60.0))
+    assertEquals(n.update(t(1, 12), 1.0), Nil)
+    assertEquals(n.update(t(2, 13), 1.0), List(t(2, 0) -> 1.0))
+    assertEquals(n.update(t(2, 10), 1.0), Nil)
+    assertEquals(n.update(t(3, 13), 1.0), List(t(3, 0) -> 1.0))
+    assertEquals(n.update(t(3, 11), 1.0), Nil)
   }
 
   test("random offset, dual reporting") {
 
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000, 120000)
-    assert(n.update(t(1, 13), 1.0) === List(t(1, 0) -> 47.0 / 60.0))
-    assert(n.update(t(1, 13), 1.0) === Nil)
-    assert(n.update(t(2, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(2, 13), 1.0) === Nil)
-    assert(n.update(t(3, 13), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(3, 13), 1.0) === Nil)
+    assertEquals(n.update(t(1, 13), 1.0), List(t(1, 0) -> 47.0 / 60.0))
+    assertEquals(n.update(t(1, 13), 1.0), Nil)
+    assertEquals(n.update(t(2, 13), 1.0), List(t(2, 0) -> 1.0))
+    assertEquals(n.update(t(2, 13), 1.0), Nil)
+    assertEquals(n.update(t(3, 13), 1.0), List(t(3, 0) -> 1.0))
+    assertEquals(n.update(t(3, 13), 1.0), Nil)
   }
 
   test("init, 17") {
@@ -132,28 +131,28 @@ class NormalizeValueFunctionSuite extends AnyFunSuite {
     val v = 1.0 / 60.0
     val wv1 = v * (43.0 / 60.0)
     val wv2 = v * (17.0 / 60.0)
-    assert(n.update(t(8, 17), 1.0 / 60.0) === List(t(8, 0) -> wv1))
-    assert(n.update(t(9, 17), 0.0) === List(t(9, 0)        -> wv2))
-    assert(n.update(t(10, 17), 0.0) === List(t(10, 0)      -> 0.0))
+    assertEquals(n.update(t(8, 17), 1.0 / 60.0), List(t(8, 0) -> wv1))
+    assertEquals(n.update(t(9, 17), 0.0), List(t(9, 0)        -> wv2))
+    assertEquals(n.update(t(10, 17), 0.0), List(t(10, 0)      -> 0.0))
   }
 
   test("frequent updates") {
     val n = newFunction(10, 50)
-    assert(n.update(0, 1.0) === List(0 -> 1.0))
-    assert(n.update(2, 2.0) === Nil)
-    assert(n.update(4, 4.0) === Nil)
-    assert(n.update(8, 8.0) === Nil)
+    assertEquals(n.update(0, 1.0), List(0L -> 1.0))
+    assertEquals(n.update(2, 2.0), Nil)
+    assertEquals(n.update(4, 4.0), Nil)
+    assertEquals(n.update(8, 8.0), Nil)
 
     var res = n.update(12, 2.0).head
-    assert(res._1 === 10)
-    assertEquals(res._2, 4.8, 1e-6)
+    assertEquals(res._1, 10L)
+    assertEqualsDouble(res._2, 4.8, 1e-6)
 
     val vs = n.update(40, 3.0)
     res = vs.head
-    assert(res._1 === 20)
-    assertEquals(res._2, 2.8, 1e-6)
+    assertEquals(res._1, 20L)
+    assertEqualsDouble(res._2, 2.8, 1e-6)
 
-    assert(vs.tail === List(30 -> 3.0, 40 -> 3.0))
+    assertEquals(vs.tail, List(30L -> 3.0, 40L -> 3.0))
   }
 
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/norm/RateValueFunctionSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/norm/RateValueFunctionSuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.core.norm
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class RateValueFunctionSuite extends AnyFunSuite {
+class RateValueFunctionSuite extends FunSuite {
 
   private def newFunction = {
     val listVF = new ListValueFunction
@@ -28,16 +28,16 @@ class RateValueFunctionSuite extends AnyFunSuite {
 
   test("basic") {
     val vf = newFunction
-    assert(vf.update(5, 1.0) === Nil)
-    assert(vf.update(15, 2.0) === List(15 -> 100.0))
-    assert(vf.update(25, 4.0) === List(25 -> 200.0))
+    assertEquals(vf.update(5L, 1.0), Nil)
+    assertEquals(vf.update(15L, 2.0), List(15L -> 100.0))
+    assertEquals(vf.update(25L, 4.0), List(25L -> 200.0))
   }
 
   test("decreasing value") {
     val vf = newFunction
-    assert(vf.update(5, 1.0) === Nil)
-    assert(vf.update(15, 2.0) === List(15 -> 100.0))
-    assert(vf.update(25, 1.0) === List(25 -> 0.0))
+    assertEquals(vf.update(5, 1.0), Nil)
+    assertEquals(vf.update(15, 2.0), List(15L -> 100.0))
+    assertEquals(vf.update(25, 1.0), List(25L -> 0.0))
   }
 
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/norm/RollingValueFunctionSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/norm/RollingValueFunctionSuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.core.norm
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class RollingValueFunctionSuite extends AnyFunSuite {
+class RollingValueFunctionSuite extends FunSuite {
 
   private def newFunction(step: Long) = {
     val listVF = new ListValueFunction
@@ -33,27 +33,27 @@ class RollingValueFunctionSuite extends AnyFunSuite {
       assert(vs == List(i -> i.toDouble))
     }
     f.close()
-    assert(f.result() === Nil)
+    assertEquals(f.result(), Nil)
   }
 
   test("values received out of order") {
     val f = newFunction(1L)
-    assert(f.update(1, 1.0) === List(1 -> 1.0))
-    assert(f.update(2, 2.0) === List(2 -> 2.0))
-    assert(f.update(1, 0.5) === List(1 -> 0.5))
-    assert(f.update(3, 3.0) === List(3 -> 3.0))
-    assert(f.update(1, 0.0) === Nil) // too old
+    assertEquals(f.update(1, 1.0), List(1L -> 1.0))
+    assertEquals(f.update(2, 2.0), List(2L -> 2.0))
+    assertEquals(f.update(1, 0.5), List(1L -> 0.5))
+    assertEquals(f.update(3, 3.0), List(3L -> 3.0))
+    assertEquals(f.update(1, 0.0), Nil) // too old
     f.close()
-    assert(f.result() === Nil)
+    assertEquals(f.result(), Nil)
   }
 
   test("values with gaps") {
     val f = newFunction(1L)
-    assert(f.update(1, 1.0) === List(1 -> 1.0))
-    assert(f.update(5, 5.0) === List(5 -> 5.0))
-    assert(f.update(6, 6.0) === List(6 -> 6.0))
-    assert(f.update(9, 9.0) === List(9 -> 9.0))
+    assertEquals(f.update(1, 1.0), List(1L -> 1.0))
+    assertEquals(f.update(5, 5.0), List(5L -> 5.0))
+    assertEquals(f.update(6, 6.0), List(6L -> 6.0))
+    assertEquals(f.update(9, 9.0), List(9L -> 9.0))
     f.close()
-    assert(f.result() === Nil)
+    assertEquals(f.result(), Nil)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/norm/SumValueFunctionSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/norm/SumValueFunctionSuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.core.norm
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class SumValueFunctionSuite extends AnyFunSuite {
+class SumValueFunctionSuite extends FunSuite {
 
   private def newFunction(step: Long) = {
     val listVF = new ListValueFunction
@@ -28,120 +28,120 @@ class SumValueFunctionSuite extends AnyFunSuite {
 
   test("basic") {
     val n = newFunction(10)
-    assert(n.update(5, 1.0) === List(10    -> 1.0))
-    assert(n.update(15, 2.0) === List(20   -> 2.0))
-    assert(n.update(25, 2.0) === List(30   -> 2.0))
-    assert(n.update(35, 1.0) === List(40   -> 1.0))
-    assert(n.update(85, 1.0) === List(90   -> 1.0))
-    assert(n.update(95, 2.0) === List(100  -> 2.0))
-    assert(n.update(105, 2.0) === List(110 -> 2.0))
+    assertEquals(n.update(5, 1.0), List(10L    -> 1.0))
+    assertEquals(n.update(15, 2.0), List(20L   -> 2.0))
+    assertEquals(n.update(25, 2.0), List(30L   -> 2.0))
+    assertEquals(n.update(35, 1.0), List(40L   -> 1.0))
+    assertEquals(n.update(85, 1.0), List(90L   -> 1.0))
+    assertEquals(n.update(95, 2.0), List(100L  -> 2.0))
+    assertEquals(n.update(105, 2.0), List(110L -> 2.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("already normalized updates") {
     val n = newFunction(10)
-    assert(n.update(0, 1.0) === List(0   -> 1.0))
-    assert(n.update(10, 2.0) === List(10 -> 2.0))
-    assert(n.update(20, 3.0) === List(20 -> 3.0))
-    assert(n.update(30, 1.0) === List(30 -> 1.0))
+    assertEquals(n.update(0, 1.0), List(0L   -> 1.0))
+    assertEquals(n.update(10, 2.0), List(10L -> 2.0))
+    assertEquals(n.update(20, 3.0), List(20L -> 3.0))
+    assertEquals(n.update(30, 1.0), List(30L -> 1.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("already normalized updates, skip 1") {
     val n = newFunction(10)
-    assert(n.update(0, 1.0) === List(0   -> 1.0))
-    assert(n.update(10, 1.0) === List(10 -> 1.0))
-    assert(n.update(30, 1.0) === List(30 -> 1.0))
+    assertEquals(n.update(0, 1.0), List(0L   -> 1.0))
+    assertEquals(n.update(10, 1.0), List(10L -> 1.0))
+    assertEquals(n.update(30, 1.0), List(30L -> 1.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("already normalized updates, miss heartbeat") {
     val n = newFunction(10)
-    assert(n.update(0, 1.0) === List(0   -> 1.0))
-    assert(n.update(10, 2.0) === List(10 -> 2.0))
-    assert(n.update(30, 1.0) === List(30 -> 1.0))
-    assert(n.update(60, 4.0) === List(60 -> 4.0))
-    assert(n.update(70, 2.0) === List(70 -> 2.0))
+    assertEquals(n.update(0, 1.0), List(0L   -> 1.0))
+    assertEquals(n.update(10, 2.0), List(10L -> 2.0))
+    assertEquals(n.update(30, 1.0), List(30L -> 1.0))
+    assertEquals(n.update(60, 4.0), List(60L -> 4.0))
+    assertEquals(n.update(70, 2.0), List(70L -> 2.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("random offset") {
 
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000)
-    assert(n.update(t(1, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(2, 13), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(3, 13), 1.0) === List(t(4, 0) -> 1.0))
+    assertEquals(n.update(t(1, 13), 1.0), List(t(2, 0) -> 1.0))
+    assertEquals(n.update(t(2, 13), 1.0), List(t(3, 0) -> 1.0))
+    assertEquals(n.update(t(3, 13), 1.0), List(t(4, 0) -> 1.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("random offset, skip 1") {
 
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000)
-    assert(n.update(t(1, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(2, 13), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(3, 13), 1.0) === List(t(4, 0) -> 1.0))
-    assert(n.update(t(5, 13), 1.0) === List(t(6, 0) -> 1.0))
+    assertEquals(n.update(t(1, 13), 1.0), List(t(2, 0) -> 1.0))
+    assertEquals(n.update(t(2, 13), 1.0), List(t(3, 0) -> 1.0))
+    assertEquals(n.update(t(3, 13), 1.0), List(t(4, 0) -> 1.0))
+    assertEquals(n.update(t(5, 13), 1.0), List(t(6, 0) -> 1.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("random offset, skip 2") {
 
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000)
-    assert(n.update(t(1, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(2, 13), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(3, 13), 1.0) === List(t(4, 0) -> 1.0))
-    assert(n.update(t(6, 13), 1.0) === List(t(7, 0) -> 1.0))
+    assertEquals(n.update(t(1, 13), 1.0), List(t(2, 0) -> 1.0))
+    assertEquals(n.update(t(2, 13), 1.0), List(t(3, 0) -> 1.0))
+    assertEquals(n.update(t(3, 13), 1.0), List(t(4, 0) -> 1.0))
+    assertEquals(n.update(t(6, 13), 1.0), List(t(7, 0) -> 1.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("random offset, skip almost 2") {
 
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000)
-    assert(n.update(t(1, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(2, 13), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(3, 13), 1.0) === List(t(4, 0) -> 1.0))
-    assert(n.update(t(6, 5), 1.0) === List(t(7, 0)  -> 1.0))
+    assertEquals(n.update(t(1, 13), 1.0), List(t(2, 0) -> 1.0))
+    assertEquals(n.update(t(2, 13), 1.0), List(t(3, 0) -> 1.0))
+    assertEquals(n.update(t(3, 13), 1.0), List(t(4, 0) -> 1.0))
+    assertEquals(n.update(t(6, 5), 1.0), List(t(7, 0)  -> 1.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("random offset, out of order") {
 
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000)
-    assert(n.update(t(1, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(1, 12), 1.0) === List(t(2, 0) -> 2.0))
-    assert(n.update(t(2, 13), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(2, 10), 1.0) === List(t(3, 0) -> 2.0))
-    assert(n.update(t(3, 13), 1.0) === List(t(4, 0) -> 1.0))
-    assert(n.update(t(3, 11), 1.0) === List(t(4, 0) -> 2.0))
+    assertEquals(n.update(t(1, 13), 1.0), List(t(2, 0) -> 1.0))
+    assertEquals(n.update(t(1, 12), 1.0), List(t(2, 0) -> 2.0))
+    assertEquals(n.update(t(2, 13), 1.0), List(t(3, 0) -> 1.0))
+    assertEquals(n.update(t(2, 10), 1.0), List(t(3, 0) -> 2.0))
+    assertEquals(n.update(t(3, 13), 1.0), List(t(4, 0) -> 1.0))
+    assertEquals(n.update(t(3, 11), 1.0), List(t(4, 0) -> 2.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("random offset, dual reporting") {
 
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000)
-    assert(n.update(t(1, 13), 1.0) === List(t(2, 0) -> 1.0))
-    assert(n.update(t(1, 13), 1.0) === List(t(2, 0) -> 2.0))
-    assert(n.update(t(2, 13), 1.0) === List(t(3, 0) -> 1.0))
-    assert(n.update(t(2, 13), 1.0) === List(t(3, 0) -> 2.0))
-    assert(n.update(t(3, 13), 1.0) === List(t(4, 0) -> 1.0))
-    assert(n.update(t(3, 13), 1.0) === List(t(4, 0) -> 2.0))
+    assertEquals(n.update(t(1, 13), 1.0), List(t(2, 0) -> 1.0))
+    assertEquals(n.update(t(1, 13), 1.0), List(t(2, 0) -> 2.0))
+    assertEquals(n.update(t(2, 13), 1.0), List(t(3, 0) -> 1.0))
+    assertEquals(n.update(t(2, 13), 1.0), List(t(3, 0) -> 2.0))
+    assertEquals(n.update(t(3, 13), 1.0), List(t(4, 0) -> 1.0))
+    assertEquals(n.update(t(3, 13), 1.0), List(t(4, 0) -> 2.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("init, 17") {
@@ -149,43 +149,43 @@ class SumValueFunctionSuite extends AnyFunSuite {
     def t(m: Int, s: Int) = (m * 60 + s) * 1000L
     val n = newFunction(60000)
     val v = 1.0 / 60.0
-    assert(n.update(t(8, 17), v) === List(t(9, 0)     -> v))
-    assert(n.update(t(9, 17), 0.0) === List(t(10, 0)  -> 0.0))
-    assert(n.update(t(10, 17), 0.0) === List(t(11, 0) -> 0.0))
+    assertEquals(n.update(t(8, 17), v), List(t(9, 0)     -> v))
+    assertEquals(n.update(t(9, 17), 0.0), List(t(10, 0)  -> 0.0))
+    assertEquals(n.update(t(10, 17), 0.0), List(t(11, 0) -> 0.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("frequent updates") {
     val n = newFunction(10)
-    assert(n.update(0, 1.0) === List(0   -> 1.0))
-    assert(n.update(2, 2.0) === List(10  -> 2.0))
-    assert(n.update(4, 4.0) === List(10  -> 6.0))
-    assert(n.update(8, 8.0) === List(10  -> 14.0))
-    assert(n.update(12, 2.0) === List(20 -> 2.0))
-    assert(n.update(40, 3.0) === List(40 -> 3.0))
+    assertEquals(n.update(0, 1.0), List(0L   -> 1.0))
+    assertEquals(n.update(2, 2.0), List(10L  -> 2.0))
+    assertEquals(n.update(4, 4.0), List(10L  -> 6.0))
+    assertEquals(n.update(8, 8.0), List(10L  -> 14.0))
+    assertEquals(n.update(12, 2.0), List(20L -> 2.0))
+    assertEquals(n.update(40, 3.0), List(40L -> 3.0))
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 
   test("multi-node updates") {
     val n = newFunction(10)
 
     // Node 1: if shutting down it can flush an interval early
-    assert(n.update(0, 1.0) === List(0   -> 1.0))
-    assert(n.update(10, 2.0) === List(10 -> 2.0))
+    assertEquals(n.update(0, 1.0), List(0L   -> 1.0))
+    assertEquals(n.update(10, 2.0), List(10L -> 2.0))
 
     // Other nodes: report around the same time. Need to ensure that the flush
     // from the node shutting down doesn't block the updates from the other nodes
-    assert(n.update(0, 3.0) === List(0 -> 4.0))
-    assert(n.update(0, 4.0) === List(0 -> 8.0))
-    assert(n.update(0, 5.0) === List(0 -> 13.0))
+    assertEquals(n.update(0, 3.0), List(0L -> 4.0))
+    assertEquals(n.update(0, 4.0), List(0L -> 8.0))
+    assertEquals(n.update(0, 5.0), List(0L -> 13.0))
 
-    assert(n.update(10, 6.0) === List(10 -> 8.0))
-    assert(n.update(10, 7.0) === List(10 -> 15.0))
-    assert(n.update(10, 8.0) === List(10 -> 23.0))
+    assertEquals(n.update(10, 6.0), List(10L -> 8.0))
+    assertEquals(n.update(10, 7.0), List(10L -> 15.0))
+    assertEquals(n.update(10, 8.0), List(10L -> 23.0))
 
     n.close()
-    assert(n.result() === Nil)
+    assertEquals(n.result(), Nil)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/BaseExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/BaseExamplesSuite.scala
@@ -19,9 +19,9 @@ import com.netflix.atlas.core.model.ModelExtractors
 import com.netflix.atlas.core.model.StyleExpr
 import com.netflix.atlas.core.model.TimeSeriesExpr
 import com.netflix.atlas.core.util.Features
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-abstract class BaseExamplesSuite extends AnyFunSuite {
+abstract class BaseExamplesSuite extends FunSuite {
 
   def vocabulary: Vocabulary
 
@@ -66,14 +66,14 @@ abstract class BaseExamplesSuite extends AnyFunSuite {
             case v           => List(v)
           }
           val stack2 = execute(Interpreter.toString(prg)).stack
-          assert(stack2 === prg)
+          assertEquals(stack2, prg)
         }
       }
 
       test(s"finalGrouping and isGrouped match -- $ex,:${w.name}") {
         execute(s"$ex,:${w.name}").stack.foreach {
-          case s: StyleExpr      => assert(s.expr.finalGrouping.nonEmpty === s.expr.isGrouped)
-          case t: TimeSeriesExpr => assert(t.finalGrouping.nonEmpty === t.isGrouped)
+          case s: StyleExpr      => assertEquals(s.expr.finalGrouping.nonEmpty, s.expr.isGrouped)
+          case t: TimeSeriesExpr => assertEquals(t.finalGrouping.nonEmpty, t.isGrouped)
           case _                 =>
         }
       }
@@ -82,7 +82,7 @@ abstract class BaseExamplesSuite extends AnyFunSuite {
       if (w.name != "offset") {
         test(s"toString(stack) -- $ex,:${w.name}") {
           val stack = execute(s"$ex,:${w.name}").stack
-          assert(stack === execute(Interpreter.toString(stack)).stack)
+          assertEquals(stack, execute(Interpreter.toString(stack)).stack)
         }
       }
     }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/BaseWordSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/BaseWordSuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.core.stacklang
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-abstract class BaseWordSuite extends AnyFunSuite {
+abstract class BaseWordSuite extends FunSuite {
 
   def interpreter: Interpreter
 
@@ -35,7 +35,7 @@ abstract class BaseWordSuite extends AnyFunSuite {
 
       test(s"execute: $prg") {
         val c = interpreter.execute(prg)
-        assert(word.execute(c).stack === after)
+        assertEquals(word.execute(c).stack, after)
       }
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/FreezeSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/FreezeSuite.scala
@@ -16,21 +16,21 @@
 package com.netflix.atlas.core.stacklang
 
 import com.netflix.atlas.core.util.Features
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class FreezeSuite extends AnyFunSuite {
+class FreezeSuite extends FunSuite {
 
   def interpreter: Interpreter = Interpreter(StandardVocabulary.allWords)
 
   test("basic operation") {
     val context = interpreter.execute("a,b,c,:freeze")
-    assert(context.stack === List("c", "b", "a"))
+    assertEquals(context.stack, List("c", "b", "a"))
     assert(context.frozenStack.isEmpty)
   }
 
   test("frozen stack is isolated") {
     val context = interpreter.execute("a,b,c,:freeze,d,e,f,:clear")
-    assert(context.stack === List("c", "b", "a"))
+    assertEquals(context.stack, List("c", "b", "a"))
     assert(context.frozenStack.isEmpty)
   }
 
@@ -38,49 +38,49 @@ class FreezeSuite extends AnyFunSuite {
     val e = intercept[NoSuchElementException] {
       interpreter.execute("foo,1,:set,:freeze,foo,:get")
     }
-    assert(e.getMessage === "key not found: foo")
+    assertEquals(e.getMessage, "key not found: foo")
   }
 
   test("original variables are preserved") {
     val vars = Map("foo" -> "original", "bar" -> "2")
     val context = interpreter.execute("foo,1,:set,:freeze,foo,:get,bar,:get", vars, Features.STABLE)
-    assert(context.stack === List("2", "original"))
+    assertEquals(context.stack, List("2", "original"))
   }
 
   test("multiple freeze operations") {
     val context = interpreter.execute("a,b,c,:freeze,d,e,f,:freeze,g,h,i,:freeze,j,k,l,:clear")
-    assert(context.stack === List("i", "h", "g", "f", "e", "d", "c", "b", "a"))
+    assertEquals(context.stack, List("i", "h", "g", "f", "e", "d", "c", "b", "a"))
     assert(context.frozenStack.isEmpty)
   }
 
   test("freeze works with macros") {
     // Before macros would force unfreeze after execution
     val context = interpreter.execute("a,b,:freeze,d,e,:2over,:clear")
-    assert(context.stack === List("b", "a"))
+    assertEquals(context.stack, List("b", "a"))
     assert(context.frozenStack.isEmpty)
   }
 
   test("freeze works with :call") {
     val context = interpreter.execute("a,b,:freeze,d,(,:dup,),:call,:clear")
-    assert(context.stack === List("b", "a"))
+    assertEquals(context.stack, List("b", "a"))
     assert(context.frozenStack.isEmpty)
   }
 
   test("freeze works with :each") {
     val context = interpreter.execute("a,b,:freeze,(,d,),(,:dup,),:each,:clear")
-    assert(context.stack === List("b", "a"))
+    assertEquals(context.stack, List("b", "a"))
     assert(context.frozenStack.isEmpty)
   }
 
   test("freeze works with :map") {
     val context = interpreter.execute("a,b,:freeze,(,d,),(,:dup,),:map,:clear")
-    assert(context.stack === List("b", "a"))
+    assertEquals(context.stack, List("b", "a"))
     assert(context.frozenStack.isEmpty)
   }
 
   test("freeze works with :get/:set") {
     val context = interpreter.execute("a,b,:freeze,d,e,:set,d,:get,:clear")
-    assert(context.stack === List("b", "a"))
+    assertEquals(context.stack, List("b", "a"))
     assert(context.frozenStack.isEmpty)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/InterpreterSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/InterpreterSuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.core.stacklang
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class InterpreterSuite extends AnyFunSuite {
+class InterpreterSuite extends FunSuite {
   import com.netflix.atlas.core.stacklang.InterpreterSuite._
 
   val interpreter = new Interpreter(
@@ -39,23 +39,23 @@ class InterpreterSuite extends AnyFunSuite {
   }
 
   test("empty") {
-    assert(interpreter.execute(Nil) === context(Nil))
+    assertEquals(interpreter.execute(Nil), context(Nil))
   }
 
   test("push items") {
-    assert(interpreter.execute(List("foo", "bar")) === context(List("bar", "foo")))
+    assertEquals(interpreter.execute(List("foo", "bar")), context(List("bar", "foo")))
   }
 
   test("execute word") {
-    assert(interpreter.execute(List(":push-foo")) === context(List("foo")))
+    assertEquals(interpreter.execute(List(":push-foo")), context(List("foo")))
   }
 
   test("overloaded word") {
-    assert(interpreter.execute(List(":overloaded")) === context(List("one")))
+    assertEquals(interpreter.execute(List(":overloaded")), context(List("one")))
   }
 
   test("overloaded word and some don't match") {
-    assert(interpreter.execute(List(":overloaded2")) === context(List("two")))
+    assertEquals(interpreter.execute(List(":overloaded2")), context(List("two")))
   }
 
   test("word with no matches") {
@@ -63,7 +63,7 @@ class InterpreterSuite extends AnyFunSuite {
       interpreter.execute(List(":no-match"))
     }
     val expected = "no matches for word ':no-match' with stack [], candidates: [exception]"
-    assert(e.getMessage === expected)
+    assertEquals(e.getMessage, expected)
   }
 
   test("using unstable word fails by default") {
@@ -71,50 +71,50 @@ class InterpreterSuite extends AnyFunSuite {
       interpreter.execute(List(":unstable"))
     }
     val expected = "to use :unstable enable unstable features"
-    assert(e.getMessage === expected)
+    assertEquals(e.getMessage, expected)
   }
 
   test("unknown word") {
     val e = intercept[IllegalStateException] {
       interpreter.execute(List("foo", ":unknown"))
     }
-    assert(e.getMessage === "unknown word ':unknown'")
+    assertEquals(e.getMessage, "unknown word ':unknown'")
   }
 
   test("unmatched closing paren") {
     val e = intercept[IllegalStateException] {
       interpreter.execute(List(")"))
     }
-    assert(e.getMessage === "unmatched closing parenthesis")
+    assertEquals(e.getMessage, "unmatched closing parenthesis")
   }
 
   test("unmatched closing paren 2") {
     val e = intercept[IllegalStateException] {
       interpreter.execute(List("(", ")", ")"))
     }
-    assert(e.getMessage === "unmatched closing parenthesis")
+    assertEquals(e.getMessage, "unmatched closing parenthesis")
   }
 
   test("unmatched opening paren") {
     val e = intercept[IllegalStateException] {
       interpreter.execute(List("("))
     }
-    assert(e.getMessage === "unmatched opening parenthesis")
+    assertEquals(e.getMessage, "unmatched opening parenthesis")
   }
 
   test("list") {
     val list = List("(", "1", ")")
-    assert(interpreter.execute(list) === context(List(List("1"))))
+    assertEquals(interpreter.execute(list), context(List(List("1"))))
   }
 
   test("nested list") {
     val list = List("(", "1", "(", ")", ")")
-    assert(interpreter.execute(list) === context(List(List("1", "(", ")"))))
+    assertEquals(interpreter.execute(list), context(List(List("1", "(", ")"))))
   }
 
   test("multiple lists") {
     val list = List("(", "1", ")", "(", "2", ")")
-    assert(interpreter.execute(list) === context(List(List("2"), List("1"))))
+    assertEquals(interpreter.execute(list), context(List(List("2"), List("1"))))
   }
 
   test("debug") {
@@ -124,33 +124,33 @@ class InterpreterSuite extends AnyFunSuite {
       Interpreter.Step(list.drop(3), Context(interpreter, List(List("1")), Map.empty)),
       Interpreter.Step(Nil, Context(interpreter, List(List("2"), List("1")), Map.empty))
     )
-    assert(interpreter.debug(list) === expected)
+    assertEquals(interpreter.debug(list), expected)
   }
 
   test("toString") {
-    assert(interpreter.toString === "Interpreter(9 words)")
+    assertEquals(interpreter.toString, "Interpreter(9 words)")
   }
 
   test("typeSummary: String") {
-    assert(Interpreter.typeSummary(List("foo")) === "[String]")
+    assertEquals(Interpreter.typeSummary(List("foo")), "[String]")
   }
 
   test("typeSummary: Primitive") {
     // Why do all of these get coerced to doubles?
-    assert(Interpreter.typeSummary(List(42, 42.0, 42L)) === "[Double,Double,Double]")
-    assert(Interpreter.typeSummary(42 :: 42.0 :: 42L :: Nil) === "[Long,Double,Integer]")
+    assertEquals(Interpreter.typeSummary(List(42, 42.0, 42L)), "[Double,Double,Double]")
+    assertEquals(Interpreter.typeSummary(42 :: 42.0 :: 42L :: Nil), "[Long,Double,Integer]")
   }
 
   test("typeSummary: List.empty") {
-    assert(Interpreter.typeSummary(List(List.empty)) === "[List]")
+    assertEquals(Interpreter.typeSummary(List(List.empty)), "[List]")
   }
 
   test("typeSummary: List(a, b)") {
-    assert(Interpreter.typeSummary(List(List("a", "b"))) === "[List]")
+    assertEquals(Interpreter.typeSummary(List(List("a", "b"))), "[List]")
   }
 
   test("typeSummary: a :: b :: Nil") {
-    assert(Interpreter.typeSummary(List("a" :: "b" :: Nil)) === "[List]")
+    assertEquals(Interpreter.typeSummary(List("a" :: "b" :: Nil)), "[List]")
   }
 
   //
@@ -159,17 +159,17 @@ class InterpreterSuite extends AnyFunSuite {
 
   test("splitAndTrim should split by comma") {
     val actual = Interpreter.splitAndTrim("a,b,c")
-    assert(actual === List("a", "b", "c"))
+    assertEquals(actual, List("a", "b", "c"))
   }
 
   test("splitAndTrim should trim whitespace") {
     val actual = Interpreter.splitAndTrim("  a\n,\t\nb ,c")
-    assert(actual === List("a", "b", "c"))
+    assertEquals(actual, List("a", "b", "c"))
   }
 
   test("splitAndTrim should ignore empty strings") {
     val actual = Interpreter.splitAndTrim(", ,\t,\n\n,")
-    assert(actual === Nil)
+    assertEquals(actual, Nil)
   }
 }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/VocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/VocabularySuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.core.stacklang
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class VocabularySuite extends AnyFunSuite {
+class VocabularySuite extends FunSuite {
   import com.netflix.atlas.core.stacklang.VocabularySuite._
 
   test("toMarkdown") {
@@ -79,7 +79,7 @@ class VocabularySuite extends AnyFunSuite {
         |IllegalStateException: no matches for word ':dup' with stack [], candidates: [a -- a a]
         |```
       """.stripMargin.trim
-    assert(TestVocabulary.toMarkdown === expected)
+    assertEquals(TestVocabulary.toMarkdown, expected)
   }
 
   test("toMarkdown standard") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/ArrayHelperSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/ArrayHelperSuite.scala
@@ -15,122 +15,122 @@
  */
 package com.netflix.atlas.core.util
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import java.util.UUID
 
-class ArrayHelperSuite extends AnyFunSuite {
+class ArrayHelperSuite extends FunSuite {
 
   test("merge arrays, limit 1: empty, one") {
     val v1 = Array.empty[String]
     val v2 = Array("a")
     val actual = ArrayHelper.merger[String](1).merge(v1).merge(v2).toArray
-    assert(actual === Array("a"))
+    assertEquals(actual.toSeq, Array("a").toSeq)
   }
 
   test("merge arrays, limit 1: empty, abcde") {
     val v1 = Array.empty[String]
     val v2 = Array("a", "b", "c", "d", "e")
     val actual = ArrayHelper.merger[String](1).merge(v1).merge(v2).toArray
-    assert(actual === Array("a"))
+    assertEquals(actual.toSeq, Array("a").toSeq)
   }
 
   test("merge arrays, limit 1: abcde, empty") {
     val v1 = Array("a", "b", "c", "d", "e")
     val v2 = Array.empty[String]
     val actual = ArrayHelper.merger[String](1).merge(v1).merge(v2).toArray
-    assert(actual === Array("a"))
+    assertEquals(actual.toSeq, Array("a").toSeq)
   }
 
   test("merge arrays, limit 1: b, a") {
     val v1 = Array("b")
     val v2 = Array("a")
     val actual = ArrayHelper.merger[String](1).merge(v1).merge(v2).toArray
-    assert(actual === Array("a"))
+    assertEquals(actual.toSeq, Array("a").toSeq)
   }
 
   test("merge arrays, limit 1: a, b") {
     val v1 = Array("a")
     val v2 = Array("b")
     val actual = ArrayHelper.merger[String](1).merge(v1).merge(v2).toArray
-    assert(actual === Array("a"))
+    assertEquals(actual.toSeq, Array("a").toSeq)
   }
 
   test("merge arrays, limit 2: b, a") {
     val v1 = Array("b")
     val v2 = Array("a")
     val actual = ArrayHelper.merger[String](2).merge(v1).merge(v2).toArray
-    assert(actual === Array("a", "b"))
+    assertEquals(actual.toSeq, Array("a", "b").toSeq)
   }
 
   test("merge arrays, limit 2: ab, a") {
     val v1 = Array("a", "b")
     val v2 = Array("a")
     val actual = ArrayHelper.merger[String](2).merge(v1).merge(v2).toArray
-    assert(actual === Array("a", "b"))
+    assertEquals(actual.toSeq, Array("a", "b").toSeq)
   }
 
   test("merge arrays, limit 2: bc, ad") {
     val v1 = Array("b", "c")
     val v2 = Array("a", "d")
     val actual = ArrayHelper.merger[String](2).merge(v1).merge(v2).toArray
-    assert(actual === Array("a", "b"))
+    assertEquals(actual.toSeq, Array("a", "b").toSeq)
   }
 
   test("merge list, limit 1: empty, one") {
     val v1 = List.empty[String]
     val v2 = List("a")
     val actual = ArrayHelper.merger[String](1).merge(v1).merge(v2).toList
-    assert(actual === List("a"))
+    assertEquals(actual, List("a"))
   }
 
   test("merge list, limit 1: empty, abcde") {
     val v1 = List.empty[String]
     val v2 = List("a", "b", "c", "d", "e")
     val actual = ArrayHelper.merger[String](1).merge(v1).merge(v2).toList
-    assert(actual === List("a"))
+    assertEquals(actual, List("a"))
   }
 
   test("merge list, limit 1: abcde, empty") {
     val v1 = List("a", "b", "c", "d", "e")
     val v2 = List.empty[String]
     val actual = ArrayHelper.merger[String](1).merge(v1).merge(v2).toList
-    assert(actual === List("a"))
+    assertEquals(actual, List("a"))
   }
 
   test("merge list, limit 1: b, a") {
     val v1 = List("b")
     val v2 = List("a")
     val actual = ArrayHelper.merger[String](1).merge(v1).merge(v2).toList
-    assert(actual === List("a"))
+    assertEquals(actual, List("a"))
   }
 
   test("merge list, limit 1: a, b") {
     val v1 = List("a")
     val v2 = List("b")
     val actual = ArrayHelper.merger[String](1).merge(v1).merge(v2).toList
-    assert(actual === List("a"))
+    assertEquals(actual, List("a"))
   }
 
   test("merge list, limit 2: b, a") {
     val v1 = List("b")
     val v2 = List("a")
     val actual = ArrayHelper.merger[String](2).merge(v1).merge(v2).toList
-    assert(actual === List("a", "b"))
+    assertEquals(actual, List("a", "b"))
   }
 
   test("merge list, limit 2: ab, a") {
     val v1 = List("a", "b")
     val v2 = List("a")
     val actual = ArrayHelper.merger[String](2).merge(v1).merge(v2).toList
-    assert(actual === List("a", "b"))
+    assertEquals(actual, List("a", "b"))
   }
 
   test("merge list, limit 2: bc, ad") {
     val v1 = List("b", "c")
     val v2 = List("a", "d")
     val actual = ArrayHelper.merger[String](2).merge(v1).merge(v2).toList
-    assert(actual === List("a", "b"))
+    assertEquals(actual, List("a", "b"))
   }
 
   test("sortPairs, empty") {
@@ -142,14 +142,14 @@ class ArrayHelperSuite extends AnyFunSuite {
     val data = Array("b", "1")
     ArrayHelper.sortPairs(data)
     val expected = Array("b", "1")
-    assert(expected.toList === data.toList)
+    assertEquals(expected.toList, data.toList)
   }
 
   test("sortPairs, two pairs") {
     val data = Array("b", "1", "a", "2")
     ArrayHelper.sortPairs(data)
     val expected = Array("a", "2", "b", "1")
-    assert(expected.toList === data.toList)
+    assertEquals(expected.toList, data.toList)
   }
 
   test("sortPairs, random") {
@@ -157,6 +157,6 @@ class ArrayHelperSuite extends AnyFunSuite {
     val data = input.flatMap(t => List(t._1, t._2)).toArray
     ArrayHelper.sortPairs(data)
     val expected = input.toList.sortWith(_._1 < _._1).flatMap(t => List(t._1, t._2))
-    assert(expected === data.toList)
+    assertEquals(expected, data.toList)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/BoundedPriorityBufferSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/BoundedPriorityBufferSuite.scala
@@ -15,16 +15,20 @@
  */
 package com.netflix.atlas.core.util
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import java.util.Comparator
 
-class BoundedPriorityBufferSuite extends AnyFunSuite {
+class BoundedPriorityBufferSuite extends FunSuite {
+
+  private def set(vs: Seq[Int]): Set[Integer] = {
+    vs.map(Integer.valueOf).toSet
+  }
 
   test("buffer is bounded, natural order") {
     val buffer = new BoundedPriorityBuffer[Integer](5, Comparator.naturalOrder[Integer]())
     (0 until 10).foreach(v => buffer.add(v))
-    assert(buffer.toList.toSet === (0 until 5).toSet)
+    assertEquals(buffer.toList.toSet, set(0 until 5))
     assert(buffer.size == 5)
   }
 
@@ -32,7 +36,7 @@ class BoundedPriorityBufferSuite extends AnyFunSuite {
     val cmp = Comparator.naturalOrder[Integer]().reversed()
     val buffer = new BoundedPriorityBuffer[Integer](5, cmp)
     (0 until 10).foreach(v => buffer.add(v))
-    assert(buffer.toList.toSet === (5 until 10).toSet)
+    assertEquals(buffer.toList.toSet, set(5 until 10))
     assert(buffer.size == 5)
   }
 
@@ -40,7 +44,7 @@ class BoundedPriorityBufferSuite extends AnyFunSuite {
     val cmp: Comparator[(Integer, Integer)] = (a, b) => Integer.compare(a._1, b._1)
     val buffer = new BoundedPriorityBuffer[(Integer, Integer)](5, cmp)
     (0 until 10).foreach(v => buffer.add(1.asInstanceOf[Integer] -> (9 - v).asInstanceOf[Integer]))
-    assert(buffer.toList.map(_._2).toSet === (5 until 10).toSet)
+    assertEquals(buffer.toList.map(_._2).toSet, set(5 until 10))
   }
 
   test("foreach") {
@@ -48,7 +52,7 @@ class BoundedPriorityBufferSuite extends AnyFunSuite {
     (0 until 10).foreach(v => buffer.add(v))
     val builder = Set.newBuilder[Integer]
     buffer.foreach(v => builder += v)
-    assert(builder.result() === Set(0, 1, 2))
+    assertEquals(builder.result(), set(Seq(0, 1, 2)))
   }
 
   test("max size of 0") {
@@ -65,10 +69,10 @@ class BoundedPriorityBufferSuite extends AnyFunSuite {
 
   test("ejected value") {
     val buffer = new BoundedPriorityBuffer[Integer](2, Comparator.naturalOrder[Integer]())
-    assert(buffer.add(2) === null)
-    assert(buffer.add(3) === null)
-    assert(buffer.add(1) === 3)
-    assert(buffer.add(4) === 4)
-    assert(buffer.add(0) === 2)
+    assertEquals(buffer.add(2), null)
+    assertEquals(buffer.add(3), null)
+    assertEquals(buffer.add(1).intValue(), 3)
+    assertEquals(buffer.add(4).intValue(), 4)
+    assertEquals(buffer.add(0).intValue(), 2)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/ByteBufferInputStreamSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/ByteBufferInputStreamSuite.scala
@@ -15,13 +15,13 @@
  */
 package com.netflix.atlas.core.util
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import scala.util.Using
 
-class ByteBufferInputStreamSuite extends AnyFunSuite {
+class ByteBufferInputStreamSuite extends FunSuite {
 
   private def wrap(str: String): ByteBuffer = {
     ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_8))
@@ -30,66 +30,66 @@ class ByteBufferInputStreamSuite extends AnyFunSuite {
   test("read()") {
     val buffer = wrap("abc")
     val in = new ByteBufferInputStream(buffer)
-    assert(in.read() === 'a')
-    assert(in.read() === 'b')
-    assert(in.read() === 'c')
-    assert(in.read() === -1)
+    assertEquals(in.read(), 'a'.toInt)
+    assertEquals(in.read(), 'b'.toInt)
+    assertEquals(in.read(), 'c'.toInt)
+    assertEquals(in.read(), -1)
   }
 
   test("read(buf)") {
     val buffer = wrap("abc")
     val in = new ByteBufferInputStream(buffer)
     val array = new Array[Byte](2)
-    assert(in.read(array) === 2)
-    assert(array === Array('a', 'b'))
-    assert(in.read(array) === 1)
-    assert(array === Array('c', 'b')) // b left over from previous
-    assert(in.read(array) === -1)
+    assertEquals(in.read(array), 2)
+    assertEquals(array.toSeq, Array[Byte]('a', 'b').toSeq)
+    assertEquals(in.read(array), 1)
+    assertEquals(array.toSeq, Array[Byte]('c', 'b').toSeq) // b left over from previous
+    assertEquals(in.read(array), -1)
   }
 
   test("read(buf, offset, length)") {
     val buffer = wrap("abc")
     val in = new ByteBufferInputStream(buffer)
     val array = new Array[Byte](5)
-    assert(in.read(array, 2, 3) === 3)
-    assert(array === Array('\u0000', '\u0000', 'a', 'b', 'c'))
-    assert(in.read(array) === -1)
+    assertEquals(in.read(array, 2, 3), 3)
+    assertEquals(array.toSeq, Array[Byte]('\u0000', '\u0000', 'a', 'b', 'c').toSeq)
+    assertEquals(in.read(array), -1)
   }
 
   test("available()") {
     val buffer = wrap("abc")
     val in = new ByteBufferInputStream(buffer)
-    assert(in.available() === 3)
-    assert(in.skip(2) === 2)
-    assert(in.available() === 1)
-    assert(in.read() === 'c')
-    assert(in.available() === 0)
+    assertEquals(in.available(), 3)
+    assertEquals(in.skip(2), 2L)
+    assertEquals(in.available(), 1)
+    assertEquals(in.read(), 'c'.toInt)
+    assertEquals(in.available(), 0)
   }
 
   test("skip()") {
     val buffer = wrap("abc")
     val in = new ByteBufferInputStream(buffer)
-    assert(in.skip(2) === 2)
-    assert(in.read() === 'c')
-    assert(in.read() === -1)
-    assert(in.skip(2) === 0)
+    assertEquals(in.skip(2), 2L)
+    assertEquals(in.read(), 'c'.toInt)
+    assertEquals(in.read(), -1)
+    assertEquals(in.skip(2), 0L)
   }
 
   test("mark() and reset()") {
     val buffer = wrap("abc")
     val in = new ByteBufferInputStream(buffer)
     assert(in.markSupported())
-    assert(in.read() === 'a')
+    assertEquals(in.read(), 'a'.toInt)
 
     in.mark(5)
-    assert(in.read() === 'b')
-    assert(in.read() === 'c')
+    assertEquals(in.read(), 'b'.toInt)
+    assertEquals(in.read(), 'c'.toInt)
 
     in.reset()
-    assert(in.read() === 'b')
+    assertEquals(in.read(), 'b'.toInt)
 
     in.reset()
-    assert(in.read() === 'b')
+    assertEquals(in.read(), 'b'.toInt)
   }
 
   test("close()") {
@@ -97,9 +97,9 @@ class ByteBufferInputStreamSuite extends AnyFunSuite {
     val in = new ByteBufferInputStream(buffer)
     (0 until 10).foreach { _ =>
       Using.resource(in) { r =>
-        assert(r.read() === 'a')
+        assertEquals(r.read(), 'a'.toInt)
         r.skip(100)
-        assert(r.read() === -1)
+        assertEquals(r.read(), -1)
       }
     }
   }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/CardinalityEstimatorSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/CardinalityEstimatorSuite.scala
@@ -15,11 +15,11 @@
  */
 package com.netflix.atlas.core.util
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.util.Using
 
-class CardinalityEstimatorSuite extends AnyFunSuite {
+class CardinalityEstimatorSuite extends FunSuite {
 
   private def check(estimator: CardinalityEstimator, values: Seq[String]): Unit = {
     var errorSum = 0.0

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/CharBufferReaderSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/CharBufferReaderSuite.scala
@@ -15,40 +15,40 @@
  */
 package com.netflix.atlas.core.util
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import java.nio.CharBuffer
 import scala.util.Using
 
-class CharBufferReaderSuite extends AnyFunSuite {
+class CharBufferReaderSuite extends FunSuite {
 
   test("read()") {
     val buffer = CharBuffer.wrap("abc")
     val reader = new CharBufferReader(buffer)
-    assert(reader.read() === 'a')
-    assert(reader.read() === 'b')
-    assert(reader.read() === 'c')
-    assert(reader.read() === -1)
+    assertEquals(reader.read(), 'a'.toInt)
+    assertEquals(reader.read(), 'b'.toInt)
+    assertEquals(reader.read(), 'c'.toInt)
+    assertEquals(reader.read(), -1)
   }
 
   test("read(cbuf)") {
     val buffer = CharBuffer.wrap("abc")
     val reader = new CharBufferReader(buffer)
     val array = new Array[Char](2)
-    assert(reader.read(array) === 2)
-    assert(array === Array('a', 'b'))
-    assert(reader.read(array) === 1)
-    assert(array === Array('c', 'b')) // b left over from previous
-    assert(reader.read(array) === -1)
+    assertEquals(reader.read(array), 2)
+    assertEquals(array.toSeq, Array('a', 'b').toSeq)
+    assertEquals(reader.read(array), 1)
+    assertEquals(array.toSeq, Array('c', 'b').toSeq) // b left over from previous
+    assertEquals(reader.read(array), -1)
   }
 
   test("read(cbuf, offset, length)") {
     val buffer = CharBuffer.wrap("abc")
     val reader = new CharBufferReader(buffer)
     val array = new Array[Char](5)
-    assert(reader.read(array, 2, 3) === 3)
-    assert(array === Array('\u0000', '\u0000', 'a', 'b', 'c'))
-    assert(reader.read(array) === -1)
+    assertEquals(reader.read(array, 2, 3), 3)
+    assertEquals(array.toSeq, Array('\u0000', '\u0000', 'a', 'b', 'c').toSeq)
+    assertEquals(reader.read(array), -1)
   }
 
   test("ready()") {
@@ -60,27 +60,27 @@ class CharBufferReaderSuite extends AnyFunSuite {
   test("skip()") {
     val buffer = CharBuffer.wrap("abc")
     val reader = new CharBufferReader(buffer)
-    assert(reader.skip(2) === 2)
-    assert(reader.read() === 'c')
-    assert(reader.read() === -1)
-    assert(reader.skip(2) === 0)
+    assertEquals(reader.skip(2), 2L)
+    assertEquals(reader.read(), 'c'.toInt)
+    assertEquals(reader.read(), -1)
+    assertEquals(reader.skip(2), 0L)
   }
 
   test("mark() and reset()") {
     val buffer = CharBuffer.wrap("abc")
     val reader = new CharBufferReader(buffer)
     assert(reader.markSupported())
-    assert(reader.read() === 'a')
+    assertEquals(reader.read(), 'a'.toInt)
 
     reader.mark(5)
-    assert(reader.read() === 'b')
-    assert(reader.read() === 'c')
+    assertEquals(reader.read(), 'b'.toInt)
+    assertEquals(reader.read(), 'c'.toInt)
 
     reader.reset()
-    assert(reader.read() === 'b')
+    assertEquals(reader.read(), 'b'.toInt)
 
     reader.reset()
-    assert(reader.read() === 'b')
+    assertEquals(reader.read(), 'b'.toInt)
   }
 
   test("close()") {
@@ -88,9 +88,9 @@ class CharBufferReaderSuite extends AnyFunSuite {
     val reader = new CharBufferReader(buffer)
     (0 until 10).foreach { _ =>
       Using.resource(reader) { r =>
-        assert(r.read() === 'a')
+        assertEquals(r.read(), 'a'.toInt)
         r.skip(100)
-        assert(r.read() === -1)
+        assertEquals(r.read(), -1)
       }
     }
   }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/DoubleIntHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/DoubleIntHashMapSuite.scala
@@ -17,65 +17,65 @@ package com.netflix.atlas.core.util
 
 import org.openjdk.jol.info.ClassLayout
 import org.openjdk.jol.info.GraphLayout
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.util.Random
 
-class DoubleIntHashMapSuite extends AnyFunSuite {
+class DoubleIntHashMapSuite extends FunSuite {
 
   test("put") {
     val m = new DoubleIntHashMap
-    assert(0 === m.size)
+    assertEquals(0, m.size)
     m.put(11.0, 42)
-    assert(1 === m.size)
-    assert(Map(11.0 -> 42) === m.toMap)
+    assertEquals(1, m.size)
+    assertEquals(Map(11.0 -> 42), m.toMap)
   }
 
   test("get") {
     val m = new DoubleIntHashMap
-    assert(m.get(42.0, -1) === -1)
+    assertEquals(m.get(42.0, -1), -1)
     m.put(11.0, 27)
-    assert(m.get(42.0, -1) === -1)
-    assert(m.get(11.0, -1) === 27)
+    assertEquals(m.get(42.0, -1), -1)
+    assertEquals(m.get(11.0, -1), 27)
   }
 
   test("dedup") {
     val m = new DoubleIntHashMap
     m.put(42.0, 1)
-    assert(Map(42.0 -> 1) === m.toMap)
-    assert(1 === m.size)
+    assertEquals(Map(42.0 -> 1), m.toMap)
+    assertEquals(1, m.size)
     m.put(42.0, 2)
-    assert(Map(42.0 -> 2) === m.toMap)
-    assert(1 === m.size)
+    assertEquals(Map(42.0 -> 2), m.toMap)
+    assertEquals(1, m.size)
   }
 
   test("increment") {
     val m = new DoubleIntHashMap
-    assert(0 === m.size)
+    assertEquals(0, m.size)
 
     m.increment(42.0)
-    assert(1 === m.size)
-    assert(Map(42.0 -> 1) === m.toMap)
+    assertEquals(1, m.size)
+    assertEquals(Map(42.0 -> 1), m.toMap)
 
     m.increment(42.0)
-    assert(1 === m.size)
-    assert(Map(42.0 -> 2) === m.toMap)
+    assertEquals(1, m.size)
+    assertEquals(Map(42.0 -> 2), m.toMap)
 
     m.increment(42.0, 7)
-    assert(1 === m.size)
-    assert(Map(42.0 -> 9) === m.toMap)
+    assertEquals(1, m.size)
+    assertEquals(Map(42.0 -> 9), m.toMap)
   }
 
   test("resize") {
     val m = new DoubleIntHashMap
     (0 until 10000).foreach(i => m.put(i, i))
-    assert((0 until 10000).map(i => i -> i).toMap === m.toMap)
+    assertEquals((0 until 10000).map(i => i.toDouble -> i).toMap, m.toMap)
   }
 
   test("resize - increment") {
     val m = new DoubleIntHashMap
     (0 until 10000).foreach(i => m.increment(i, i))
-    assert((0 until 10000).map(i => i -> i).toMap === m.toMap)
+    assertEquals((0 until 10000).map(i => i.toDouble -> i).toMap, m.toMap)
   }
 
   test("random") {
@@ -86,14 +86,14 @@ class DoubleIntHashMapSuite extends AnyFunSuite {
       imap.put(v, i)
       jmap.put(v, i)
     }
-    assert(jmap.toMap === imap.toMap)
-    assert(jmap.size === imap.size)
+    assertEquals(jmap.toMap, imap.toMap)
+    assertEquals(jmap.size, imap.size)
   }
 
   test("memory per map") {
     // Sanity check to verify if some change introduces more overhead per set
     val bytes = ClassLayout.parseClass(classOf[DoubleIntHashMap]).instanceSize()
-    assert(bytes === 16)
+    assertEquals(bytes, 16L)
   }
 
   test("memory - 5 items") {
@@ -111,7 +111,7 @@ class DoubleIntHashMapSuite extends AnyFunSuite {
     //println(jgraph.toFootprint)
 
     // Only objects should be the key/value arrays and the map itself
-    assert(igraph.totalCount() === 4)
+    assertEquals(igraph.totalCount(), 4L)
 
     // Sanity check size is < 300 bytes
     assert(igraph.totalSize() <= 300)
@@ -132,7 +132,7 @@ class DoubleIntHashMapSuite extends AnyFunSuite {
     //println(jgraph.toFootprint)
 
     // Only objects should be the key/value arrays and the map itself
-    assert(igraph.totalCount() === 4)
+    assertEquals(igraph.totalCount(), 4L)
 
     // Sanity check size is < 320kb
     assert(igraph.totalSize() <= 320000)
@@ -148,7 +148,7 @@ class DoubleIntHashMapSuite extends AnyFunSuite {
     // scala> math.abs(java.lang.Long.hashCode(java.lang.Double.doubleToLongBits(0.4182373879985505)))
     // res11: Int = -2147483648
     val m = new DoubleIntHashMap
-    assert(m.get(0.778945326637231, 0) === 0)
+    assertEquals(m.get(0.778945326637231, 0), 0)
   }
 
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/HashSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/HashSuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.core.util
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class HashSuite extends AnyFunSuite {
+class HashSuite extends FunSuite {
 
   test("md5") {
     assert(Hash.md5("42").toString(10) == "215089739385482443301854222253501995174")
@@ -30,6 +30,6 @@ class HashSuite extends AnyFunSuite {
   test("sha1bytes zeroPad") {
     val expected = Strings.zeroPad(Hash.sha1("42"), 40)
     val actual = Strings.zeroPad(Hash.sha1bytes("42"), 40)
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/IdMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/IdMapSuite.scala
@@ -16,31 +16,31 @@
 package com.netflix.atlas.core.util
 
 import com.netflix.spectator.api.Id
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class IdMapSuite extends AnyFunSuite {
+class IdMapSuite extends FunSuite {
 
   test("basic map") {
-    assert(IdMap(Id.create("foo")) === Map("name" -> "foo"))
+    assertEquals(Map("name" -> "foo"), IdMap(Id.create("foo")))
   }
 
   test("removed") {
     val id = Id.create("foo").withTags("a", "1", "b", "2")
-    assert(IdMap(id).removed("name") === Map("a" -> "1", "b"   -> "2"))
-    assert(IdMap(id).removed("a") === Map("name" -> "foo", "b" -> "2"))
+    assertEquals(IdMap(id).removed("name"), Map("a" -> "1", "b"   -> "2"))
+    assertEquals(IdMap(id).removed("a"), Map("name" -> "foo", "b" -> "2"))
   }
 
   test("updated") {
     val id = Id.create("foo").withTags("a", "1")
-    assert(IdMap(id).updated("b", "2") === Map("name" -> "foo", "a" -> "1", "b" -> "2"))
+    assertEquals(IdMap(id).updated("b", "2"), Map("name" -> "foo", "a" -> "1", "b" -> "2"))
   }
 
   test("get") {
     val id = Id.create("foo").withTags("a", "1", "b", "2")
-    assert(IdMap(id).get("name") === Some("foo"))
-    assert(IdMap(id).get("a") === Some("1"))
-    assert(IdMap(id).get("b") === Some("2"))
-    assert(IdMap(id).get("c") === None)
+    assertEquals(IdMap(id).get("name"), Some("foo"))
+    assertEquals(IdMap(id).get("a"), Some("1"))
+    assertEquals(IdMap(id).get("b"), Some("2"))
+    assertEquals(IdMap(id).get("c"), None)
   }
 
   test("iterator") {
@@ -50,7 +50,7 @@ class IdMapSuite extends AnyFunSuite {
       "a"    -> "1",
       "b"    -> "2"
     )
-    assert(IdMap(id).iterator.toList === expected)
+    assertEquals(IdMap(id).iterator.toList, expected)
   }
 
   test("foreachEntry") {
@@ -65,6 +65,6 @@ class IdMapSuite extends AnyFunSuite {
       "a"    -> "1",
       "b"    -> "2"
     )
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/IdentityMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/IdentityMapSuite.scala
@@ -15,29 +15,29 @@
  */
 package com.netflix.atlas.core.util
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class IdentityMapSuite extends AnyFunSuite {
+class IdentityMapSuite extends FunSuite {
 
   test("add") {
     val m = IdentityMap.empty[String, Int] + ("a" -> 42)
-    assert(m.get("a") === Some(42))
+    assertEquals(m.get("a"), Some(42))
   }
 
   test("remove") {
     val m = IdentityMap(Map("a" -> 42)) - "a"
-    assert(m.get("a") === None)
+    assertEquals(m.get("a"), None)
   }
 
   test("overwrite") {
     val m = IdentityMap(Map("a" -> 42)) + ("a" -> 2)
-    assert(m.get("a") === Some(2))
+    assertEquals(m.get("a"), Some(2))
   }
 
   test("iterate") {
     val m = IdentityMap(new String("a") -> 2, new String("a") -> 1, "b" -> 3)
     val values = m.iterator.map(_._2).toSet
-    assert(values === Set(1, 2, 3))
+    assertEquals(values, Set(1, 2, 3))
   }
 
   test("foreachEntry") {
@@ -63,14 +63,14 @@ class IdentityMapSuite extends AnyFunSuite {
 
   test("uses reference equality") {
     val m = IdentityMap.empty[String, Int] + ("a" -> 42)
-    assert(m.get(new String("a")) === None)
+    assertEquals(m.get(new String("a")), None)
   }
 
   test("++ preserves map type") {
     val m1 = IdentityMap(new String("a") -> 1)
     val m2 = IdentityMap(new String("a") -> 2)
     val m3 = m1 ++ m2
-    assert(m3.size === 2)
-    assert(m3.values.toSet === Set(1, 2))
+    assertEquals(m3.size, 2)
+    assertEquals(m3.values.toSet, Set(1, 2))
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntHashSetSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntHashSetSuite.scala
@@ -17,34 +17,34 @@ package com.netflix.atlas.core.util
 
 import org.openjdk.jol.info.ClassLayout
 import org.openjdk.jol.info.GraphLayout
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.util.Random
 
-class IntHashSetSuite extends AnyFunSuite {
+class IntHashSetSuite extends FunSuite {
 
   test("add") {
     val s = new IntHashSet(-1, 10)
     s.add(11)
-    assert(List(11) === s.toList)
-    assert(1 === s.size)
+    assertEquals(List(11), s.toList)
+    assertEquals(1, s.size)
   }
 
   test("dedup") {
     val s = new IntHashSet(-1, 10)
     s.add(42)
-    assert(List(42) === s.toList)
-    assert(1 === s.size)
+    assertEquals(List(42), s.toList)
+    assertEquals(1, s.size)
     s.add(42)
-    assert(List(42) === s.toList)
-    assert(1 === s.size)
+    assertEquals(List(42), s.toList)
+    assertEquals(1, s.size)
   }
 
   test("resize") {
     val s = new IntHashSet(-1, 10)
     (0 until 10000).foreach(s.add)
-    assert((0 until 10000).toSet === s.toList.toSet)
-    assert(s.size === 10000)
+    assertEquals((0 until 10000).toSet, s.toList.toSet)
+    assertEquals(s.size, 10000)
   }
 
   test("random") {
@@ -55,7 +55,7 @@ class IntHashSetSuite extends AnyFunSuite {
       iset.add(v)
       jset.add(v)
     }
-    assert(jset.toSet === iset.toList.toSet)
+    assertEquals(jset.toSet, iset.toList.toSet)
   }
 
   private def arrayCompare(a1: Array[Int], a2: Array[Int]): Unit = {
@@ -63,7 +63,7 @@ class IntHashSetSuite extends AnyFunSuite {
     // Need to sort as traversal order could be different when generating the arrays
     java.util.Arrays.sort(a1)
     java.util.Arrays.sort(a2)
-    assert(a1 === a2)
+    assertEquals(a1.toSeq, a2.toSeq)
   }
 
   test("toArray") {
@@ -80,7 +80,7 @@ class IntHashSetSuite extends AnyFunSuite {
   test("memory per set") {
     // Sanity check to verify if some change introduces more overhead per set
     val bytes = ClassLayout.parseClass(classOf[IntHashSet]).instanceSize()
-    assert(bytes === 32)
+    assertEquals(bytes, 32L)
   }
 
   test("memory - 5 items") {
@@ -98,7 +98,7 @@ class IntHashSetSuite extends AnyFunSuite {
     //println(jgraph.toFootprint)
 
     // Only objects should be the array and the set itself
-    assert(igraph.totalCount() === 2)
+    assertEquals(igraph.totalCount(), 2L)
 
     // Sanity check size is < 100 bytes
     assert(igraph.totalSize() <= 100)
@@ -119,7 +119,7 @@ class IntHashSetSuite extends AnyFunSuite {
     //println(jgraph.toFootprint)
 
     // Only objects should be the array and the set itself
-    assert(igraph.totalCount() === 2)
+    assertEquals(igraph.totalCount(), 2L)
 
     // Sanity check size is < 110kb
     assert(igraph.totalSize() <= 110000)

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntIntHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntIntHashMapSuite.scala
@@ -17,26 +17,26 @@ package com.netflix.atlas.core.util
 
 import org.openjdk.jol.info.ClassLayout
 import org.openjdk.jol.info.GraphLayout
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.util.Random
 
-class IntIntHashMapSuite extends AnyFunSuite {
+class IntIntHashMapSuite extends FunSuite {
 
   test("put") {
     val m = new IntIntHashMap(-1)
-    assert(0 === m.size)
+    assertEquals(0, m.size)
     m.put(11, 42)
-    assert(1 === m.size)
-    assert(Map(11 -> 42) === m.toMap)
+    assertEquals(1, m.size)
+    assertEquals(Map(11 -> 42), m.toMap)
   }
 
   test("get") {
     val m = new IntIntHashMap(-1)
-    assert(m.get(42, -1) === -1)
+    assertEquals(m.get(42, -1), -1)
     m.put(11, 27)
-    assert(m.get(42, -1) === -1)
-    assert(m.get(11, -1) === 27)
+    assertEquals(m.get(42, -1), -1)
+    assertEquals(m.get(11, -1), 27)
   }
 
   test("get - collisions") {
@@ -46,43 +46,43 @@ class IntIntHashMapSuite extends AnyFunSuite {
     m.put(0, 0)
     m.put(11, 1)
     m.put(22, 2)
-    assert(m.size === 3)
-    assert(m.get(0, -1) === 0)
-    assert(m.get(11, -1) === 1)
-    assert(m.get(22, -1) === 2)
+    assertEquals(m.size, 3)
+    assertEquals(m.get(0, -1), 0)
+    assertEquals(m.get(11, -1), 1)
+    assertEquals(m.get(22, -1), 2)
   }
 
   test("dedup") {
     val m = new IntIntHashMap(-1)
     m.put(42, 1)
-    assert(Map(42 -> 1) === m.toMap)
-    assert(1 === m.size)
+    assertEquals(Map(42 -> 1), m.toMap)
+    assertEquals(1, m.size)
     m.put(42, 2)
-    assert(Map(42 -> 2) === m.toMap)
-    assert(1 === m.size)
+    assertEquals(Map(42 -> 2), m.toMap)
+    assertEquals(1, m.size)
   }
 
   test("increment") {
     val m = new IntIntHashMap(-1)
-    assert(0 === m.size)
+    assertEquals(0, m.size)
 
     m.increment(42)
-    assert(1 === m.size)
-    assert(Map(42 -> 1) === m.toMap)
+    assertEquals(1, m.size)
+    assertEquals(Map(42 -> 1), m.toMap)
 
     m.increment(42)
-    assert(1 === m.size)
-    assert(Map(42 -> 2) === m.toMap)
+    assertEquals(1, m.size)
+    assertEquals(Map(42 -> 2), m.toMap)
 
     m.increment(42, 7)
-    assert(1 === m.size)
-    assert(Map(42 -> 9) === m.toMap)
+    assertEquals(1, m.size)
+    assertEquals(Map(42 -> 9), m.toMap)
   }
 
   test("resize") {
     val m = new IntIntHashMap(-1, 10)
     (0 until 10000).foreach(i => m.put(i, i))
-    assert((0 until 10000).map(i => i -> i).toMap === m.toMap)
+    assertEquals((0 until 10000).map(i => i -> i).toMap, m.toMap)
   }
 
   test("random") {
@@ -93,14 +93,14 @@ class IntIntHashMapSuite extends AnyFunSuite {
       imap.put(v, i)
       jmap.put(v, i)
     }
-    assert(jmap.toMap === imap.toMap)
-    assert(jmap.size === imap.size)
+    assertEquals(jmap.toMap, imap.toMap)
+    assertEquals(jmap.size, imap.size)
   }
 
   test("memory per map") {
     // Sanity check to verify if some change introduces more overhead per set
     val bytes = ClassLayout.parseClass(classOf[IntIntHashMap]).instanceSize()
-    assert(bytes === 32)
+    assertEquals(bytes, 32L)
   }
 
   test("memory - 5 items") {
@@ -118,7 +118,7 @@ class IntIntHashMapSuite extends AnyFunSuite {
     //println(jgraph.toFootprint)
 
     // Only objects should be the key/value arrays and the map itself
-    assert(igraph.totalCount() === 3)
+    assertEquals(igraph.totalCount(), 3L)
 
     // Sanity check size is < 200 bytes
     assert(igraph.totalSize() <= 200)
@@ -139,7 +139,7 @@ class IntIntHashMapSuite extends AnyFunSuite {
     //println(jgraph.toFootprint)
 
     // Only objects should be the key/value arrays and the map itself
-    assert(igraph.totalCount() === 3)
+    assertEquals(igraph.totalCount(), 3L)
 
     // Sanity check size is < 220kb
     assert(igraph.totalSize() <= 220000)
@@ -147,7 +147,7 @@ class IntIntHashMapSuite extends AnyFunSuite {
 
   test("negative absolute value") {
     val s = new IntIntHashMap(-1, 10)
-    assert(s.get(Integer.MIN_VALUE, 0) === 0)
+    assertEquals(s.get(Integer.MIN_VALUE, 0), 0)
   }
 
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntRefHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/IntRefHashMapSuite.scala
@@ -17,26 +17,26 @@ package com.netflix.atlas.core.util
 
 import org.openjdk.jol.info.ClassLayout
 import org.openjdk.jol.info.GraphLayout
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.util.Random
 
-class IntRefHashMapSuite extends AnyFunSuite {
+class IntRefHashMapSuite extends FunSuite {
 
   test("put") {
     val m = new IntRefHashMap[Integer](-1)
-    assert(0 === m.size)
+    assertEquals(0, m.size)
     m.put(11, 42)
-    assert(1 === m.size)
-    assert(Map(11 -> 42) === m.toMap)
+    assertEquals(1, m.size)
+    assertEquals(Map(11 -> Integer.valueOf(42)), m.toMap)
   }
 
   test("get") {
     val m = new IntRefHashMap[Integer](-1)
-    assert(m.get(42) === null)
+    assertEquals(m.get(42), null)
     m.put(11, 27)
-    assert(m.get(42) === null)
-    assert(m.get(11) === 27)
+    assertEquals(m.get(42), null)
+    assertEquals(m.get(11), Integer.valueOf(27))
   }
 
   test("get - collisions") {
@@ -46,44 +46,44 @@ class IntRefHashMapSuite extends AnyFunSuite {
     m.put(0, 0)
     m.put(11, 1)
     m.put(22, 2)
-    assert(m.size === 3)
-    assert(m.get(0) === 0)
-    assert(m.get(11) === 1)
-    assert(m.get(22) === 2)
+    assertEquals(m.size, 3)
+    assertEquals(m.get(0), Integer.valueOf(0))
+    assertEquals(m.get(11), Integer.valueOf(1))
+    assertEquals(m.get(22), Integer.valueOf(2))
   }
 
   test("dedup") {
     val m = new IntRefHashMap[Integer](-1)
     m.put(42, 1)
-    assert(Map(42 -> 1) === m.toMap)
-    assert(1 === m.size)
+    assertEquals(Map(42 -> Integer.valueOf(1)), m.toMap)
+    assertEquals(1, m.size)
     m.put(42, 2)
-    assert(Map(42 -> 2) === m.toMap)
-    assert(1 === m.size)
+    assertEquals(Map(42 -> Integer.valueOf(2)), m.toMap)
+    assertEquals(1, m.size)
   }
 
   test("resize") {
     val m = new IntRefHashMap[Integer](-1, 10)
     (0 until 10000).foreach(i => m.put(i, i))
-    assert((0 until 10000).map(i => i -> i).toMap === m.toMap)
+    assertEquals((0 until 10000).map(i => i -> Integer.valueOf(i)).toMap, m.toMap)
   }
 
   test("random") {
-    val jmap = new scala.collection.mutable.HashMap[Int, Int]
+    val jmap = new scala.collection.mutable.HashMap[Int, Integer]
     val imap = new IntRefHashMap[Integer](-1, 10)
     (0 until 10000).foreach { i =>
       val v = Random.nextInt()
       imap.put(v, i)
       jmap.put(v, i)
     }
-    assert(jmap.toMap === imap.toMap)
-    assert(jmap.size === imap.size)
+    assertEquals(jmap.toMap, imap.toMap)
+    assertEquals(jmap.size, imap.size)
   }
 
   test("memory per map") {
     // Sanity check to verify if some change introduces more overhead per set
     val bytes = ClassLayout.parseClass(classOf[IntRefHashMap[Integer]]).instanceSize()
-    assert(bytes === 32)
+    assertEquals(bytes, 32L)
   }
 
   test("memory - 5 items") {
@@ -101,7 +101,7 @@ class IntRefHashMapSuite extends AnyFunSuite {
     //println(jgraph.toFootprint)
 
     // Integer class creates a bunch of objects
-    assert(igraph.totalCount() === 8)
+    assertEquals(igraph.totalCount(), 8L)
 
     // Sanity check size is < 340, mostly for Integer static fields
     assert(igraph.totalSize() <= 340)
@@ -122,7 +122,7 @@ class IntRefHashMapSuite extends AnyFunSuite {
     //println(jgraph.toFootprint)
 
     // Around 10 or so for the Integer class + 10k for the values
-    assert(igraph.totalCount() === 10003)
+    assertEquals(igraph.totalCount(), 10003L)
 
     // Sanity check size is < 370kb
     assert(igraph.totalSize() <= 370e3)
@@ -130,7 +130,7 @@ class IntRefHashMapSuite extends AnyFunSuite {
 
   test("negative absolute value") {
     val s = new IntRefHashMap[Integer](-1, 10)
-    assert(s.get(Integer.MIN_VALUE) === null)
+    assertEquals(s.get(Integer.MIN_VALUE), null)
   }
 
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/InternMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/InternMapSuite.scala
@@ -16,9 +16,9 @@
 package com.netflix.atlas.core.util
 
 import com.netflix.spectator.api.ManualClock
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class InternMapSuite extends AnyFunSuite {
+class InternMapSuite extends FunSuite {
 
   test("open hash") {
     val i = new OpenHashInternMap[String](2)
@@ -26,8 +26,8 @@ class InternMapSuite extends AnyFunSuite {
     val s2 = new String("foo")
     assert(s1 ne s2)
     assert(i.intern(s1) eq i.intern(s2))
-    assert(i.size === 1)
-    assert(i.capacity === 3)
+    assertEquals(i.size, 1)
+    assertEquals(i.capacity, 3)
   }
 
   test("open hash resize") {
@@ -37,7 +37,7 @@ class InternMapSuite extends AnyFunSuite {
       val s2 = new String(s1)
       assert(s1 ne s2)
       assert(interner.intern(s1) eq interner.intern(s2))
-      assert(interner.size === i)
+      assertEquals(interner.size, i)
     }
   }
 
@@ -70,7 +70,7 @@ class InternMapSuite extends AnyFunSuite {
     val s2 = new String("foo")
     assert(s1 ne s2)
     assert(i.intern(s1) eq i.intern(s2))
-    assert(i.size === 1)
+    assertEquals(i.size, 1)
   }
 
   test("concurrent resize") {
@@ -80,7 +80,7 @@ class InternMapSuite extends AnyFunSuite {
       val s2 = new String(s1)
       assert(s1 ne s2)
       assert(interner.intern(s1) eq interner.intern(s2))
-      assert(interner.size === i)
+      assertEquals(interner.size, i)
     }
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/InternerSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/InternerSuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.core.util
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class InternerSuite extends AnyFunSuite {
+class InternerSuite extends FunSuite {
 
   test("noop") {
     val i = new NoopInterner[String]

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/IsoDateTimeParserSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/IsoDateTimeParserSuite.scala
@@ -20,9 +20,9 @@ import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class IsoDateTimeParserSuite extends AnyFunSuite {
+class IsoDateTimeParserSuite extends FunSuite {
 
   private val utcZones = List("Z", "+00", "+0000", "+000000", "+00:00", "+00:00:00")
 
@@ -31,14 +31,14 @@ class IsoDateTimeParserSuite extends AnyFunSuite {
   test("date") {
     val t = "2020-07-28"
     val expected = ZonedDateTime.parse(s"${t}T00:00:00Z")
-    assert(expected === IsoDateTimeParser.parse(t, ZoneOffset.UTC))
+    assertEquals(expected, IsoDateTimeParser.parse(t, ZoneOffset.UTC))
   }
 
   utcZones.foreach { zone =>
     test(s"date $zone") {
       val t = s"2020-07-28"
       val expected = ZonedDateTime.parse(s"${t}T00:00:00Z")
-      assert(expected === IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
+      assertEquals(expected, IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
     }
   }
 
@@ -48,7 +48,7 @@ class IsoDateTimeParserSuite extends AnyFunSuite {
         val t = s"2020-07-28"
         val z = if (zone.startsWith("-")) "-07:00:00" else "+07:00:00"
         val expected = ZonedDateTime.parse(s"${t}T00:00:00$z")
-        assert(expected === IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
+        assertEquals(expected, IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
       }
     }
   }
@@ -56,14 +56,14 @@ class IsoDateTimeParserSuite extends AnyFunSuite {
   test("date time hh:mm") {
     val t = "2020-07-28T21:07"
     val expected = ZonedDateTime.parse(s"$t:00Z")
-    assert(expected === IsoDateTimeParser.parse(t, ZoneOffset.UTC))
+    assertEquals(expected, IsoDateTimeParser.parse(t, ZoneOffset.UTC))
   }
 
   utcZones.foreach { zone =>
     test(s"date time hh:mm $zone") {
       val t = s"2020-07-28T21:07"
       val expected = ZonedDateTime.parse(s"$t:00Z")
-      assert(expected === IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
+      assertEquals(expected, IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
     }
   }
 
@@ -73,7 +73,7 @@ class IsoDateTimeParserSuite extends AnyFunSuite {
         val t = s"2020-07-28T21:07"
         val z = if (zone.startsWith("-")) "-07:00:00" else "+07:00:00"
         val expected = ZonedDateTime.parse(s"$t:00$z")
-        assert(expected === IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
+        assertEquals(expected, IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
       }
     }
   }
@@ -81,14 +81,14 @@ class IsoDateTimeParserSuite extends AnyFunSuite {
   test("date time hh:mm:ss") {
     val t = "2020-07-28T21:07:56"
     val expected = ZonedDateTime.parse(s"${t}Z")
-    assert(expected === IsoDateTimeParser.parse(t, ZoneOffset.UTC))
+    assertEquals(expected, IsoDateTimeParser.parse(t, ZoneOffset.UTC))
   }
 
   utcZones.foreach { zone =>
     test(s"date time hh:mm:ss $zone") {
       val t = s"2020-07-28T21:07:56"
       val expected = ZonedDateTime.parse(s"${t}Z")
-      assert(expected === IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
+      assertEquals(expected, IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
     }
   }
 
@@ -98,7 +98,7 @@ class IsoDateTimeParserSuite extends AnyFunSuite {
         val t = s"2020-07-28T21:07:56"
         val z = if (zone.startsWith("-")) "-07:00:00" else "+07:00:00"
         val expected = ZonedDateTime.parse(s"$t$z")
-        assert(expected === IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
+        assertEquals(expected, IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
       }
     }
   }
@@ -106,14 +106,14 @@ class IsoDateTimeParserSuite extends AnyFunSuite {
   test("date time hh:mm:ss.mmm") {
     val t = "2020-07-28T21:07:56.195"
     val expected = ZonedDateTime.parse(s"${t}Z")
-    assert(expected === IsoDateTimeParser.parse(t, ZoneOffset.UTC))
+    assertEquals(expected, IsoDateTimeParser.parse(t, ZoneOffset.UTC))
   }
 
   utcZones.foreach { zone =>
     test(s"date time hh:mm:ss.mmm $zone") {
       val t = s"2020-07-28T21:07:56.195"
       val expected = ZonedDateTime.parse(s"${t}Z")
-      assert(expected === IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
+      assertEquals(expected, IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
     }
   }
 
@@ -123,7 +123,7 @@ class IsoDateTimeParserSuite extends AnyFunSuite {
         val t = s"2020-07-28T21:07:56.195"
         val z = if (zone.startsWith("-")) "-07:00:00" else "+07:00:00"
         val expected = ZonedDateTime.parse(s"$t$z")
-        assert(expected === IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
+        assertEquals(expected, IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
       }
     }
   }
@@ -132,7 +132,7 @@ class IsoDateTimeParserSuite extends AnyFunSuite {
     val t = "2020-07-28"
     val zone = "+12:34:56"
     val expected = ZonedDateTime.parse(s"${t}T00:00:00$zone")
-    assert(expected === IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
+    assertEquals(expected, IsoDateTimeParser.parse(s"$t$zone", ZoneOffset.UTC))
   }
 
   test("date default US/Pacific") {
@@ -140,6 +140,6 @@ class IsoDateTimeParserSuite extends AnyFunSuite {
     val zone = ZoneId.of("US/Pacific")
     val expected =
       ZonedDateTime.parse(s"${t}T00:00:00", DateTimeFormatter.ISO_DATE_TIME.withZone(zone))
-    assert(expected === IsoDateTimeParser.parse(t, zone))
+    assertEquals(expected, IsoDateTimeParser.parse(t, zone))
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/ListHelperSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/ListHelperSuite.scala
@@ -15,44 +15,44 @@
  */
 package com.netflix.atlas.core.util
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class ListHelperSuite extends AnyFunSuite {
+class ListHelperSuite extends FunSuite {
 
   test("merge two sorted lists") {
     val v1 = List("a", "c", "d")
     val v2 = List("b", "e", "f")
-    assert(ListHelper.merge(10, v1, v2) === List("a", "b", "c", "d", "e", "f"))
+    assertEquals(ListHelper.merge(10, v1, v2), List("a", "b", "c", "d", "e", "f"))
   }
 
   test("merge two sorted lists with limit") {
     val v1 = List("a", "c", "d")
     val v2 = List("b", "e")
-    assert(ListHelper.merge(2, v1, v2) === List("a", "b"))
+    assertEquals(ListHelper.merge(2, v1, v2), List("a", "b"))
   }
 
   test("merge empty and sorted list") {
     val v1 = List.empty[String]
     val v2 = List("a", "b", "c")
-    assert(ListHelper.merge(2, v1, v2) === List("a", "b"))
+    assertEquals(ListHelper.merge(2, v1, v2), List("a", "b"))
   }
 
   test("merge empty and sorted list with size equal to limit") {
     val v1 = List.empty[String]
     val v2 = List("a", "b")
-    assert(ListHelper.merge(2, v1, v2) === List("a", "b"))
+    assertEquals(ListHelper.merge(2, v1, v2), List("a", "b"))
   }
 
   test("merge empty and sorted list with size less than limit") {
     val v1 = List.empty[String]
     val v2 = List("a")
-    assert(ListHelper.merge(2, v1, v2) === List("a"))
+    assertEquals(ListHelper.merge(2, v1, v2), List("a"))
   }
 
   test("merge sorted and empty list") {
     val v1 = List("a", "b", "c")
     val v2 = List.empty[String]
-    assert(ListHelper.merge(2, v1, v2) === List("a", "b"))
+    assertEquals(ListHelper.merge(2, v1, v2), List("a", "b"))
   }
 
   test("merge many sorted lists with limit") {
@@ -60,12 +60,12 @@ class ListHelperSuite extends AnyFunSuite {
     val v2 = List("b", "e")
     val v3 = List("aa", "d")
     val v4 = List("z")
-    assert(ListHelper.merge(3, List(v1, v2, v3, v4)) === List("a", "aa", "b"))
+    assertEquals(ListHelper.merge(3, List(v1, v2, v3, v4)), List("a", "aa", "b"))
   }
 
   test("dedup while merging") {
     val v1 = List("a", "c", "d")
     val v2 = List("a", "b", "f")
-    assert(ListHelper.merge(10, v1, v2) === List("a", "b", "c", "d", "f"))
+    assertEquals(ListHelper.merge(10, v1, v2), List("a", "b", "c", "d", "f"))
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/LongHashSetSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/LongHashSetSuite.scala
@@ -17,34 +17,34 @@ package com.netflix.atlas.core.util
 
 import org.openjdk.jol.info.ClassLayout
 import org.openjdk.jol.info.GraphLayout
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.util.Random
 
-class LongHashSetSuite extends AnyFunSuite {
+class LongHashSetSuite extends FunSuite {
 
   test("add") {
     val s = new LongHashSet(-1, 10)
     s.add(11)
-    assert(List(11) === s.toList)
-    assert(1 === s.size)
+    assertEquals(List(11L), s.toList)
+    assertEquals(1, s.size)
   }
 
   test("dedup") {
     val s = new LongHashSet(-1, 10)
     s.add(42)
-    assert(List(42) === s.toList)
-    assert(1 === s.size)
+    assertEquals(List(42L), s.toList)
+    assertEquals(1, s.size)
     s.add(42)
-    assert(List(42) === s.toList)
-    assert(1 === s.size)
+    assertEquals(List(42L), s.toList)
+    assertEquals(1, s.size)
   }
 
   test("resize") {
     val s = new LongHashSet(-1L, 10)
     (0L until 10000L).foreach(s.add)
-    assert((0L until 10000L).toSet === s.toList.toSet)
-    assert(s.size === 10000)
+    assertEquals((0L until 10000L).toSet, s.toList.toSet)
+    assertEquals(s.size, 10000)
   }
 
   test("random") {
@@ -55,7 +55,7 @@ class LongHashSetSuite extends AnyFunSuite {
       iset.add(v)
       jset.add(v)
     }
-    assert(jset.toSet === iset.toList.toSet)
+    assertEquals(jset.toSet, iset.toList.toSet)
   }
 
   private def arrayCompare(a1: Array[Long], a2: Array[Long]): Unit = {
@@ -63,7 +63,7 @@ class LongHashSetSuite extends AnyFunSuite {
     // Need to sort as traversal order could be different when generating the arrays
     java.util.Arrays.sort(a1)
     java.util.Arrays.sort(a2)
-    assert(a1 === a2)
+    assertEquals(a1.toSeq, a2.toSeq)
   }
 
   test("toArray") {
@@ -80,7 +80,7 @@ class LongHashSetSuite extends AnyFunSuite {
   test("memory per set") {
     // Sanity check to verify if some change introduces more overhead per set
     val bytes = ClassLayout.parseClass(classOf[LongHashSet]).instanceSize()
-    assert(bytes === 32)
+    assertEquals(bytes, 32L)
   }
 
   test("memory - 5 items") {
@@ -98,7 +98,7 @@ class LongHashSetSuite extends AnyFunSuite {
     //println(jgraph.toFootprint)
 
     // Only objects should be the array and the set itself
-    assert(igraph.totalCount() === 2)
+    assertEquals(igraph.totalCount(), 2L)
 
     // Sanity check size is < 100 bytes
     assert(igraph.totalSize() <= 250)
@@ -119,7 +119,7 @@ class LongHashSetSuite extends AnyFunSuite {
     //println(jgraph.toFootprint)
 
     // Only objects should be the array and the set itself
-    assert(igraph.totalCount() === 2)
+    assertEquals(igraph.totalCount(), 2L)
 
     // Sanity check size is < 220kb
     assert(igraph.totalSize() <= 220000)

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/LongIntHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/LongIntHashMapSuite.scala
@@ -17,26 +17,26 @@ package com.netflix.atlas.core.util
 
 import org.openjdk.jol.info.ClassLayout
 import org.openjdk.jol.info.GraphLayout
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.util.Random
 
-class LongIntHashMapSuite extends AnyFunSuite {
+class LongIntHashMapSuite extends FunSuite {
 
   test("put") {
     val m = new LongIntHashMap(-1)
-    assert(0 === m.size)
+    assertEquals(0, m.size)
     m.put(11, 42)
-    assert(1 === m.size)
-    assert(Map(11 -> 42) === m.toMap)
+    assertEquals(1, m.size)
+    assertEquals(Map(11L -> 42), m.toMap)
   }
 
   test("get") {
     val m = new LongIntHashMap(-1)
-    assert(m.get(42, -1) === -1)
+    assertEquals(m.get(42, -1), -1)
     m.put(11, 27)
-    assert(m.get(42, -1) === -1)
-    assert(m.get(11, -1) === 27)
+    assertEquals(m.get(42, -1), -1)
+    assertEquals(m.get(11, -1), 27)
   }
 
   test("get - collisions") {
@@ -46,37 +46,37 @@ class LongIntHashMapSuite extends AnyFunSuite {
     m.put(0, 0)
     m.put(11, 1)
     m.put(22, 2)
-    assert(m.size === 3)
-    assert(m.get(0, -1) === 0)
-    assert(m.get(11, -1) === 1)
-    assert(m.get(22, -1) === 2)
+    assertEquals(m.size, 3)
+    assertEquals(m.get(0, -1), 0)
+    assertEquals(m.get(11, -1), 1)
+    assertEquals(m.get(22, -1), 2)
   }
 
   test("dedup") {
     val m = new LongIntHashMap(-1)
     m.put(42, 1)
-    assert(Map(42 -> 1) === m.toMap)
-    assert(1 === m.size)
+    assertEquals(Map(42L -> 1), m.toMap)
+    assertEquals(1, m.size)
     m.put(42, 2)
-    assert(Map(42 -> 2) === m.toMap)
-    assert(1 === m.size)
+    assertEquals(Map(42L -> 2), m.toMap)
+    assertEquals(1, m.size)
   }
 
   test("increment") {
     val m = new LongIntHashMap(-1)
-    assert(0 === m.size)
+    assertEquals(0, m.size)
 
     m.increment(42)
-    assert(1 === m.size)
-    assert(Map(42 -> 1) === m.toMap)
+    assertEquals(1, m.size)
+    assertEquals(Map(42L -> 1), m.toMap)
 
     m.increment(42)
-    assert(1 === m.size)
-    assert(Map(42 -> 2) === m.toMap)
+    assertEquals(1, m.size)
+    assertEquals(Map(42L -> 2), m.toMap)
 
     m.increment(42, 7)
-    assert(1 === m.size)
-    assert(Map(42 -> 9) === m.toMap)
+    assertEquals(1, m.size)
+    assertEquals(Map(42L -> 9), m.toMap)
   }
 
   test("increment - collisions") {
@@ -86,22 +86,22 @@ class LongIntHashMapSuite extends AnyFunSuite {
     m.increment(0)
     m.increment(11)
     m.increment(22)
-    assert(m.size === 3)
+    assertEquals(m.size, 3)
     m.foreach { (_, v) =>
-      assert(v === 1)
+      assertEquals(v, 1)
     }
   }
 
   test("resize") {
     val m = new LongIntHashMap(-1, 10)
     (0 until 10000).foreach(i => m.put(i, i))
-    assert((0 until 10000).map(i => i -> i).toMap === m.toMap)
+    assertEquals((0 until 10000).map(i => i.toLong -> i).toMap, m.toMap)
   }
 
   test("resize - increment") {
     val m = new LongIntHashMap(-1, 10)
     (0 until 10000).foreach(i => m.increment(i, i))
-    assert((0 until 10000).map(i => i -> i).toMap === m.toMap)
+    assertEquals((0 until 10000).map(i => i.toLong -> i).toMap, m.toMap)
   }
 
   test("random") {
@@ -112,14 +112,14 @@ class LongIntHashMapSuite extends AnyFunSuite {
       imap.put(v, i)
       jmap.put(v, i)
     }
-    assert(jmap.toMap === imap.toMap)
-    assert(jmap.size === imap.size)
+    assertEquals(jmap.toMap, imap.toMap)
+    assertEquals(jmap.size, imap.size)
   }
 
   test("memory per map") {
     // Sanity check to verify if some change introduces more overhead per set
     val bytes = ClassLayout.parseClass(classOf[LongIntHashMap]).instanceSize()
-    assert(bytes === 40)
+    assertEquals(bytes, 40L)
   }
 
   test("memory - 5 items") {
@@ -137,7 +137,7 @@ class LongIntHashMapSuite extends AnyFunSuite {
     //println(jgraph.toFootprint)
 
     // Only objects should be the key/value arrays and the map itself
-    assert(igraph.totalCount() === 3)
+    assertEquals(igraph.totalCount(), 3L)
 
     // Sanity check size is < 300 bytes
     assert(igraph.totalSize() <= 300)
@@ -158,7 +158,7 @@ class LongIntHashMapSuite extends AnyFunSuite {
     //println(jgraph.toFootprint)
 
     // Only objects should be the key/value arrays and the map itself
-    assert(igraph.totalCount() === 3)
+    assertEquals(igraph.totalCount(), 3L)
 
     // Sanity check size is < 320kb
     assert(igraph.totalSize() <= 320000)
@@ -167,7 +167,7 @@ class LongIntHashMapSuite extends AnyFunSuite {
   test("negative absolute value") {
     // hashes to Integer.MIN_VALUE causing: java.lang.ArrayIndexOutOfBoundsException: -2
     val m = new LongIntHashMap(-1, 10)
-    assert(m.get(Integer.MIN_VALUE.toLong - 1, 0) === 0)
+    assertEquals(m.get(Integer.MIN_VALUE.toLong - 1, 0), 0)
   }
 
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/MathSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/MathSuite.scala
@@ -15,75 +15,75 @@
  */
 package com.netflix.atlas.core.util
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class MathSuite extends AnyFunSuite {
+class MathSuite extends FunSuite {
 
   import java.lang.{Double => JDouble}
 
   import com.netflix.atlas.core.util.Math._
 
   test("isNearlyZero") {
-    assert(isNearlyZero(1.0) === false)
-    assert(isNearlyZero(-1000.0) === false)
-    assert(isNearlyZero(0.0) === true)
-    assert(isNearlyZero(1e-12) === false)
-    assert(isNearlyZero(1e-13) === true)
-    assert(isNearlyZero(Double.NaN) === true)
+    assertEquals(isNearlyZero(1.0), false)
+    assertEquals(isNearlyZero(-1000.0), false)
+    assertEquals(isNearlyZero(0.0), true)
+    assertEquals(isNearlyZero(1e-12), false)
+    assertEquals(isNearlyZero(1e-13), true)
+    assertEquals(isNearlyZero(Double.NaN), true)
   }
 
   test("toBoolean") {
-    assert(toBoolean(1.0) === true)
-    assert(toBoolean(-1000.0) === true)
-    assert(toBoolean(0.0) === false)
-    assert(toBoolean(1e-12) === true)
-    assert(toBoolean(1e-13) === false)
-    assert(toBoolean(Double.NaN) === false)
+    assertEquals(toBoolean(1.0), true)
+    assertEquals(toBoolean(-1000.0), true)
+    assertEquals(toBoolean(0.0), false)
+    assertEquals(toBoolean(1e-12), true)
+    assertEquals(toBoolean(1e-13), false)
+    assertEquals(toBoolean(Double.NaN), false)
   }
 
   test("addNaN") {
-    assert(addNaN(1.0, 2.0) === 3.0)
-    assert(addNaN(Double.NaN, 2.0) === 2.0)
-    assert(addNaN(1.0, Double.NaN) === 1.0)
+    assertEquals(addNaN(1.0, 2.0), 3.0)
+    assertEquals(addNaN(Double.NaN, 2.0), 2.0)
+    assertEquals(addNaN(1.0, Double.NaN), 1.0)
     assert(JDouble.isNaN(addNaN(Double.NaN, Double.NaN)))
   }
 
   test("subtractNaN") {
-    assert(subtractNaN(1.0, 2.0) === -1.0)
-    assert(subtractNaN(Double.NaN, 2.0) === -2.0)
-    assert(subtractNaN(1.0, Double.NaN) === 1.0)
+    assertEquals(subtractNaN(1.0, 2.0), -1.0)
+    assertEquals(subtractNaN(Double.NaN, 2.0), -2.0)
+    assertEquals(subtractNaN(1.0, Double.NaN), 1.0)
     assert(JDouble.isNaN(subtractNaN(Double.NaN, Double.NaN)))
   }
 
   test("maxNaN") {
-    assert(maxNaN(1.0, 2.0) === 2.0)
-    assert(maxNaN(2.0, 1.0) === 2.0)
-    assert(maxNaN(Double.NaN, 2.0) === 2.0)
-    assert(maxNaN(1.0, Double.NaN) === 1.0)
+    assertEquals(maxNaN(1.0, 2.0), 2.0)
+    assertEquals(maxNaN(2.0, 1.0), 2.0)
+    assertEquals(maxNaN(Double.NaN, 2.0), 2.0)
+    assertEquals(maxNaN(1.0, Double.NaN), 1.0)
     assert(JDouble.isNaN(maxNaN(Double.NaN, Double.NaN)))
   }
 
   test("minNaN") {
-    assert(minNaN(1.0, 2.0) === 1.0)
-    assert(minNaN(2.0, 1.0) === 1.0)
-    assert(minNaN(Double.NaN, 2.0) === 2.0)
-    assert(minNaN(1.0, Double.NaN) === 1.0)
+    assertEquals(minNaN(1.0, 2.0), 1.0)
+    assertEquals(minNaN(2.0, 1.0), 1.0)
+    assertEquals(minNaN(Double.NaN, 2.0), 2.0)
+    assertEquals(minNaN(1.0, Double.NaN), 1.0)
     assert(JDouble.isNaN(minNaN(Double.NaN, Double.NaN)))
   }
 
   test("gtNaN") {
-    assert(gtNaN(1.0, 2.0) === 0.0)
-    assert(gtNaN(2.0, 1.0) === 1.0)
-    assert(gtNaN(Double.NaN, 2.0) === 0.0)
-    assert(gtNaN(1.0, Double.NaN) === 1.0)
+    assertEquals(gtNaN(1.0, 2.0), 0.0)
+    assertEquals(gtNaN(2.0, 1.0), 1.0)
+    assertEquals(gtNaN(Double.NaN, 2.0), 0.0)
+    assertEquals(gtNaN(1.0, Double.NaN), 1.0)
     assert(JDouble.isNaN(gtNaN(Double.NaN, Double.NaN)))
   }
 
   test("ltNaN") {
-    assert(ltNaN(1.0, 2.0) === 1.0)
-    assert(ltNaN(2.0, 1.0) === 0.0)
-    assert(ltNaN(Double.NaN, 2.0) === 1.0)
-    assert(ltNaN(1.0, Double.NaN) === 0.0)
+    assertEquals(ltNaN(1.0, 2.0), 1.0)
+    assertEquals(ltNaN(2.0, 1.0), 0.0)
+    assertEquals(ltNaN(Double.NaN, 2.0), 1.0)
+    assertEquals(ltNaN(1.0, Double.NaN), 0.0)
     assert(JDouble.isNaN(ltNaN(Double.NaN, Double.NaN)))
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/RefIntHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/RefIntHashMapSuite.scala
@@ -17,40 +17,40 @@ package com.netflix.atlas.core.util
 
 import org.openjdk.jol.info.ClassLayout
 import org.openjdk.jol.info.GraphLayout
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.util.Random
 
-class RefIntHashMapSuite extends AnyFunSuite {
+class RefIntHashMapSuite extends FunSuite {
 
   import java.lang.{Long => JLong}
 
   test("put") {
     val m = new RefIntHashMap[JLong]
-    assert(0 === m.size)
+    assertEquals(0, m.size)
     m.put(11L, 42)
-    assert(1 === m.size)
-    assert(Map(11L -> 42) === m.toMap)
+    assertEquals(1, m.size)
+    assertEquals(Map(JLong.valueOf(11) -> 42), m.toMap)
   }
 
   test("putIfAbsent") {
     val m = new RefIntHashMap[JLong]
-    assert(0 === m.size)
+    assertEquals(0, m.size)
     assert(m.putIfAbsent(11L, 42))
-    assert(1 === m.size)
-    assert(Map(11L -> 42) === m.toMap)
+    assertEquals(1, m.size)
+    assertEquals(Map(JLong.valueOf(11) -> 42), m.toMap)
 
     assert(!m.putIfAbsent(11L, 43))
-    assert(1 === m.size)
-    assert(Map(11L -> 42) === m.toMap)
+    assertEquals(1, m.size)
+    assertEquals(Map(JLong.valueOf(11) -> 42), m.toMap)
   }
 
   test("get") {
     val m = new RefIntHashMap[JLong]
-    assert(m.get(42L, -1) === -1)
+    assertEquals(m.get(42L, -1), -1)
     m.put(11L, 27)
-    assert(m.get(42L, -1) === -1)
-    assert(m.get(11L, -1) === 27)
+    assertEquals(m.get(42L, -1), -1)
+    assertEquals(m.get(11L, -1), 27)
   }
 
   test("get - collisions") {
@@ -60,37 +60,37 @@ class RefIntHashMapSuite extends AnyFunSuite {
     m.put(0L, 0)
     m.put(11L, 1)
     m.put(22L, 2)
-    assert(m.size === 3)
-    assert(m.get(0L, -1) === 0)
-    assert(m.get(11L, -1) === 1)
-    assert(m.get(22L, -1) === 2)
+    assertEquals(m.size, 3)
+    assertEquals(m.get(0L, -1), 0)
+    assertEquals(m.get(11L, -1), 1)
+    assertEquals(m.get(22L, -1), 2)
   }
 
   test("dedup") {
     val m = new RefIntHashMap[JLong]
     m.put(42L, 1)
-    assert(Map(42L -> 1) === m.toMap)
-    assert(1 === m.size)
+    assertEquals(Map(JLong.valueOf(42) -> 1), m.toMap)
+    assertEquals(1, m.size)
     m.put(42L, 2)
-    assert(Map(42L -> 2) === m.toMap)
-    assert(1 === m.size)
+    assertEquals(Map(JLong.valueOf(42) -> 2), m.toMap)
+    assertEquals(1, m.size)
   }
 
   test("increment") {
     val m = new RefIntHashMap[JLong]
-    assert(0 === m.size)
+    assertEquals(0, m.size)
 
     m.increment(42L)
-    assert(1 === m.size)
-    assert(Map(42L -> 1) === m.toMap)
+    assertEquals(1, m.size)
+    assertEquals(Map(JLong.valueOf(42) -> 1), m.toMap)
 
     m.increment(42L)
-    assert(1 === m.size)
-    assert(Map(42L -> 2) === m.toMap)
+    assertEquals(1, m.size)
+    assertEquals(Map(JLong.valueOf(42) -> 2), m.toMap)
 
     m.increment(42L, 7)
-    assert(1 === m.size)
-    assert(Map(42L -> 9) === m.toMap)
+    assertEquals(1, m.size)
+    assertEquals(Map(JLong.valueOf(42) -> 9), m.toMap)
   }
 
   test("increment - collisions") {
@@ -100,9 +100,9 @@ class RefIntHashMapSuite extends AnyFunSuite {
     m.increment(0L)
     m.increment(11L)
     m.increment(22L)
-    assert(m.size === 3)
+    assertEquals(m.size, 3)
     m.foreach { (_, v) =>
-      assert(v === 1)
+      assertEquals(v, 1)
     }
   }
 
@@ -114,7 +114,7 @@ class RefIntHashMapSuite extends AnyFunSuite {
     val data = m.mapToArray(new Array[Long](m.size)) { (k, v) =>
       k + v
     }
-    assert(data.toList === List(1, 12, 23))
+    assertEquals(data.toList, List(1L, 12L, 23L))
   }
 
   test("mapToArray -- invalid length") {
@@ -132,31 +132,31 @@ class RefIntHashMapSuite extends AnyFunSuite {
   test("resize") {
     val m = new RefIntHashMap[JLong]
     (0 until 10000).foreach(i => m.put(i.toLong, i))
-    assert((0 until 10000).map(i => i -> i).toMap === m.toMap)
+    assertEquals((0 until 10000).map(i => JLong.valueOf(i) -> i).toMap, m.toMap)
   }
 
   test("resize - increment") {
     val m = new RefIntHashMap[JLong]
     (0 until 10000).foreach(i => m.increment(i.toLong, i))
-    assert((0 until 10000).map(i => i -> i).toMap === m.toMap)
+    assertEquals((0 until 10000).map(i => JLong.valueOf(i) -> i).toMap, m.toMap)
   }
 
   test("random") {
-    val jmap = new scala.collection.mutable.HashMap[Long, Int]
+    val jmap = new scala.collection.mutable.HashMap[JLong, Int]
     val imap = new RefIntHashMap[JLong]
     (0 until 10000).foreach { i =>
       val v = Random.nextInt()
       imap.put(v.toLong, i)
       jmap.put(v, i)
     }
-    assert(jmap.toMap === imap.toMap)
-    assert(jmap.size === imap.size)
+    assertEquals(jmap.toMap, imap.toMap)
+    assertEquals(jmap.size, imap.size)
   }
 
   test("memory per map") {
     // Sanity check to verify if some change introduces more overhead per set
     val bytes = ClassLayout.parseClass(classOf[RefIntHashMap[JLong]]).instanceSize()
-    assert(bytes === 32)
+    assertEquals(bytes, 32L)
   }
 
   test("memory - 5 items") {
@@ -174,7 +174,7 @@ class RefIntHashMapSuite extends AnyFunSuite {
     //println(jgraph.toFootprint)
 
     // Only objects should be the key/value arrays and the map itself + 5 key objects
-    assert(igraph.totalCount() === 8)
+    assertEquals(igraph.totalCount(), 8L)
 
     // Sanity check size is < 300 bytes
     assert(igraph.totalSize() <= 300)
@@ -195,7 +195,7 @@ class RefIntHashMapSuite extends AnyFunSuite {
     //println(jgraph.toFootprint)
 
     // Only objects should be the key/value arrays and the map itself + 10000 key objects
-    assert(igraph.totalCount() === 3 + 10000)
+    assertEquals(igraph.totalCount(), 3L + 10000)
 
     // Sanity check size is < 500kb
     assert(igraph.totalSize() <= 500000)
@@ -203,7 +203,7 @@ class RefIntHashMapSuite extends AnyFunSuite {
 
   test("negative absolute value") {
     val s = new RefIntHashMap[RefIntHashMapSuite.MinHash]()
-    assert(s.get(new RefIntHashMapSuite.MinHash, 0) === 0)
+    assertEquals(s.get(new RefIntHashMapSuite.MinHash, 0), 0)
   }
 }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/RollingIntervalSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/RollingIntervalSuite.scala
@@ -19,38 +19,38 @@ import java.time.Duration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class RollingIntervalSuite extends AnyFunSuite {
+class RollingIntervalSuite extends FunSuite {
 
   test("ceil should not round up if on exact boundary") {
     val expected = Instant.parse("2007-12-03T10:00:00.00Z")
     val t = Instant.parse("2007-12-03T10:00:00.00Z")
-    assert(RollingInterval.ceil(t, ChronoUnit.HOURS) === expected)
+    assertEquals(RollingInterval.ceil(t, ChronoUnit.HOURS), expected)
   }
 
   test("ceil should round up to next boundary MINUTES") {
     val expected = Instant.parse("2007-12-03T10:16:00.00Z")
     val t = Instant.parse("2007-12-03T10:15:30.00Z")
-    assert(RollingInterval.ceil(t, ChronoUnit.MINUTES) === expected)
+    assertEquals(RollingInterval.ceil(t, ChronoUnit.MINUTES), expected)
   }
 
   test("ceil should round up to next boundary HOURS") {
     val expected = Instant.parse("2007-12-03T11:00:00.00Z")
     val t = Instant.parse("2007-12-03T10:15:30.00Z")
-    assert(RollingInterval.ceil(t, ChronoUnit.HOURS) === expected)
+    assertEquals(RollingInterval.ceil(t, ChronoUnit.HOURS), expected)
   }
 
   test("ceil should round up to next boundary DAYS") {
     val expected = Instant.parse("2007-12-04T00:00:00.00Z")
     val t = Instant.parse("2007-12-03T10:15:30.00Z")
-    assert(RollingInterval.ceil(t, ChronoUnit.DAYS) === expected)
+    assertEquals(RollingInterval.ceil(t, ChronoUnit.DAYS), expected)
   }
 
   test("from string") {
     val expected = RollingInterval(Duration.ZERO, Duration.ofDays(4), ChronoUnit.HOURS)
     val actual = RollingInterval("0h,4d,HOURS")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("from string, missing unit") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/ShardsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/ShardsSuite.scala
@@ -17,9 +17,9 @@ package com.netflix.atlas.core.util
 
 import java.util.UUID
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class ShardsSuite extends AnyFunSuite {
+class ShardsSuite extends FunSuite {
 
   private def createGroups(n: Int, sz: Int): List[Shards.Group[Int]] = {
     val groups = (0 until n).map { i =>
@@ -61,7 +61,7 @@ class ShardsSuite extends AnyFunSuite {
       }
 
       // make sure all shards are used
-      assert(counts.size === n * sz)
+      assertEquals(counts.size, n * sz)
 
       // make sure that the distribution is uniform
       val (min, max, _) = minMaxAvg(counts)
@@ -82,7 +82,7 @@ class ShardsSuite extends AnyFunSuite {
       }
 
       // make sure all shards are used
-      assert(counts.size === n * sz)
+      assertEquals(counts.size, n * sz)
 
       // make sure that the distribution is uniform
       val (min, max, avg) = minMaxAvg(counts)
@@ -109,7 +109,7 @@ class ShardsSuite extends AnyFunSuite {
     }
 
     // make sure all shards are used
-    assert(counts.size === 8)
+    assertEquals(counts.size, 8)
 
     // make sure that the distribution is uniform
     val maxAC = 20000 / 6 + 1
@@ -137,7 +137,7 @@ class ShardsSuite extends AnyFunSuite {
     )
 
     val mapper = Shards.mapper(groups)
-    assert(mapper.instanceForIndex(1) === null)
+    assertEquals(mapper.instanceForIndex(1), null)
   }
 
   test("local mapper containsIndex") {
@@ -153,8 +153,9 @@ class ShardsSuite extends AnyFunSuite {
     (0 until 20000).foreach { i =>
       val idx = mapper.instanceForIndex(i)
       val contains = localMapper.containsIndex(i)
-      assert(
-        contains === (idx == localInstance),
+      assertEquals(
+        contains,
+        (idx == localInstance),
         s"$i => instance = $localInstance; mapper.instance = $idx; local.contains = $contains"
       )
     }
@@ -174,8 +175,9 @@ class ShardsSuite extends AnyFunSuite {
       val id = Hash.sha1(UUID.randomUUID().toString)
       val idx = mapper.instanceForId(id)
       val contains = localMapper.containsId(id)
-      assert(
-        contains === (idx == localInstance),
+      assertEquals(
+        contains,
+        (idx == localInstance),
         s"$id => instance = $localInstance; mapper.instance = $idx; local.contains = $contains"
       )
     }
@@ -209,7 +211,7 @@ class ShardsSuite extends AnyFunSuite {
     }
 
     // make sure all shards are used
-    assert(counts.size === 6 + 2)
+    assertEquals(counts.size, 6 + 2)
 
     // make sure that the distribution is uniform
     val (min, max, _) = minMaxAvg(counts)
@@ -233,7 +235,7 @@ class ShardsSuite extends AnyFunSuite {
     }
 
     // make sure all shards are used
-    assert(counts.size === 6 + 4)
+    assertEquals(counts.size, 6 + 4)
 
     // make sure data is replicated to new group
     var sum = 0

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/SmallHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/SmallHashMapSuite.scala
@@ -17,11 +17,11 @@ package com.netflix.atlas.core.util
 
 import java.util.UUID
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.util.Random
 
-class SmallHashMapSuite extends AnyFunSuite {
+class SmallHashMapSuite extends FunSuite {
 
   // Set of keys taken from prod.us-east-1. This tends to be our biggest region and these are the
   // actual keys we see in the data.
@@ -203,78 +203,78 @@ class SmallHashMapSuite extends AnyFunSuite {
     val m1 = SmallHashMap("k1" -> "v1")
     val m2 = SmallHashMap("k1" -> "v1", "k2" -> "v2")
 
-    assert(empty.size === 0)
-    assert(m1.size === 1)
-    assert(m2.size === 2)
+    assertEquals(empty.size, 0)
+    assertEquals(m1.size, 1)
+    assertEquals(m2.size, 2)
 
-    assert(m1("k1") === "v1")
+    assertEquals(m1("k1"), "v1")
     assert(m1.contains("k1"))
     intercept[NoSuchElementException] { m1("k2") }
     assert(!m1.contains("k2"))
-    assert(m2("k1") === "v1")
-    assert(m2("k2") === "v2")
+    assertEquals(m2("k1"), "v1")
+    assertEquals(m2("k2"), "v2")
 
-    assert(m1.get("k1") === Some("v1"))
-    assert(m1.get("k2") === None)
-    assert(m2.get("k1") === Some("v1"))
-    assert(m2.get("k2") === Some("v2"))
+    assertEquals(m1.get("k1"), Some("v1"))
+    assertEquals(m1.get("k2"), None)
+    assertEquals(m2.get("k1"), Some("v1"))
+    assertEquals(m2.get("k2"), Some("v2"))
 
     val s = m2.toSet
     m2.foreach { t =>
       assert(s.contains(t))
     }
 
-    assert(m1 === m2 - "k2")
+    assertEquals(m2 - "k2", m1)
   }
 
   test("retains type after removal of key") {
     val m1 = SmallHashMap("k1" -> "v1")
     val m2 = SmallHashMap("k1" -> "v1", "k2" -> "v2")
-    assert(m1 === m2 - "k2")
+    assertEquals(m2 - "k2", m1)
     assert((m2 - "k2").isInstanceOf[SmallHashMap[_, _]])
   }
 
   test("remove key not in map") {
     val m1 = SmallHashMap("k1" -> "v1", "k2" -> "v2")
-    assert(m1 === m1 - "k3")
+    assertEquals(m1 - "k3", m1)
     assert((m1 - "k3").isInstanceOf[SmallHashMap[_, _]])
   }
 
   test("retains type after adding pair") {
     val m1 = SmallHashMap("k1" -> "v1")
     val m2 = SmallHashMap("k1" -> "v1", "k2" -> "v2")
-    assert(m1 + ("k2" -> "v2") === m2)
+    assertEquals(m1 + ("k2" -> "v2"), m2)
     assert((m1 + ("k2" -> "v2")).isInstanceOf[SmallHashMap[_, _]])
   }
 
   test("empty map") {
     val m = SmallHashMap.empty[String, String]
-    assert(m.keySet === Set.empty)
-    assert(m.get("k1") === None)
-    assert(m.size === 0)
+    assertEquals(m.keySet, Set.empty[String])
+    assertEquals(m.get("k1"), None)
+    assertEquals(m.size, 0)
   }
 
   test("map with 1 pair") {
     val m = SmallHashMap("k1" -> "v1")
-    assert(m.keySet === Set("k1"))
-    assert(m.get("k1") === Some("v1"))
-    assert(m.get("k2") === None)
-    assert(m.size === 1)
+    assertEquals(m.keySet, Set("k1"))
+    assertEquals(m.get("k1"), Some("v1"))
+    assertEquals(m.get("k2"), None)
+    assertEquals(m.size, 1)
   }
 
   test("keySet") {
     val m = SmallHashMap("k1" -> "v1", "k2" -> "v2")
-    assert(m.keySet === Set("k1", "k2"))
+    assertEquals(m.keySet, Set("k1", "k2"))
   }
 
   test("values") {
     val m = SmallHashMap("k1" -> "v1", "k2" -> "v2")
-    assert(m.values.toSet === Set("v1", "v2"))
+    assertEquals(m.values.toSet, Set("v1", "v2"))
   }
 
   test("toSet") {
-    val m = SmallHashMap("k1"   -> "v1", "k2" -> "v2")
-    assert(m.toSet === Set("k1" -> "v1", "k2" -> "v2"))
+    val m = SmallHashMap("k1"      -> "v1", "k2" -> "v2")
+    assertEquals(m.toSet, Set("k1" -> "v1", "k2" -> "v2"))
   }
 
   test("using builder") {
@@ -283,7 +283,7 @@ class SmallHashMapSuite extends AnyFunSuite {
       .add("k1", "v1")
       .addAll(Map("k2" -> "v2"))
       .result
-    assert(expected === actual)
+    assertEquals(expected, actual)
   }
 
   private def testNumCollisions(m: SmallHashMap[String, String]): Unit = {
@@ -307,8 +307,8 @@ class SmallHashMapSuite extends AnyFunSuite {
     builder.add(findStringWithHash(12, 42), "1")
     builder.add(findStringWithHash(12, 42), "2")
     val m = builder.result
-    assert(m.numCollisions === 1)
-    assert(m.numProbesPerKey === 0.5)
+    assertEquals(m.numCollisions, 1)
+    assertEquals(m.numProbesPerKey, 0.5)
   }
 
   test("numCollisions 25") {
@@ -316,7 +316,7 @@ class SmallHashMapSuite extends AnyFunSuite {
     val m = SmallHashMap(rkeys.take(25).map(v => v -> v): _*)
     testNumCollisions(m)
     rkeys.take(25).foreach { k =>
-      assert(m.get(k) === Some(k))
+      assertEquals(m.get(k), Some(k))
     }
   }
 
@@ -325,7 +325,7 @@ class SmallHashMapSuite extends AnyFunSuite {
     val m = SmallHashMap(rkeys.take(50).map(v => v -> v): _*)
     testNumCollisions(m)
     rkeys.take(50).foreach { k =>
-      assert(m.get(k) === Some(k))
+      assertEquals(m.get(k), Some(k))
     }
   }
 
@@ -334,7 +334,7 @@ class SmallHashMapSuite extends AnyFunSuite {
     val m = SmallHashMap(rkeys.map(v => v -> v): _*)
     testNumCollisions(m)
     rkeys.foreach { k =>
-      assert(m.get(k) === Some(k))
+      assertEquals(m.get(k), Some(k))
     }
   }
 
@@ -347,8 +347,8 @@ class SmallHashMapSuite extends AnyFunSuite {
       }
       val m1 = SmallHashMap(100, data.iterator)
       val m2 = SmallHashMap(100, Random.shuffle(data).iterator)
-      assert(m1.hashCode === m2.hashCode)
-      assert(m1 === m2)
+      assertEquals(m1.hashCode, m2.hashCode)
+      assertEquals(m1, m2)
     }
   }
 
@@ -361,8 +361,8 @@ class SmallHashMapSuite extends AnyFunSuite {
       }
       val m1 = SmallHashMap(data)
       val m2 = SmallHashMap(Random.shuffle(data))
-      assert(m1.hashCode === m2.hashCode)
-      assert(m1 === m2)
+      assertEquals(m1.hashCode, m2.hashCode)
+      assertEquals(m1, m2)
     }
   }
 
@@ -458,9 +458,9 @@ class SmallHashMapSuite extends AnyFunSuite {
 
   test("javaMap: get") {
     val m = SmallHashMap("a" -> "1", "b" -> "2").asJavaMap
-    assert(m.get("a") === "1")
-    assert(m.get("b") === "2")
-    assert(m.get("c") === null)
+    assertEquals(m.get("a"), "1")
+    assertEquals(m.get("b"), "2")
+    assertEquals(m.get("c"), null)
   }
 
   test("javaMap: containsKey") {
@@ -472,14 +472,14 @@ class SmallHashMapSuite extends AnyFunSuite {
 
   test("javaMap: entrySet") {
     val entries = SmallHashMap("a" -> "1", "b" -> "2").asJavaMap.entrySet()
-    assert(entries.size() === 2)
+    assertEquals(entries.size(), 2)
 
     val it = entries.iterator()
     while (it.hasNext) {
       val entry = it.next()
       entry.getKey match {
-        case "a" => assert(entry.getValue === "1")
-        case "b" => assert(entry.getValue === "2")
+        case "a" => assertEquals(entry.getValue, "1")
+        case "b" => assertEquals(entry.getValue, "2")
       }
     }
   }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/SortedTagMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/SortedTagMapSuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.core.util
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class SortedTagMapSuite extends AnyFunSuite {
+class SortedTagMapSuite extends FunSuite {
 
   test("empty") {
     val m = SortedTagMap.empty
@@ -25,7 +25,7 @@ class SortedTagMapSuite extends AnyFunSuite {
     assert(m.size == 0)
     assert(m.get("a").isEmpty)
     assert(!m.contains("a"))
-    assert(m.toList === List.empty)
+    assertEquals(m.toList, List.empty)
   }
 
   test("single pair") {
@@ -34,7 +34,7 @@ class SortedTagMapSuite extends AnyFunSuite {
     assert(m.size == 1)
     assert(m.get("a").contains("1"))
     assert(m.contains("a"))
-    assert(m.toList === List("a" -> "1"))
+    assertEquals(m.toList, List("a" -> "1"))
   }
 
   test("four pairs") {
@@ -45,7 +45,7 @@ class SortedTagMapSuite extends AnyFunSuite {
       val k = s"${('a' + i).asInstanceOf[Char]}"
       assert(m.get(k).contains(i.toString))
     }
-    assert(m.toList === List("a" -> "0", "b" -> "1", "c" -> "2", "d" -> "3"))
+    assertEquals(m.toList, List("a" -> "0", "b" -> "1", "c" -> "2", "d" -> "3"))
   }
 
   private def pairs: List[(String, String)] = {
@@ -63,7 +63,7 @@ class SortedTagMapSuite extends AnyFunSuite {
     input.foreach { t =>
       assert(m.get(t._1).contains(t._2))
     }
-    assert(m.toList === pairs)
+    assertEquals(m.toList, pairs)
   }
 
   test("updates: adding new keys") {
@@ -72,7 +72,7 @@ class SortedTagMapSuite extends AnyFunSuite {
       acc + t
     }
     val expected = SortedTagMap(input)
-    assert(actual === expected)
+    assertEquals(actual, expected)
     assert(actual.isInstanceOf[SortedTagMap])
   }
 
@@ -83,7 +83,7 @@ class SortedTagMapSuite extends AnyFunSuite {
       acc + t
     }
     val expected = SortedTagMap(input)
-    assert(actual === expected)
+    assertEquals(actual, expected)
     assert(actual.isInstanceOf[SortedTagMap])
   }
 
@@ -93,10 +93,10 @@ class SortedTagMapSuite extends AnyFunSuite {
       // remove key that exists
       val actual = SortedTagMap(input) - input.head._1
       val expected = SortedTagMap(input.tail)
-      assert(actual === expected)
+      assertEquals(actual, expected)
 
       // remove key that is missing
-      assert(actual - input.head._1 === expected)
+      assertEquals(actual - input.head._1, expected)
 
       // check type
       assert(actual.isInstanceOf[SortedTagMap])
@@ -115,7 +115,7 @@ class SortedTagMapSuite extends AnyFunSuite {
       actual += k -> v
     }
     val expected = pairs
-    assert(actual.result() === expected)
+    assertEquals(actual.result(), expected)
   }
 
   test("create from SortedTagMap") {
@@ -128,14 +128,14 @@ class SortedTagMapSuite extends AnyFunSuite {
     val map = pairs.toMap
     val actual = SortedTagMap(map)
     val expected = SortedTagMap(pairs)
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("create from IterableOnce") {
     val map = pairs.toMap.view
     val actual = SortedTagMap(map)
     val expected = SortedTagMap(pairs)
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("create uneven size") {
@@ -147,13 +147,13 @@ class SortedTagMapSuite extends AnyFunSuite {
   test("compareTo: empty") {
     val a = SortedTagMap.empty
     val b = SortedTagMap(List.empty)
-    assert(a.compareTo(b) === 0)
-    assert(b.compareTo(a) === 0)
+    assertEquals(a.compareTo(b), 0)
+    assertEquals(b.compareTo(a), 0)
   }
 
   test("compareTo: self") {
     val a = SortedTagMap(Array("a", "1", "b", "2"))
-    assert(a.compareTo(a) === 0)
+    assertEquals(a.compareTo(a), 0)
   }
 
   test("compareTo: different keys") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StepSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StepSuite.scala
@@ -18,35 +18,35 @@ package com.netflix.atlas.core.util
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class StepSuite extends AnyFunSuite {
+class StepSuite extends FunSuite {
 
   private def days(n: Long): Long = n * 24 * 60 * 60 * 1000
 
   test("round: allow arbitrary number of days") {
     (1 until 500).foreach { i =>
-      assert(days(i) === Step.round(60000, days(i)))
+      assertEquals(days(i), Step.round(60000, days(i)))
     }
   }
 
   test("round: up if less than a day") {
-    assert(days(1) === Step.round(60000, days(1) / 2 + 1))
+    assertEquals(days(1), Step.round(60000, days(1) / 2 + 1))
   }
 
   test("round: up if not on day boundary") {
-    assert(days(3) === Step.round(60000, days(2) + 1))
+    assertEquals(days(3), Step.round(60000, days(2) + 1))
   }
 
   test("compute: allow arbitrary number of days") {
     (1 until 500).foreach { i =>
-      assert(days(i) === Step.compute(60000, 1, 0L, days(i)))
+      assertEquals(days(i), Step.compute(60000, 1, 0L, days(i)))
     }
   }
 
   test("compute: round less than a day") {
     val e = Instant.parse("2017-06-27T00:00:00Z")
     val s = e.minus(12 * 30, ChronoUnit.DAYS)
-    assert(days(1) === Step.compute(60000, 430, s.toEpochMilli, e.toEpochMilli))
+    assertEquals(days(1), Step.compute(60000, 430, s.toEpochMilli, e.toEpochMilli))
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StreamsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StreamsSuite.scala
@@ -18,11 +18,11 @@ package com.netflix.atlas.core.util
 import java.nio.file.Files
 import java.nio.file.Paths
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.util.Using
 
-class StreamsSuite extends AnyFunSuite {
+class StreamsSuite extends FunSuite {
 
   test("scope with Stream") {
     val cwd = Paths.get(".")

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
@@ -25,9 +25,9 @@ import java.util.Locale
 import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class StringsSuite extends AnyFunSuite {
+class StringsSuite extends FunSuite {
 
   import com.netflix.atlas.core.util.Strings._
 
@@ -140,12 +140,12 @@ class StringsSuite extends AnyFunSuite {
 
   test("conversionsDateTimeZone - UTC") {
     val tz = ZoneId.of("UTC")
-    assert(conversions(classOf[ZoneId])("UTC") === tz)
+    assertEquals(conversions(classOf[ZoneId])("UTC"), tz)
   }
 
   test("conversionsDateTimeZone - US/Pacific") {
     val tz = ZoneId.of("US/Pacific")
-    assert(conversions(classOf[ZoneId])("US/Pacific") === tz)
+    assertEquals(conversions(classOf[ZoneId])("US/Pacific"), tz)
   }
 
   test("conversionsPeriod") {
@@ -172,101 +172,101 @@ class StringsSuite extends AnyFunSuite {
   test("urlDecode") {
     val str = "a b %25 % %%% %21%zb"
     val expected = "a b % % %%% !%zb"
-    assert(urlDecode(str) === expected)
+    assertEquals(urlDecode(str), expected)
   }
 
   test("hexDecode, escape with _") {
     val str = "a b %25 _ %_% _21%zb"
     val expected = "a b %25 _ %_% !%zb"
-    assert(hexDecode(str, '_') === expected)
+    assertEquals(hexDecode(str, '_'), expected)
   }
 
   test("urlEncode") {
     val str = "a&?= +[]()<>^$%\"':;-_|!@#*.~`\\/{}"
     val expected = "a%26%3F%3D%20%2B%5B%5D()%3C%3E%5E$%25%22':%3B-_%7C!@%23*.~`%5C/%7B%7D"
-    assert(urlEncode(str) === expected)
-    assert(urlDecode(expected) === str)
-    assert(urlDecode(expected.toLowerCase(Locale.US)) === str)
+    assertEquals(urlEncode(str), expected)
+    assertEquals(urlDecode(expected), str)
+    assertEquals(urlDecode(expected.toLowerCase(Locale.US)), str)
   }
 
   test("urlEncode: CLDMTA-1582") {
     val str = "aggregator.http.post.(?!200)._count"
     val expected = "aggregator.http.post.(%3F!200)._count"
-    assert(urlEncode(str) === expected)
+    assertEquals(urlEncode(str), expected)
   }
 
   test("parseQueryString, null") {
     val query = null
-    val expected = Map.empty
-    assert(parseQueryString(query) === expected)
+    val expected = Map.empty[String, List[String]]
+    assertEquals(parseQueryString(query), expected)
   }
 
   test("parseQueryString") {
     val query = "foo=bar&foo=baz;bar&foo=%21&;foo&abc=42"
     val expected =
       Map("abc" -> List("42"), "bar" -> List("1"), "foo" -> List("bar", "baz", "!", "1").reverse)
-    assert(parseQueryString(query) === expected)
+    assertEquals(parseQueryString(query), expected)
   }
 
   test("parseDuration, at seconds") {
-    assert(parseDuration("42seconds") === Duration.ofSeconds(42))
-    assert(parseDuration("42second") === Duration.ofSeconds(42))
-    assert(parseDuration("42s") === Duration.ofSeconds(42))
+    assertEquals(parseDuration("42seconds"), Duration.ofSeconds(42))
+    assertEquals(parseDuration("42second"), Duration.ofSeconds(42))
+    assertEquals(parseDuration("42s"), Duration.ofSeconds(42))
   }
 
   test("parseDuration, at minutes") {
-    assert(parseDuration("42minutes") === Duration.ofMinutes(42))
-    assert(parseDuration("42minute") === Duration.ofMinutes(42))
-    assert(parseDuration("42min") === Duration.ofMinutes(42))
-    assert(parseDuration("42m") === Duration.ofMinutes(42))
+    assertEquals(parseDuration("42minutes"), Duration.ofMinutes(42))
+    assertEquals(parseDuration("42minute"), Duration.ofMinutes(42))
+    assertEquals(parseDuration("42min"), Duration.ofMinutes(42))
+    assertEquals(parseDuration("42m"), Duration.ofMinutes(42))
   }
 
   test("parseDuration, at hours") {
-    assert(parseDuration("42hours") === Duration.ofHours(42))
-    assert(parseDuration("42hour") === Duration.ofHours(42))
-    assert(parseDuration("42h") === Duration.ofHours(42))
+    assertEquals(parseDuration("42hours"), Duration.ofHours(42))
+    assertEquals(parseDuration("42hour"), Duration.ofHours(42))
+    assertEquals(parseDuration("42h"), Duration.ofHours(42))
   }
 
   // TODO: Need a combination of period with duration using java.time, similar to joda Period
 
   test("parseDuration, at days") {
-    assert(parseDuration("42days") === Duration.ofDays(42))
-    assert(parseDuration("42day") === Duration.ofDays(42))
-    assert(parseDuration("42d") === Duration.ofDays(42))
+    assertEquals(parseDuration("42days"), Duration.ofDays(42))
+    assertEquals(parseDuration("42day"), Duration.ofDays(42))
+    assertEquals(parseDuration("42d"), Duration.ofDays(42))
   }
 
   test("parseDuration, at weeks") {
-    assert(parseDuration("42weeks") === Duration.ofDays(42 * 7))
-    assert(parseDuration("42week") === Duration.ofDays(42 * 7))
-    assert(parseDuration("42wk") === Duration.ofDays(42 * 7))
-    assert(parseDuration("42w") === Duration.ofDays(42 * 7))
+    assertEquals(parseDuration("42weeks"), Duration.ofDays(42 * 7))
+    assertEquals(parseDuration("42week"), Duration.ofDays(42 * 7))
+    assertEquals(parseDuration("42wk"), Duration.ofDays(42 * 7))
+    assertEquals(parseDuration("42w"), Duration.ofDays(42 * 7))
   }
 
   test("parseDuration, at months") {
-    assert(parseDuration("42months") === Duration.ofDays(42 * 30))
-    assert(parseDuration("42month") === Duration.ofDays(42 * 30))
+    assertEquals(parseDuration("42months"), Duration.ofDays(42 * 30))
+    assertEquals(parseDuration("42month"), Duration.ofDays(42 * 30))
   }
 
   test("parseDuration, at years") {
-    assert(parseDuration("42years") === Duration.ofDays(42 * 365))
-    assert(parseDuration("42year") === Duration.ofDays(42 * 365))
-    assert(parseDuration("42y") === Duration.ofDays(42 * 365))
+    assertEquals(parseDuration("42years"), Duration.ofDays(42 * 365))
+    assertEquals(parseDuration("42year"), Duration.ofDays(42 * 365))
+    assertEquals(parseDuration("42y"), Duration.ofDays(42 * 365))
   }
 
   test("parseDuration, at invalid unit") {
     val e = intercept[IllegalArgumentException] {
       parseDuration("42fubars")
     }
-    assert(e.getMessage === "unknown unit fubars")
+    assertEquals(e.getMessage, "unknown unit fubars")
   }
 
   test("parseDuration, iso") {
-    //assert(parseDuration("P42Y") === Period.years(42))
-    assert(parseDuration("PT42M") === Duration.ofMinutes(42))
+    //assertEquals(parseDuration("P42Y"), Period.years(42))
+    assertEquals(parseDuration("PT42M"), Duration.ofMinutes(42))
   }
 
   test("toString Duration: weeks") {
-    assert(Strings.toString(Duration.ofDays(5 * 7)) === "5w")
+    assertEquals(Strings.toString(Duration.ofDays(5 * 7)), "5w")
   }
 
   test("toString Duration: weeks + 10h") {
@@ -279,84 +279,84 @@ class StringsSuite extends AnyFunSuite {
     // res6: java.time.Duration = PT850H
     //
     // If it becomes enough of a pain point we can customize the output for the fallback
-    assert(Strings.toString(Duration.ofDays(5 * 7).plusHours(10)) === "850h")
+    assertEquals(Strings.toString(Duration.ofDays(5 * 7).plusHours(10)), "850h")
   }
 
   test("toString Duration: days") {
-    assert(Strings.toString(Duration.ofDays(5)) === "5d")
+    assertEquals(Strings.toString(Duration.ofDays(5)), "5d")
   }
 
   test("toString Duration: hours") {
-    assert(Strings.toString(Duration.ofHours(5)) === "5h")
+    assertEquals(Strings.toString(Duration.ofHours(5)), "5h")
   }
 
   test("toString Duration: minutes") {
-    assert(Strings.toString(Duration.ofMinutes(5)) === "5m")
+    assertEquals(Strings.toString(Duration.ofMinutes(5)), "5m")
   }
 
   test("toString Duration: seconds") {
-    assert(Strings.toString(Duration.ofSeconds(5)) === "5s")
+    assertEquals(Strings.toString(Duration.ofSeconds(5)), "5s")
   }
 
   test("parseDate, iso date only") {
     val expected = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC)
-    assert(parseDate("2012-02-01") === expected)
+    assertEquals(parseDate("2012-02-01"), expected)
   }
 
   // Note: will fail prior to 8u20:
   // https://github.com/Netflix/atlas/issues/9
   test("parseDate, iso date with time no seconds") {
     val expected = ZonedDateTime.of(2012, 2, 1, 4, 5, 0, 0, ZoneOffset.UTC)
-    assert(parseDate("2012-02-01T04:05") === expected)
-    assert(parseDate("2012-02-01T04:05Z") === expected)
+    assertEquals(parseDate("2012-02-01T04:05"), expected)
+    assertEquals(parseDate("2012-02-01T04:05Z"), expected)
 
     val result =
       ZonedDateTime.ofInstant(parseDate("2012-02-01T12:05+08:00").toInstant, ZoneOffset.UTC)
-    assert(result === expected)
+    assertEquals(result, expected)
   }
 
   // Note: will fail prior to 8u20:
   // https://github.com/Netflix/atlas/issues/9
   test("parseDate, iso date with time") {
     val expected = ZonedDateTime.of(2012, 2, 1, 4, 5, 6, 0, ZoneOffset.UTC)
-    assert(parseDate("2012-02-01T04:05:06") === expected)
+    assertEquals(parseDate("2012-02-01T04:05:06"), expected)
   }
 
   test("parseDate, iso date with time and zone") {
     val expected = ZonedDateTime.of(2012, 1, 31, 20, 5, 6, 0, ZoneOffset.UTC)
     val result =
       ZonedDateTime.ofInstant(parseDate("2012-02-01T04:05:06+08:00").toInstant, ZoneOffset.UTC)
-    assert(result === expected)
+    assertEquals(result, expected)
   }
 
   test("parseDate, iso date with time with millis and zone") {
     val nanos = TimeUnit.MILLISECONDS.toNanos(123).toInt
     val expected = ZonedDateTime.of(2012, 2, 1, 4, 5, 6, nanos, ZoneOffset.UTC)
-    assert(parseDate("2012-02-01T04:05:06.123Z") === expected)
+    assertEquals(parseDate("2012-02-01T04:05:06.123Z"), expected)
   }
 
   test("parseDate, iso date with time with millis and zone (+00:00)") {
     val nanos = TimeUnit.MILLISECONDS.toNanos(123).toInt
     val expected = ZonedDateTime.of(2012, 2, 1, 4, 5, 6, nanos, ZoneOffset.UTC)
-    assert(parseDate("2012-02-01T04:05:06.123+00:00") === expected)
+    assertEquals(parseDate("2012-02-01T04:05:06.123+00:00"), expected)
   }
 
   test("parseDate, iso date with time with millis and zone (+0000)") {
     val nanos = TimeUnit.MILLISECONDS.toNanos(123).toInt
     val expected = ZonedDateTime.of(2012, 2, 1, 4, 5, 6, nanos, ZoneOffset.UTC)
-    assert(parseDate("2012-02-01T04:05:06.123+0000") === expected)
+    assertEquals(parseDate("2012-02-01T04:05:06.123+0000"), expected)
   }
 
   test("parseDate, iso date with time with millis and zone (+00)") {
     val nanos = TimeUnit.MILLISECONDS.toNanos(123).toInt
     val expected = ZonedDateTime.of(2012, 2, 1, 4, 5, 6, nanos, ZoneOffset.UTC)
-    assert(parseDate("2012-02-01T04:05:06.123+00") === expected)
+    assertEquals(parseDate("2012-02-01T04:05:06.123+00"), expected)
   }
 
   test("parseDate, iso date with time with millis and zone offset") {
     val nanos = TimeUnit.MILLISECONDS.toNanos(123).toInt
     val expected = ZonedDateTime.of(2012, 2, 1, 7, 5, 6, nanos, ZoneOffset.UTC).toInstant
-    assert(parseDate("2012-02-01T04:05:06.123-03:00").toInstant === expected)
+    assertEquals(parseDate("2012-02-01T04:05:06.123-03:00").toInstant, expected)
   }
 
   test("parseDate, iso formats") {
@@ -388,7 +388,7 @@ class StringsSuite extends AnyFunSuite {
   test("parseDate, iso date with time with millis") {
     val nanos = TimeUnit.MILLISECONDS.toNanos(123).toInt
     val expected = ZonedDateTime.of(2012, 2, 1, 4, 5, 6, nanos, ZoneOffset.UTC)
-    assert(parseDate("2012-02-01T04:05:06.123") === expected)
+    assertEquals(parseDate("2012-02-01T04:05:06.123"), expected)
   }
 
   test("parseDate, iso invalid") {
@@ -400,32 +400,32 @@ class StringsSuite extends AnyFunSuite {
   test("parseDate, relative minus") {
     val ref = ZonedDateTime.of(2012, 2, 1, 3, 0, 0, 0, ZoneOffset.UTC)
     val expected = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC)
-    assert(parseDate(ref, "e-3h", ZoneOffset.UTC) === expected)
+    assertEquals(parseDate(ref, "e-3h", ZoneOffset.UTC), expected)
   }
 
   test("parseDate, relative plus") {
     val ref = ZonedDateTime.of(2012, 2, 1, 3, 0, 0, 0, ZoneOffset.UTC)
     val expected = ZonedDateTime.of(2012, 2, 1, 3, 0, 42, 0, ZoneOffset.UTC)
-    assert(parseDate(ref, "start+42s", ZoneOffset.UTC) === expected)
+    assertEquals(parseDate(ref, "start+42s", ZoneOffset.UTC), expected)
   }
 
   test("parseDate, relative iso") {
     val ref = ZonedDateTime.of(2012, 2, 2, 3, 0, 0, 0, ZoneOffset.UTC)
     val expected = ZonedDateTime.of(2012, 2, 1, 2, 54, 18, 0, ZoneOffset.UTC)
-    assert(parseDate(ref, "start-P1DT5M42S", ZoneOffset.UTC) === expected)
+    assertEquals(parseDate(ref, "start-P1DT5M42S", ZoneOffset.UTC), expected)
   }
 
   test("parseDate, epoch + 4h") {
     val ref = ZonedDateTime.of(2012, 2, 2, 3, 0, 0, 0, ZoneOffset.UTC)
     val expected = ZonedDateTime.of(1970, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC)
-    assert(parseDate(ref, "epoch+4h", ZoneOffset.UTC) === expected)
+    assertEquals(parseDate(ref, "epoch+4h", ZoneOffset.UTC), expected)
   }
 
   test("parseDate, relative invalid op") {
     val e = intercept[IllegalArgumentException] {
       parseDate("e*42h")
     }
-    assert(e.getMessage === "invalid date e*42h")
+    assertEquals(e.getMessage, "invalid date e*42h")
   }
 
   test("parseDate, named now") {
@@ -436,51 +436,51 @@ class StringsSuite extends AnyFunSuite {
 
   test("parseDate, named epoch") {
     val received = parseDate("epoch").toInstant.toEpochMilli
-    assert(received === 0)
+    assertEquals(received, 0L)
   }
 
   test("parseDate, unix") {
     val ref = ZonedDateTime.of(2012, 2, 1, 3, 0, 0, 0, ZoneOffset.UTC)
     val refStr = "%d".format(ref.toInstant.toEpochMilli / 1000)
     val received = parseDate(refStr)
-    assert(received === ref)
+    assertEquals(received, ref)
   }
 
   test("parseDate, unix millis") {
     val ref = ZonedDateTime.of(2012, 2, 1, 3, 0, 0, 0, ZoneOffset.UTC)
     val refStr = "%d".format(ref.toInstant.toEpochMilli)
     val received = parseDate(refStr)
-    assert(received === ref)
+    assertEquals(received, ref)
   }
 
   test("parseDate, s=e-0h") {
     val ref = ZonedDateTime.of(2012, 2, 1, 3, 0, 0, 0, ZoneOffset.UTC)
     val expected = ZonedDateTime.of(2012, 2, 1, 3, 0, 0, 0, ZoneOffset.UTC)
-    assert(parseDate(ref, "e-0h", ZoneOffset.UTC) === expected)
+    assertEquals(parseDate(ref, "e-0h", ZoneOffset.UTC), expected)
   }
 
   test("parseDate, s=e") {
     val ref = ZonedDateTime.of(2012, 2, 1, 3, 0, 0, 0, ZoneOffset.UTC)
     val expected = ZonedDateTime.of(2012, 2, 1, 3, 0, 0, 0, ZoneOffset.UTC)
-    assert(parseDate(ref, "e", ZoneOffset.UTC) === expected)
+    assertEquals(parseDate(ref, "e", ZoneOffset.UTC), expected)
   }
 
   test("parseColor") {
-    assert(parseColor("FF0000") === Color.RED)
-    assert(parseColor("ff0000") === Color.RED)
+    assertEquals(parseColor("FF0000"), Color.RED)
+    assertEquals(parseColor("ff0000"), Color.RED)
   }
 
   test("parseColor triple hex") {
-    assert(parseColor("f00") === Color.RED)
-    assert(parseColor("F00") === Color.RED)
+    assertEquals(parseColor("f00"), Color.RED)
+    assertEquals(parseColor("F00"), Color.RED)
   }
 
   test("parseColor with alpha") {
     val c = parseColor("0FFF0000")
-    assert(c.getAlpha === 15)
-    assert(c.getRed === 255)
-    assert(c.getGreen === 0)
-    assert(c.getBlue === 0)
+    assertEquals(c.getAlpha, 15)
+    assertEquals(c.getRed, 255)
+    assertEquals(c.getGreen, 0)
+    assertEquals(c.getBlue, 0)
   }
 
   test("isRelativeDate") {
@@ -503,109 +503,109 @@ class StringsSuite extends AnyFunSuite {
 
   test("substitute") {
     val vars = Map("foo" -> "bar", "bar" -> "baz")
-    assert(substitute("$(foo)", vars) === "bar")
-    assert(substitute("$(bar)", vars) === "baz")
-    assert(substitute("$foo", vars) === "bar")
-    assert(substitute("$(foo)$(bar)", vars) === "barbaz")
-    assert(substitute("$(foo) ::: $(bar)", vars) === "bar ::: baz")
-    assert(substitute("$(missing) ::: $(bar)", vars) === "missing ::: baz")
-    assert(substitute("$missing ::: $bar", vars) === "missing ::: baz")
+    assertEquals(substitute("$(foo)", vars), "bar")
+    assertEquals(substitute("$(bar)", vars), "baz")
+    assertEquals(substitute("$foo", vars), "bar")
+    assertEquals(substitute("$(foo)$(bar)", vars), "barbaz")
+    assertEquals(substitute("$(foo) ::: $(bar)", vars), "bar ::: baz")
+    assertEquals(substitute("$(missing) ::: $(bar)", vars), "missing ::: baz")
+    assertEquals(substitute("$missing ::: $bar", vars), "missing ::: baz")
   }
 
   test("substitute: ends with $") {
     val vars = Map("foo" -> "bar", "bar" -> "baz")
-    assert(substitute("foo$", vars) === "foo$")
+    assertEquals(substitute("foo$", vars), "foo$")
   }
 
   test("substitute: followed by whitespace") {
     val vars = Map("foo" -> "bar", "bar" -> "baz")
-    assert(substitute("$ foo", vars) === "$ foo")
+    assertEquals(substitute("$ foo", vars), "$ foo")
   }
 
   test("substitute: whitespace in paren") {
     val vars = Map(" foo" -> "bar", "bar" -> "baz")
-    assert(substitute("$( foo)", vars) === "bar")
+    assertEquals(substitute("$( foo)", vars), "bar")
   }
 
   test("substitute: parens used to escape literal $") {
     val vars = Map("foo" -> "bar", "bar" -> "baz")
-    assert(substitute("$()foo", vars) === "$foo")
+    assertEquals(substitute("$()foo", vars), "$foo")
   }
 
   test("substitute: unmatched open paren") {
     val vars = Map("foo" -> "bar", "bar" -> "baz")
-    assert(substitute("$(foo", vars) === "$foo")
-    assert(substitute("foo$(", vars) === "foo$")
+    assertEquals(substitute("$(foo", vars), "$foo")
+    assertEquals(substitute("foo$(", vars), "foo$")
   }
 
   test("substitute: unmatched closed paren") {
     val vars = Map("foo" -> "bar", "bar" -> "baz")
-    assert(substitute("$)foo", vars) === "$)foo")
-    assert(substitute("foo$)", vars) === "foo$)")
+    assertEquals(substitute("$)foo", vars), "$)foo")
+    assertEquals(substitute("foo$)", vars), "foo$)")
   }
 
   test("zeroPad int") {
-    assert(zeroPad(42, 1) === "2a")
-    assert(zeroPad(42, 2) === "2a")
-    assert(zeroPad(42, 3) === "02a")
-    assert(zeroPad(42, 8) === "0000002a")
-    assert(zeroPad(-42, 8) === "ffffffd6")
-    assert(zeroPad(-42, 12) === "0000ffffffd6")
+    assertEquals(zeroPad(42, 1), "2a")
+    assertEquals(zeroPad(42, 2), "2a")
+    assertEquals(zeroPad(42, 3), "02a")
+    assertEquals(zeroPad(42, 8), "0000002a")
+    assertEquals(zeroPad(-42, 8), "ffffffd6")
+    assertEquals(zeroPad(-42, 12), "0000ffffffd6")
   }
 
   test("zeroPad long") {
-    assert(zeroPad(42L, 1) === "2a")
-    assert(zeroPad(42L, 2) === "2a")
-    assert(zeroPad(42L, 3) === "02a")
-    assert(zeroPad(42L, 8) === "0000002a")
-    assert(zeroPad(-42L, 8) === "ffffffffffffffd6")
-    assert(zeroPad(-42L, 18) === "00ffffffffffffffd6")
+    assertEquals(zeroPad(42L, 1), "2a")
+    assertEquals(zeroPad(42L, 2), "2a")
+    assertEquals(zeroPad(42L, 3), "02a")
+    assertEquals(zeroPad(42L, 8), "0000002a")
+    assertEquals(zeroPad(-42L, 8), "ffffffffffffffd6")
+    assertEquals(zeroPad(-42L, 18), "00ffffffffffffffd6")
   }
 
   test("zeroPad BigInteger") {
     val b = new BigInteger("42")
-    assert(zeroPad(b, 1) === "2a")
-    assert(zeroPad(b, 2) === "2a")
-    assert(zeroPad(b, 3) === "02a")
-    assert(zeroPad(b, 8) === "0000002a")
+    assertEquals(zeroPad(b, 1), "2a")
+    assertEquals(zeroPad(b, 2), "2a")
+    assertEquals(zeroPad(b, 3), "02a")
+    assertEquals(zeroPad(b, 8), "0000002a")
   }
 
   test("zeroPad byte array empty") {
     val b = Array.empty[Byte]
-    assert(zeroPad(b, 1) === "0")
-    assert(zeroPad(b, 2) === "00")
-    assert(zeroPad(b, 3) === "000")
-    assert(zeroPad(b, 8) === "00000000")
+    assertEquals(zeroPad(b, 1), "0")
+    assertEquals(zeroPad(b, 2), "00")
+    assertEquals(zeroPad(b, 3), "000")
+    assertEquals(zeroPad(b, 8), "00000000")
   }
 
   test("zeroPad byte array unsigned conversion") {
     val b = Array[Byte](-1)
-    assert(zeroPad(b, 1) === "ff")
-    assert(zeroPad(b, 2) === "ff")
-    assert(zeroPad(b, 3) === "0ff")
-    assert(zeroPad(b, 8) === "000000ff")
+    assertEquals(zeroPad(b, 1), "ff")
+    assertEquals(zeroPad(b, 2), "ff")
+    assertEquals(zeroPad(b, 3), "0ff")
+    assertEquals(zeroPad(b, 8), "000000ff")
   }
 
   test("zeroPad byte array minimum padding of 2") {
     val b = Array[Byte](1)
-    assert(zeroPad(b, 1) === "01")
-    assert(zeroPad(b, 2) === "01")
-    assert(zeroPad(b, 3) === "001")
-    assert(zeroPad(b, 8) === "00000001")
+    assertEquals(zeroPad(b, 1), "01")
+    assertEquals(zeroPad(b, 2), "01")
+    assertEquals(zeroPad(b, 3), "001")
+    assertEquals(zeroPad(b, 8), "00000001")
   }
 
   test("zeroPad byte array all values") {
     (java.lang.Byte.MIN_VALUE until java.lang.Byte.MAX_VALUE).foreach { i =>
       val s = zeroPad(Array(i.toByte), 1)
       val v = Integer.parseInt(s, 16).byteValue()
-      assert(v === i)
+      assertEquals(v, i.toByte)
     }
   }
 
   test("range: both absolute") {
     val (s, e) = timeRange("2018-07-24", "2018-07-24T00:05")
-    assert(s === parseDate("2018-07-24").toInstant)
-    assert(e === parseDate("2018-07-24T00:05").toInstant)
+    assertEquals(s, parseDate("2018-07-24").toInstant)
+    assertEquals(e, parseDate("2018-07-24T00:05").toInstant)
   }
 
   test("range: end is before start") {
@@ -616,7 +616,7 @@ class StringsSuite extends AnyFunSuite {
 
   test("range: start time is the same as end time") {
     val (s, e) = timeRange("2018-07-24", "2018-07-24")
-    assert(s === e)
+    assertEquals(s, e)
   }
 
   test("range: both relative") {
@@ -627,13 +627,13 @@ class StringsSuite extends AnyFunSuite {
 
   test("range: start relative to end") {
     val (s, e) = timeRange("e-5m", "2018-07-24T00:05")
-    assert(s === parseDate("2018-07-24").toInstant)
-    assert(e === parseDate("2018-07-24T00:05").toInstant)
+    assertEquals(s, parseDate("2018-07-24").toInstant)
+    assertEquals(e, parseDate("2018-07-24T00:05").toInstant)
   }
 
   test("range: end relative to start") {
     val (s, e) = timeRange("2018-07-24", "s+5m")
-    assert(s === parseDate("2018-07-24").toInstant)
-    assert(e === parseDate("2018-07-24T00:05").toInstant)
+    assertEquals(s, parseDate("2018-07-24").toInstant)
+    assertEquals(e, parseDate("2018-07-24T00:05").toInstant)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/UnitPrefixSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/UnitPrefixSuite.scala
@@ -15,81 +15,81 @@
  */
 package com.netflix.atlas.core.util
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class UnitPrefixSuite extends AnyFunSuite {
+class UnitPrefixSuite extends FunSuite {
 
   test("decimal isNearlyZero") {
-    assert(UnitPrefix.decimal(1e-13).text === "")
+    assertEquals(UnitPrefix.decimal(1e-13).text, "")
   }
 
   test("decimal infinity") {
-    assert(UnitPrefix.decimal(Double.PositiveInfinity).text === "")
+    assertEquals(UnitPrefix.decimal(Double.PositiveInfinity).text, "")
   }
 
   test("decimal NaN") {
-    assert(UnitPrefix.decimal(Double.NaN).text === "")
+    assertEquals(UnitPrefix.decimal(Double.NaN).text, "")
   }
 
   test("decimal milli") {
-    assert(UnitPrefix.decimal(1.23e-3).text === "milli")
-    assert(UnitPrefix.decimal(-1.23e-3).text === "milli")
+    assertEquals(UnitPrefix.decimal(1.23e-3).text, "milli")
+    assertEquals(UnitPrefix.decimal(-1.23e-3).text, "milli")
   }
 
   test("decimal kilo") {
-    assert(UnitPrefix.decimal(1.23e3).text === "kilo")
-    assert(UnitPrefix.decimal(-1.23e3).text === "kilo")
+    assertEquals(UnitPrefix.decimal(1.23e3).text, "kilo")
+    assertEquals(UnitPrefix.decimal(-1.23e3).text, "kilo")
   }
 
   test("decimal mega") {
-    assert(UnitPrefix.decimal(1.23e6).text === "mega")
-    assert(UnitPrefix.decimal(-1.23e6).text === "mega")
+    assertEquals(UnitPrefix.decimal(1.23e6).text, "mega")
+    assertEquals(UnitPrefix.decimal(-1.23e6).text, "mega")
   }
 
   test("decimal giga") {
-    assert(UnitPrefix.decimal(1.23e9).text === "giga")
-    assert(UnitPrefix.decimal(-1.23e9).text === "giga")
+    assertEquals(UnitPrefix.decimal(1.23e9).text, "giga")
+    assertEquals(UnitPrefix.decimal(-1.23e9).text, "giga")
   }
 
   test("binary isNearlyZero") {
-    assert(UnitPrefix.binary(1e-13).text === "")
+    assertEquals(UnitPrefix.binary(1e-13).text, "")
   }
 
   test("binary infinity") {
-    assert(UnitPrefix.binary(Double.PositiveInfinity).text === "")
+    assertEquals(UnitPrefix.binary(Double.PositiveInfinity).text, "")
   }
 
   test("binary NaN") {
-    assert(UnitPrefix.binary(Double.NaN).text === "")
+    assertEquals(UnitPrefix.binary(Double.NaN).text, "")
   }
 
   test("binary milli") {
-    assert(UnitPrefix.binary(1.23e-3).text === "milli")
-    assert(UnitPrefix.binary(-1.23e-3).text === "milli")
+    assertEquals(UnitPrefix.binary(1.23e-3).text, "milli")
+    assertEquals(UnitPrefix.binary(-1.23e-3).text, "milli")
   }
 
   test("binary kibi") {
-    assert(UnitPrefix.binary(1023.0).text === "")
-    assert(UnitPrefix.binary(1.23e3).text === "kibi")
-    assert(UnitPrefix.binary(-1.23e3).text === "kibi")
+    assertEquals(UnitPrefix.binary(1023.0).text, "")
+    assertEquals(UnitPrefix.binary(1.23e3).text, "kibi")
+    assertEquals(UnitPrefix.binary(-1.23e3).text, "kibi")
   }
 
   test("binary mebi") {
-    assert(UnitPrefix.binary(1.23e6).text === "mebi")
-    assert(UnitPrefix.binary(-1.23e6).text === "mebi")
+    assertEquals(UnitPrefix.binary(1.23e6).text, "mebi")
+    assertEquals(UnitPrefix.binary(-1.23e6).text, "mebi")
   }
 
   test("binary gibi") {
-    assert(UnitPrefix.binary(1.23e9).text === "gibi")
-    assert(UnitPrefix.binary(-1.23e9).text === "gibi")
+    assertEquals(UnitPrefix.binary(1.23e9).text, "gibi")
+    assertEquals(UnitPrefix.binary(-1.23e9).text, "gibi")
   }
 
   test("format MaxValue") {
-    assert(UnitPrefix.format(Double.MaxValue) === " 2e+308")
+    assertEquals(UnitPrefix.format(Double.MaxValue), " 2e+308")
   }
 
   test("format MinValue") {
-    assert(UnitPrefix.format(Double.MinValue) === "-2e+308")
+    assertEquals(UnitPrefix.format(Double.MinValue), "-2e+308")
   }
 
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/HasKeyRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/HasKeyRuleSuite.scala
@@ -18,15 +18,15 @@ package com.netflix.atlas.core.validation
 import com.netflix.atlas.core.util.SortedTagMap
 import com.netflix.spectator.api.Id
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class HasKeyRuleSuite extends AnyFunSuite {
+class HasKeyRuleSuite extends FunSuite {
 
   private val config = ConfigFactory.parseString("key = name")
   private val rule = HasKeyRule(config)
 
   test("has key") {
-    assert(rule.validate(Map("name" -> "foo")) === ValidationResult.Pass)
+    assertEquals(rule.validate(Map("name" -> "foo")), ValidationResult.Pass)
   }
 
   test("missing key") {
@@ -35,7 +35,7 @@ class HasKeyRuleSuite extends AnyFunSuite {
   }
 
   test("sorted: has key") {
-    assert(rule.validate(SortedTagMap("name" -> "foo")) === ValidationResult.Pass)
+    assertEquals(rule.validate(SortedTagMap("name" -> "foo")), ValidationResult.Pass)
   }
 
   test("sorted: missing key") {
@@ -44,12 +44,12 @@ class HasKeyRuleSuite extends AnyFunSuite {
   }
 
   test("id: has key name") {
-    assert(rule.validate(Id.create("foo")) === ValidationResult.Pass)
+    assertEquals(rule.validate(Id.create("foo")), ValidationResult.Pass)
   }
 
   test("id: has key other") {
     val id = Id.create("foo").withTag("a", "1")
-    assert(HasKeyRule("a").validate(id) === ValidationResult.Pass)
+    assertEquals(HasKeyRule("a").validate(id), ValidationResult.Pass)
   }
 
   test("id: missing key other") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/KeyLengthRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/KeyLengthRuleSuite.scala
@@ -16,9 +16,9 @@
 package com.netflix.atlas.core.validation
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class KeyLengthRuleSuite extends AnyFunSuite {
+class KeyLengthRuleSuite extends FunSuite {
 
   private val config = ConfigFactory.parseString("""
       |min-length = 2
@@ -32,9 +32,9 @@ class KeyLengthRuleSuite extends AnyFunSuite {
   }
 
   test("valid") {
-    assert(validate("ab", "def") === ValidationResult.Pass)
-    assert(validate("abc", "def") === ValidationResult.Pass)
-    assert(validate("abcd", "def") === ValidationResult.Pass)
+    assertEquals(validate("ab", "def"), ValidationResult.Pass)
+    assertEquals(validate("abc", "def"), ValidationResult.Pass)
+    assertEquals(validate("abcd", "def"), ValidationResult.Pass)
   }
 
   test("too short") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/KeyPatternRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/KeyPatternRuleSuite.scala
@@ -16,9 +16,9 @@
 package com.netflix.atlas.core.validation
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class KeyPatternRuleSuite extends AnyFunSuite {
+class KeyPatternRuleSuite extends FunSuite {
 
   private val config = ConfigFactory.parseString("""pattern = "^[a-c]+$" """)
 
@@ -29,8 +29,8 @@ class KeyPatternRuleSuite extends AnyFunSuite {
   }
 
   test("valid") {
-    assert(validate("abc", "ab") === ValidationResult.Pass)
-    assert(validate("aaa", "abc") === ValidationResult.Pass)
+    assertEquals(validate("abc", "ab"), ValidationResult.Pass)
+    assertEquals(validate("aaa", "abc"), ValidationResult.Pass)
   }
 
   test("invalid") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/MaxUserTagsRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/MaxUserTagsRuleSuite.scala
@@ -17,9 +17,9 @@ package com.netflix.atlas.core.validation
 
 import com.netflix.spectator.api.Id
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class MaxUserTagsRuleSuite extends AnyFunSuite {
+class MaxUserTagsRuleSuite extends FunSuite {
 
   private val config = ConfigFactory.parseString("limit = 2")
   private val rule = MaxUserTagsRule(config)
@@ -28,9 +28,9 @@ class MaxUserTagsRuleSuite extends AnyFunSuite {
     val t1 = Map("name" -> "foo")
     val t2 = t1 + ("foo"       -> "bar")
     val t3 = t2 + ("nf.region" -> "west")
-    assert(rule.validate(t1) === ValidationResult.Pass)
-    assert(rule.validate(t2) === ValidationResult.Pass)
-    assert(rule.validate(t3) === ValidationResult.Pass)
+    assertEquals(rule.validate(t1), ValidationResult.Pass)
+    assertEquals(rule.validate(t2), ValidationResult.Pass)
+    assertEquals(rule.validate(t3), ValidationResult.Pass)
   }
 
   test("too many") {
@@ -42,9 +42,9 @@ class MaxUserTagsRuleSuite extends AnyFunSuite {
     val id1 = Id.create("foo")
     val id2 = id1.withTag("foo", "bar")
     val id3 = id2.withTag("nf.region", "west")
-    assert(rule.validate(id1) === ValidationResult.Pass)
-    assert(rule.validate(id2) === ValidationResult.Pass)
-    assert(rule.validate(id3) === ValidationResult.Pass)
+    assertEquals(rule.validate(id1), ValidationResult.Pass)
+    assertEquals(rule.validate(id2), ValidationResult.Pass)
+    assertEquals(rule.validate(id3), ValidationResult.Pass)
   }
 
   test("id: too many") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/NameValueLengthRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/NameValueLengthRuleSuite.scala
@@ -17,9 +17,9 @@ package com.netflix.atlas.core.validation
 
 import com.netflix.spectator.api.Id
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class NameValueLengthRuleSuite extends AnyFunSuite {
+class NameValueLengthRuleSuite extends FunSuite {
 
   private val config = ConfigFactory.parseString("""
       |name {
@@ -40,9 +40,9 @@ class NameValueLengthRuleSuite extends AnyFunSuite {
   }
 
   test("name valid") {
-    assert(validate("name", "abc") === ValidationResult.Pass)
-    assert(validate("name", "abcd") === ValidationResult.Pass)
-    assert(validate("name", "abcde") === ValidationResult.Pass)
+    assertEquals(validate("name", "abc"), ValidationResult.Pass)
+    assertEquals(validate("name", "abcd"), ValidationResult.Pass)
+    assertEquals(validate("name", "abcde"), ValidationResult.Pass)
   }
 
   test("name too short") {
@@ -56,9 +56,9 @@ class NameValueLengthRuleSuite extends AnyFunSuite {
   }
 
   test("others valid") {
-    assert(validate("def", "ab") === ValidationResult.Pass)
-    assert(validate("def", "abc") === ValidationResult.Pass)
-    assert(validate("def", "abcd") === ValidationResult.Pass)
+    assertEquals(validate("def", "ab"), ValidationResult.Pass)
+    assertEquals(validate("def", "abc"), ValidationResult.Pass)
+    assertEquals(validate("def", "abcd"), ValidationResult.Pass)
   }
 
   test("others too short") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ReservedKeyRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ReservedKeyRuleSuite.scala
@@ -16,9 +16,9 @@
 package com.netflix.atlas.core.validation
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class ReservedKeyRuleSuite extends AnyFunSuite {
+class ReservedKeyRuleSuite extends FunSuite {
 
   private val config = ConfigFactory.parseString("""
       |prefix = "nf."
@@ -32,11 +32,11 @@ class ReservedKeyRuleSuite extends AnyFunSuite {
   }
 
   test("valid") {
-    assert(validate("nf.region", "def") === ValidationResult.Pass)
+    assertEquals(validate("nf.region", "def"), ValidationResult.Pass)
   }
 
   test("valid, no reserved prefix") {
-    assert(validate("foo", "def") === ValidationResult.Pass)
+    assertEquals(validate("foo", "def"), ValidationResult.Pass)
   }
 
   test("invalid") {
@@ -45,11 +45,11 @@ class ReservedKeyRuleSuite extends AnyFunSuite {
   }
 
   test("job") {
-    assert(validate("nf.job", "def") === ValidationResult.Pass)
+    assertEquals(validate("nf.job", "def"), ValidationResult.Pass)
   }
 
   test("task") {
-    assert(validate("nf.task", "def") === ValidationResult.Pass)
+    assertEquals(validate("nf.task", "def"), ValidationResult.Pass)
   }
 
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/RuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/RuleSuite.scala
@@ -16,9 +16,9 @@
 package com.netflix.atlas.core.validation
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class RuleSuite extends AnyFunSuite {
+class RuleSuite extends FunSuite {
 
   private val config =
     ConfigFactory.parseString(
@@ -65,14 +65,14 @@ class RuleSuite extends AnyFunSuite {
 
   test("load") {
     val rules = Rule.load(config.getConfigList("rules"))
-    assert(rules.size === 9)
+    assertEquals(rules.size, 9)
   }
 
   test("load, useComposite") {
     val rules = Rule.load(config.getConfigList("rules"), true)
-    assert(rules.size === 3)
+    assertEquals(rules.size, 3)
     assert(rules.head.isInstanceOf[CompositeTagRule])
-    assert(rules.head.asInstanceOf[CompositeTagRule].tagRules.size === 7)
+    assertEquals(rules.head.asInstanceOf[CompositeTagRule].tagRules.size, 7)
   }
 
   test("validate ok") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ValidCharactersRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ValidCharactersRuleSuite.scala
@@ -16,9 +16,9 @@
 package com.netflix.atlas.core.validation
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class ValidCharactersRuleSuite extends AnyFunSuite {
+class ValidCharactersRuleSuite extends FunSuite {
 
   private val config = ConfigFactory.parseString("")
 
@@ -41,7 +41,7 @@ class ValidCharactersRuleSuite extends AnyFunSuite {
 
   test("valid") {
     val rule = ValidCharactersRule(config)
-    assert(validate(rule, alpha, alpha) === ValidationResult.Pass)
+    assertEquals(validate(rule, alpha, alpha), ValidationResult.Pass)
   }
 
   test("invalid key") {
@@ -70,7 +70,7 @@ class ValidCharactersRuleSuite extends AnyFunSuite {
 
   test("custom pattern valid") {
     val rule = ValidCharactersRule(customPattern)
-    assert(validate(rule, "abcdef", "fedcba") === ValidationResult.Pass)
+    assertEquals(validate(rule, "abcdef", "fedcba"), ValidationResult.Pass)
   }
 
   test("custom pattern invalid key") {
@@ -87,6 +87,6 @@ class ValidCharactersRuleSuite extends AnyFunSuite {
 
   test("custom pattern value override") {
     val rule = ValidCharactersRule(customPattern)
-    assert(validate(rule, "nf.asg", alpha + "^~") === ValidationResult.Pass)
+    assertEquals(validate(rule, "nf.asg", alpha + "^~"), ValidationResult.Pass)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ValueLengthRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ValueLengthRuleSuite.scala
@@ -16,9 +16,9 @@
 package com.netflix.atlas.core.validation
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class ValueLengthRuleSuite extends AnyFunSuite {
+class ValueLengthRuleSuite extends FunSuite {
 
   private val config = ConfigFactory.parseString("""
       |min-length = 2
@@ -32,9 +32,9 @@ class ValueLengthRuleSuite extends AnyFunSuite {
   }
 
   test("valid") {
-    assert(validate("def", "ab") === ValidationResult.Pass)
-    assert(validate("def", "abc") === ValidationResult.Pass)
-    assert(validate("def", "abcd") === ValidationResult.Pass)
+    assertEquals(validate("def", "ab"), ValidationResult.Pass)
+    assertEquals(validate("def", "abc"), ValidationResult.Pass)
+    assertEquals(validate("def", "abcd"), ValidationResult.Pass)
   }
 
   test("too short") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ValuePatternRuleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ValuePatternRuleSuite.scala
@@ -16,9 +16,9 @@
 package com.netflix.atlas.core.validation
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class ValuePatternRuleSuite extends AnyFunSuite {
+class ValuePatternRuleSuite extends FunSuite {
 
   private val config = ConfigFactory.parseString("""pattern = "^[a-c]+$" """)
 
@@ -29,8 +29,8 @@ class ValuePatternRuleSuite extends AnyFunSuite {
   }
 
   test("valid") {
-    assert(validate("def", "abc") === ValidationResult.Pass)
-    assert(validate("def", "aaa") === ValidationResult.Pass)
+    assertEquals(validate("def", "abc"), ValidationResult.Pass)
+    assertEquals(validate("def", "aaa"), ValidationResult.Pass)
   }
 
   test("invalid") {

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GraphUriSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GraphUriSuite.scala
@@ -21,9 +21,9 @@ import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.StyleExpr
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class GraphUriSuite extends AnyFunSuite {
+class GraphUriSuite extends FunSuite {
 
   private val grapher = Grapher(ConfigFactory.load())
 
@@ -33,56 +33,56 @@ class GraphUriSuite extends AnyFunSuite {
 
   test("simple expr") {
     val cfg = parseUri("/api/v1/graph?q=name,foo,:eq,:sum")
-    assert(cfg.exprs === List(StyleExpr(DataExpr.Sum(Query.Equal("name", "foo")), Map.empty)))
+    assertEquals(cfg.exprs, List(StyleExpr(DataExpr.Sum(Query.Equal("name", "foo")), Map.empty)))
   }
 
   test("empty title") {
     val cfg = parseUri("/api/v1/graph?q=name,foo,:eq,:sum&title=")
-    assert(cfg.flags.title === None)
+    assertEquals(cfg.flags.title, None)
   }
 
   test("with title") {
     val cfg = parseUri("/api/v1/graph?q=name,foo,:eq,:sum&title=foo")
-    assert(cfg.flags.title === Some("foo"))
+    assertEquals(cfg.flags.title, Some("foo"))
   }
 
   test("empty ylabel") {
     val cfg = parseUri("/api/v1/graph?q=name,foo,:eq,:sum&ylabel=")
-    assert(cfg.flags.axes(0).ylabel === None)
+    assertEquals(cfg.flags.axes(0).ylabel, None)
   }
 
   test("with ylabel") {
     val cfg = parseUri("/api/v1/graph?q=name,foo,:eq,:sum&ylabel=foo")
-    assert(cfg.flags.axes(0).ylabel === Some("foo"))
+    assertEquals(cfg.flags.axes(0).ylabel, Some("foo"))
   }
 
   test("empty ylabel.1") {
     val cfg = parseUri("/api/v1/graph?q=name,foo,:eq,:sum&ylabel.1=")
-    assert(cfg.flags.axes(1).ylabel === None)
+    assertEquals(cfg.flags.axes(1).ylabel, None)
   }
 
   test("empty ylabel.1 with ylabel") {
     val cfg = parseUri("/api/v1/graph?q=name,foo,:eq,:sum&ylabel.1=&ylabel=foo")
-    assert(cfg.flags.axes(1).ylabel === None)
+    assertEquals(cfg.flags.axes(1).ylabel, None)
   }
 
   test("lower bound") {
     val cfg = parseUri("/api/v1/graph?q=name,foo,:eq,:sum&l=0")
-    assert(cfg.flags.axes(0).newPlotDef().lower === PlotBound.Explicit(0.0))
+    assertEquals(cfg.flags.axes(0).newPlotDef().lower, PlotBound.Explicit(0.0))
   }
 
   test("lower bound auto-data") {
     val cfg = parseUri("/api/v1/graph?q=name,foo,:eq,:sum&l=auto-data")
-    assert(cfg.flags.axes(0).newPlotDef().lower === PlotBound.AutoData)
+    assertEquals(cfg.flags.axes(0).newPlotDef().lower, PlotBound.AutoData)
   }
 
   test("lower bound auto-style") {
     val cfg = parseUri("/api/v1/graph?q=name,foo,:eq,:sum&l=auto-style")
-    assert(cfg.flags.axes(0).newPlotDef().lower === PlotBound.AutoStyle)
+    assertEquals(cfg.flags.axes(0).newPlotDef().lower, PlotBound.AutoStyle)
   }
 
   test("lower bound default") {
     val cfg = parseUri("/api/v1/graph?q=name,foo,:eq,:sum")
-    assert(cfg.flags.axes(0).newPlotDef().lower === PlotBound.AutoStyle)
+    assertEquals(cfg.flags.axes(0).newPlotDef().lower, PlotBound.AutoStyle)
   }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GrapherSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GrapherSuite.scala
@@ -26,10 +26,9 @@ import com.netflix.atlas.core.util.Hash
 import com.netflix.atlas.core.util.Strings
 import com.netflix.atlas.json.Json
 import com.typesafe.config.ConfigFactory
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class GrapherSuite extends AnyFunSuite with BeforeAndAfterAll {
+class GrapherSuite extends FunSuite {
 
   private val bless = false
 
@@ -37,7 +36,9 @@ class GrapherSuite extends AnyFunSuite with BeforeAndAfterAll {
   private val baseDir = SrcPath.forProject("atlas-eval")
   private val goldenDir = s"$baseDir/src/test/resources/graph/${getClass.getSimpleName}"
   private val targetDir = s"$baseDir/target/${getClass.getSimpleName}"
-  private val graphAssertions = new GraphAssertions(goldenDir, targetDir, (a, b) => assert(a === b))
+
+  private val graphAssertions =
+    new GraphAssertions(goldenDir, targetDir, (a, b) => assertEquals(a, b))
 
   private val db = StaticDatabase.demo
   private val grapher = Grapher(ConfigFactory.load())
@@ -461,7 +462,7 @@ class GrapherSuite extends AnyFunSuite with BeforeAndAfterAll {
     val e = intercept[IllegalArgumentException] {
       grapher.toGraphConfig(Uri(uri)).parsedQuery.get
     }
-    assert(e.getMessage === "expecting time series expr, found String 'foo'")
+    assertEquals(e.getMessage, "expecting time series expr, found String 'foo'")
   }
 
   def renderTest(name: String)(uri: => String): Unit = {
@@ -508,13 +509,13 @@ class GrapherSuite extends AnyFunSuite with BeforeAndAfterAll {
   test("host rewrite: no match") {
     val request = mkRequest("foo.example.com")
     val config = grapher.toGraphConfig(request)
-    assert(config === grapher.toGraphConfig(request.uri))
+    assertEquals(config, grapher.toGraphConfig(request.uri))
   }
 
   test("host rewrite: match") {
     val request = mkRequest("foo.us-east-1.example.com")
     val config = grapher.toGraphConfig(request)
-    assert(config !== grapher.toGraphConfig(request.uri))
+    assertNotEquals(config, grapher.toGraphConfig(request.uri))
     assert(config.query.contains("region,us-east-1,:eq"))
     assert(config.parsedQuery.get.forall(_.toString.contains("region,us-east-1,:eq")))
   }
@@ -522,7 +523,7 @@ class GrapherSuite extends AnyFunSuite with BeforeAndAfterAll {
   test("host rewrite: bad query") {
     val request = mkRequest("foo.us-east-1.example.com", "a,b,:foo")
     val config = grapher.toGraphConfig(request)
-    assert(config.query === "a,b,:foo")
+    assertEquals(config.query, "a,b,:foo")
     assert(config.parsedQuery.isFailure)
   }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/SimpleLegendsSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/SimpleLegendsSuite.scala
@@ -20,9 +20,9 @@ import com.netflix.atlas.core.model.ModelExtractors
 import com.netflix.atlas.core.model.StyleExpr
 import com.netflix.atlas.core.stacklang.Interpreter
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class SimpleLegendsSuite extends AnyFunSuite {
+class SimpleLegendsSuite extends FunSuite {
 
   private val notSet = "__NOT_SET__"
 
@@ -45,83 +45,83 @@ class SimpleLegendsSuite extends AnyFunSuite {
   }
 
   test("honor explicit legend") {
-    assert(legends("name,cpu,:eq,:sum,foo,:legend") === List("foo"))
+    assertEquals(legends("name,cpu,:eq,:sum,foo,:legend"), List("foo"))
   }
 
   test("just math") {
-    assert(legends("4,5,:add,10,:mul") === List(notSet))
+    assertEquals(legends("4,5,:add,10,:mul"), List(notSet))
   }
 
   test("reqular query and just math") {
-    assert(legends("name,cpu,:eq,:sum,seconds,:time") === List("cpu", notSet))
+    assertEquals(legends("name,cpu,:eq,:sum,seconds,:time"), List("cpu", notSet))
   }
 
   test("prefer just name") {
-    assert(legends("name,cpu,:eq,:sum") === List("cpu"))
-    assert(legends("name,cpu,:eq,id,user,:eq,:and,:sum") === List("cpu"))
+    assertEquals(legends("name,cpu,:eq,:sum"), List("cpu"))
+    assertEquals(legends("name,cpu,:eq,id,user,:eq,:and,:sum"), List("cpu"))
   }
 
   test("use group by keys") {
-    assert(legends("name,cpu,:eq,:sum,(,app,id,),:by") === List("$app $id"))
+    assertEquals(legends("name,cpu,:eq,:sum,(,app,id,),:by"), List("$app $id"))
   }
 
   test("name with math") {
-    assert(legends("name,cpu,:eq,:sum,4,:add,6,:mul,:abs") === List("cpu"))
+    assertEquals(legends("name,cpu,:eq,:sum,4,:add,6,:mul,:abs"), List("cpu"))
   }
 
   test("name regex") {
-    assert(legends("name,cpu,:re,:sum") === List("cpu"))
+    assertEquals(legends("name,cpu,:re,:sum"), List("cpu"))
   }
 
   test("name not present") {
-    assert(legends("id,user,:eq,:sum") === List("user"))
+    assertEquals(legends("id,user,:eq,:sum"), List("user"))
   }
 
   test("name with offsets") {
     val expr = "name,cpu,:eq,:sum,(,0h,1w,),:offset"
-    assert(legends(expr) === List("cpu", "cpu (offset=$atlas.offset)"))
+    assertEquals(legends(expr), List("cpu", "cpu (offset=$atlas.offset)"))
   }
 
   test("name with avg") {
-    assert(legends("name,cpu,:eq,:avg") === List("cpu"))
+    assertEquals(legends("name,cpu,:eq,:avg"), List("cpu"))
   }
 
   test("name with dist avg") {
-    assert(legends("name,cpu,:eq,:dist-avg") === List("cpu"))
+    assertEquals(legends("name,cpu,:eq,:dist-avg"), List("cpu"))
   }
 
   test("name with dist-stddev") {
-    assert(legends("name,cpu,:eq,:dist-stddev") === List("cpu"))
+    assertEquals(legends("name,cpu,:eq,:dist-stddev"), List("cpu"))
   }
 
   test("name not clause") {
-    assert(legends("name,cpu,:eq,:not,:sum") === List("!cpu"))
+    assertEquals(legends("name,cpu,:eq,:not,:sum"), List("!cpu"))
   }
 
   test("name with node avg") {
-    assert(legends("name,cpu,:eq,:node-avg") === List("cpu"))
+    assertEquals(legends("name,cpu,:eq,:node-avg"), List("cpu"))
   }
 
   test("group by with offsets") {
     val expr = "name,cpu,:eq,:sum,(,id,),:by,(,0h,1w,),:offset"
-    assert(legends(expr) === List("$id", "$id (offset=$atlas.offset)"))
+    assertEquals(legends(expr), List("$id", "$id (offset=$atlas.offset)"))
   }
 
   test("complex: same name and math") {
-    assert(legends("name,cpu,:eq,:sum,:dup,:add") === List("cpu"))
+    assertEquals(legends("name,cpu,:eq,:sum,:dup,:add"), List("cpu"))
   }
 
   test("complex: not clause") {
     val expr = "name,cpu,:eq,:dup,id,user,:eq,:and,:sum,:swap,id,user,:eq,:not,:and,:sum"
-    assert(legends(expr) === List("user", "!user"))
+    assertEquals(legends(expr), List("user", "!user"))
   }
 
   test("complex: different names and math") {
-    assert(legends("name,cpu,:eq,:sum,name,disk,:eq,:sum,:and") === List(notSet))
+    assertEquals(legends("name,cpu,:eq,:sum,name,disk,:eq,:sum,:and"), List(notSet))
   }
 
   test("multi: different names") {
-    assert(legends("name,cpu,:eq,:sum,name,disk,:eq,:sum") === List("cpu", "disk"))
+    assertEquals(legends("name,cpu,:eq,:sum,name,disk,:eq,:sum"), List("cpu", "disk"))
   }
 
   test("multi: same name further restricted") {
@@ -131,11 +131,11 @@ class SimpleLegendsSuite extends AnyFunSuite {
       "name,cpu,:eq,id,system,:eq,:and,:sum," +
       "name,cpu,:eq,id,idle,:eq,:and,:sum,"
     )
-    assert(vs === List("cpu", "user", "system", "idle"))
+    assertEquals(vs, List("cpu", "user", "system", "idle"))
   }
 
   test("multi: same name with math") {
     val vs = legends("name,cpu,:eq,:sum,:dup,4,:add")
-    assert(vs === List("cpu", "cpu"))
+    assertEquals(vs, List("cpu", "cpu"))
   }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/AggrDatapointSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/AggrDatapointSuite.scala
@@ -17,9 +17,9 @@ package com.netflix.atlas.eval.model
 
 import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.Query
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class AggrDatapointSuite extends AnyFunSuite {
+class AggrDatapointSuite extends FunSuite {
 
   private val step = 60000
 
@@ -35,37 +35,37 @@ class AggrDatapointSuite extends AnyFunSuite {
   }
 
   test("aggregate empty") {
-    assert(AggrDatapoint.aggregate(Nil) === Nil)
+    assertEquals(AggrDatapoint.aggregate(Nil), Nil)
   }
 
   test("aggregate simple") {
     val expr = DataExpr.Sum(Query.True)
     val dataset = createDatapoints(expr, 0, 10)
     val result = AggrDatapoint.aggregate(dataset)
-    assert(result.size === 1)
-    assert(result.head.timestamp === 0L)
-    assert(result.head.tags === Map("name" -> "cpu"))
-    assert(result.head.value === 45.0)
+    assertEquals(result.size, 1)
+    assertEquals(result.head.timestamp, 0L)
+    assertEquals(result.head.tags, Map("name" -> "cpu"))
+    assertEquals(result.head.value, 45.0)
   }
 
   test("aggregate dedups using source") {
     val expr = DataExpr.Sum(Query.True)
     val dataset = createDatapoints(expr, 0, 10)
     val result = AggrDatapoint.aggregate(dataset ::: dataset)
-    assert(result.size === 1)
-    assert(result.head.timestamp === 0L)
-    assert(result.head.tags === Map("name" -> "cpu"))
-    assert(result.head.value === 45.0)
+    assertEquals(result.size, 1)
+    assertEquals(result.head.timestamp, 0L)
+    assertEquals(result.head.tags, Map("name" -> "cpu"))
+    assertEquals(result.head.value, 45.0)
   }
 
   test("aggregate group by") {
     val expr = DataExpr.GroupBy(DataExpr.Sum(Query.True), List("node"))
     val dataset = createDatapoints(expr, 0, 10)
     val result = AggrDatapoint.aggregate(dataset)
-    assert(result.size === 10)
+    assertEquals(result.size, 10)
     result.foreach { d =>
       val v = d.tags("node").substring(2).toDouble
-      assert(d.value === v)
+      assertEquals(d.value, v)
     }
   }
 
@@ -73,10 +73,10 @@ class AggrDatapointSuite extends AnyFunSuite {
     val expr = DataExpr.GroupBy(DataExpr.Sum(Query.True), List("node"))
     val dataset = createDatapoints(expr, 0, 10)
     val result = AggrDatapoint.aggregate(dataset ::: dataset)
-    assert(result.size === 10)
+    assertEquals(result.size, 10)
     result.foreach { d =>
       val v = d.tags("node").substring(2).toDouble
-      assert(d.value === v)
+      assertEquals(d.value, v)
     }
   }
 
@@ -84,10 +84,10 @@ class AggrDatapointSuite extends AnyFunSuite {
     val expr = DataExpr.All(Query.True)
     val dataset = createDatapoints(expr, 0, 10)
     val result = AggrDatapoint.aggregate(dataset)
-    assert(result.size === 10)
+    assertEquals(result.size, 10)
     result.foreach { d =>
       val v = d.tags("node").substring(2).toDouble
-      assert(d.value === v)
+      assertEquals(d.value, v)
     }
   }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/ChunkDataSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/ChunkDataSuite.scala
@@ -17,9 +17,9 @@ package com.netflix.atlas.eval.model
 
 import nl.jqno.equalsverifier.EqualsVerifier
 import nl.jqno.equalsverifier.Warning
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class ChunkDataSuite extends AnyFunSuite {
+class ChunkDataSuite extends FunSuite {
   test("ArrayData equals") {
     EqualsVerifier
       .forClass(classOf[ArrayData])
@@ -29,11 +29,11 @@ class ChunkDataSuite extends AnyFunSuite {
 
   test("ArrayData encode empty") {
     val empty = ArrayData(Array())
-    assert(empty.toJson === """{"type":"array","values":[]}""")
+    assertEquals(empty.toJson, """{"type":"array","values":[]}""")
   }
 
   test("ArrayData encode values") {
     val data = ArrayData(Array(1.0, 2.0, 3.0))
-    assert(data.toJson === """{"type":"array","values":[1.0,2.0,3.0]}""")
+    assertEquals(data.toJson, """{"type":"array","values":[1.0,2.0,3.0]}""")
   }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcDataExprSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcDataExprSuite.scala
@@ -19,9 +19,9 @@ import com.netflix.atlas.core.model.ModelExtractors
 import com.netflix.atlas.core.model.StyleExpr
 import com.netflix.atlas.core.model.StyleVocabulary
 import com.netflix.atlas.core.stacklang.Interpreter
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class LwcDataExprSuite extends AnyFunSuite {
+class LwcDataExprSuite extends FunSuite {
 
   private def styleExpr(str: String): StyleExpr = {
     val interpreter = new Interpreter(StyleVocabulary.allWords)
@@ -35,7 +35,7 @@ class LwcDataExprSuite extends AnyFunSuite {
     val exprStr = "statistic,max,:eq,name,foo,:eq,:and,:max,(,nf.asg,),:by"
     val distExprStr = "name,foo,:eq,:dist-max,(,nf.asg,),:by"
     val lwcExpr = LwcDataExpr("123", exprStr, 10L)
-    assert(lwcExpr.expr === styleExpr(distExprStr).expr.dataExprs.head)
-    assert(lwcExpr.expr.hashCode === styleExpr(exprStr).expr.hashCode)
+    assertEquals(lwcExpr.expr, styleExpr(distExprStr).expr.dataExprs.head)
+    assertEquals(lwcExpr.expr.hashCode, styleExpr(exprStr).expr.hashCode)
   }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcMessagesSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcMessagesSuite.scala
@@ -19,13 +19,13 @@ import akka.util.ByteString
 import com.netflix.atlas.akka.DiagnosticMessage
 import com.netflix.atlas.core.util.Streams
 import com.netflix.atlas.json.Json
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import java.util.Random
 import java.util.UUID
 import scala.util.Using
 
-class LwcMessagesSuite extends AnyFunSuite {
+class LwcMessagesSuite extends FunSuite {
 
   private val step = 60000
 
@@ -35,7 +35,7 @@ class LwcMessagesSuite extends AnyFunSuite {
     try {
       val actual = LwcMessages.parseDataExprs(parser).head
       val expected = LwcDataExpr("1234", "name,cpu,:eq,:sum", 10)
-      assert(actual === expected)
+      assertEquals(actual, expected)
     } finally {
       parser.close()
     }
@@ -48,37 +48,37 @@ class LwcMessagesSuite extends AnyFunSuite {
     val dataExprs = List(LwcDataExpr("a", sum, step), LwcDataExpr("b", count, step))
     val expected = LwcSubscription(expr, dataExprs)
     val actual = LwcMessages.parse(Json.encode(expected))
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("datapoint") {
     val expected = LwcDatapoint(step, "a", Map("foo" -> "bar"), 42.0)
     val actual = LwcMessages.parse(Json.encode(expected))
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("datapoint, custom encode") {
     val expected = LwcDatapoint(step, "a", Map("foo" -> "bar"), 42.0)
     val actual = LwcMessages.parse(expected.toJson)
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("diagnostic message") {
     val expected = DiagnosticMessage.error("something bad happened")
     val actual = LwcMessages.parse(Json.encode(expected))
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("diagnostic message for a particular expression") {
     val expected = LwcDiagnosticMessage("abc", DiagnosticMessage.error("something bad happened"))
     val actual = LwcMessages.parse(Json.encode(expected))
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("heartbeat") {
     val expected = LwcHeartbeat(1234567890L, 10L)
     val actual = LwcMessages.parse(Json.encode(expected))
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("heartbeat not on step boundary") {
@@ -92,7 +92,7 @@ class LwcMessagesSuite extends AnyFunSuite {
       LwcExpression("name,cpu,:eq,:max", i)
     }
     val actual = LwcMessages.parseBatch(LwcMessages.encodeBatch(expected))
-    assert(actual === expected)
+    assertEquals(actual, expected.toList)
   }
 
   test("batch: subscription") {
@@ -106,7 +106,7 @@ class LwcMessagesSuite extends AnyFunSuite {
       )
     }
     val actual = LwcMessages.parseBatch(LwcMessages.encodeBatch(expected))
-    assert(actual === expected)
+    assertEquals(actual, expected.toList)
   }
 
   test("batch: datapoint") {
@@ -119,7 +119,7 @@ class LwcMessagesSuite extends AnyFunSuite {
       )
     }
     val actual = LwcMessages.parseBatch(LwcMessages.encodeBatch(expected))
-    assert(actual === expected)
+    assertEquals(actual, expected.toList)
   }
 
   test("batch: lwc diagnostic") {
@@ -127,7 +127,7 @@ class LwcMessagesSuite extends AnyFunSuite {
       LwcDiagnosticMessage(s"$i", DiagnosticMessage.error("foo"))
     }
     val actual = LwcMessages.parseBatch(LwcMessages.encodeBatch(expected))
-    assert(actual === expected)
+    assertEquals(actual, expected.toList)
   }
 
   test("batch: diagnostic") {
@@ -135,7 +135,7 @@ class LwcMessagesSuite extends AnyFunSuite {
       DiagnosticMessage.error(s"error $i")
     }
     val actual = LwcMessages.parseBatch(LwcMessages.encodeBatch(expected))
-    assert(actual === expected)
+    assertEquals(actual, expected.toList)
   }
 
   test("batch: heartbeat") {
@@ -144,7 +144,7 @@ class LwcMessagesSuite extends AnyFunSuite {
       LwcHeartbeat(System.currentTimeMillis() / step * step, step)
     }
     val actual = LwcMessages.parseBatch(LwcMessages.encodeBatch(expected))
-    assert(actual === expected)
+    assertEquals(actual, expected.toList)
   }
 
   test("batch: compatibility") {
@@ -179,7 +179,7 @@ class LwcMessagesSuite extends AnyFunSuite {
     val actual = Using.resource(Streams.resource("lwc-batch.smile")) { in =>
       LwcMessages.parseBatch(ByteString(Streams.byteArray(in)))
     }
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("batch: random") {
@@ -188,7 +188,7 @@ class LwcMessagesSuite extends AnyFunSuite {
       val n = random.nextInt(1000)
       val expected = (0 until n).map(_ => randomObject(random)).toList
       val actual = LwcMessages.parseBatch(LwcMessages.encodeBatch(expected))
-      assert(actual === expected)
+      assertEquals(actual, expected)
     }
   }
 

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/TimeSeriesMessageSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/TimeSeriesMessageSuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.eval.model
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class TimeSeriesMessageSuite extends AnyFunSuite {
+class TimeSeriesMessageSuite extends FunSuite {
 
   private val baseMessage = TimeSeriesMessage(
     id = "12345",

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/DataSourceSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/DataSourceSuite.scala
@@ -19,9 +19,9 @@ import java.time.Duration
 
 import com.netflix.atlas.eval.stream.Evaluator.DataSource
 import com.netflix.atlas.json.Json
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class DataSourceSuite extends AnyFunSuite {
+class DataSourceSuite extends FunSuite {
 
   test("parse without explicit step") {
     val id = "123"
@@ -34,7 +34,7 @@ class DataSourceSuite extends AnyFunSuite {
         |}
         |""".stripMargin
     val expected = new DataSource(id, Duration.ofSeconds(60), uri)
-    assert(expected === Json.decode[DataSource](json))
+    assertEquals(expected, Json.decode[DataSource](json))
   }
 
   test("parse with explicit step") {
@@ -49,7 +49,7 @@ class DataSourceSuite extends AnyFunSuite {
          |}
          |""".stripMargin
     val expected = new DataSource(id, Duration.ofSeconds(5), uri)
-    assert(expected === Json.decode[DataSource](json))
+    assertEquals(expected, Json.decode[DataSource](json))
   }
 
   test("parse with explicit step in uri") {
@@ -63,7 +63,7 @@ class DataSourceSuite extends AnyFunSuite {
          |}
          |""".stripMargin
     val expected = new DataSource(id, Duration.ofSeconds(10), uri)
-    assert(expected === Json.decode[DataSource](json))
+    assertEquals(expected, Json.decode[DataSource](json))
   }
 
   test("parse with explicit step in uri and paylaod") {
@@ -79,6 +79,6 @@ class DataSourceSuite extends AnyFunSuite {
          |""".stripMargin
     // Payload should win
     val expected = new DataSource(id, Duration.ofSeconds(5), uri)
-    assert(expected === Json.decode[DataSource](json))
+    assertEquals(expected, Json.decode[DataSource](json))
   }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookupSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookupSuite.scala
@@ -26,13 +26,13 @@ import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import com.netflix.atlas.akka.AccessLogger
 import com.netflix.atlas.json.Json
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Success
 
-class EurekaGroupsLookupSuite extends AnyFunSuite {
+class EurekaGroupsLookupSuite extends FunSuite {
 
   import EurekaSource._
   import Evaluator._
@@ -98,9 +98,9 @@ class EurekaGroupsLookupSuite extends AnyFunSuite {
       DataSources.empty()
     )
     val output = run(input)
-    assert(output.size === 1)
-    assert(output.head._1.getSources.size() === 0)
-    assert(output.head._2.groups.size === 0)
+    assertEquals(output.size, 1)
+    assertEquals(output.head._1.getSources.size(), 0)
+    assertEquals(output.head._2.groups.size, 0)
   }
 
   test("one data source") {
@@ -108,8 +108,8 @@ class EurekaGroupsLookupSuite extends AnyFunSuite {
       sources(ds("a", "http://atlas/api/v1/graph?q=name,jvm.gc.pause,:eq,:dist-avg"))
     )
     val output = run(input)
-    assert(output.head._2.groups.size === 1)
-    assert(output.head._2.groups.head === eurekaGroup)
+    assertEquals(output.head._2.groups.size, 1)
+    assertEquals(output.head._2.groups.head, eurekaGroup)
   }
 
   test("unknown data source") {
@@ -117,7 +117,7 @@ class EurekaGroupsLookupSuite extends AnyFunSuite {
       sources(ds("a", "http://unknown/api/v1/graph?q=name,jvm.gc.pause,:eq,:dist-avg"))
     )
     val output = run(input)
-    assert(output.head._2.groups.size === 0)
+    assertEquals(output.head._2.groups.size, 0)
     // TODO: check for diagnostic message
   }
 
@@ -126,9 +126,9 @@ class EurekaGroupsLookupSuite extends AnyFunSuite {
       sources(ds("a", "http://atlas/api/v1/graph?q=name,jvm.gc.pause,:eq,:dist-avg"))
     )
     val output = run(input, 5)
-    assert(output.size === 5)
+    assertEquals(output.size, 5)
     output.foreach {
-      case (_, g) => assert(g.groups.size === 1)
+      case (_, g) => assertEquals(g.groups.size, 1)
     }
   }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaSourceSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaSourceSuite.scala
@@ -37,7 +37,7 @@ import com.fasterxml.jackson.databind.exc.ValueInstantiationException
 import com.netflix.atlas.akka.AccessLogger
 import com.netflix.atlas.core.util.Streams
 import com.netflix.atlas.eval.stream.EurekaSource.GroupResponse
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.Future
@@ -47,7 +47,7 @@ import scala.util.Success
 import scala.util.Try
 import scala.util.Using
 
-class EurekaSourceSuite extends AnyFunSuite {
+class EurekaSourceSuite extends FunSuite {
 
   private def mkResponse(data: String, status: StatusCode = StatusCodes.OK): HttpResponse = {
     mkResponse(data.getBytes(StandardCharsets.UTF_8), false, status)
@@ -110,26 +110,26 @@ class EurekaSourceSuite extends AnyFunSuite {
   test("handles vip uri") {
     val uri = "http://eureka/v1/vips/www-dev:7001"
     val res = run(uri, Success(mkResponse(vipJson)))
-    assert(res.uri === uri)
-    assert(res.instances.size === 1)
-    assert(res.instances.map(_.instanceId).toSet === Set("i-12345"))
+    assertEquals(res.uri, uri)
+    assertEquals(res.instances.size, 1)
+    assertEquals(res.instances.map(_.instanceId).toSet, Set("i-12345"))
   }
 
   test("supports compressed response") {
     val uri = "http://eureka/v1/vips/www-dev:7001"
     val res = run(uri, Success(mkResponse(gzip(vipJson), true, StatusCodes.OK)))
-    assert(res.uri === uri)
-    assert(res.instances.size === 1)
-    assert(res.instances.map(_.instanceId).toSet === Set("i-12345"))
+    assertEquals(res.uri, uri)
+    assertEquals(res.instances.size, 1)
+    assertEquals(res.instances.map(_.instanceId).toSet, Set("i-12345"))
   }
 
   test("handles app uri") {
     val uri = "http://eureka/v1/apps/www-dev:7001"
     val res = run(uri, Success(mkResponse(appJson)))
-    assert(res.uri === uri)
-    assert(res.instances.size === 1)
-    assert(res.instances.map(_.instanceId).toSet === Set("i-12345"))
-    assert(res.instances.map(_.port.port).toSet === Set(7001))
+    assertEquals(res.uri, uri)
+    assertEquals(res.instances.size, 1)
+    assertEquals(res.instances.map(_.instanceId).toSet, Set("i-12345"))
+    assertEquals(res.instances.map(_.port.port).toSet, Set(7001))
   }
 
   test("invalid json response") {
@@ -183,32 +183,32 @@ class EurekaSourceSuite extends AnyFunSuite {
   test("handles edda uri, 1 group") {
     val uri = "http://edda/api/v2/group/autoScalingGroups;cluster=atlas_lwcapi-main;_expand"
     val res = run(uri, Success(mkResponse(eddaResponseSingleGroup)))
-    assert(res.uri === uri)
-    assert(res.instances.size === 2)
-    assert(res.instances.map(_.instanceId).toSet === Set("id1", "id2"))
-    assert("http://1.2.3.4:7101" === res.instances(0).substitute("http://{local-ipv4}:{port}"))
-    assert("http://1.2.3.5:7101" === res.instances(1).substitute("http://{local-ipv4}:{port}"))
+    assertEquals(res.uri, uri)
+    assertEquals(res.instances.size, 2)
+    assertEquals(res.instances.map(_.instanceId).toSet, Set("id1", "id2"))
+    assertEquals("http://1.2.3.4:7101", res.instances(0).substitute("http://{local-ipv4}:{port}"))
+    assertEquals("http://1.2.3.5:7101", res.instances(1).substitute("http://{local-ipv4}:{port}"))
   }
 
   test("handles edda uri, 2 groups") {
     val uri = "http://edda/api/v2/group/autoScalingGroups;cluster=atlas_lwcapi-main;_expand"
     val res = run(uri, Success(mkResponse(eddaResponse2Groups)))
-    assert(res.uri === uri)
-    assert(res.instances.size === 3)
-    assert(res.instances.map(_.instanceId).toSet === Set("id1", "id2", "id3"))
-    assert("http://1.2.3.4:7101" === res.instances(0).substitute("http://{local-ipv4}:{port}"))
-    assert("http://1.2.3.5:7101" === res.instances(1).substitute("http://{local-ipv4}:{port}"))
-    assert("http://1.2.3.6:7101" === res.instances(2).substitute("http://{local-ipv4}:{port}"))
+    assertEquals(res.uri, uri)
+    assertEquals(res.instances.size, 3)
+    assertEquals(res.instances.map(_.instanceId).toSet, Set("id1", "id2", "id3"))
+    assertEquals("http://1.2.3.4:7101", res.instances(0).substitute("http://{local-ipv4}:{port}"))
+    assertEquals("http://1.2.3.5:7101", res.instances(1).substitute("http://{local-ipv4}:{port}"))
+    assertEquals("http://1.2.3.6:7101", res.instances(2).substitute("http://{local-ipv4}:{port}"))
   }
 
   test("handles edda uri, 1 empty 1 not") {
     val uri = "http://edda/api/v2/group/autoScalingGroups;cluster=atlas_lwcapi-main;_expand"
     val res = run(uri, Success(mkResponse(eddaResponseOneEmptyGroup)))
-    assert(res.uri === uri)
-    assert(res.instances.size === 2)
-    assert(res.instances.map(_.instanceId).toSet === Set("id1", "id2"))
-    assert("http://1.2.3.4:7101" === res.instances(0).substitute("http://{local-ipv4}:{port}"))
-    assert("http://1.2.3.5:7101" === res.instances(1).substitute("http://{local-ipv4}:{port}"))
+    assertEquals(res.uri, uri)
+    assertEquals(res.instances.size, 2)
+    assertEquals(res.instances.map(_.instanceId).toSet, Set("id1", "id2"))
+    assertEquals("http://1.2.3.4:7101", res.instances(0).substitute("http://{local-ipv4}:{port}"))
+    assertEquals("http://1.2.3.5:7101", res.instances(1).substitute("http://{local-ipv4}:{port}"))
   }
 
   val eddaResponseSingleGroup =

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FillRemovedKeysWithSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FillRemovedKeysWithSuite.scala
@@ -18,12 +18,12 @@ package com.netflix.atlas.eval.stream
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class FillRemovedKeysWithSuite extends AnyFunSuite {
+class FillRemovedKeysWithSuite extends FunSuite {
 
   implicit val system = ActorSystem(getClass.getSimpleName)
 
@@ -39,9 +39,9 @@ class FillRemovedKeysWithSuite extends AnyFunSuite {
 
     val outputList = Await.result(future, Duration.Inf).toList
 
-    assert(
-      outputList ===
-        List(Map("a" -> "1"), Map("a" -> "?", "b" -> "2"), Map("b" -> "?", "c" -> "3", "d" -> "4"))
+    assertEquals(
+      outputList,
+      List(Map("a" -> "1"), Map("a" -> "?", "b" -> "2"), Map("b" -> "?", "c" -> "3", "d" -> "4"))
     )
   }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
@@ -33,12 +33,12 @@ import com.netflix.atlas.eval.stream.Evaluator.DataSource
 import com.netflix.atlas.eval.stream.Evaluator.DataSources
 import com.netflix.atlas.eval.stream.Evaluator.MessageEnvelope
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class FinalExprEvalSuite extends AnyFunSuite {
+class FinalExprEvalSuite extends FunSuite {
 
   private val step = 60000L
 
@@ -76,9 +76,9 @@ class FinalExprEvalSuite extends AnyFunSuite {
       sources(ds("a", "http://atlas/graph?q=foo,:time"))
     )
     val output = run(input)
-    assert(output.size === 1)
+    assertEquals(output.size, 1)
     output.foreach { env =>
-      assert(env.getId === "a")
+      assertEquals(env.getId, "a")
 
       val msg = "invalid expression [[http://atlas/graph?q=foo,:time]]: " +
         "IllegalArgumentException: No enum constant java.time.temporal.ChronoField.foo"
@@ -92,13 +92,13 @@ class FinalExprEvalSuite extends AnyFunSuite {
       TimeGroup(0L, step, Map.empty)
     )
     val output = run(input)
-    assert(output.size === 1)
+    assertEquals(output.size, 1)
 
     val tsMsgs = output.filter(isTimeSeries)
-    assert(tsMsgs.size === 1)
+    assertEquals(tsMsgs.size, 1)
     val (tsId, tsMsg) = tsMsgs.head.getId -> tsMsgs.head.getMessage.asInstanceOf[TimeSeriesMessage]
     assert(tsId == "a")
-    assert(tsMsg.label === "(NO DATA / NO DATA)")
+    assertEquals(tsMsg.label, "(NO DATA / NO DATA)")
 
   }
 
@@ -130,17 +130,17 @@ class FinalExprEvalSuite extends AnyFunSuite {
     intermediateSize: EvalDataSize,
     outputSize: EvalDataSize
   ): Unit = {
-    assert(rate.timestamp === timestamp)
-    assert(rate.step === step)
-    assert(rate.inputSize === inputSize)
-    assert(rate.intermediateSize === intermediateSize)
-    assert(rate.outputSize === outputSize)
+    assertEquals(rate.timestamp, timestamp)
+    assertEquals(rate.step, step)
+    assertEquals(rate.inputSize, inputSize)
+    assertEquals(rate.intermediateSize, intermediateSize)
+    assertEquals(rate.outputSize, outputSize)
   }
 
   private def getValue(ts: TimeSeriesMessage): Double = {
     ts.data match {
       case ArrayData(vs) =>
-        assert(vs.length === 1)
+        assertEquals(vs.length, 1)
         vs(0)
       case v =>
         fail(s"unexpected data value: $v")
@@ -152,7 +152,7 @@ class FinalExprEvalSuite extends AnyFunSuite {
     if (expected.isNaN)
       assert(v.isNaN)
     else
-      assert(v === expected)
+      assertEquals(v, expected)
   }
 
   test("aggregate with single datapoint per group") {
@@ -169,11 +169,11 @@ class FinalExprEvalSuite extends AnyFunSuite {
     val output = run(input)
 
     val timeseries = output.filter(isTimeSeries)
-    assert(timeseries.size === 4)
+    assertEquals(timeseries.size, 4)
     val expectedTimeseries = List(Double.NaN, 42.0, 43.0, 44.0)
     timeseries.zip(expectedTimeseries).foreach {
       case (env, expectedValue) =>
-        assert(env.getId === "a")
+        assertEquals(env.getId, "a")
         val ts = env.getMessage.asInstanceOf[TimeSeriesMessage]
         checkValue(ts, expectedValue)
     }
@@ -234,11 +234,11 @@ class FinalExprEvalSuite extends AnyFunSuite {
     val output = run(input)
 
     val timeseries = output.filter(isTimeSeries)
-    assert(timeseries.size === 4)
+    assertEquals(timeseries.size, 4)
     val expectedTimeseries = List(Double.NaN, 42.0, 129.0, 87.0)
     timeseries.zip(expectedTimeseries).foreach {
       case (env, expectedValue) =>
-        assert(env.getId === "a")
+        assertEquals(env.getId, "a")
         val ts = env.getMessage.asInstanceOf[TimeSeriesMessage]
         checkValue(ts, expectedValue)
     }
@@ -303,7 +303,7 @@ class FinalExprEvalSuite extends AnyFunSuite {
     val output = run(input)
 
     val timeseries = output.filter(isTimeSeries)
-    assert(timeseries.size === 3 + 3) // 3 for expr1, 3 for expr2
+    assertEquals(timeseries.size, 3 + 3) // 3 for expr1, 3 for expr2
 
     val expectedTimeseries1 = scala.collection.mutable.Queue(42.0, 84.0, 44.0)
     val expectedTimeseries2 = scala.collection.mutable.Queue(Double.NaN, 45.0, 49.0)
@@ -405,7 +405,7 @@ class FinalExprEvalSuite extends AnyFunSuite {
     val output = run(input)
 
     val timeseries = output.filter(isTimeSeries)
-    assert(timeseries.size === 4)
+    assertEquals(timeseries.size, 4)
     timeseries.foreach { env =>
       val ts = env.getMessage.asInstanceOf[TimeSeriesMessage]
       if (ts.tags("node") == "i-1") {
@@ -465,11 +465,11 @@ class FinalExprEvalSuite extends AnyFunSuite {
     val output = run(input)
 
     val timeseries = output.filter(_.getMessage.isInstanceOf[TimeSeriesMessage])
-    assert(timeseries.size === 4)
+    assertEquals(timeseries.size, 4)
     // tail to ignore initial no data entry
     timeseries.tail.foreach { env =>
       val ts = env.getMessage.asInstanceOf[TimeSeriesMessage]
-      assert(ts.label === "legend for rps")
+      assertEquals(ts.label, "legend for rps")
     }
   }
 
@@ -491,11 +491,11 @@ class FinalExprEvalSuite extends AnyFunSuite {
     val output = run(input)
 
     val timeseries = output.filter(isTimeSeries)
-    assert(timeseries.size === 4)
+    assertEquals(timeseries.size, 4)
     val expectedTimeseries = List(0.0, 0.0, 0.0, 0.0)
     timeseries.zip(expectedTimeseries).foreach {
       case (env, expectedValue) =>
-        assert(env.getId === "a")
+        assertEquals(env.getId, "a")
         val ts = env.getMessage.asInstanceOf[TimeSeriesMessage]
         checkValue(ts, expectedValue)
     }
@@ -521,11 +521,11 @@ class FinalExprEvalSuite extends AnyFunSuite {
     val output = run(input)
 
     val timeseries = output.filter(isTimeSeries)
-    assert(timeseries.size === 5)
+    assertEquals(timeseries.size, 5)
     val expectedTimeseries = List(Double.NaN, Double.NaN, -2.0, 0.0, -4.0)
     timeseries.zip(expectedTimeseries).foreach {
       case (env, expectedValue) =>
-        assert(env.getId === "a")
+        assertEquals(env.getId, "a")
         val ts = env.getMessage.asInstanceOf[TimeSeriesMessage]
         checkValue(ts, expectedValue)
     }
@@ -542,9 +542,10 @@ class FinalExprEvalSuite extends AnyFunSuite {
     val e = intercept[IllegalStateException] {
       run(input)
     }
-    assert(
-      e.getMessage === "inconsistent step sizes, expected 60000, found 10000 " +
-        "on DataSource(b,PT10S,http://atlas/graph?q=name,rps,:eq,:sum)"
+    assertEquals(
+      e.getMessage,
+      "inconsistent step sizes, expected 60000, found 10000 " +
+      "on DataSource(b,PT10S,http://atlas/graph?q=name,rps,:eq,:sum)"
     )
   }
 
@@ -567,11 +568,11 @@ class FinalExprEvalSuite extends AnyFunSuite {
     val output = run(input)
 
     val timeseries = output.filter(isTimeSeries)
-    assert(timeseries.size === 8)
+    assertEquals(timeseries.size, 8)
     val expectedTimeseries = List(0.0, 1.0, 1.0, 2.0, 1.0, 1.0, 0.0, 1.0)
     timeseries.zip(expectedTimeseries).foreach {
       case (env, expectedValue) =>
-        assert(env.getId === "a")
+        assertEquals(env.getId, "a")
         val ts = env.getMessage.asInstanceOf[TimeSeriesMessage]
         checkValue(ts, expectedValue)
     }
@@ -605,14 +606,14 @@ class FinalExprEvalSuite extends AnyFunSuite {
     val output = run(input)
 
     val timeseries = output.filter(isTimeSeries)
-    assert(timeseries.size === 8)
+    assertEquals(timeseries.size, 8)
     timeseries.foreach { env =>
       val ts = env.getMessage.asInstanceOf[TimeSeriesMessage]
       val v = getValue(ts)
       if (ts.label == "NO DATA")
         assert(v.isNaN)
       else
-        assert(v === 0.0)
+        assertEquals(v, 0.0)
     }
   }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/HostSourceSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/HostSourceSuite.scala
@@ -34,7 +34,7 @@ import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.Future
@@ -43,7 +43,7 @@ import scala.util.Success
 import scala.util.Try
 import scala.util.Using
 
-class HostSourceSuite extends AnyFunSuite {
+class HostSourceSuite extends FunSuite {
 
   import scala.concurrent.duration._
 
@@ -68,7 +68,7 @@ class HostSourceSuite extends AnyFunSuite {
       .map(_.decodeString(StandardCharsets.UTF_8))
       .runWith(Sink.seq[String])
     val result = Await.result(future, Duration.Inf).toList
-    assert(result === (0 until 5).map(_ => "ok").toList)
+    assertEquals(result, (0 until 5).map(_ => "ok").toList)
   }
 
   test("no size limit on data stream") {
@@ -79,7 +79,7 @@ class HostSourceSuite extends AnyFunSuite {
       .map(_.decodeString(StandardCharsets.UTF_8))
       .runWith(Sink.seq[String])
     val result = Await.result(future, Duration.Inf).toList
-    assert(result === (0 until 5).map(_ => "ok").toList)
+    assertEquals(result, (0 until 5).map(_ => "ok").toList)
   }
 
   test("handles decompression") {
@@ -91,7 +91,7 @@ class HostSourceSuite extends AnyFunSuite {
       .map(_.decodeString(StandardCharsets.UTF_8))
       .runWith(Sink.seq[String])
     val result = Await.result(future, Duration.Inf).toList
-    assert(result === (0 until 5).map(_ => "ok").toList)
+    assertEquals(result, (0 until 5).map(_ => "ok").toList)
   }
 
   test("retries on error response from host") {
@@ -164,6 +164,6 @@ class HostSourceSuite extends AnyFunSuite {
       .take(5)
       .runWith(Sink.seq[String])
     val result = Await.result(future, Duration.Inf).toList
-    assert(result === (0 until 5).map(_ => "ok").toList)
+    assertEquals(result, (0 until 5).map(_ => "ok").toList)
   }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
@@ -30,12 +30,12 @@ import com.netflix.atlas.eval.stream.Evaluator.DataSource
 import com.netflix.atlas.eval.stream.Evaluator.DataSources
 import com.netflix.atlas.json.JsonSupport
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class LwcToAggrDatapointSuite extends AnyFunSuite {
+class LwcToAggrDatapointSuite extends FunSuite {
 
   implicit val system = ActorSystem(getClass.getSimpleName)
   private implicit val materializer = Materializer(system)
@@ -92,28 +92,28 @@ class LwcToAggrDatapointSuite extends AnyFunSuite {
 
   test("eval") {
     val results = eval(input)
-    assert(results.size === 8)
+    assertEquals(results.size, 8)
 
     val groups = results.groupBy(_.expr)
-    assert(groups.size === 2)
+    assertEquals(groups.size, 2)
 
     val sumData = groups(DataExpr.Sum(Query.Equal("name", "cpu")))
-    assert(sumData.map(_.value).toSet === Set(1.0, 2.0, 3.0, 4.0))
+    assertEquals(sumData.map(_.value).toSet, Set(1.0, 2.0, 3.0, 4.0))
 
     val countData = groups(DataExpr.Count(Query.Equal("name", "cpu")))
-    assert(countData.size === 4)
-    assert(countData.map(_.value).toSet === Set(4.0))
+    assertEquals(countData.size, 4)
+    assertEquals(countData.map(_.value).toSet, Set(4.0))
   }
 
   test("diagnostic messages are logged") {
     logMessages.clear()
     eval(input)
-    assert(logMessages.size() === 2)
+    assertEquals(logMessages.size(), 2)
     List("1", "2").foreach { i =>
       logMessages.poll() match {
         case (_, msg: DiagnosticMessage) =>
-          assert(msg.`type` === "error")
-          assert(msg.message === i)
+          assertEquals(msg.`type`, "error")
+          assertEquals(msg.message, i)
         case v =>
           fail(s"unexpected message: $v")
       }
@@ -125,11 +125,11 @@ class LwcToAggrDatapointSuite extends AnyFunSuite {
       """{"type":"heartbeat","timestamp":1234567890,"step":10}"""
     )
     val results = eval(data)
-    assert(results.size === 1)
+    assertEquals(results.size, 1)
 
     val d = results.head
     assert(d.isHeartbeat)
-    assert(d.timestamp === 1234567890)
-    assert(d.step === 10)
+    assertEquals(d.timestamp, 1234567890L)
+    assertEquals(d.step, 10L)
   }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
@@ -24,13 +24,13 @@ import com.netflix.atlas.eval.model.AggrDatapoint
 import com.netflix.atlas.eval.model.AggrValuesInfo
 import com.netflix.atlas.eval.model.TimeGroup
 import com.netflix.spectator.api.DefaultRegistry
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 
-class TimeGroupedSuite extends AnyFunSuite {
+class TimeGroupedSuite extends FunSuite {
 
   private implicit val system = ActorSystem(getClass.getSimpleName)
   private implicit val materializer = Materializer(system)
@@ -84,12 +84,13 @@ class TimeGroupedSuite extends AnyFunSuite {
       )
 
     val groups = run(data)
-    assert(
-      groups === List(
-          timeGroup(10, List(datapoint(10, 1), datapoint(10, 2), datapoint(10, 3))),
-          timeGroup(20, List(datapoint(20, 1))),
-          timeGroup(30, List(datapoint(30, 1), datapoint(30, 2)))
-        )
+    assertEquals(
+      groups,
+      List(
+        timeGroup(10, List(datapoint(10, 1), datapoint(10, 2), datapoint(10, 3))),
+        timeGroup(20, List(datapoint(20, 1))),
+        timeGroup(30, List(datapoint(30, 1), datapoint(30, 2)))
+      )
     )
   }
 
@@ -105,12 +106,13 @@ class TimeGroupedSuite extends AnyFunSuite {
       )
 
     val groups = run(data)
-    assert(
-      groups === List(
-          timeGroup(10, List(datapoint(10, 1), datapoint(10, 2), datapoint(10, 3))),
-          timeGroup(20, List(datapoint(20, 1))),
-          timeGroup(30, List(datapoint(30, 1), datapoint(30, 2)))
-        )
+    assertEquals(
+      groups,
+      List(
+        timeGroup(10, List(datapoint(10, 1), datapoint(10, 2), datapoint(10, 3))),
+        timeGroup(20, List(datapoint(20, 1))),
+        timeGroup(30, List(datapoint(30, 1), datapoint(30, 2)))
+      )
     )
   }
 
@@ -137,16 +139,17 @@ class TimeGroupedSuite extends AnyFunSuite {
     val groups = run(data)
     val after = counts
 
-    assert(
-      groups === List(
-          timeGroup(10, List(datapoint(10, 1), datapoint(10, 2), datapoint(10, 3))),
-          timeGroup(20, List(datapoint(20, 1))),
-          timeGroup(30, List(datapoint(30, 1), datapoint(30, 2)))
-        )
+    assertEquals(
+      groups,
+      List(
+        timeGroup(10, List(datapoint(10, 1), datapoint(10, 2), datapoint(10, 3))),
+        timeGroup(20, List(datapoint(20, 1))),
+        timeGroup(30, List(datapoint(30, 1), datapoint(30, 2)))
+      )
     )
 
-    assert(before._1 + 6 === after._1) // 6 buffered messages
-    assert(before._2 + 1 === after._2) // 1 dropped message
+    assertEquals(before._1 + 6, after._1) // 6 buffered messages
+    assertEquals(before._2 + 1, after._2) // 1 dropped message
   }
 
   test("future events dropped") {
@@ -165,16 +168,17 @@ class TimeGroupedSuite extends AnyFunSuite {
     val groups = run(data)
     val after = counts
 
-    assert(
-      groups === List(
-          timeGroup(10, List(datapoint(10, 2), datapoint(10, 3))),
-          timeGroup(20, List(datapoint(20, 1))),
-          timeGroup(30, List(datapoint(30, 1), datapoint(30, 2)))
-        )
+    assertEquals(
+      groups,
+      List(
+        timeGroup(10, List(datapoint(10, 2), datapoint(10, 3))),
+        timeGroup(20, List(datapoint(20, 1))),
+        timeGroup(30, List(datapoint(30, 1), datapoint(30, 2)))
+      )
     )
 
-    assert(before._1 + 5 === after._1) // 5 buffered messages
-    assert(before._2 + 2 === after._2) // 2 dropped message
+    assertEquals(before._1 + 5, after._1) // 5 buffered messages
+    assertEquals(before._2 + 2, after._2) // 2 dropped message
   }
 
   test("heartbeat will flush if no data for an interval") {
@@ -191,12 +195,13 @@ class TimeGroupedSuite extends AnyFunSuite {
       )
 
     val groups = run(data)
-    assert(
-      groups === List(
-          timeGroup(10, List(datapoint(10, 1), datapoint(10, 2), datapoint(10, 3))),
-          timeGroup(20, Nil),
-          timeGroup(30, List(datapoint(30, 1), datapoint(30, 2)))
-        )
+    assertEquals(
+      groups,
+      List(
+        timeGroup(10, List(datapoint(10, 1), datapoint(10, 2), datapoint(10, 3))),
+        timeGroup(20, Nil),
+        timeGroup(30, List(datapoint(30, 1), datapoint(30, 2)))
+      )
     )
   }
 
@@ -209,7 +214,7 @@ class TimeGroupedSuite extends AnyFunSuite {
     val expected = AggrDatapoint(10, 10, expr, "test", Map.empty, n * (n - 1) / 2)
 
     val groups = run(data)
-    assert(groups === List(TimeGroup(10, step, Map(expr -> AggrValuesInfo(List(expected), n)))))
+    assertEquals(groups, List(TimeGroup(10, step, Map(expr -> AggrValuesInfo(List(expected), n)))))
   }
 
   test("simple aggregate: min") {
@@ -221,7 +226,7 @@ class TimeGroupedSuite extends AnyFunSuite {
     val expected = AggrDatapoint(10, 10, expr, "test", Map.empty, 0)
 
     val groups = run(data)
-    assert(groups === List(TimeGroup(10, step, Map(expr -> AggrValuesInfo(List(expected), n)))))
+    assertEquals(groups, List(TimeGroup(10, step, Map(expr -> AggrValuesInfo(List(expected), n)))))
   }
 
   test("simple aggregate: max") {
@@ -233,7 +238,7 @@ class TimeGroupedSuite extends AnyFunSuite {
     val expected = AggrDatapoint(10, 10, expr, "test", Map.empty, n - 1)
 
     val groups = run(data)
-    assert(groups === List(TimeGroup(10, step, Map(expr -> AggrValuesInfo(List(expected), n)))))
+    assertEquals(groups, List(TimeGroup(10, step, Map(expr -> AggrValuesInfo(List(expected), n)))))
   }
 
   test("simple aggregate: count") {
@@ -245,7 +250,7 @@ class TimeGroupedSuite extends AnyFunSuite {
     val expected = AggrDatapoint(10, 10, expr, "test", Map.empty, n * (n - 1) / 2)
 
     val groups = run(data)
-    assert(groups === List(TimeGroup(10, step, Map(expr -> AggrValuesInfo(List(expected), n)))))
+    assertEquals(groups, List(TimeGroup(10, step, Map(expr -> AggrValuesInfo(List(expected), n)))))
   }
 
   test("group by aggregate: sum") {
@@ -266,7 +271,7 @@ class TimeGroupedSuite extends AnyFunSuite {
     )
 
     val groups = run(data)
-    assert(groups === List(TimeGroup(10, step, expected)))
+    assertEquals(groups, List(TimeGroup(10, step, expected)))
   }
 
   test("group by aggregate: min") {
@@ -287,7 +292,7 @@ class TimeGroupedSuite extends AnyFunSuite {
     )
 
     val groups = run(data)
-    assert(groups === List(TimeGroup(10, step, expected)))
+    assertEquals(groups, List(TimeGroup(10, step, expected)))
   }
 
   test("group by aggregate: max") {
@@ -308,7 +313,7 @@ class TimeGroupedSuite extends AnyFunSuite {
     )
 
     val groups = run(data)
-    assert(groups === List(TimeGroup(10, step, expected)))
+    assertEquals(groups, List(TimeGroup(10, step, expected)))
   }
 
   test("group by aggregate: count") {
@@ -329,6 +334,6 @@ class TimeGroupedSuite extends AnyFunSuite {
     )
 
     val groups = run(data)
-    assert(groups === List(TimeGroup(10, step, expected)))
+    assertEquals(groups, List(TimeGroup(10, step, expected)))
   }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/util/HostRewriterSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/util/HostRewriterSuite.scala
@@ -20,9 +20,9 @@ import com.netflix.atlas.core.model.ModelExtractors
 import com.netflix.atlas.core.model.StyleExpr
 import com.netflix.atlas.core.stacklang.Interpreter
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class HostRewriterSuite extends AnyFunSuite {
+class HostRewriterSuite extends FunSuite {
 
   private val config = ConfigFactory.load()
   private val interpreter = Interpreter(new CustomVocabulary(config).allWords)
@@ -38,7 +38,7 @@ class HostRewriterSuite extends AnyFunSuite {
     val rewriter = new HostRewriter(config.getConfig("atlas.eval.host-rewrite"))
     val exprs = interpret("name,sps,:eq,:sum")
     val host = "foo.example.com"
-    assert(rewriter.rewrite(host, exprs) === exprs)
+    assertEquals(rewriter.rewrite(host, exprs), exprs)
   }
 
   test("restrict by region extracted from host") {
@@ -50,7 +50,7 @@ class HostRewriterSuite extends AnyFunSuite {
     val exprs = interpret("name,sps,:eq,:sum")
     val expected = interpret("name,sps,:eq,region,us-east-1,:eq,:and,:sum")
     val host = "foo.us-east-1.example.com"
-    assert(rewriter.rewrite(host, exprs) === expected)
+    assertEquals(rewriter.rewrite(host, exprs), expected)
   }
 
   test("use first group if multiple in pattern") {
@@ -63,7 +63,7 @@ class HostRewriterSuite extends AnyFunSuite {
     val exprs = interpret("name,sps,:eq,:sum")
     val expected = interpret("name,sps,:eq,region,us-east-1,:eq,:and,:sum")
     val host = "foo.us-east-1.example.com"
-    assert(rewriter.rewrite(host, exprs) === expected)
+    assertEquals(rewriter.rewrite(host, exprs), expected)
   }
 
   test("no group in pattern") {

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/CaseClassDeserializerSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/CaseClassDeserializerSuite.scala
@@ -25,9 +25,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class CaseClassDeserializerSuite extends AnyFunSuite {
+class CaseClassDeserializerSuite extends FunSuite {
 
   import CaseClassDeserializerSuite._
 
@@ -41,7 +41,7 @@ class CaseClassDeserializerSuite extends AnyFunSuite {
   test("read simple object") {
     val expected = SimpleObject(123, "abc", Some("def"))
     val actual = decode[SimpleObject]("""{"foo": 123, "bar": "abc", "baz": "def"}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("read array") {
@@ -59,7 +59,7 @@ class CaseClassDeserializerSuite extends AnyFunSuite {
   test("invalid type for field (quoted number)") {
     val expected = SimpleObject(123, "abc", Some("def"))
     val actual = decode[SimpleObject]("""{"foo": "123", "bar": "abc", "baz": "def"}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("invalid type for field (invalid number)") {
@@ -71,43 +71,43 @@ class CaseClassDeserializerSuite extends AnyFunSuite {
   test("read simple object missing Option") {
     val expected = SimpleObject(42, "abc", None)
     val actual = decode[SimpleObject]("""{"foo": 42, "bar": "abc"}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("read simple object missing required") {
     val expected = SimpleObject(123, null, Some("def"))
     val actual = decode[SimpleObject]("""{"foo": 123, "baz": "def"}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("read simple object with defaults") {
     val expected = SimpleObjectWithDefaults()
     val actual = decode[SimpleObjectWithDefaults]("""{}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("read simple object with overridden defaults") {
     val expected = SimpleObjectWithDefaults(foo = 21)
     val actual = decode[SimpleObjectWithDefaults]("""{"foo": 21}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("read simple object with one default") {
     val expected = SimpleObjectWithOneDefault(21)
     val actual = decode[SimpleObjectWithOneDefault]("""{"foo": 21}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("read simple object with one default missing required") {
     val expected = SimpleObjectWithOneDefault(0)
     val actual = decode[SimpleObjectWithOneDefault]("""{}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("read simple object with validation") {
     val expected = SimpleObjectWithValidation("abc")
     val actual = decode[SimpleObjectWithValidation]("""{"foo": "abc"}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("read simple object with error") {
@@ -119,84 +119,84 @@ class CaseClassDeserializerSuite extends AnyFunSuite {
   test("read with Option[Int] field") {
     val expected = OptionInt(Some(42))
     val actual = decode[OptionInt]("""{"v":42}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("read with Option[Int] field, null") {
     val expected = OptionInt(None)
     val actual = decode[OptionInt]("""{"v":null}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("read with Option[Long] field") {
     val expected = OptionLong(Some(42L))
     val actual = decode[OptionLong]("""{"v":42}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("read with List[Option[Int]] field") {
     val expected = ListOptionInt(List(Some(42), Some(21)))
     val actual = decode[ListOptionInt]("""{"v":[42, 21]}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("read with List[String] field") {
     val expected = ListString(List("a", "b"))
     val actual = decode[ListString]("""{"vs":["a", "b"]}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("read with List[String] field, null") {
     val expected = ListString(null)
     val actual = decode[ListString]("""{"vs":null}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("read with List[String] field, with default, null") {
     val expected = ListStringDflt()
     val actual = decode[ListStringDflt]("""{"vs":null}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("generics") {
     val expected = Outer(List(List(Inner("a"), Inner("b")), List(Inner("c"))))
     val actual = decode[Outer]("""{"vs":[[{"v":"a"},{"v":"b"}],[{"v":"c"}]]}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("generics 2") {
     val expected = OuterT(List(List(Inner("a"), Inner("b")), List(Inner("c"))))
     val actual =
       decode[OuterT[List[List[Inner]]]]("""{"vs":[[{"v":"a"},{"v":"b"}],[{"v":"c"}]]}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("honors @JsonAlias annotation") {
     val expected = AliasAnno("foo")
     val actual = decode[AliasAnno]("""{"v":"foo"}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("honors @JsonProperty annotation") {
     val expected = PropAnno("foo")
     val actual = decode[PropAnno]("""{"v":"foo"}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("honors @JsonDeserialize.contentAs annotation") {
     val expected = DeserAnno(Some(42L))
     val actual = decode[DeserAnno]("""{"value":42}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
     // Line above will pass even if a java.lang.Integer is created. The
     // check below will fail with:
     // java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Long
-    assert(actual.value.get.asInstanceOf[java.lang.Long] === 42)
+    assertEquals(actual.value.get.asInstanceOf[java.lang.Long], java.lang.Long.valueOf(42L))
   }
 
   test("honors @JsonDeserialize.using annotation") {
     val expected = DeserUsingAnno(43L)
     val actual = decode[DeserUsingAnno]("""{"value":42}""")
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 }
 

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/JsonParserHelperSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/JsonParserHelperSuite.scala
@@ -23,9 +23,9 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class JsonParserHelperSuite extends AnyFunSuite {
+class JsonParserHelperSuite extends FunSuite {
 
   import JsonParserHelper._
 
@@ -35,9 +35,9 @@ class JsonParserHelperSuite extends AnyFunSuite {
     foreachField(parser) {
       case v =>
         fields += v
-        assert(parser.nextIntValue(-1) === v.charAt(0) - 'a')
+        assertEquals(parser.nextIntValue(-1), v.charAt(0) - 'a')
     }
-    assert(fields.result() === Set("a", "b"))
+    assertEquals(fields.result(), Set("a", "b"))
   }
 
   test("foreachField unsupported field") {
@@ -55,9 +55,9 @@ class JsonParserHelperSuite extends AnyFunSuite {
     firstField(parser) {
       case "a" =>
         fields += "a"
-        assert(parser.nextIntValue(-1) === 0)
+        assertEquals(parser.nextIntValue(-1), 0)
     }
-    assert(fields.result() === Set("a"))
+    assertEquals(fields.result(), Set("a"))
   }
 
   test("firstField unsupported field") {
@@ -75,7 +75,7 @@ class JsonParserHelperSuite extends AnyFunSuite {
     foreachItem(parser) {
       builder += parser.getIntValue
     }
-    assert(builder.result() === List(1, 2, 3))
+    assertEquals(builder.result(), List(1, 2, 3))
   }
 
   test("foreachItem, endless loop bug") {
@@ -92,23 +92,23 @@ class JsonParserHelperSuite extends AnyFunSuite {
 
   test("skipNext: empty object") {
     val parser = Json.newJsonParser("""[{}]""")
-    assert(parser.nextToken() === JsonToken.START_ARRAY)
+    assertEquals(parser.nextToken(), JsonToken.START_ARRAY)
     skipNext(parser)
-    assert(parser.nextToken() === JsonToken.END_ARRAY)
+    assertEquals(parser.nextToken(), JsonToken.END_ARRAY)
   }
 
   test("skipNext: object with simple fields") {
     val parser = Json.newJsonParser("""[{"a":1,"b":"foo","c":false,"d":null}]""")
-    assert(parser.nextToken() === JsonToken.START_ARRAY)
+    assertEquals(parser.nextToken(), JsonToken.START_ARRAY)
     skipNext(parser)
-    assert(parser.nextToken() === JsonToken.END_ARRAY)
+    assertEquals(parser.nextToken(), JsonToken.END_ARRAY)
   }
 
   test("skipNext: object with complex field") {
     val parser = Json.newJsonParser("""[{"a":{"b":[{"c":{"d":["f",1,null]}}]}}]""")
-    assert(parser.nextToken() === JsonToken.START_ARRAY)
+    assertEquals(parser.nextToken(), JsonToken.START_ARRAY)
     skipNext(parser)
-    assert(parser.nextToken() === JsonToken.END_ARRAY)
+    assertEquals(parser.nextToken(), JsonToken.END_ARRAY)
   }
 
   test("skipNext: complex object") {
@@ -145,18 +145,18 @@ class JsonParserHelperSuite extends AnyFunSuite {
         |  }
         |]
         |""".stripMargin)
-    assert(parser.nextToken() === JsonToken.START_ARRAY)
+    assertEquals(parser.nextToken(), JsonToken.START_ARRAY)
     skipNext(parser)
-    assert(parser.nextToken() === JsonToken.END_ARRAY)
+    assertEquals(parser.nextToken(), JsonToken.END_ARRAY)
   }
 
   test("skipNext: random") {
     (0 until 10000).foreach { i =>
       val json = s"""[${randomJson(i)}]"""
       val parser = Json.newJsonParser(json)
-      assert(parser.nextToken() === JsonToken.START_ARRAY)
+      assertEquals(parser.nextToken(), JsonToken.START_ARRAY)
       skipNext(parser)
-      assert(parser.nextToken() === JsonToken.END_ARRAY, s"json: $json")
+      assertEquals(parser.nextToken(), JsonToken.END_ARRAY, s"json: $json")
     }
   }
 

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
@@ -24,13 +24,13 @@ import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.core.JsonToken
 import com.fasterxml.jackson.databind.JsonNode
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 /**
   * Test case for the capabilities we need from a json parser. Mostly to document what we are using
   * and ease transition to alternative libraries if we want to switch.
   */
-class JsonSuite extends AnyFunSuite {
+class JsonSuite extends FunSuite {
 
   import java.lang.{Double => JDouble}
 
@@ -43,56 +43,56 @@ class JsonSuite extends AnyFunSuite {
 
   test("true") {
     val v = true
-    assert(encode(v) === "true")
-    assert(decode[Boolean](encode(v)) === v)
+    assertEquals(encode(v), "true")
+    assertEquals(decode[Boolean](encode(v)), v)
   }
 
   test("false") {
     val v = false
-    assert(encode(v) === "false")
-    assert(decode[Boolean](encode(v)) === v)
+    assertEquals(encode(v), "false")
+    assertEquals(decode[Boolean](encode(v)), v)
   }
 
   test("byte") {
     val v = 42.asInstanceOf[Byte]
-    assert(encode(v) === "42")
-    assert(decode[Byte](encode(v)) === v)
+    assertEquals(encode(v), "42")
+    assertEquals(decode[Byte](encode(v)), v)
   }
 
   test("short") {
     val v = 42.asInstanceOf[Short]
-    assert(encode(v) === "42")
-    assert(decode[Short](encode(v)) === v)
+    assertEquals(encode(v), "42")
+    assertEquals(decode[Short](encode(v)), v)
   }
 
   test("int") {
     val v = 42
-    assert(encode(v) === "42")
-    assert(decode[Int](encode(v)) === v)
+    assertEquals(encode(v), "42")
+    assertEquals(decode[Int](encode(v)), v)
   }
 
   test("long") {
     val v = 42L
-    assert(encode(v) === "42")
-    assert(decode[Long](encode(v)) === v)
+    assertEquals(encode(v), "42")
+    assertEquals(decode[Long](encode(v)), v)
   }
 
   test("float") {
     val v = 42.0f
-    assert(encode(v) === "42.0")
-    assert(decode[Float](encode(v)) === v)
+    assertEquals(encode(v), "42.0")
+    assertEquals(decode[Float](encode(v)), v)
   }
 
   test("double") {
     val v = 42.0
-    assert(encode(v) === "42.0")
-    assert(decode[Double](encode(v)) === v)
+    assertEquals(encode(v), "42.0")
+    assertEquals(decode[Double](encode(v)), v)
   }
 
   // This is non-standard, but we prefer to differentiate from infinity or other special values
   test("double NaN") {
     val v = Double.NaN
-    assert(encode(v) === "\"NaN\"")
+    assertEquals(encode(v), "\"NaN\"")
     assert(JDouble.isNaN(decode[Double](encode(v))))
   }
 
@@ -144,7 +144,7 @@ class JsonSuite extends AnyFunSuite {
     assert(java.util.Arrays.equals(decode[JsonSuiteListDouble](vs).vs.toArray, expected))
   }
 
-  ignore("object double list and string non numeric values") {
+  test("object double list and string non numeric values".ignore) {
     val expected = Array(
       1.0,
       JDouble.NaN,
@@ -158,114 +158,114 @@ class JsonSuite extends AnyFunSuite {
 
   test("BigInteger") {
     val v = new BigInteger("42")
-    assert(encode(v) === "42")
-    assert(decode[BigInteger](encode(v)) === v)
+    assertEquals(encode(v), "42")
+    assertEquals(decode[BigInteger](encode(v)), v)
   }
 
   test("String") {
     val v = "42"
-    assert(encode(v) === "\"42\"")
-    assert(decode[String](encode(v)) === v)
+    assertEquals(encode(v), "\"42\"")
+    assertEquals(decode[String](encode(v)), v)
   }
 
   test("Pattern") {
     val v = Pattern.compile("^42.*")
-    assert(encode(v) === "\"^42.*\"")
-    assert(decode[Pattern](encode(v)).toString === v.toString)
+    assertEquals(encode(v), "\"^42.*\"")
+    assertEquals(decode[Pattern](encode(v)).toString, v.toString)
   }
 
   test("enum") {
     val v = JsonToken.NOT_AVAILABLE
-    assert(encode(v) === "\"NOT_AVAILABLE\"")
-    assert(decode[JsonToken](encode(v)) === v)
+    assertEquals(encode(v), "\"NOT_AVAILABLE\"")
+    assertEquals(decode[JsonToken](encode(v)), v)
   }
 
   test("java8 Instant") {
     val v = java.time.Instant.parse("2012-01-13T04:37:52Z")
-    assert(encode(v) === "1326429472000")
-    assert(decode[java.time.Instant](encode(v)) === v)
+    assertEquals(encode(v), "1326429472000")
+    assertEquals(decode[java.time.Instant](encode(v)), v)
   }
 
   test("java8 Duration") {
     val v = java.time.Duration.ofSeconds(42)
-    assert(encode(v) === "42000")
-    assert(decode[java.time.Duration](encode(v)) === v)
+    assertEquals(encode(v), "42000")
+    assertEquals(decode[java.time.Duration](encode(v)), v)
   }
 
   test("java8 Period") {
     val v = java.time.Period.ofDays(42)
-    assert(encode(v) === "\"P42D\"")
-    assert(decode[java.time.Period](encode(v)) === v)
+    assertEquals(encode(v), "\"P42D\"")
+    assertEquals(decode[java.time.Period](encode(v)), v)
   }
 
   test("java8 Optional[String] -- None") {
     val v = Optional.empty[String]()
-    assert(encode(v) === "null")
-    assert(decode[Optional[String]](encode(v)) === v)
+    assertEquals(encode(v), "null")
+    assertEquals(decode[Optional[String]](encode(v)), v)
   }
 
   test("java8 Optional[String] -- Some") {
     val v = Optional.of("42")
-    assert(encode(v) === "\"42\"")
-    assert(decode[Optional[String]](encode(v)) === v)
+    assertEquals(encode(v), "\"42\"")
+    assertEquals(decode[Optional[String]](encode(v)), v)
   }
 
   test("scala Option[String] -- None") {
     val v = None
-    assert(encode(v) === "null")
-    assert(decode[Option[String]](encode(v)) === v)
+    assertEquals(encode(v), "null")
+    assertEquals(decode[Option[String]](encode(v)), v)
   }
 
   test("scala Option[String] -- Some") {
     val v = Some("42")
-    assert(encode(v) === "\"42\"")
-    assert(decode[Option[String]](encode(v)) === v)
+    assertEquals(encode(v), "\"42\"")
+    assertEquals(decode[Option[String]](encode(v)), v)
   }
 
   test("scala Option[Int] -- None") {
     val v = None
-    assert(encode(v) === "null")
-    assert(decode[Option[Int]](encode(v)) === v)
+    assertEquals(encode(v), "null")
+    assertEquals(decode[Option[Int]](encode(v)), v)
   }
 
   test("scala Option[Int] -- Some") {
     val v = Some(42)
-    assert(encode(v) === "42")
-    assert(decode[Option[Int]](encode(v)) === v)
+    assertEquals(encode(v), "42")
+    assertEquals(decode[Option[Int]](encode(v)), v)
   }
 
   // Ugly nested generics, just to see if it would work
   test("scala List[Map[String, List[Option[Int]]]]") {
     val v = List(Map("foo" -> List(Some(42), None, Some(43))))
-    assert(encode(v) === """[{"foo":[42,null,43]}]""")
-    assert(decode[List[Map[String, List[Option[Int]]]]](encode(v)) === v)
+    assertEquals(encode(v), """[{"foo":[42,null,43]}]""")
+    assertEquals(decode[List[Map[String, List[Option[Int]]]]](encode(v)), v)
   }
 
   test("scala List[Int]") {
     val v = List(42, 43, 44)
-    assert(encode(v) === "[42,43,44]")
-    assert(decode[List[Int]](encode(v)) === v)
+    assertEquals(encode(v), "[42,43,44]")
+    assertEquals(decode[List[Int]](encode(v)), v)
   }
 
   test("scala Set[Int]") {
     val v = Set(42, 43, 44)
-    assert(encode(v) === "[42,43,44]")
-    assert(decode[Set[Int]](encode(v)) === v)
+    assertEquals(encode(v), "[42,43,44]")
+    assertEquals(decode[Set[Int]](encode(v)), v)
   }
 
   test("scala Map[String, Int]") {
     val v = Map("foo" -> 42)
-    assert(encode(v) === "{\"foo\":42}")
-    assert(decode[Map[String, Int]](encode(v)) === v)
+    assertEquals(encode(v), "{\"foo\":42}")
+    assertEquals(decode[Map[String, Int]](encode(v)), v)
   }
 
   test("scala Tuple2[String, Int]") {
     val v = "foo" -> 42
-    assert(encode(v) === "[\"foo\",42]")
-    assert(decode[(String, Int)](encode(v)) === v)
+    assertEquals(encode(v), "[\"foo\",42]")
+    assertEquals(decode[(String, Int)](encode(v)), v)
   }
 
-  ignore("comments") {
+  test("comments".ignore) {
     // UI now handles most config, comments aren't needed and trying to stick with standard
     // json if possible
     // factory.enable(ALLOW_COMMENTS) to enable in jackson if we want to reenable
@@ -278,29 +278,29 @@ class JsonSuite extends AnyFunSuite {
         "bar": 43
       }
     """
-    assert(decode[Map[String, Int]](json) === v)
+    assertEquals(decode[Map[String, Int]](json), v)
   }
 
   // It seems like this manages to break the singleton property of the object...
-  ignore("case object") {
+  test("case object".ignore) {
     val v = JsonSuiteObject
-    assert(encode(v) === """{}""")
+    assertEquals(encode(v), """{}""")
     val result = decode[JsonSuiteObject.type](encode(v))
-    assert(result === v)
+    assertEquals(result, v)
   }
 
   test("case class simple") {
     val v = JsonSuiteSimple(42, "forty-two")
-    assert(encode(v) === """{"foo":42,"bar":"forty-two"}""")
-    assert(decode[JsonSuiteSimple](encode(v)) === v)
+    assertEquals(encode(v), """{"foo":42,"bar":"forty-two"}""")
+    assertEquals(decode[JsonSuiteSimple](encode(v)), v)
   }
 
   // We don't want null values for fields of case classes, if a field is optional it should be
   // specified as Option[T].
-  ignore("case class simple -- missing field") {
+  test("case class simple -- missing field".ignore) {
     val v = JsonSuiteSimple(42, "forty-two")
     val json = """{"foo":42}"""
-    assert(decode[JsonSuiteSimple](json) === v)
+    assertEquals(decode[JsonSuiteSimple](json), v)
   }
 
   // We want to ignore unknown fields so we have the option of introducing new fields without
@@ -309,13 +309,13 @@ class JsonSuite extends AnyFunSuite {
   test("case class simple -- unknown field") {
     val v = JsonSuiteSimple(42, "forty-two")
     val json = """{"foo":42,"bar":"forty-two","baz":"new field"}"""
-    assert(decode[JsonSuiteSimple](json) === v)
+    assertEquals(decode[JsonSuiteSimple](json), v)
   }
 
   test("case class nested -- Some") {
     val v = JsonSuiteNested(Map("a" -> JsonSuiteSimple(42, "forty-two")), Some("forty-two"))
-    assert(encode(v) === """{"simple":{"a":{"foo":42,"bar":"forty-two"}},"bar":"forty-two"}""")
-    assert(decode[JsonSuiteNested](encode(v)) === v)
+    assertEquals(encode(v), """{"simple":{"a":{"foo":42,"bar":"forty-two"}},"bar":"forty-two"}""")
+    assertEquals(decode[JsonSuiteNested](encode(v)), v)
   }
 
   test("case class nested -- None") {
@@ -323,20 +323,20 @@ class JsonSuite extends AnyFunSuite {
     // java 8 Optional. It needs the NON_ABSENT include setting rather
     // than NON_NULL
     val v = JsonSuiteNested(Map("a" -> JsonSuiteSimple(42, "forty-two")), None)
-    assert(encode(v) === """{"simple":{"a":{"foo":42,"bar":"forty-two"}}}""")
-    assert(decode[JsonSuiteNested](encode(v)) === v)
+    assertEquals(encode(v), """{"simple":{"a":{"foo":42,"bar":"forty-two"}}}""")
+    assertEquals(decode[JsonSuiteNested](encode(v)), v)
   }
 
   test("case class nested -- missing Option") {
     val v = JsonSuiteNested(Map("a" -> JsonSuiteSimple(42, "forty-two")), None)
     val json = """{"simple":{"a":{"foo":42,"bar":"forty-two"}}}"""
-    assert(decode[JsonSuiteNested](json) === v)
+    assertEquals(decode[JsonSuiteNested](json), v)
   }
 
-  ignore("case class Option[Long]") {
+  test("case class Option[Long]".ignore) {
     val v = JsonSuiteOptionLong(Some(42L))
-    assert(encode(v) === """{"foo":42}""")
-    assert(decode[JsonSuiteOptionLong](encode(v)) === v)
+    assertEquals(encode(v), """{"foo":42}""")
+    assertEquals(decode[JsonSuiteOptionLong](encode(v)), v)
     assert(decode[JsonSuiteOptionLong](encode(v)).foo == v.foo)
 
     // java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Long
@@ -345,80 +345,74 @@ class JsonSuite extends AnyFunSuite {
 
   test("case class Array[Double]") {
     val v = JsonSuiteArrayDouble("foo", Array(1.0, 2.0, 3.0, 4.0))
-    assert(encode(v) === """{"name":"foo","values":[1.0,2.0,3.0,4.0]}""")
-    assert(decode[JsonSuiteArrayDouble](encode(v)).name === v.name)
+    assertEquals(encode(v), """{"name":"foo","values":[1.0,2.0,3.0,4.0]}""")
+    assertEquals(decode[JsonSuiteArrayDouble](encode(v)).name, v.name)
     assert(util.Arrays.equals(decode[JsonSuiteArrayDouble](encode(v)).values, v.values))
-  }
-
-  ignore("trait") {
-    val v = List(JsonSuiteImpl1(42), JsonSuiteImpl2("42"))
-    val json = """{"simple":{"a":{"foo":42,"bar":"forty-two"}}}"""
-    assert(decode[JsonSuiteTrait](json) === v)
   }
 
   // Should get base64 encoded
   test("array Byte") {
     val v = Array[Byte](1, 2, 3, 4)
-    assert(encode(v) === "\"AQIDBA==\"")
+    assertEquals(encode(v), "\"AQIDBA==\"")
     assert(util.Arrays.equals(decode[Array[Byte]](encode(v)), v))
   }
 
   test("array Short") {
     val v = Array[Short](1, 2, 3, 4)
-    assert(encode(v) === """[1,2,3,4]""")
+    assertEquals(encode(v), """[1,2,3,4]""")
     assert(util.Arrays.equals(decode[Array[Short]](encode(v)), v))
   }
 
   test("array Int") {
     val v = Array[Int](1, 2, 3, 4)
-    assert(encode(v) === """[1,2,3,4]""")
+    assertEquals(encode(v), """[1,2,3,4]""")
     assert(util.Arrays.equals(decode[Array[Int]](encode(v)), v))
   }
 
   test("array Long") {
     val v = Array[Long](1L, 2L, 3L, 4L)
-    assert(encode(v) === """[1,2,3,4]""")
+    assertEquals(encode(v), """[1,2,3,4]""")
     assert(util.Arrays.equals(decode[Array[Long]](encode(v)), v))
   }
 
   test("array Float") {
     val v = Array[Float](1.0f, 2.0f, 3.0f, 4.0f)
-    assert(encode(v) === """[1.0,2.0,3.0,4.0]""")
+    assertEquals(encode(v), """[1.0,2.0,3.0,4.0]""")
     assert(util.Arrays.equals(decode[Array[Float]](encode(v)), v))
   }
 
   test("array Double") {
     val v = Array[Double](1.0, 2.0, 3.0, 4.0)
-    assert(encode(v) === """[1.0,2.0,3.0,4.0]""")
+    assertEquals(encode(v), """[1.0,2.0,3.0,4.0]""")
     assert(util.Arrays.equals(decode[Array[Double]](encode(v)), v))
   }
 
   test("array case class") {
     val v = Array[JsonSuiteSimple](JsonSuiteSimple(42, "a"), JsonSuiteSimple(43, "b"))
-    assert(encode(v) === """[{"foo":42,"bar":"a"},{"foo":43,"bar":"b"}]""")
-    assert(decode[Array[JsonSuiteSimple]](encode(v)).toList === v.toList)
+    assertEquals(encode(v), """[{"foo":42,"bar":"a"},{"foo":43,"bar":"b"}]""")
+    assertEquals(decode[Array[JsonSuiteSimple]](encode(v)).toList, v.toList)
   }
 
   // CLDMTA-2174
   test("case class defined in object") {
     import com.netflix.atlas.json.JsonSuiteObjectWithClass._
     val v = ClassInObject("a", 42)
-    assert(encode(v) === """{"s":"a","v":42}""")
-    assert(decode[ClassInObject](encode(v)) === v)
+    assertEquals(encode(v), """{"s":"a","v":42}""")
+    assertEquals(decode[ClassInObject](encode(v)), v)
   }
 
   // CLDMTA-2174
   test("list of case class defined in object") {
     import com.netflix.atlas.json.JsonSuiteObjectWithClass._
     val v = List(ClassInObject("a", 42))
-    assert(encode(v) === """[{"s":"a","v":42}]""")
-    assert(decode[List[ClassInObject]](encode(v)) === v)
+    assertEquals(encode(v), """[{"s":"a","v":42}]""")
+    assertEquals(decode[List[ClassInObject]](encode(v)), v)
   }
 
   test("smile encode/decode") {
     val v = List(1, 2, 3)
     val b = Json.smileEncode[List[Int]](v)
-    assert(Json.smileDecode[List[Int]](b) === v)
+    assertEquals(Json.smileDecode[List[Int]](b), v)
   }
 
   // See ObjWithLambda comments for details
@@ -426,30 +420,30 @@ class JsonSuite extends AnyFunSuite {
     val obj = new ObjWithLambda
     obj.setFoo("abc")
     val json = Json.encode(obj)
-    assert(json === """{"foo":"abc"}""")
+    assertEquals(json, """{"foo":"abc"}""")
   }
 
   test("object with defaults") {
     val obj = Json.decode[JsonSuiteObjectWithDefaults]("{}")
     val json = Json.encode(obj)
-    assert(json === """{"foo":42,"bar":"abc","values":[]}""")
+    assertEquals(json, """{"foo":42,"bar":"abc","values":[]}""")
   }
 
   test("object with missing key") {
     val obj = Json.decode[JsonSuiteSimple]("{}")
     val json = Json.encode(obj)
-    assert(json === """{"foo":0}""")
+    assertEquals(json, """{"foo":0}""")
   }
 
   test("dots in field name") {
     val obj = Json.decode[JsonKeyWithDot]("""{"a.b": "bar"}""")
-    assert(obj === JsonKeyWithDot("bar"))
+    assertEquals(obj, JsonKeyWithDot("bar"))
   }
 
   test("object with empty array renders empty array") {
     val obj = Json.decode[JsonSuiteArrayString]("""{"name":"name", "values":[]}""")
     val json = Json.encode(obj)
-    assert(json === """{"name":"name","values":[]}""")
+    assertEquals(json, """{"name":"name","values":[]}""")
   }
 
   test("decode from JsonData") {
@@ -462,12 +456,12 @@ class JsonSuite extends AnyFunSuite {
     }
     val list = parse("""[{"foo":42,"bar":"abc"}]""")
     val obj = parse("""{"foo":42,"bar":"abc"}""")
-    assert(list === obj)
+    assertEquals(list, obj)
   }
 
   test("JsonSupport NaN encoding") {
     val obj = JsonObjectWithSupport(Double.NaN)
-    assert(obj.toJson === """{"v":"NaN"}""")
+    assertEquals(obj.toJson, """{"v":"NaN"}""")
   }
 }
 

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ApiSettingsSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ApiSettingsSuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.lwcapi
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class ApiSettingsSuite extends AnyFunSuite {
+class ApiSettingsSuite extends FunSuite {
   test("loads") {
     assert(ApiSettings.defaultStep > 0)
   }

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/EvaluateApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/EvaluateApiSuite.scala
@@ -17,14 +17,13 @@ package com.netflix.atlas.lwcapi
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.RouteTestTimeout
-import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.netflix.atlas.akka.DiagnosticMessage
+import com.netflix.atlas.akka.testkit.MUnitRouteSuite
 import com.netflix.atlas.eval.model.LwcDiagnosticMessage
 import com.netflix.atlas.lwcapi.EvaluateApi._
 import com.netflix.spectator.api.NoopRegistry
-import org.scalatest.funsuite.AnyFunSuite
 
-class EvaluateApiSuite extends AnyFunSuite with ScalatestRouteTest {
+class EvaluateApiSuite extends MUnitRouteSuite {
   import scala.concurrent.duration._
 
   private implicit val routeTestTimeout = RouteTestTimeout(5.second)
@@ -35,7 +34,7 @@ class EvaluateApiSuite extends AnyFunSuite with ScalatestRouteTest {
   test("post empty payload") {
     val json = EvaluateRequest(1234L, Nil, Nil).toJson
     Post("/lwc/api/v1/evaluate", json) ~> endpoint.routes ~> check {
-      assert(response.status === StatusCodes.OK)
+      assertEquals(response.status, StatusCodes.OK)
     }
   }
 
@@ -43,7 +42,7 @@ class EvaluateApiSuite extends AnyFunSuite with ScalatestRouteTest {
     val metrics = List(Item("abc", Map("a" -> "1"), 42.0))
     val json = EvaluateRequest(1234L, metrics, Nil).toJson
     Post("/lwc/api/v1/evaluate", json) ~> endpoint.routes ~> check {
-      assert(response.status === StatusCodes.OK)
+      assertEquals(response.status, StatusCodes.OK)
     }
   }
 
@@ -51,21 +50,21 @@ class EvaluateApiSuite extends AnyFunSuite with ScalatestRouteTest {
     val msgs = List(LwcDiagnosticMessage("abc", DiagnosticMessage.error("bad expression")))
     val json = EvaluateRequest(1234L, Nil, msgs).toJson
     Post("/lwc/api/v1/evaluate", json) ~> endpoint.routes ~> check {
-      assert(response.status === StatusCodes.OK)
+      assertEquals(response.status, StatusCodes.OK)
     }
   }
 
   test("post missing messages field") {
     val json = """{"timestamp":12345,"metrics":[]}"""
     Post("/lwc/api/v1/evaluate", json) ~> endpoint.routes ~> check {
-      assert(response.status === StatusCodes.OK)
+      assertEquals(response.status, StatusCodes.OK)
     }
   }
 
   test("post missing metrics field") {
     val json = """{"timestamp":12345,"messages":[]}"""
     Post("/lwc/api/v1/evaluate", json) ~> endpoint.routes ~> check {
-      assert(response.status === StatusCodes.OK)
+      assertEquals(response.status, StatusCodes.OK)
     }
   }
 }

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
@@ -18,22 +18,21 @@ package com.netflix.atlas.lwcapi
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.testkit.RouteTestTimeout
-import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Sink
 import com.netflix.atlas.akka.StreamOps
+import com.netflix.atlas.akka.testkit.MUnitRouteSuite
 import com.netflix.atlas.core.util.Streams
 import com.netflix.atlas.json.JsonSupport
 import com.netflix.spectator.api.NoopRegistry
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
 
 import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
 import java.util.zip.GZIPInputStream
 import scala.util.Using
 
-class ExpressionApiSuite extends AnyFunSuite with ScalatestRouteTest {
+class ExpressionApiSuite extends MUnitRouteSuite {
   import scala.concurrent.duration._
 
   private implicit val routeTestTimeout = RouteTestTimeout(5.second)
@@ -61,10 +60,10 @@ class ExpressionApiSuite extends AnyFunSuite with ScalatestRouteTest {
   test("get of a path returns empty data") {
     val expected_etag = ExpressionApi.encode(List()).etag
     Get("/lwc/api/v1/expressions/123") ~> endpoint.routes ~> check {
-      assert(response.status === StatusCodes.OK)
-      assert(unzip(responseAs[Array[Byte]]) === """{"expressions":[]}""")
+      assertEquals(response.status, StatusCodes.OK)
+      assertEquals(unzip(responseAs[Array[Byte]]), """{"expressions":[]}""")
       assert(header("ETag").isDefined)
-      assert(header("ETag").get.value === expected_etag)
+      assertEquals(header("ETag").get.value, expected_etag)
     }
   }
 
@@ -72,10 +71,10 @@ class ExpressionApiSuite extends AnyFunSuite with ScalatestRouteTest {
     val etag = ExpressionApi.encode(List()).etag
     val headers = List(RawHeader("If-None-Match", etag))
     Get("/lwc/api/v1/expressions/123").withHeaders(headers) ~> endpoint.routes ~> check {
-      assert(response.status === StatusCodes.NotModified)
+      assertEquals(response.status, StatusCodes.NotModified)
       assert(responseAs[String].isEmpty)
       assert(header("ETag").isDefined)
-      assert(header("ETag").get.value === etag)
+      assertEquals(header("ETag").get.value, etag)
     }
   }
 
@@ -84,10 +83,10 @@ class ExpressionApiSuite extends AnyFunSuite with ScalatestRouteTest {
     val emptyETag = ExpressionApi.encode(List()).etag
     val headers = List(RawHeader("If-None-Match", etag))
     Get("/lwc/api/v1/expressions/123").withHeaders(headers) ~> endpoint.routes ~> check {
-      assert(response.status === StatusCodes.OK)
-      assert(unzip(responseAs[Array[Byte]]) === """{"expressions":[]}""")
+      assertEquals(response.status, StatusCodes.OK)
+      assertEquals(unzip(responseAs[Array[Byte]]), """{"expressions":[]}""")
       assert(header("ETag").isDefined)
-      assert(header("ETag").get.value === emptyETag)
+      assertEquals(header("ETag").get.value, emptyETag)
     }
   }
 
@@ -100,7 +99,7 @@ class ExpressionApiSuite extends AnyFunSuite with ScalatestRouteTest {
     sm.regenerateQueryIndex()
     Get("/lwc/api/v1/expressions/skan") ~> endpoint.routes ~> check {
       val expected = s"""{"expressions":[$skanCount,$skanSum]}"""
-      assert(unzip(responseAs[Array[Byte]]) === expected)
+      assertEquals(unzip(responseAs[Array[Byte]]), expected)
     }
   }
 
@@ -113,7 +112,7 @@ class ExpressionApiSuite extends AnyFunSuite with ScalatestRouteTest {
     sm.regenerateQueryIndex()
     Get("/lwc/api/v1/expressions") ~> endpoint.routes ~> check {
       val expected = s"""{"expressions":[$brhMax,$skanCount,$skanSum]}"""
-      assert(unzip(responseAs[Array[Byte]]) === expected)
+      assertEquals(unzip(responseAs[Array[Byte]]), expected)
     }
   }
 
@@ -122,7 +121,7 @@ class ExpressionApiSuite extends AnyFunSuite with ScalatestRouteTest {
     endpoint.clearCache()
     Get("/lwc/api/v1/expressions") ~> endpoint.routes ~> check {
       val expected = """{"expressions":[]}"""
-      assert(unzip(responseAs[Array[Byte]]) === expected)
+      assertEquals(unzip(responseAs[Array[Byte]]), expected)
     }
   }
 
@@ -131,7 +130,7 @@ class ExpressionApiSuite extends AnyFunSuite with ScalatestRouteTest {
     endpoint.clearCache()
     Get("/lwc/api/v1/expressions/") ~> endpoint.routes ~> check {
       val expected = """{"expressions":[]}"""
-      assert(unzip(responseAs[Array[Byte]]) === expected)
+      assertEquals(unzip(responseAs[Array[Byte]]), expected)
     }
   }
 
@@ -141,7 +140,7 @@ class ExpressionApiSuite extends AnyFunSuite with ScalatestRouteTest {
     val ordered = unordered.sorted
     val tagUnordered = ExpressionApi.encode(unordered).etag
     val tagOrdered = ExpressionApi.encode(ordered).etag
-    assert(tagUnordered === tagOrdered)
+    assertEquals(tagUnordered, tagOrdered)
   }
 
   test("etags for no expressions works") {

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionMetadataSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionMetadataSuite.scala
@@ -18,13 +18,13 @@ package com.netflix.atlas.lwcapi
 import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException
 import com.netflix.atlas.json.Json
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class ExpressionMetadataSuite extends AnyFunSuite {
+class ExpressionMetadataSuite extends FunSuite {
   test("default frequency is applied") {
     val ret1 = ExpressionMetadata("this")
     val ret2 = ExpressionMetadata("this", ApiSettings.defaultStep)
-    assert(ret1 === ret2)
+    assertEquals(ret1, ret2)
   }
 
   test("default id is applied") {
@@ -34,19 +34,19 @@ class ExpressionMetadataSuite extends AnyFunSuite {
 
   test("full params") {
     val expr = ExpressionMetadata("test", 60000, "idHere")
-    assert(expr.expression === "test")
-    assert(expr.frequency === 60000)
-    assert(expr.id === "idHere")
+    assertEquals(expr.expression, "test")
+    assertEquals(expr.frequency, 60000L)
+    assertEquals(expr.id, "idHere")
   }
 
   test("default frequency") {
     val expr = ExpressionMetadata("test")
-    assert(expr.frequency === ApiSettings.defaultStep)
+    assertEquals(expr.frequency, ApiSettings.defaultStep)
   }
 
   test("computes id") {
     val expr = ExpressionMetadata("test")
-    assert(expr.id === "2684d3c5cb245bd2fd6ee4ea30a500e97ace8141")
+    assertEquals(expr.id, "2684d3c5cb245bd2fd6ee4ea30a500e97ace8141")
   }
 
   test("id computation considers frequency") {
@@ -59,8 +59,8 @@ class ExpressionMetadataSuite extends AnyFunSuite {
     val json = """{"expression": "this"}"""
 
     val o = Json.decode[ExpressionMetadata](json)
-    assert(o.expression === "this")
-    assert(o.frequency === ApiSettings.defaultStep)
+    assertEquals(o.expression, "this")
+    assertEquals(o.frequency, ApiSettings.defaultStep)
   }
 
   test("parses from json with frequency, without id") {
@@ -71,8 +71,8 @@ class ExpressionMetadataSuite extends AnyFunSuite {
 
     val o = Json.decode[ExpressionMetadata](json)
 
-    assert(o.expression === "this")
-    assert(o.frequency === 9999)
+    assertEquals(o.expression, "this")
+    assertEquals(o.frequency, 9999L)
     assert(o.id.isEmpty)
   }
 
@@ -107,21 +107,21 @@ class ExpressionMetadataSuite extends AnyFunSuite {
   test("renders as json") {
     val expected = """{"expression":"this","frequency":99000,"id":"foo"}"""
     val json = ExpressionMetadata("this", 99000, "foo").toJson
-    assert(expected === json)
+    assertEquals(expected, json)
   }
 
   test("renders as json with default frequency") {
     val expected =
       "{\"expression\":\"this\",\"frequency\":60000,\"id\":\"fc3a081088771e05bdc3aa99ffd8770157dfe6ce\"}"
     val json = ExpressionMetadata("this").toJson
-    assert(expected === json)
+    assertEquals(expected, json)
   }
 
   test("renders as json with frequency of 0") {
     val expected =
       "{\"expression\":\"this\",\"frequency\":60000,\"id\":\"fc3a081088771e05bdc3aa99ffd8770157dfe6ce\"}"
     val json = ExpressionMetadata("this", 0).toJson
-    assert(expected === json)
+    assertEquals(expected, json)
   }
 
   test("expression is required to be non-null") {
@@ -135,6 +135,6 @@ class ExpressionMetadataSuite extends AnyFunSuite {
       List(ExpressionMetadata("a", 2), ExpressionMetadata("z", 1), ExpressionMetadata("c", 3))
     val expected =
       List(ExpressionMetadata("a", 2), ExpressionMetadata("c", 3), ExpressionMetadata("z", 1))
-    assert(expected === source.sorted)
+    assertEquals(expected, source.sorted)
   }
 }

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionSplitterSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionSplitterSuite.scala
@@ -17,9 +17,9 @@ package com.netflix.atlas.lwcapi
 
 import com.netflix.atlas.core.model.Query
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class ExpressionSplitterSuite extends AnyFunSuite {
+class ExpressionSplitterSuite extends FunSuite {
 
   private val query1 =
     "nf.cluster,skan-test,:eq,name,memUsed,:eq,:and,:avg,(,nf.node,),:by,4500000000,:gt,30,:rolling-count,15,:ge,$nf.node,:legend"
@@ -36,7 +36,7 @@ class ExpressionSplitterSuite extends AnyFunSuite {
       Subscription(matchList1, ExpressionMetadata(ds1a, frequency1)),
       Subscription(matchList1, ExpressionMetadata(ds1b, frequency1))
     ).reverse
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("splits compound expression into data expressions") {
@@ -46,14 +46,14 @@ class ExpressionSplitterSuite extends AnyFunSuite {
       Subscription(matchList1, ExpressionMetadata(ds1a, frequency1)),
       Subscription(matchList1, ExpressionMetadata(ds1b, frequency1))
     ).reverse
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("throws IAE for invalid expressions") {
     val msg = intercept[IllegalArgumentException] {
       splitter.split("foo", frequency1)
     }
-    assert(msg.getMessage === "expression is invalid")
+    assertEquals(msg.getMessage, "expression is invalid")
   }
 
   test("throws IAE for expressions with offset") {
@@ -61,7 +61,7 @@ class ExpressionSplitterSuite extends AnyFunSuite {
     val msg = intercept[IllegalArgumentException] {
       splitter.split(expr, frequency1)
     }
-    assert(msg.getMessage === s":offset not supported for streaming evaluation [[$expr]]")
+    assertEquals(msg.getMessage, s":offset not supported for streaming evaluation [[$expr]]")
   }
 
   test("throws IAE for expressions with style offset") {
@@ -70,7 +70,7 @@ class ExpressionSplitterSuite extends AnyFunSuite {
       splitter.split(expr, frequency1)
     }
     val badExpr = "name,foo,:eq,:sum,PT168H,:offset"
-    assert(msg.getMessage === s":offset not supported for streaming evaluation [[$badExpr]]")
+    assertEquals(msg.getMessage, s":offset not supported for streaming evaluation [[$badExpr]]")
   }
 
   //
@@ -83,22 +83,22 @@ class ExpressionSplitterSuite extends AnyFunSuite {
 
   test("compress keeps nf.app") {
     val ret = splitter.compress(Query.Equal("nf.app", "skan"))
-    assert(ret === Query.Equal("nf.app", "skan"))
+    assertEquals(ret, Query.Equal("nf.app", "skan"))
   }
 
   test("compress keeps nf.stack") {
     val ret = splitter.compress(Query.Equal("nf.stack", "skan"))
-    assert(ret === Query.Equal("nf.stack", "skan"))
+    assertEquals(ret, Query.Equal("nf.stack", "skan"))
   }
 
   test("compress keeps nf.cluster") {
     val ret = splitter.compress(Query.Equal("nf.cluster", "skan"))
-    assert(ret === Query.Equal("nf.cluster", "skan"))
+    assertEquals(ret, Query.Equal("nf.cluster", "skan"))
   }
 
   test("compress removes arbitrary other equal comparisons") {
     val ret = splitter.compress(Query.Equal("xxx", "skan"))
-    assert(ret === Query.True)
+    assertEquals(ret, Query.True)
   }
 
   //
@@ -107,48 +107,48 @@ class ExpressionSplitterSuite extends AnyFunSuite {
 
   test("compress converts true,true,:and to true") {
     val ret = splitter.compress(Query.And(Query.True, Query.True))
-    assert(ret === Query.True)
+    assertEquals(ret, Query.True)
   }
 
   test("compress converts false,true,:and to false") {
     val ret = splitter.compress(Query.And(Query.False, Query.True))
-    assert(ret === Query.False)
+    assertEquals(ret, Query.False)
   }
 
   test("compress converts true,false,:and to false") {
     val ret = splitter.compress(Query.And(Query.True, Query.False))
-    assert(ret === Query.False)
+    assertEquals(ret, Query.False)
   }
 
   test("compress converts false,false,:and to false") {
     val ret = splitter.compress(Query.And(Query.False, Query.False))
-    assert(ret === Query.False)
+    assertEquals(ret, Query.False)
   }
 
   test("compress converts nf.app,b,:eq,:true,:and to nf.app,b,:eq") {
     val ret = splitter.compress(Query.And(Query.Equal("nf.app", "b"), Query.True))
-    assert(ret === Query.Equal("nf.app", "b"))
+    assertEquals(ret, Query.Equal("nf.app", "b"))
   }
 
   test("compress converts :true,nf.app,b,:eq,:and to nf.app,b,:eq") {
     val ret = splitter.compress(Query.And(Query.True, Query.Equal("nf.app", "b")))
-    assert(ret === Query.Equal("nf.app", "b"))
+    assertEquals(ret, Query.Equal("nf.app", "b"))
   }
 
   test("compress converts nf.app,b,:eq,:false,:and to :false") {
     val ret = splitter.compress(Query.And(Query.Equal("nf.app", "b"), Query.False))
-    assert(ret === Query.False)
+    assertEquals(ret, Query.False)
   }
 
   test("compress converts :false,nf.app,b,:eq,:and to :false") {
     val ret = splitter.compress(Query.And(Query.False, Query.Equal("nf.app", "b")))
-    assert(ret === Query.False)
+    assertEquals(ret, Query.False)
   }
 
   test("compress converts nf.stack,iep,:eq,nf.app,b,:eq,:and to identity") {
     val query = Query.And(Query.Equal("nf.stack", "iep"), Query.Equal("nf.app", "b"))
     val ret = splitter.compress(query)
-    assert(ret === query)
+    assertEquals(ret, query)
   }
 
   //
@@ -157,28 +157,28 @@ class ExpressionSplitterSuite extends AnyFunSuite {
 
   test("compress converts false,true,:or to true") {
     val ret = splitter.compress(Query.Or(Query.False, Query.True))
-    assert(ret === Query.True)
+    assertEquals(ret, Query.True)
   }
 
   test("compress converts true,false,:or to true") {
     val ret = splitter.compress(Query.Or(Query.True, Query.False))
-    assert(ret === Query.True)
+    assertEquals(ret, Query.True)
   }
 
   test("compress converts false,false,:or to false") {
     val ret = splitter.compress(Query.Or(Query.False, Query.False))
-    assert(ret === Query.False)
+    assertEquals(ret, Query.False)
   }
 
   test("compress converts a,b,:eq,c:d::eq:and to :true") {
     val ret = splitter.compress(Query.And(Query.Equal("a", "b"), Query.Equal("a", "b")))
-    assert(ret === Query.True)
+    assertEquals(ret, Query.True)
   }
 
   test("compress converts nf.stack,iep,:eq,nf.app,b,:eq,:or to identity") {
     val query = Query.Or(Query.Equal("nf.stack", "iep"), Query.Equal("nf.app", "b"))
     val ret = splitter.compress(query)
-    assert(ret === query)
+    assertEquals(ret, query)
   }
 
   //
@@ -188,18 +188,18 @@ class ExpressionSplitterSuite extends AnyFunSuite {
   test("compress converts :true,:not to :true") {
     // yes, not converts to true here on purpose.
     val ret = splitter.compress(Query.Not(Query.True))
-    assert(ret === Query.True)
+    assertEquals(ret, Query.True)
   }
 
   test("compress converts :false,:not to :true") {
     val ret = splitter.compress(Query.Not(Query.False))
-    assert(ret === Query.True)
+    assertEquals(ret, Query.True)
   }
 
   test("compress converts nf.stack,iep,:eq,:not to identity") {
     val query = Query.Not(Query.Equal("nf.stack", "iep"))
     val ret = splitter.compress(query)
-    assert(ret === query)
+    assertEquals(ret, query)
   }
 
   //

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/StartupDelayServiceSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/StartupDelayServiceSuite.scala
@@ -20,9 +20,9 @@ import java.time.Duration
 import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spectator.api.ManualClock
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class StartupDelayServiceSuite extends AnyFunSuite {
+class StartupDelayServiceSuite extends FunSuite {
 
   private def newInstance(delay: String): (StartupDelayService, ManualClock) = {
     val config = ConfigFactory.parseString(s"atlas.lwcapi.startup-delay = $delay")

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiJsonSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiJsonSuite.scala
@@ -19,9 +19,9 @@ import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException
 import com.netflix.atlas.json.Json
 import com.netflix.atlas.lwcapi.SubscribeApi._
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class SubscribeApiJsonSuite extends AnyFunSuite {
+class SubscribeApiJsonSuite extends FunSuite {
   test("encode and decode loop") {
     val expressions: List[ExpressionMetadata] = List(
       ExpressionMetadata("this", 1234, "idGoesHere"),
@@ -30,7 +30,7 @@ class SubscribeApiJsonSuite extends AnyFunSuite {
     val original = SubscribeRequest("sid", expressions)
     val json = original.toJson
     val decoded = Json.decode[SubscribeRequest](json)
-    assert(original === decoded)
+    assertEquals(original, decoded)
   }
 
   test("decode empty expression list throws") {
@@ -62,8 +62,8 @@ class SubscribeApiJsonSuite extends AnyFunSuite {
         ]
       }
       """)
-    assert(decoded.expressions.size === 3)
-    assert(decoded.streamId === "testsink")
+    assertEquals(decoded.expressions.size, 3)
+    assertEquals(decoded.streamId, "testsink")
   }
 
 }

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
@@ -16,9 +16,9 @@
 package com.netflix.atlas.lwcapi
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class SubscriptionManagerSuite extends AnyFunSuite {
+class SubscriptionManagerSuite extends FunSuite {
 
   private val config = ConfigFactory.load()
 
@@ -38,25 +38,25 @@ class SubscriptionManagerSuite extends AnyFunSuite {
     sm.register(sse1, 1)
 
     sm.subscribe(sse1, exp1)
-    assert(sm.handlersForSubscription(exp1.metadata.id) === List(1))
+    assertEquals(sm.handlersForSubscription(exp1.metadata.id), List(Integer.valueOf(1)))
 
     sm.subscribe(sse1, exp2)
-    assert(sm.handlersForSubscription(exp2.metadata.id) === List(1))
+    assertEquals(sm.handlersForSubscription(exp2.metadata.id), List(Integer.valueOf(1)))
 
     sm.unsubscribe(sse1, exp1.metadata.id)
-    assert(sm.handlersForSubscription(exp1.metadata.id) === List.empty)
+    assertEquals(sm.handlersForSubscription(exp1.metadata.id), List.empty)
 
-    assert(sm.unregister(sse1) === Some(1))
-    assert(sm.handlersForSubscription(exp1.metadata.id) === List.empty)
+    assertEquals(sm.unregister(sse1), Some(Integer.valueOf(1)))
+    assertEquals(sm.handlersForSubscription(exp1.metadata.id), List.empty)
 
-    assert(sm.unregister(sse1) === None)
+    assertEquals(sm.unregister(sse1), None)
   }
 
   test("multiple registrations") {
     val sm = new SubscriptionManager[Integer]()
     assert(sm.register("a", 1))
     assert(!sm.register("a", 1))
-    assert(sm.unregister("a") === Some(1))
+    assertEquals(sm.unregister("a"), Some(Integer.valueOf(1)))
     assert(sm.register("a", 1))
   }
 
@@ -66,10 +66,10 @@ class SubscriptionManagerSuite extends AnyFunSuite {
 
     val exp1 = sub("name,exp1,:eq")
     sm.subscribe("a", exp1)
-    assert(sm.subscriptions === List(exp1))
+    assertEquals(sm.subscriptions, List(exp1))
 
     assert(!sm.register("a", 1))
-    assert(sm.subscriptions === List(exp1))
+    assertEquals(sm.subscriptions, List(exp1))
   }
 
   test("multiple subscriptions for stream") {
@@ -79,7 +79,7 @@ class SubscriptionManagerSuite extends AnyFunSuite {
     val subs = List(sub("name,exp1,:eq"), sub("name,exp2,:eq"))
     sm.subscribe("a", subs)
 
-    assert(sm.subscriptions.toSet === subs.toSet)
+    assertEquals(sm.subscriptions.toSet, subs.toSet)
   }
 
   test("duplicate subscriptions") {
@@ -90,7 +90,7 @@ class SubscriptionManagerSuite extends AnyFunSuite {
     sm.subscribe("a", s)
     sm.subscribe("a", s)
 
-    assert(sm.subscriptions === List(s))
+    assertEquals(sm.subscriptions, List(s))
   }
 
   test("same subscription for two streams") {
@@ -102,10 +102,13 @@ class SubscriptionManagerSuite extends AnyFunSuite {
     sm.subscribe("a", s)
     sm.subscribe("b", s)
 
-    assert(sm.subscriptions === List(s))
-    assert(sm.subscriptionsForStream("a") === List(s))
-    assert(sm.subscriptionsForStream("b") === List(s))
-    assert(sm.handlersForSubscription(s.metadata.id).sorted === List(1, 2))
+    assertEquals(sm.subscriptions, List(s))
+    assertEquals(sm.subscriptionsForStream("a"), List(s))
+    assertEquals(sm.subscriptionsForStream("b"), List(s))
+    assertEquals(
+      sm.handlersForSubscription(s.metadata.id).sorted,
+      List(Integer.valueOf(1), Integer.valueOf(2))
+    )
   }
 
   private def checkSubsForCluster(expr: String, cluster: String): Unit = {
@@ -114,7 +117,7 @@ class SubscriptionManagerSuite extends AnyFunSuite {
     sm.register("a", 1)
     sm.subscribe("a", s)
     sm.regenerateQueryIndex()
-    assert(sm.subscriptionsForCluster(cluster) === List(s))
+    assertEquals(sm.subscriptionsForCluster(cluster), List(s))
   }
 
   test("subscriptions for cluster, just name") {
@@ -159,7 +162,7 @@ class SubscriptionManagerSuite extends AnyFunSuite {
 
   test("unregister for unknown stream does not cause any exceptions") {
     val sm = new SubscriptionManager[Integer]()
-    assert(sm.unregister("a") === None)
+    assertEquals(sm.unregister("a"), None)
   }
 
   test("unregister should remove handlers") {
@@ -168,10 +171,10 @@ class SubscriptionManagerSuite extends AnyFunSuite {
 
     val s = sub("name,exp1,:eq")
     sm.subscribe("a", s)
-    assert(sm.handlersForSubscription(s.metadata.id) === List(1))
+    assertEquals(sm.handlersForSubscription(s.metadata.id), List(Integer.valueOf(1)))
 
     sm.unregister("a")
-    assert(sm.handlersForSubscription(s.metadata.id) === Nil)
+    assertEquals(sm.handlersForSubscription(s.metadata.id), Nil)
   }
 
   test("subscribe returns added expressions") {
@@ -183,10 +186,10 @@ class SubscriptionManagerSuite extends AnyFunSuite {
     val s2 = sub("name,exp2,:eq")
     val s3 = sub("name,exp3,:eq")
 
-    assert(sm.subscribe("a", List(s1, s2)) === 1     -> List(s1, s2))
-    assert(sm.subscribe("a", List(s1, s2)) === 1     -> Nil)
-    assert(sm.subscribe("b", List(s1, s2)) === 2     -> List(s1, s2))
-    assert(sm.subscribe("b", List(s1, s2, s3)) === 2 -> List(s3))
-    assert(sm.subscribe("a", List(s1, s3)) === 1     -> List(s3))
+    assertEquals(sm.subscribe("a", List(s1, s2)), Integer.valueOf(1)     -> List(s1, s2))
+    assertEquals(sm.subscribe("a", List(s1, s2)), Integer.valueOf(1)     -> Nil)
+    assertEquals(sm.subscribe("b", List(s1, s2)), Integer.valueOf(2)     -> List(s1, s2))
+    assertEquals(sm.subscribe("b", List(s1, s2, s3)), Integer.valueOf(2) -> List(s3))
+    assertEquals(sm.subscribe("a", List(s1, s3)), Integer.valueOf(1)     -> List(s3))
   }
 }

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/WebSocketSessionManagerSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/WebSocketSessionManagerSuite.scala
@@ -20,13 +20,13 @@ import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import com.netflix.atlas.json.JsonSupport
 import com.netflix.atlas.lwcapi.SubscribeApi.ErrorMsg
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class WebSocketSessionManagerSuite extends AnyFunSuite {
+class WebSocketSessionManagerSuite extends FunSuite {
 
   private implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)
 
@@ -42,11 +42,12 @@ class WebSocketSessionManagerSuite extends AnyFunSuite {
 
     run(subscriptionList, regFun, subFunc)
 
-    assert(
-      subsCollector.toList === List(
-          List(ExpressionMetadata("name,a,:eq,:sum", 10000)),
-          List(ExpressionMetadata("name,b,:eq", 5000))
-        )
+    assertEquals(
+      subsCollector.toList,
+      List(
+        List(ExpressionMetadata("name,a,:eq,:sum", 10000)),
+        List(ExpressionMetadata("name,b,:eq", 5000))
+      )
     )
   }
 
@@ -61,10 +62,11 @@ class WebSocketSessionManagerSuite extends AnyFunSuite {
 
     run(subscriptionList, regFun, subFunc)
 
-    assert(
-      subsCollector.toList === List(
-          List(ExpressionMetadata("name,b,:eq", 5000))
-        )
+    assertEquals(
+      subsCollector.toList,
+      List(
+        List(ExpressionMetadata("name,b,:eq", 5000))
+      )
     )
   }
 

--- a/atlas-module-akka/src/test/scala/com/netflix/atlas/akka/AkkaModuleSuite.scala
+++ b/atlas-module-akka/src/test/scala/com/netflix/atlas/akka/AkkaModuleSuite.scala
@@ -24,9 +24,9 @@ import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.api.Registry
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class AkkaModuleSuite extends AnyFunSuite {
+class AkkaModuleSuite extends FunSuite {
 
   private val testCfg = ConfigFactory.parseString("""
       |atlas.akka.name = test
@@ -45,7 +45,7 @@ class AkkaModuleSuite extends AnyFunSuite {
     // Module listed twice to verify dedup works
     val injector = Guice.createInjector(deps, new AkkaModule, new AkkaModule)
     assert(injector.getInstance(classOf[ActorSystem]) != null)
-    assert(injector.getInstance(classOf[ServiceManager]).services().size === 2)
+    assertEquals(injector.getInstance(classOf[ServiceManager]).services().size, 2)
     injector.getInstance(classOf[PreDestroyList]).invokeAll()
   }
 }

--- a/atlas-module-eval/src/test/scala/com/netflix/atlas/eval/EvalModuleSuite.scala
+++ b/atlas-module-eval/src/test/scala/com/netflix/atlas/eval/EvalModuleSuite.scala
@@ -17,9 +17,9 @@ package com.netflix.atlas.eval
 
 import com.google.inject.Guice
 import com.netflix.atlas.eval.stream.Evaluator
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class EvalModuleSuite extends AnyFunSuite {
+class EvalModuleSuite extends FunSuite {
 
   test("load module") {
     // Module listed twice to verify dedup works

--- a/atlas-module-lwcapi/src/test/scala/com/netflix/atlas/guice/LwcApiModuleSuite.scala
+++ b/atlas-module-lwcapi/src/test/scala/com/netflix/atlas/guice/LwcApiModuleSuite.scala
@@ -22,9 +22,9 @@ import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spectator.api.Registry
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class LwcApiModuleSuite extends AnyFunSuite {
+class LwcApiModuleSuite extends FunSuite {
 
   test("load module") {
     val deps = new AbstractModule {

--- a/atlas-module-webapi/src/test/scala/com/netflix/atlas/guice/WebApiModuleSuite.scala
+++ b/atlas-module-webapi/src/test/scala/com/netflix/atlas/guice/WebApiModuleSuite.scala
@@ -21,9 +21,9 @@ import com.netflix.atlas.core.db.Database
 import com.netflix.iep.guice.PreDestroyList
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class WebApiModuleSuite extends AnyFunSuite {
+class WebApiModuleSuite extends FunSuite {
 
   test("load module") {
     val deps = new AbstractModule {

--- a/atlas-postgres/src/test/scala/com/netflix/atlas/postgres/PostgresCopyBufferSuite.scala
+++ b/atlas-postgres/src/test/scala/com/netflix/atlas/postgres/PostgresCopyBufferSuite.scala
@@ -22,14 +22,13 @@ import java.sql.Statement
 import scala.util.Using
 import org.postgresql.copy.CopyManager
 import org.postgresql.core.BaseConnection
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import java.sql.Connection
 import java.sql.DriverManager
 import java.sql.ResultSet
 
-class PostgresCopyBufferSuite extends AnyFunSuite with BeforeAndAfterAll {
+class PostgresCopyBufferSuite extends FunSuite {
 
   private val buffers = List(
     "text"   -> new TextCopyBuffer(1024),
@@ -87,7 +86,7 @@ class PostgresCopyBufferSuite extends AnyFunSuite with BeforeAndAfterAll {
       assert(buffer.putString("foo").nextRow())
       assert(buffer.putString("bar").nextRow())
       buffer.copyIn(copyManager, tableName)
-      assert(getData(stmt, _.getString(1)) === List(null, "foo", "bar"))
+      assertEquals(getData(stmt, _.getString(1)), List(null, "foo", "bar"))
     }
   }
 
@@ -115,7 +114,7 @@ class PostgresCopyBufferSuite extends AnyFunSuite with BeforeAndAfterAll {
             """{"a":"1","b":"2"}"""
           )
           val actual = getData(stmt, _.getString(1))
-          assert(actual === expected)
+          assertEquals(actual, expected)
         }
       }
 
@@ -133,7 +132,7 @@ class PostgresCopyBufferSuite extends AnyFunSuite with BeforeAndAfterAll {
             """{"a": "1", "b": "2"}"""
           )
           val actual = getData(stmt, _.getString(1))
-          assert(actual === expected)
+          assertEquals(actual, expected)
         }
       }
 
@@ -151,7 +150,7 @@ class PostgresCopyBufferSuite extends AnyFunSuite with BeforeAndAfterAll {
             """"a"=>"1", "b"=>"2""""
           )
           val actual = getData(stmt, _.getString(1))
-          assert(actual === expected)
+          assertEquals(actual, expected)
         }
       }
 
@@ -164,12 +163,12 @@ class PostgresCopyBufferSuite extends AnyFunSuite with BeforeAndAfterAll {
           assert(buffer.putShort(Short.MaxValue).nextRow())
           buffer.copyIn(copyManager, tableName)
           val expected = List(
-            0,
+            0.toShort,
             Short.MinValue,
             Short.MaxValue
           )
           val actual = getData(stmt, _.getShort(1))
-          assert(actual === expected)
+          assertEquals(actual, expected)
         }
       }
 
@@ -187,7 +186,7 @@ class PostgresCopyBufferSuite extends AnyFunSuite with BeforeAndAfterAll {
             Int.MaxValue
           )
           val actual = getData(stmt, _.getInt(1))
-          assert(actual === expected)
+          assertEquals(actual, expected)
         }
       }
 
@@ -205,7 +204,7 @@ class PostgresCopyBufferSuite extends AnyFunSuite with BeforeAndAfterAll {
             Long.MaxValue
           )
           val actual = getData(stmt, _.getLong(1))
-          assert(actual === expected)
+          assertEquals(actual, expected)
         }
       }
 
@@ -232,7 +231,7 @@ class PostgresCopyBufferSuite extends AnyFunSuite with BeforeAndAfterAll {
           )
           val actual = getData(stmt, _.getDouble(1))
           actual.zip(expected).foreach {
-            case (a, e) => if (a.isNaN) assert(e.isNaN) else assert(a === e)
+            case (a, e) => if (a.isNaN) assert(e.isNaN) else assertEquals(a, e)
           }
         }
       }
@@ -253,10 +252,10 @@ class PostgresCopyBufferSuite extends AnyFunSuite with BeforeAndAfterAll {
           assert(buffer.putDoubleArray(expected.toArray).nextRow())
           buffer.copyIn(copyManager, tableName)
           val actual = getData(stmt, _.getArray(1).getArray.asInstanceOf[Array[java.lang.Double]])
-          assert(actual.size === 1)
+          assertEquals(actual.size, 1)
           actual.foreach { data =>
             data.toList.zip(expected).foreach {
-              case (a, e) => if (a.isNaN) assert(e.isNaN) else assert(a === e)
+              case (a, e) => if (a.isNaN) assert(e.isNaN) else assertEquals(a.doubleValue(), e)
             }
           }
         }

--- a/atlas-postgres/src/test/scala/com/netflix/atlas/postgres/TextCopyBufferSuite.scala
+++ b/atlas-postgres/src/test/scala/com/netflix/atlas/postgres/TextCopyBufferSuite.scala
@@ -17,11 +17,11 @@ package com.netflix.atlas.postgres
 
 import com.netflix.atlas.core.model.ItemIdCalculator
 import com.netflix.atlas.core.util.SortedTagMap
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import java.io.Reader
 
-class TextCopyBufferSuite extends AnyFunSuite {
+class TextCopyBufferSuite extends FunSuite {
 
   test("too small") {
     intercept[IllegalArgumentException] {
@@ -42,31 +42,31 @@ class TextCopyBufferSuite extends AnyFunSuite {
     val buffer = new TextCopyBuffer(100)
     val id = ItemIdCalculator.compute(SortedTagMap("a" -> "1"))
     buffer.putId(id)
-    assert(buffer.toString === s"$id\t")
+    assertEquals(buffer.toString, s"$id\t")
   }
 
   test("putString") {
     val buffer = new TextCopyBuffer(100)
     buffer.putString("foo")
-    assert(buffer.toString === "foo\t")
+    assertEquals(buffer.toString, "foo\t")
   }
 
   test("putString null") {
     val buffer = new TextCopyBuffer(100)
     buffer.putString(null)
-    assert(buffer.toString === "\\N\t")
+    assertEquals(buffer.toString, "\\N\t")
   }
 
   test("putString escape") {
     val buffer = new TextCopyBuffer(100)
     buffer.putString("\b\f\n\r\t\u000b\"\\")
-    assert(buffer.toString === "\\b\\f\\n\\r\\t\\v\\\"\\\\\t")
+    assertEquals(buffer.toString, "\\b\\f\\n\\r\\t\\v\\\"\\\\\t")
   }
 
   test("putString escape disabled") {
     val buffer = new TextCopyBuffer(100, false)
     buffer.putString("\b\f\n\r\t\u000b\"\\")
-    assert(buffer.toString === "\b\f\n\r\t\u000b\"\\\t")
+    assertEquals(buffer.toString, "\b\f\n\r\t\u000b\"\\\t")
   }
 
   test("putString not enough space") {
@@ -85,96 +85,96 @@ class TextCopyBufferSuite extends AnyFunSuite {
     val buffer = new TextCopyBuffer(100)
     val tags = SortedTagMap("a" -> "1", "b" -> "2")
     buffer.putTagsJson(tags)
-    assert(buffer.toString === "{\"a\":\"1\",\"b\":\"2\"}\t")
+    assertEquals(buffer.toString, "{\"a\":\"1\",\"b\":\"2\"}\t")
   }
 
   test("putTagsJson empty") {
     val buffer = new TextCopyBuffer(100)
     val tags = SortedTagMap.empty
     buffer.putTagsJson(tags)
-    assert(buffer.toString === "{}\t")
+    assertEquals(buffer.toString, "{}\t")
   }
 
   test("putTagsJsonb") {
     val buffer = new TextCopyBuffer(100)
     val tags = SortedTagMap("a" -> "1", "b" -> "2")
     buffer.putTagsJsonb(tags)
-    assert(buffer.toString === "{\"a\":\"1\",\"b\":\"2\"}\t")
+    assertEquals(buffer.toString, "{\"a\":\"1\",\"b\":\"2\"}\t")
   }
 
   test("putTagsHstore") {
     val buffer = new TextCopyBuffer(100)
     val tags = SortedTagMap("a" -> "1", "b" -> "2")
     buffer.putTagsHstore(tags)
-    assert(buffer.toString === "\"a\"=>\"1\",\"b\"=>\"2\"\t")
+    assertEquals(buffer.toString, "\"a\"=>\"1\",\"b\"=>\"2\"\t")
   }
 
   test("putTagsHstore empty") {
     val buffer = new TextCopyBuffer(100)
     val tags = SortedTagMap.empty
     buffer.putTagsHstore(tags)
-    assert(buffer.toString === "\t")
+    assertEquals(buffer.toString, "\t")
   }
 
   test("putTagsText") {
     val buffer = new TextCopyBuffer(100)
     val tags = SortedTagMap("a" -> "1", "b" -> "2")
     buffer.putTagsText(tags)
-    assert(buffer.toString === "{\"a\":\"1\",\"b\":\"2\"}\t")
+    assertEquals(buffer.toString, "{\"a\":\"1\",\"b\":\"2\"}\t")
   }
 
   test("putShort") {
     val buffer = new TextCopyBuffer(100)
     buffer.putShort(42)
-    assert(buffer.toString === "42\t")
+    assertEquals(buffer.toString, "42\t")
   }
 
   test("putInt") {
     val buffer = new TextCopyBuffer(100)
     buffer.putInt(42)
-    assert(buffer.toString === "42\t")
+    assertEquals(buffer.toString, "42\t")
   }
 
   test("putLong") {
     val buffer = new TextCopyBuffer(100)
     buffer.putLong(42L)
-    assert(buffer.toString === "42\t")
+    assertEquals(buffer.toString, "42\t")
   }
 
   test("putDouble") {
     val buffer = new TextCopyBuffer(100)
     buffer.putDouble(42.0)
-    assert(buffer.toString === "42.0\t")
+    assertEquals(buffer.toString, "42.0\t")
   }
 
   test("putDouble NaN") {
     val buffer = new TextCopyBuffer(100)
     buffer.putDouble(Double.NaN)
-    assert(buffer.toString === "NaN\t")
+    assertEquals(buffer.toString, "NaN\t")
   }
 
   test("putDouble Infinity") {
     val buffer = new TextCopyBuffer(100)
     buffer.putDouble(Double.PositiveInfinity)
-    assert(buffer.toString === "Infinity\t")
+    assertEquals(buffer.toString, "Infinity\t")
   }
 
   test("putDouble -Infinity") {
     val buffer = new TextCopyBuffer(100)
     buffer.putDouble(Double.NegativeInfinity)
-    assert(buffer.toString === "-Infinity\t")
+    assertEquals(buffer.toString, "-Infinity\t")
   }
 
   test("putDoubleArray") {
     val buffer = new TextCopyBuffer(100)
     buffer.putDoubleArray(Array.empty).putDoubleArray(Array(1.0, 1.5, 2.0, 2.5))
-    assert(buffer.toString === "{}\t{1.0,1.5,2.0,2.5}\t")
+    assertEquals(buffer.toString, "{}\t{1.0,1.5,2.0,2.5}\t")
   }
 
   test("nextRow") {
     val buffer = new TextCopyBuffer(100)
     buffer.putString("foo").putString("bar").nextRow()
-    assert(buffer.toString === "foo\tbar\n")
+    assertEquals(buffer.toString, "foo\tbar\n")
   }
 
   test("nextRow on empty row") {
@@ -202,25 +202,25 @@ class TextCopyBufferSuite extends AnyFunSuite {
   test("reader") {
     val buffer = new TextCopyBuffer(100)
     buffer.putInt(0).putString("foo").nextRow()
-    assert(toString(buffer.reader()) === "0\tfoo\n")
+    assertEquals(toString(buffer.reader()), "0\tfoo\n")
   }
 
   test("reader with partial row") {
     val buffer = new TextCopyBuffer(9)
     assert(buffer.putInt(0).putString("foo").nextRow())
     assert(!buffer.putInt(1).putString("bar").nextRow())
-    assert(toString(buffer.reader()) === "0\tfoo\n")
+    assertEquals(toString(buffer.reader()), "0\tfoo\n")
   }
 
   test("remaining") {
     val buffer = new TextCopyBuffer(4)
     buffer.putInt(2)
     assert(buffer.hasRemaining)
-    assert(buffer.remaining === 2)
+    assertEquals(buffer.remaining, 2)
 
     buffer.putString("foo")
     assert(!buffer.hasRemaining)
-    assert(buffer.remaining === 0)
+    assertEquals(buffer.remaining, 0)
   }
 
   test("rows") {
@@ -228,17 +228,17 @@ class TextCopyBufferSuite extends AnyFunSuite {
     var i = 0
     while (buffer.putInt(i).nextRow()) {
       i = i + 1
-      assert(buffer.rows === i)
+      assertEquals(buffer.rows, i)
     }
-    assert(buffer.rows === i)
+    assertEquals(buffer.rows, i)
   }
 
   test("clear") {
     val buffer = new TextCopyBuffer(100)
     buffer.putInt(0).putString("foo").nextRow()
-    assert(toString(buffer.reader()) === "0\tfoo\n")
+    assertEquals(toString(buffer.reader()), "0\tfoo\n")
     buffer.clear()
     buffer.putInt(1).putString("bar").nextRow()
-    assert(toString(buffer.reader()) === "1\tbar\n")
+    assertEquals(toString(buffer.reader()), "1\tbar\n")
   }
 }

--- a/atlas-standalone/src/test/scala/com/netflix/atlas/standalone/MainSuite.scala
+++ b/atlas-standalone/src/test/scala/com/netflix/atlas/standalone/MainSuite.scala
@@ -15,9 +15,9 @@
  */
 package com.netflix.atlas.standalone
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class MainSuite extends AnyFunSuite {
+class MainSuite extends FunSuite {
 
   test("start/shutdown") {
     Main.start()

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ApiSettingsSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ApiSettingsSuite.scala
@@ -19,9 +19,9 @@ import com.netflix.atlas.core.model.CustomVocabulary
 import com.netflix.atlas.core.stacklang.Vocabulary
 import com.netflix.atlas.core.stacklang.Word
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class ApiSettingsSuite extends AnyFunSuite {
+class ApiSettingsSuite extends FunSuite {
 
   test("graphVocabulary default") {
     val cfg = new ApiSettings(ConfigFactory.parseString("""

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
@@ -18,8 +18,8 @@ package com.netflix.atlas.webapi
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.RouteTestTimeout
-import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.netflix.atlas.akka.RequestHandler
+import com.netflix.atlas.akka.testkit.MUnitRouteSuite
 import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.MathExpr
 import com.netflix.atlas.core.model.Query
@@ -27,9 +27,8 @@ import com.netflix.atlas.core.model.StyleExpr
 import com.netflix.atlas.core.model.StyleVocabulary
 import com.netflix.atlas.core.stacklang.Interpreter
 import com.netflix.atlas.json.Json
-import org.scalatest.funsuite.AnyFunSuite
 
-class ExprApiSuite extends AnyFunSuite with ScalatestRouteTest {
+class ExprApiSuite extends MUnitRouteSuite {
 
   import scala.concurrent.duration._
 
@@ -46,142 +45,142 @@ class ExprApiSuite extends AnyFunSuite with ScalatestRouteTest {
   private def routes: Route = RequestHandler.standardOptions(endpoint.routes)
 
   testGet("/api/v1/expr") {
-    assert(response.status === StatusCodes.BadRequest)
+    assertEquals(response.status, StatusCodes.BadRequest)
   }
 
   testGet("/api/v1/expr?q=name,sps,:eq") {
-    assert(response.status === StatusCodes.OK)
+    assertEquals(response.status, StatusCodes.OK)
     val data = Json.decode[List[ExprApiSuite.Output]](responseAs[String])
-    assert(data.size === 4)
+    assertEquals(data.size, 4)
   }
 
   testGet("/api/v1/expr/debug") {
-    assert(response.status === StatusCodes.BadRequest)
+    assertEquals(response.status, StatusCodes.BadRequest)
   }
 
   testGet("/api/v1/expr/debug?q=name,sps,:eq") {
-    assert(response.status === StatusCodes.OK)
+    assertEquals(response.status, StatusCodes.OK)
     val data = Json.decode[List[ExprApiSuite.Output]](responseAs[String])
-    assert(data.size === 4)
+    assertEquals(data.size, 4)
   }
 
   testGet("/api/v1/expr/debug?q=name,sps,:eq,:sum,$name,:legend&vocab=style") {
-    assert(response.status === StatusCodes.OK)
+    assertEquals(response.status, StatusCodes.OK)
     val data = Json.decode[List[ExprApiSuite.Output]](responseAs[String])
-    assert(data.size === 7)
+    assertEquals(data.size, 7)
   }
 
   testGet("/api/v1/expr/debug?q=name,sps,:eq,:sum,$name,:legend,foo,:sset,foo,:get") {
-    assert(response.status === StatusCodes.OK)
+    assertEquals(response.status, StatusCodes.OK)
     val data = Json.decode[List[ExprApiSuite.Output]](responseAs[String])
-    assert(data.size === 11)
+    assertEquals(data.size, 11)
     assert(data.last.context.variables("foo") == "name,sps,:eq,:sum,$name,:legend")
   }
 
   testGet("/api/v1/expr/debug?q=name,sps,:eq,:sum,$name,:legend&vocab=query") {
-    assert(response.status === StatusCodes.BadRequest)
+    assertEquals(response.status, StatusCodes.BadRequest)
   }
 
   testGet("/api/v1/expr/debug?q=name,sps,:eq,cluster,:has&vocab=query") {
-    assert(response.status === StatusCodes.BadRequest)
+    assertEquals(response.status, StatusCodes.BadRequest)
   }
 
   testGet("/api/v1/expr/debug?q=name,sps,:eq,:clear&vocab=query") {
-    assert(response.status === StatusCodes.BadRequest)
+    assertEquals(response.status, StatusCodes.BadRequest)
   }
 
   testGet("/api/v1/expr/debug?q=name,sps,:eq,:sum,$name,:legend,foo") {
-    assert(response.status === StatusCodes.BadRequest)
+    assertEquals(response.status, StatusCodes.BadRequest)
   }
 
   testGet("/api/v1/expr/debug?q=name,sps,:eq,:sum,$name,:legend,foo,:clear") {
-    assert(response.status === StatusCodes.BadRequest)
+    assertEquals(response.status, StatusCodes.BadRequest)
   }
 
   testGet("/api/v1/expr/normalize") {
-    assert(response.status === StatusCodes.BadRequest)
+    assertEquals(response.status, StatusCodes.BadRequest)
   }
 
   testGet("/api/v1/expr/normalize?q=name,sps,:eq") {
-    assert(response.status === StatusCodes.OK)
+    assertEquals(response.status, StatusCodes.OK)
     val data = Json.decode[List[String]](responseAs[String])
-    assert(data === List("name,sps,:eq,:sum"))
+    assertEquals(data, List("name,sps,:eq,:sum"))
   }
 
   testGet("/api/v1/expr/normalize?q=name,sps,:eq,:dup,2,:mul,:swap") {
-    assert(response.status === StatusCodes.OK)
+    assertEquals(response.status, StatusCodes.OK)
     val data = Json.decode[List[String]](responseAs[String])
-    assert(data === List("name,sps,:eq,:sum,2.0,:mul", "name,sps,:eq,:sum"))
+    assertEquals(data, List("name,sps,:eq,:sum,2.0,:mul", "name,sps,:eq,:sum"))
   }
 
   testGet(
     "/api/v1/expr/normalize?q=(,name,:swap,:eq,nf.cluster,foo,:eq,:and,:sum,),foo,:sset,cpu,foo,:fcall,disk,foo,:fcall"
   ) {
-    assert(response.status === StatusCodes.OK)
+    assertEquals(response.status, StatusCodes.OK)
     val data = Json.decode[List[String]](responseAs[String])
     val expected =
       List("name,cpu,:eq,:sum", "name,disk,:eq,:sum", ":list,(,nf.cluster,foo,:eq,:cq,),:each")
-    assert(data === expected)
+    assertEquals(data, expected)
   }
 
   testGet("/api/v1/expr/complete") {
-    assert(response.status === StatusCodes.BadRequest)
+    assertEquals(response.status, StatusCodes.BadRequest)
   }
 
   testGet("/api/v1/expr/complete?q=name,sps,:eq") {
-    assert(response.status === StatusCodes.OK)
+    assertEquals(response.status, StatusCodes.OK)
     val data = Json.decode[List[ExprApiSuite.Candidate]](responseAs[String]).map(_.name)
     assert(data.nonEmpty)
     assert(!data.contains("add"))
   }
 
   testGet("/api/v1/expr/complete?q=name,sps,:eq,(,nf.cluster,)") {
-    assert(response.status === StatusCodes.OK)
+    assertEquals(response.status, StatusCodes.OK)
     val data = Json.decode[List[ExprApiSuite.Candidate]](responseAs[String]).map(_.name)
-    assert(data === List("by", "by", "offset", "palette"))
+    assertEquals(data, List("by", "by", "offset", "palette"))
   }
 
   // TODO: Right now these fail. As a future improvement suggestions should be possible within
   // a list context by ignoring everything outside of the list.
   testGet("/api/v1/expr/complete?q=name,sps,:eq,(,nf.cluster,name") {
-    assert(response.status === StatusCodes.BadRequest)
+    assertEquals(response.status, StatusCodes.BadRequest)
   }
 
   testGet("/api/v1/expr/complete?q=1,2") {
-    assert(response.status === StatusCodes.OK)
+    assertEquals(response.status, StatusCodes.OK)
     val data = Json.decode[List[ExprApiSuite.Candidate]](responseAs[String]).map(_.name)
     assert(data.nonEmpty)
     assert(data.contains("add"))
   }
 
   testGet("/api/v1/expr/queries?q=1,2") {
-    assert(response.status === StatusCodes.OK)
+    assertEquals(response.status, StatusCodes.OK)
     val data = Json.decode[List[String]](responseAs[String])
     assert(data.isEmpty)
   }
 
   testGet("/api/v1/expr/queries?q=name,sps,:eq") {
-    assert(response.status === StatusCodes.OK)
+    assertEquals(response.status, StatusCodes.OK)
     val data = Json.decode[List[String]](responseAs[String])
-    assert(data === List("name,sps,:eq"))
+    assertEquals(data, List("name,sps,:eq"))
   }
 
   testGet("/api/v1/expr/queries?q=name,sps,:eq,(,nf.cluster,),:by") {
-    assert(response.status === StatusCodes.OK)
+    assertEquals(response.status, StatusCodes.OK)
     val data = Json.decode[List[String]](responseAs[String])
-    assert(data === List("name,sps,:eq"))
+    assertEquals(data, List("name,sps,:eq"))
   }
 
   testGet("/api/v1/expr/queries?q=name,sps,:eq,(,nf.cluster,),:by,:dup,:dup,4,:add") {
-    assert(response.status === StatusCodes.OK)
+    assertEquals(response.status, StatusCodes.OK)
     val data = Json.decode[List[String]](responseAs[String])
-    assert(data === List("name,sps,:eq"))
+    assertEquals(data, List("name,sps,:eq"))
   }
 
   testGet("/api/v1/expr/queries?q=name,sps,:eq,(,nf.cluster,),:by,:true,:sum,name,:has,:add") {
-    assert(response.status === StatusCodes.OK)
+    assertEquals(response.status, StatusCodes.OK)
     val data = Json.decode[List[String]](responseAs[String])
-    assert(data === List(":true", "name,:has", "name,sps,:eq"))
+    assertEquals(data, List(":true", "name,:has", "name,sps,:eq"))
   }
 
   import Query._
@@ -194,17 +193,18 @@ class ExprApiSuite extends AnyFunSuite with ScalatestRouteTest {
   test("normalize query order") {
     val q1 = "app,foo,:eq,name,cpu,:eq,:and"
     val q2 = "name,cpu,:eq,app,foo,:eq,:and"
-    assert(normalize(q1) === normalize(q2))
+    assertEquals(normalize(q1), normalize(q2))
   }
 
   test("normalize single query") {
     val e1 = DataExpr.Sum(And(Equal("app", "foo"), Equal("name", "cpuUser")))
     val add = StyleExpr(MathExpr.Add(e1, e1), Map.empty)
-    assert(
-      normalize(add.toString) === List(
-          ":true,:sum,:true,:sum,:add",
-          ":list,(,app,foo,:eq,name,cpuUser,:eq,:and,:cq,),:each"
-        )
+    assertEquals(
+      normalize(add.toString),
+      List(
+        ":true,:sum,:true,:sum,:add",
+        ":list,(,app,foo,:eq,name,cpuUser,:eq,:and,:cq,),:each"
+      )
     )
   }
 
@@ -212,76 +212,78 @@ class ExprApiSuite extends AnyFunSuite with ScalatestRouteTest {
     val e1 = DataExpr.Sum(And(Equal("app", "foo"), Equal("name", "cpuUser")))
     val e2 = DataExpr.Sum(And(Equal("app", "foo"), Equal("name", "cpuSystem")))
     val add = StyleExpr(MathExpr.Add(e1, e2), Map.empty)
-    assert(
-      normalize(add.toString) === List(
-          "name,cpuUser,:eq,:sum,name,cpuSystem,:eq,:sum,:add",
-          ":list,(,app,foo,:eq,:cq,),:each"
-        )
+    assertEquals(
+      normalize(add.toString),
+      List(
+        "name,cpuUser,:eq,:sum,name,cpuSystem,:eq,:sum,:add",
+        ":list,(,app,foo,:eq,:cq,),:each"
+      )
     )
   }
 
   test("normalize :avg") {
     val avg = "app,foo,:eq,name,cpuUser,:eq,:and,:avg"
-    assert(normalize(avg) === List(avg))
+    assertEquals(normalize(avg), List(avg))
   }
 
   test("normalize :dist-avg") {
     val avg = "app,foo,:eq,name,cpuUser,:eq,:and,:dist-avg"
-    assert(normalize(avg) === List(avg))
+    assertEquals(normalize(avg), List(avg))
   }
 
   test("normalize :dist-avg,(,nf.cluster,),:by") {
     val avg = "app,foo,:eq,name,cpuUser,:eq,:and,:dist-avg,(,nf.cluster,),:by"
-    assert(normalize(avg) === List(avg))
+    assertEquals(normalize(avg), List(avg))
   }
 
   test("normalize :dist-stddev") {
     val stddev = "app,foo,:eq,name,cpuUser,:eq,:and,:dist-stddev"
-    assert(normalize(stddev) === List(stddev))
+    assertEquals(normalize(stddev), List(stddev))
   }
 
   test("normalize :dist-max") {
     val max = "app,foo,:eq,name,cpuUser,:eq,:and,:dist-max"
-    assert(normalize(max) === List(max))
+    assertEquals(normalize(max), List(max))
   }
 
   test("normalize :dist-avg + expr2") {
     val avg =
       "app,foo,:eq,name,cpuUser,:eq,:and,:dist-avg,app,foo,:eq,name,cpuSystem,:eq,:and,:max"
-    assert(
-      normalize(avg) === List(
-          "name,cpuUser,:eq,:dist-avg",
-          "name,cpuSystem,:eq,:max",
-          ":list,(,app,foo,:eq,:cq,),:each"
-        )
+    assertEquals(
+      normalize(avg),
+      List(
+        "name,cpuUser,:eq,:dist-avg",
+        "name,cpuSystem,:eq,:max",
+        ":list,(,app,foo,:eq,:cq,),:each"
+      )
     )
   }
 
   test("normalize :avg,(,nf.cluster,),:by,:pct") {
     val avg = "app,foo,:eq,name,cpuUser,:eq,:and,:avg,(,nf.cluster,),:by,:pct"
-    assert(normalize(avg) === List(avg))
+    assertEquals(normalize(avg), List(avg))
   }
 
   test("normalize :des-fast") {
     val expr = "app,foo,:eq,name,cpuUser,:eq,:and,:sum,:des-fast"
-    assert(normalize(expr) === List(expr))
+    assertEquals(normalize(expr), List(expr))
   }
 
   test("normalize legend vars, include parenthesis") {
     val expr = "name,cpuUser,:eq,:sum,$name,:legend"
     val expected = "name,cpuUser,:eq,:sum,$(name),:legend"
-    assert(normalize(expr) === List(expected))
+    assertEquals(normalize(expr), List(expected))
   }
 
   test("normalize legend vars, noop if parens already present") {
     val expr = "name,cpuUser,:eq,:sum,$(name),:legend"
-    assert(normalize(expr) === List(expr))
+    assertEquals(normalize(expr), List(expr))
   }
 
   test("normalize legend vars, mix") {
     val expr = "name,cpuUser,:eq,:sum,foo$name$abc bar$(def)baz,:legend"
     val expected = "name,cpuUser,:eq,:sum,foo$(name)$(abc) bar$(def)baz,:legend"
-    assert(normalize(expr) === List(expected))
+    assertEquals(normalize(expr), List(expected))
   }
 }
 

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiMemDbSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiMemDbSuite.scala
@@ -19,15 +19,14 @@ import akka.actor.Props
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.testkit.RouteTestTimeout
-import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.netflix.atlas.akka.DiagnosticMessage
 import com.netflix.atlas.akka.RequestHandler
+import com.netflix.atlas.akka.testkit.MUnitRouteSuite
 import com.netflix.atlas.core.db.MemoryDatabase
 import com.netflix.atlas.json.Json
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
 
-class GraphApiMemDbSuite extends AnyFunSuite with ScalatestRouteTest {
+class GraphApiMemDbSuite extends MUnitRouteSuite {
 
   import scala.concurrent.duration._
 
@@ -55,35 +54,35 @@ class GraphApiMemDbSuite extends AnyFunSuite with ScalatestRouteTest {
   test("sendError image if browser") {
     val agent = `User-Agent`("Mozilla/5.0 (Android; Mobile; rv:13.0) Gecko/13.0 Firefox/13.0")
     Get("/api/v1/graph?q=:foo").addHeader(agent) ~> routes ~> check {
-      assert(response.status === StatusCodes.OK)
+      assertEquals(response.status, StatusCodes.OK)
     }
   }
 
   test("sendError json if not browser") {
     val agent = `User-Agent`("java")
     Get("/api/v1/graph?q=:foo").addHeader(agent) ~> routes ~> check {
-      assert(response.status === StatusCodes.BadRequest)
+      assertEquals(response.status, StatusCodes.BadRequest)
       val msg = Json.decode[DiagnosticMessage](responseAs[String])
-      assert(msg.typeName === "error")
-      assert(msg.message === "IllegalStateException: unknown word ':foo'")
+      assertEquals(msg.typeName, "error")
+      assertEquals(msg.message, "IllegalStateException: unknown word ':foo'")
     }
   }
 
   test("sendError txt") {
     Get("/api/v1/graph?q=:foo&format=txt") ~> routes ~> check {
-      assert(response.status === StatusCodes.BadRequest)
+      assertEquals(response.status, StatusCodes.BadRequest)
     }
   }
 
   test("image: IAE if not match for argument to binary op") {
     Get("/api/v1/graph?q=name,foo,:eq,:sum,name,bar,:eq,:sum,:add") ~> routes ~> check {
-      assert(response.status === StatusCodes.OK)
+      assertEquals(response.status, StatusCodes.OK)
     }
   }
 
   test("txt: IAE if not match for argument to binary op") {
     Get("/api/v1/graph?q=name,bar,:eq,:sum,name,foo,:eq,:sum,:add&format=txt") ~> routes ~> check {
-      assert(response.status === StatusCodes.OK)
+      assertEquals(response.status, StatusCodes.OK)
     }
   }
 

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiSuite.scala
@@ -20,8 +20,8 @@ import akka.http.scaladsl.model.MediaTypes
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.testkit.RouteTestTimeout
-import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.netflix.atlas.akka.RequestHandler
+import com.netflix.atlas.akka.testkit.MUnitRouteSuite
 import com.netflix.atlas.chart.util.GraphAssertions
 import com.netflix.atlas.chart.util.PngImage
 import com.netflix.atlas.chart.util.SrcPath
@@ -30,11 +30,10 @@ import com.netflix.atlas.core.util.Hash
 import com.netflix.atlas.core.util.Streams
 import com.netflix.atlas.core.util.Strings
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
 
 import scala.util.Using
 
-class GraphApiSuite extends AnyFunSuite with ScalatestRouteTest {
+class GraphApiSuite extends MUnitRouteSuite {
 
   import scala.concurrent.duration._
 
@@ -60,7 +59,9 @@ class GraphApiSuite extends AnyFunSuite with ScalatestRouteTest {
   private val baseDir = SrcPath.forProject("atlas-webapi")
   private val goldenDir = s"$baseDir/src/test/resources/${getClass.getSimpleName}"
   private val targetDir = s"$baseDir/target/${getClass.getSimpleName}"
-  private val graphAssertions = new GraphAssertions(goldenDir, targetDir, (a, b) => assert(a === b))
+
+  private val graphAssertions =
+    new GraphAssertions(goldenDir, targetDir, (a, b) => assertEquals(a, b))
 
   private val bless = false
 
@@ -70,7 +71,7 @@ class GraphApiSuite extends AnyFunSuite with ScalatestRouteTest {
 
   test("simple line") {
     Get("/api/v1/graph?q=1") ~> routes ~> check {
-      assert(response.status === StatusCodes.OK)
+      assertEquals(response.status, StatusCodes.OK)
     }
   }
 
@@ -82,8 +83,8 @@ class GraphApiSuite extends AnyFunSuite with ScalatestRouteTest {
       Get(uri).addHeader(agent) ~> routes ~> check {
         // Note: will fail prior to 8u20:
         // https://github.com/Netflix/atlas/issues/9
-        assert(response.status === StatusCodes.OK)
-        assert(response.entity.contentType.mediaType === MediaTypes.`image/png`)
+        assertEquals(response.status, StatusCodes.OK)
+        assertEquals(response.entity.contentType.mediaType, MediaTypes.`image/png`)
         val image = PngImage(responseAs[Array[Byte]])
         graphAssertions.assertEquals(image, imageFileName(uri), bless)
       }

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishApiJsonSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishApiJsonSuite.scala
@@ -17,33 +17,33 @@ package com.netflix.atlas.webapi
 
 import com.netflix.atlas.core.model.Datapoint
 import com.netflix.atlas.json.Json
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class PublishApiJsonSuite extends AnyFunSuite {
+class PublishApiJsonSuite extends FunSuite {
 
   test("encode and decode datapoint") {
     val original = Datapoint(Map("name" -> "foo", "id" -> "bar"), 42L, 1024.0)
     val decoded = PublishApi.decodeDatapoint(PublishApi.encodeDatapoint(original))
-    assert(original === decoded)
+    assertEquals(original, decoded)
   }
 
   test("encode and decode batch") {
     val commonTags = Map("id" -> "bar")
     val original = List(Datapoint(Map("name" -> "foo"), 42L, 1024.0))
     val decoded = PublishApi.decodeBatch(PublishApi.encodeBatch(commonTags, original))
-    assert(original.map(d => d.copy(tags = d.tags ++ commonTags)) === decoded)
+    assertEquals(original.map(d => d.copy(tags = d.tags ++ commonTags)), decoded)
   }
 
   test("decode batch empty") {
     val decoded = PublishApi.decodeBatch("{}")
-    assert(decoded.size === 0)
+    assertEquals(decoded.size, 0)
   }
 
   test("decode with legacy array value") {
     val expected = Datapoint(Map("name" -> "foo"), 42L, 1024.0)
     val decoded =
       PublishApi.decodeDatapoint("""{"tags":{"name":"foo"},"timestamp":42,"values":[1024.0]}""")
-    assert(expected === decoded)
+    assertEquals(expected, decoded)
   }
 
   test("decode legacy batch empty") {
@@ -53,7 +53,7 @@ class PublishApiJsonSuite extends AnyFunSuite {
         "metrics": []
       }
       """)
-    assert(decoded.size === 0)
+    assertEquals(decoded.size, 0)
   }
 
   test("decode legacy batch no tags") {
@@ -62,7 +62,7 @@ class PublishApiJsonSuite extends AnyFunSuite {
         "metrics": []
       }
       """)
-    assert(decoded.size === 0)
+    assertEquals(decoded.size, 0)
   }
 
   test("decode legacy batch with tags before") {
@@ -80,8 +80,8 @@ class PublishApiJsonSuite extends AnyFunSuite {
         ]
       }
       """)
-    assert(decoded.size === 1)
-    assert(decoded.head.tags === Map("name" -> "test", "foo" -> "bar"))
+    assertEquals(decoded.size, 1)
+    assertEquals(decoded.head.tags, Map("name" -> "test", "foo" -> "bar"))
   }
 
   test("decode legacy batch with tags after") {
@@ -99,8 +99,8 @@ class PublishApiJsonSuite extends AnyFunSuite {
         }
       }
       """)
-    assert(decoded.size === 1)
-    assert(decoded.head.tags === Map("name" -> "test", "foo" -> "bar"))
+    assertEquals(decoded.size, 1)
+    assertEquals(decoded.head.tags, Map("name" -> "test", "foo" -> "bar"))
   }
 
   test("decode legacy batch no tags metric") {
@@ -115,7 +115,7 @@ class PublishApiJsonSuite extends AnyFunSuite {
         ]
       }
       """)
-    assert(decoded.size === 1)
+    assertEquals(decoded.size, 1)
   }
 
   test("decode legacy batch with empty name") {
@@ -130,9 +130,9 @@ class PublishApiJsonSuite extends AnyFunSuite {
         ]
       }
       """)
-    assert(decoded.size === 1)
+    assertEquals(decoded.size, 1)
     decoded.foreach { d =>
-      assert(d.tags === Map("name" -> ""))
+      assertEquals(d.tags, Map("name" -> ""))
     }
   }
 
@@ -148,9 +148,9 @@ class PublishApiJsonSuite extends AnyFunSuite {
         ]
       }
       """)
-    assert(decoded.size === 1)
+    assertEquals(decoded.size, 1)
     decoded.foreach { d =>
-      assert(d.tags === Map.empty)
+      assertEquals(d.tags, Map.empty[String, String])
     }
   }
 
@@ -158,7 +158,7 @@ class PublishApiJsonSuite extends AnyFunSuite {
     val decoded = PublishApi.decodeList("""
       []
       """)
-    assert(decoded.size === 0)
+    assertEquals(decoded.size, 0)
   }
 
   test("decode list") {
@@ -171,7 +171,7 @@ class PublishApiJsonSuite extends AnyFunSuite {
         }
       ]
       """)
-    assert(decoded.size === 1)
+    assertEquals(decoded.size, 1)
   }
 
   test("decode list with unknown key") {
@@ -203,7 +203,7 @@ class PublishApiJsonSuite extends AnyFunSuite {
         }
       ]
       """)
-    assert(decoded.size === 4)
+    assertEquals(decoded.size, 4)
   }
 
   test("decode batch bad object") {
@@ -215,12 +215,12 @@ class PublishApiJsonSuite extends AnyFunSuite {
   test("decode list from encoded datapoint") {
     val vs = List(Datapoint(Map("a" -> "b"), 0L, 42.0))
     val decoded = PublishApi.decodeList(Json.encode(vs))
-    assert(decoded.size === 1)
+    assertEquals(decoded.size, 1)
   }
 
   test("decode list from PublishApi.encoded datapoint") {
     val vs = "[" + PublishApi.encodeDatapoint(Datapoint(Map("a" -> "b"), 0L, 42.0)) + "]"
     val decoded = PublishApi.decodeList(vs)
-    assert(decoded.size === 1)
+    assertEquals(decoded.size, 1)
   }
 }

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishApiSuite.scala
@@ -20,14 +20,13 @@ import akka.actor.Props
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.RouteTestTimeout
-import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.netflix.atlas.akka.RequestHandler
+import com.netflix.atlas.akka.testkit.MUnitRouteSuite
 import com.netflix.atlas.core.model.Datapoint
 import com.netflix.atlas.webapi.PublishApi.FailureMessage
 import com.netflix.atlas.webapi.PublishApi.PublishRequest
-import org.scalatest.funsuite.AnyFunSuite
 
-class PublishApiSuite extends AnyFunSuite with ScalatestRouteTest {
+class PublishApiSuite extends MUnitRouteSuite {
 
   import PublishApiSuite._
 
@@ -41,14 +40,14 @@ class PublishApiSuite extends AnyFunSuite with ScalatestRouteTest {
 
   test("publish no content") {
     Post("/api/v1/publish") ~> routes ~> check {
-      assert(response.status === StatusCodes.BadRequest)
+      assertEquals(response.status, StatusCodes.BadRequest)
     }
   }
 
   test("publish empty object") {
     Post("/api/v1/publish", "{}") ~> routes ~> check {
-      assert(response.status === StatusCodes.BadRequest)
-      assert(lastUpdate === Nil)
+      assertEquals(response.status, StatusCodes.BadRequest)
+      assertEquals(lastUpdate, Nil)
     }
   }
 
@@ -67,8 +66,8 @@ class PublishApiSuite extends AnyFunSuite with ScalatestRouteTest {
         ]
       }"""
     Post("/api/v1/publish", json) ~> routes ~> check {
-      assert(response.status === StatusCodes.OK)
-      assert(lastUpdate === PublishApi.decodeBatch(json))
+      assertEquals(response.status, StatusCodes.OK)
+      assertEquals(lastUpdate, PublishApi.decodeBatch(json))
     }
   }
 
@@ -83,7 +82,7 @@ class PublishApiSuite extends AnyFunSuite with ScalatestRouteTest {
         ]
       }"""
     Post("/api/v1/publish", json) ~> routes ~> check {
-      assert(response.status === StatusCodes.BadRequest)
+      assertEquals(response.status, StatusCodes.BadRequest)
     }
   }
 
@@ -103,20 +102,20 @@ class PublishApiSuite extends AnyFunSuite with ScalatestRouteTest {
         ]
       }"""
     Post("/api/v1/publish", json) ~> routes ~> check {
-      assert(response.status === StatusCodes.Accepted)
-      assert(lastUpdate === PublishApi.decodeBatch(json).tail)
+      assertEquals(response.status, StatusCodes.Accepted)
+      assertEquals(lastUpdate, PublishApi.decodeBatch(json).tail)
     }
   }
 
   test("publish bad json") {
     Post("/api/v1/publish", "fubar") ~> routes ~> check {
-      assert(response.status === StatusCodes.BadRequest)
+      assertEquals(response.status, StatusCodes.BadRequest)
     }
   }
 
   test("publish invalid object") {
     Post("/api/v1/publish", "{\"foo\":\"bar\"}") ~> routes ~> check {
-      assert(response.status === StatusCodes.BadRequest)
+      assertEquals(response.status, StatusCodes.BadRequest)
     }
   }
 
@@ -131,7 +130,7 @@ class PublishApiSuite extends AnyFunSuite with ScalatestRouteTest {
         ]
       }"""
     Post("/api/v1/publish", json) ~> routes ~> check {
-      assert(response.status === StatusCodes.BadRequest)
+      assertEquals(response.status, StatusCodes.BadRequest)
     }
   }
 
@@ -146,7 +145,7 @@ class PublishApiSuite extends AnyFunSuite with ScalatestRouteTest {
         ]
       }"""
     Post("/api/v1/publish", json) ~> routes ~> check {
-      assert(response.status === StatusCodes.BadRequest)
+      assertEquals(response.status, StatusCodes.BadRequest)
     }
   }
 
@@ -161,7 +160,7 @@ class PublishApiSuite extends AnyFunSuite with ScalatestRouteTest {
         ]
       }"""
     Post("/api/v1/publish", json) ~> routes ~> check {
-      assert(response.status === StatusCodes.BadRequest)
+      assertEquals(response.status, StatusCodes.BadRequest)
     }
   }
 
@@ -181,7 +180,7 @@ class PublishApiSuite extends AnyFunSuite with ScalatestRouteTest {
         ]
       }"""
     Post("/api/v1/publish", json) ~> routes ~> check {
-      assert(response.status === StatusCodes.Accepted)
+      assertEquals(response.status, StatusCodes.Accepted)
     }
   }
 
@@ -200,8 +199,8 @@ class PublishApiSuite extends AnyFunSuite with ScalatestRouteTest {
         ]
       }"""
     Post("/api/v1/publish-fast", json) ~> routes ~> check {
-      assert(response.status === StatusCodes.OK)
-      assert(lastUpdate === PublishApi.decodeBatch(json))
+      assertEquals(response.status, StatusCodes.OK)
+      assertEquals(lastUpdate, PublishApi.decodeBatch(json))
     }
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,7 @@ lazy val atlas = project.in(file("."))
   .configure(BuildSettings.profile)
   .aggregate(
     `atlas-akka`,
+    `atlas-akka-testkit`,
     `atlas-chart`,
     `atlas-core`,
     `atlas-eval`,
@@ -21,7 +22,7 @@ lazy val atlas = project.in(file("."))
 
 lazy val `atlas-akka` = project
   .configure(BuildSettings.profile)
-  .dependsOn(`atlas-json`)
+  .dependsOn(`atlas-json`, `atlas-akka-testkit` % "test")
   .settings(libraryDependencies ++= Seq(
     Dependencies.akkaActor,
     Dependencies.akkaSlf4j,
@@ -34,6 +35,15 @@ lazy val `atlas-akka` = project
     Dependencies.akkaHttpTestkit % "test",
     Dependencies.akkaStreamTestkit % "test",
     Dependencies.akkaTestkit % "test"
+  ))
+
+lazy val `atlas-akka-testkit` = project
+  .configure(BuildSettings.profile)
+  .settings(libraryDependencies ++= Seq(
+      Dependencies.akkaHttpTestkit,
+      Dependencies.akkaStreamTestkit,
+      Dependencies.akkaTestkit,
+      Dependencies.munit
   ))
 
 lazy val `atlas-chart` = project
@@ -80,7 +90,7 @@ lazy val `atlas-json` = project
 
 lazy val `atlas-lwcapi` = project
   .configure(BuildSettings.profile)
-  .dependsOn(`atlas-akka`, `atlas-core`, `atlas-eval`, `atlas-json`)
+  .dependsOn(`atlas-akka`, `atlas-akka-testkit` % "test", `atlas-core`, `atlas-eval`, `atlas-json`)
   .settings(libraryDependencies ++= Seq(
     Dependencies.iepNflxEnv,
     Dependencies.frigga,
@@ -143,6 +153,7 @@ lazy val `atlas-webapi` = project
   .configure(BuildSettings.profile)
   .dependsOn(
     `atlas-akka`,
+    `atlas-akka-testkit` % "test",
     `atlas-chart`,
     `atlas-core`,
     `atlas-eval`,

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -49,7 +49,8 @@ object BuildSettings {
       "Build-Date"   -> java.time.Instant.now().toString,
       "Build-Number" -> sys.env.getOrElse("GITHUB_RUN_ID", "unknown"),
       "Commit"       -> sys.env.getOrElse("GITHUB_SHA", "unknown")
-    )
+    ),
+    testFrameworks += new TestFramework("munit.Framework")
   )
 
   val commonDeps = Seq(
@@ -59,7 +60,7 @@ object BuildSettings {
     Dependencies.slf4jApi,
     Dependencies.spectatorApi,
     Dependencies.typesafeConfig,
-    Dependencies.scalatest % "test"
+    Dependencies.munit % "test"
   )
 
   val resolvers = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -57,6 +57,7 @@ object Dependencies {
   val log4jJcl          = "org.apache.logging.log4j" % "log4j-jcl" % log4j
   val log4jJul          = "org.apache.logging.log4j" % "log4j-jul" % log4j
   val log4jSlf4j        = "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4j
+  val munit             = "org.scalameta" %% "munit" % "0.7.29"
   val postgres          = "org.postgresql" % "postgresql" % "42.2.24"
   val postgresEmbedded  = "io.zonky.test" % "embedded-postgres" % "1.3.1"
   val roaringBitmap     = "org.roaringbitmap" % "RoaringBitmap" % "0.9.22"
@@ -66,7 +67,6 @@ object Dependencies {
   val scalaLibraryAll   = "org.scala-lang" % "scala-library-all"
   val scalaLogging      = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4"
   val scalaReflect      = "org.scala-lang" % "scala-reflect" % scala
-  val scalatest         = "org.scalatest" %% "scalatest" % "3.2.10"
   val slf4jApi          = "org.slf4j" % "slf4j-api" % slf4j
   val slf4jLog4j        = "org.slf4j" % "slf4j-log4j12" % slf4j
   val slf4jSimple       = "org.slf4j" % "slf4j-simple" % slf4j


### PR DESCRIPTION
MUnit is used internally as it is easier to use with
gradle. Switching this project so the test frameworks
will be consistent.