### PR TITLE
fix stats for combining collectors

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/AggregateCollector.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/AggregateCollector.scala
@@ -138,7 +138,9 @@ abstract class SimpleAggregateCollector extends AggregateCollector {
     collector match {
       case c: SimpleAggregateCollector =>
         if (buffer == null && c.buffer != null) {
-          add(c.buffer)
+          buffer = c.buffer
+          if (!buffer.isAllNaN) valueCount = 1
+          statBuffer.update(c.stats)
         } else if (c.buffer != null) {
           aggregate(buffer, c.buffer)
           // 0 out output, since that is only based on the result of a single collector

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/AggregateCollectorSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/AggregateCollectorSuite.scala
@@ -71,6 +71,30 @@ class AggregateCollectorSuite extends FunSuite {
     assertEquals(c1.stats, CollectorStats(1, 1, 1, 1))
   }
 
+  test("sum collector -- combine(null, c4)") {
+    val c1 = new SumAggregateCollector
+    val c2 = new SumAggregateCollector
+    c2.add(newBuffer(1.0))
+    c2.add(newBuffer(1.0))
+    c2.add(newBuffer(1.0))
+    c2.add(newBuffer(1.0))
+    c1.combine(c2)
+    assertEquals(c1.result, List(newBuffer(4.0)))
+    assertEquals(c1.stats, CollectorStats(4, 4, 1, 1))
+  }
+
+  test("sum collector -- combine(c4, null)") {
+    val c1 = new SumAggregateCollector
+    c1.add(newBuffer(1.0))
+    c1.add(newBuffer(1.0))
+    c1.add(newBuffer(1.0))
+    c1.add(newBuffer(1.0))
+    val c2 = new SumAggregateCollector
+    c1.combine(c2)
+    assertEquals(c1.result, List(newBuffer(4.0)))
+    assertEquals(c1.stats, CollectorStats(4, 4, 1, 1))
+  }
+
   test("min collector") {
     val c = new MinAggregateCollector
     assertEquals(c.result, Nil)


### PR DESCRIPTION
In the case where the receiving collector had not received
any data and the collector being combined had multiple
updates, the stats were being incorrectly reported as a
single update.