### PR TITLE
Minor improvements to SubscribeApi

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
@@ -87,7 +87,6 @@ class SubscribeApi @Inject() (
     }
   }
 
-
   /**
     * Drop any other connections that may already be using the same id
     */


### PR DESCRIPTION
* Refactor the common code to drop connections using the same Id to its
  own method

* Avoid creating new Ids and a doing counter lookups in the Registry
  since the Ids are always the same for the eval and items counters