### PR TITLE
indicate if input arrays were fully consumed

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/ArrayHelper.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/ArrayHelper.scala
@@ -247,11 +247,13 @@ object ArrayHelper {
     *     Aggregation function to use if duplicate values are encountered. The user should
     *     ensure that the aggregation function does not influence the order of the elements.
     * @param vs1
-    *     First source array.
+    *     First source array, may be modified. The first position will be set to null if the
+    *     contents of this array have been fully merged into the destination.
     * @param vs1size
     *     Number of valid elements in the first source array.
     * @param vs2
-    *     Second source array.
+    *     Second source array, may be modified. The first position will be set to null if the
+    *     contents of this array have been fully merged into the destination.
     * @param vs2size
     *     Number of valid elements in the second source array.
     * @param dst
@@ -300,14 +302,26 @@ object ArrayHelper {
     if (vs1idx < vs1size && didx < limit) {
       val length = math.min(limit - didx, vs1size - vs1idx)
       System.arraycopy(vs1, vs1idx, dst, didx, length)
+      vs1idx += length
       didx += length
+    }
+
+    // Update first position of source array with null if fully consumed
+    if (vs1idx >= vs1size && vs1size > 0) {
+      vs1(0) = null.asInstanceOf[T]
     }
 
     // Only the merge array has data left, fill in the remainder
     if (vs2idx < vs2size && didx < limit) {
       val length = math.min(limit - didx, vs2size - vs2idx)
       System.arraycopy(vs2, vs2idx, dst, didx, length)
+      vs2idx += length
       didx += length
+    }
+
+    // Update first position of merge array with null if fully consumed
+    if (vs2idx >= vs2size && vs2size > 0) {
+      vs2(0) = null.asInstanceOf[T]
     }
 
     // Final output size

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/ArrayHelperSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/ArrayHelperSuite.scala
@@ -89,6 +89,58 @@ class ArrayHelperSuite extends FunSuite {
     assertEquals(actual.toSeq, Array("a", "b").toSeq)
   }
 
+  test("merge: both fully consumed") {
+    val comparator = new ComparableComparator[String]
+    val pickFirst = (v: String, _: String) => v
+    val v1 = Array("b", "c")
+    val v2 = Array("a", "d")
+    val merged = Array("", "")
+    val length = ArrayHelper.merge(comparator, pickFirst, v1, 1, v2, 1, merged)
+    assertEquals(length, 2)
+    assertEquals(merged.toSeq, Seq("a", "b"))
+    assert(v1(0) == null)
+    assert(v2(0) == null)
+  }
+
+  test("merge: v1 partially consumed") {
+    val comparator = new ComparableComparator[String]
+    val pickFirst = (v: String, _: String) => v
+    val v1 = Array("b", "c")
+    val v2 = Array("a", "d")
+    val merged = Array("", "")
+    val length = ArrayHelper.merge(comparator, pickFirst, v1, 2, v2, 1, merged)
+    assertEquals(length, 2)
+    assertEquals(merged.toSeq, Seq("a", "b"))
+    assert(v1(0) != null)
+    assert(v2(0) == null)
+  }
+
+  test("merge: v2 partially consumed") {
+    val comparator = new ComparableComparator[String]
+    val pickFirst = (v: String, _: String) => v
+    val v1 = Array("b", "c")
+    val v2 = Array("a", "d")
+    val merged = Array("", "")
+    val length = ArrayHelper.merge(comparator, pickFirst, v1, 1, v2, 2, merged)
+    assertEquals(length, 2)
+    assertEquals(merged.toSeq, Seq("a", "b"))
+    assert(v1(0) == null)
+    assert(v2(0) != null)
+  }
+
+  test("merge: both partially consumed") {
+    val comparator = new ComparableComparator[String]
+    val pickFirst = (v: String, _: String) => v
+    val v1 = Array("b", "c")
+    val v2 = Array("a", "d")
+    val merged = Array("", "")
+    val length = ArrayHelper.merge(comparator, pickFirst, v1, 2, v2, 2, merged)
+    assertEquals(length, 2)
+    assertEquals(merged.toSeq, Seq("a", "b"))
+    assert(v1(0) != null)
+    assert(v2(0) != null)
+  }
+
   test("merge list, limit 1: empty, one") {
     val v1 = List.empty[String]
     val v2 = List("a")


### PR DESCRIPTION
Update the ArrayHelper.merge method to indicate if the
source arrays have been fully consumed. The first position
of the source array will be set to null if it was fully
consumed and merged into the destination.