### PR TITLE
Common-group-by operator

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataVocabulary.scala
@@ -35,6 +35,7 @@ object DataVocabulary extends Vocabulary {
     Min,
     Max,
     GroupBy,
+    CommonGroupBy,
     Offset,
     CfAvg,
     CfSum,
@@ -160,9 +161,7 @@ object DataVocabulary extends Vocabulary {
       """.stripMargin.trim
   }
 
-  case object GroupBy extends SimpleWord {
-
-    override def name: String = "by"
+  trait DataGroupBy extends SimpleWord {
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
       case (_: List[_]) :: (_: Query) :: _             => true
@@ -190,6 +189,15 @@ object DataVocabulary extends Vocabulary {
         "name,sps,:eq,:max,(,nf.cluster,)",
         "name,sps,:eq,nf.cluster,nccp-silverlight,:eq,:and,(,nf.asg,nf.zone,)"
       )
+  }
+
+  case object GroupBy extends DataGroupBy {
+    override def name: String = "by"
+  }
+
+  // In this context :cg is just an alias to :by
+  case object CommonGroupBy extends DataGroupBy {
+    override def name: String = "cg"
   }
 
   case object Offset extends SimpleWord {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathGroupBySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathGroupBySuite.scala
@@ -222,4 +222,29 @@ class MathGroupBySuite extends FunSuite {
     val expr = eval(input)
     assertEquals(expr.toString, "0.0,:const")
   }
+
+  test("cg with no group by") {
+    val input = "foo,1,:eq,(,a,),:cg"
+    val inputExplicit = "foo,1,:eq,(,a,),:by"
+    val expr = eval(input)
+    val exprExplicit = eval(inputExplicit)
+    assertEquals(expr.toString, exprExplicit.toString)
+  }
+
+  test("cg with simple group by") {
+    val input = "foo,1,:eq,(,a,),:by,(,b,c,),:cg"
+    val inputExplicit = "foo,1,:eq,(,a,b,c,),:by"
+    val expr = eval(input)
+    val exprExplicit = eval(inputExplicit)
+    assertEquals(expr.toString, exprExplicit.toString)
+  }
+
+  test("cg with multiple group by") {
+    val input = "name,foo,:eq,(,a,b,),:by,name,bar,:eq,(,b,),:by,:div,name,baz,:eq,:mul,(,c,d,),:cg"
+    val inputExplicit = "name,foo,:eq,(,a,b,c,d,),:by,name,bar,:eq,(,b,c,d,),:by,:div,name,baz,:eq,(,c,d,),:by,:mul"
+
+    val expr = eval(input)
+    val exprExplicit = eval(inputExplicit)
+    assertEquals(expr.toString, exprExplicit.toString)
+  }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
@@ -36,5 +36,5 @@ class ModelExtractorsSuite extends FunSuite {
   completionTest("name,sps", 19)
   completionTest("name,sps,:eq", 20)
   completionTest("name,sps,:eq,app,foo,:eq", 41)
-  completionTest("name,sps,:eq,app,foo,:eq,:and,(,asg,)", 11)
+  completionTest("name,sps,:eq,app,foo,:eq,:and,(,asg,)", 13)
 }

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
@@ -137,7 +137,7 @@ class ExprApiSuite extends MUnitRouteSuite {
   testGet("/api/v1/expr/complete?q=name,sps,:eq,(,nf.cluster,)") {
     assertEquals(response.status, StatusCodes.OK)
     val data = Json.decode[List[ExprApiSuite.Candidate]](responseAs[String]).map(_.name)
-    assertEquals(data, List("by", "by", "offset", "palette"))
+    assertEquals(data, List("by", "cg", "by", "cg", "offset", "palette"))
   }
 
   // TODO: Right now these fail. As a future improvement suggestions should be possible within


### PR DESCRIPTION
This adds a common-group-by operator (`:cg`) that includes additional
keys in group-by clauses.

```
name,foo,:eq,(,a,b,),:by,
name,bar,:eq,(,b,),:by,:div,
name,baz,:eq,:mul,
(,c,d,),:cg
```

Gets rewritten to:

```
name,foo,:eq,(,a,b,c,d,),:by,
name,bar,:eq,(,b,c,d,),:by,:div,
name,baz,:eq,(,c,d,),:by,:mul
```

Fixes #1354