### PR TITLE
lwcapi: add endpoint to browse current streams

### DIFF
--- a/atlas-lwcapi/src/main/resources/reference.conf
+++ b/atlas-lwcapi/src/main/resources/reference.conf
@@ -23,6 +23,7 @@ atlas {
     api-endpoints = ${?atlas.akka.api-endpoints} [
       "com.netflix.atlas.lwcapi.EvaluateApi",
       "com.netflix.atlas.lwcapi.ExpressionApi",
+      "com.netflix.atlas.lwcapi.StreamsApi",
       "com.netflix.atlas.lwcapi.SubscribeApi"
     ]
   }

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamMetadata.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamMetadata.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwcapi
+
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+  * Metadata for a stream.
+  *
+  * @param streamId
+  *     Unique id for a stream specified by the caller. Used to route data and detect
+  *     reconnections.
+  * @param remoteAddress
+  *     IP address of the remote consumer. Only used to help with debugging.
+  * @param receivedMessages
+  *     Number of messages that were successfully received.
+  * @param droppedMessages
+  *     Number of messages that were dropped because the queue was full.
+  */
+case class StreamMetadata(
+  streamId: String,
+  remoteAddress: String = "unknown",
+  receivedMessages: AtomicLong = new AtomicLong(),
+  droppedMessages: AtomicLong = new AtomicLong()
+)

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamsApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamsApi.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwcapi
+
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import com.netflix.atlas.akka.CustomDirectives._
+import com.netflix.atlas.akka.DiagnosticMessage
+import com.netflix.atlas.akka.WebApi
+import com.netflix.atlas.json.Json
+
+import javax.inject.Inject
+
+/**
+  * Provides a summary of the current streams. This is to aide in debugging and can be
+  * disabled without impacting the service.
+  */
+class StreamsApi @Inject() (sm: StreamSubscriptionManager) extends WebApi {
+
+  def routes: Route = {
+    endpointPathPrefix("api" / "v1" / "streams") {
+      path(Remaining) { streamId =>
+        sm.streamSummary(streamId) match {
+          case Some(summary) => complete(Json.encode(summary))
+          case None          => complete(notFound(streamId))
+        }
+      } ~
+      pathEnd {
+        complete(Json.encode(sm.streamSummaries.map(_.metadata)))
+      }
+    }
+  }
+
+  private def notFound(streamId: String): HttpResponse = {
+    val msg = DiagnosticMessage.info(s"no stream with id: $streamId")
+    HttpResponse(StatusCodes.NotFound, entity = Json.encode(msg))
+  }
+}

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
@@ -41,7 +41,7 @@ class ExpressionApiSuite extends MUnitRouteSuite {
 
   // Dummy queue used for handler
   private val queue = new QueueHandler(
-    "test",
+    StreamMetadata("test"),
     StreamOps
       .blockingQueue[Seq[JsonSupport]](new NoopRegistry, "test", 1)
       .toMat(Sink.ignore)(Keep.left)
@@ -92,7 +92,7 @@ class ExpressionApiSuite extends MUnitRouteSuite {
 
   test("has data") {
     val splits = splitter.split("nf.cluster,skan,:eq,:avg", 60000)
-    sm.register("a", queue)
+    sm.register(StreamMetadata("a"), queue)
     splits.foreach { s =>
       sm.subscribe("a", s)
     }
@@ -105,7 +105,7 @@ class ExpressionApiSuite extends MUnitRouteSuite {
 
   test("fetch all with data") {
     val splits = splitter.split("nf.cluster,skan,:eq,:avg,nf.app,brh,:eq,:max", 60000)
-    sm.register("a", queue)
+    sm.register(StreamMetadata("a"), queue)
     splits.foreach { s =>
       sm.subscribe("a", s)
     }


### PR DESCRIPTION
To make debugging easier, adds an endpoint to quickly get
a summary of the current streams. Basic counts for messages
are included to be able to find streams that are not keeping
up.