### PR TITLE
methods on SortedTagMap to get key/value arrays

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/SortedTagMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/SortedTagMap.scala
@@ -159,6 +159,28 @@ final class SortedTagMap private (data: Array[String], length: Int)
   def copyToArray(buffer: Array[String]): Unit = {
     System.arraycopy(data, 0, buffer, 0, length)
   }
+
+  /** Return a sorted array containing the keys for this map. */
+  def keysArray: Array[String] = {
+    val ks = new Array[String](size)
+    var i = 0
+    while (i < ks.length) {
+      ks(i) = key(i)
+      i += 1
+    }
+    ks
+  }
+
+  /** Return an array containing the values in order based on the keys. */
+  def valuesArray: Array[String] = {
+    val vs = new Array[String](size)
+    var i = 0
+    while (i < vs.length) {
+      vs(i) = value(i)
+      i += 1
+    }
+    vs
+  }
 }
 
 /** Helper functions for working with sorted tag maps. */

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/SortedTagMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/SortedTagMapSuite.scala
@@ -26,6 +26,8 @@ class SortedTagMapSuite extends FunSuite {
     assert(m.get("a").isEmpty)
     assert(!m.contains("a"))
     assertEquals(m.toList, List.empty)
+    assertEquals(m.keysArray.toSeq, Seq.empty)
+    assertEquals(m.valuesArray.toSeq, Seq.empty)
   }
 
   test("single pair") {
@@ -35,6 +37,8 @@ class SortedTagMapSuite extends FunSuite {
     assert(m.get("a").contains("1"))
     assert(m.contains("a"))
     assertEquals(m.toList, List("a" -> "1"))
+    assertEquals(m.keysArray.toSeq, Seq("a"))
+    assertEquals(m.valuesArray.toSeq, Seq("1"))
   }
 
   test("four pairs") {
@@ -46,6 +50,8 @@ class SortedTagMapSuite extends FunSuite {
       assert(m.get(k).contains(i.toString))
     }
     assertEquals(m.toList, List("a" -> "0", "b" -> "1", "c" -> "2", "d" -> "3"))
+    assertEquals(m.keysArray.toSeq, Seq("a", "b", "c", "d"))
+    assertEquals(m.valuesArray.toSeq, Seq("0", "1", "2", "3"))
   }
 
   private def pairs: List[(String, String)] = {


### PR DESCRIPTION
Update SortedTagMap to have helper methods for getting the
keys and values as an array. Avoids the overhead of using
the `keys` or `values` method on Map and creating the array
from the returned iterable.