### PR TITLE
support arbitrary comparator for merge

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/ComparableComparator.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/ComparableComparator.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import java.util.Comparator
+
+/** Comparator for classes that implement Comparable. */
+class ComparableComparator[T <: Comparable[T]] extends Comparator[T] {
+  override def compare(a: T, b: T): Int = a.compareTo(b)
+}


### PR DESCRIPTION
Generalize the merge helpers to take an arbitrary comparator.
This allows them to be used for objects that are not directly
comparable or where an alternate order is desirable.