### PR TITLE
add codec for more efficient publish format

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Datapoint.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Datapoint.scala
@@ -40,7 +40,7 @@ case class Datapoint(
   require(tags != null, "tags cannot be null")
   require(timestamp >= 0L, s"invalid timestamp: $timestamp")
 
-  def id: ItemId = TaggedItem.computeId(tags)
+  lazy val id: ItemId = TaggedItem.computeId(tags)
 
   def label: String = TimeSeries.toLabel(tags)
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/ItemId.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/ItemId.scala
@@ -80,6 +80,13 @@ class ItemId private (private val data: Array[Byte], private val hc: Int)
     }
     result
   }
+
+  /**
+    * Returns the byte array representing the id. This accessor is only provided to allow
+    * for serialization without additional allocations. The returned array should not be
+    * modified.
+    */
+  def byteArrayUnsafe: Array[Byte] = data
 }
 
 object ItemId {

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/webapi/PublishPayloadsBench.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/webapi/PublishPayloadsBench.scala
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.webapi
+
+import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.core.model.ItemId
+import com.netflix.atlas.core.util.SortedTagMap
+import com.netflix.atlas.core.util.Streams
+import com.netflix.atlas.json.Json
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.infra.Blackhole
+
+import java.io.ByteArrayInputStream
+import scala.util.Using
+
+/**
+  * > jmh:run -prof stack -prof gc -wi 5 -i 10 -f1 -t1 .*PublishPayloads.*
+  *
+  * ```
+  * Benchmark                         Mode  Cnt         Score         Error   Units
+  * decodeBatch                      thrpt    5        23.787 ±       1.148   ops/s
+  * decodeCompactBatch               thrpt    5       173.148 ±       1.835   ops/s
+  * decodeList                       thrpt    5        25.277 ±       0.254   ops/s
+  * encodeBatch                      thrpt    5       179.382 ±      39.696   ops/s
+  * encodeCompactBatch               thrpt    5        78.944 ±      13.537   ops/s
+  * encodeList                       thrpt    5       170.112 ±      19.728   ops/s
+  * ```
+  */
+@State(Scope.Thread)
+class PublishPayloadsBench {
+
+  import PublishPayloadsBench._
+
+  private val tagMap = SortedTagMap(
+    "nf.app"     -> "atlas_backend",
+    "nf.cluster" -> "atlas_backend-dev",
+    "nf.asg"     -> "atlas_backend-dev-v001",
+    "nf.stack"   -> "dev",
+    "nf.region"  -> "us-east-1",
+    "nf.zone"    -> "us-east-1e",
+    "nf.node"    -> "i-123456789",
+    "nf.ami"     -> "ami-987654321",
+    "nf.vmtype"  -> "r3.2xlarge",
+    "name"       -> "jvm.gc.pause",
+    "cause"      -> "Allocation_Failure",
+    "action"     -> "end_of_major_GC",
+    "statistic"  -> "totalTime"
+  )
+
+  private val datapoints = {
+    (0 until 10_000).toList.map { i =>
+      val tags = SortedTagMap(tagMap + ("i" -> i.toString))
+      val datapoint = Datapoint(tags, 1636116180000L, Math.PI)
+      datapoint.id // lazy val, force it early
+      datapoint
+    }
+  }
+
+  private def decodeBatch(data: Array[Byte]): List[Datapoint] = {
+    Using.resource(Json.newSmileParser(new ByteArrayInputStream(data))) { parser =>
+      PublishPayloads.decodeBatch(parser)
+    }
+  }
+
+  private def encodeBatch(values: List[Datapoint]): Array[Byte] = {
+    Streams.byteArray { out =>
+      Using.resource(Json.newSmileGenerator(out)) { gen =>
+        PublishPayloads.encodeBatch(gen, Map.empty, values)
+      }
+    }
+  }
+
+  private def decodeCompactBatch(data: Array[Byte], consumer: PublishConsumer): Unit = {
+    Using.resource(Json.newSmileParser(new ByteArrayInputStream(data))) { parser =>
+      PublishPayloads.decodeCompactBatch(parser, consumer)
+    }
+  }
+
+  private def encodeCompactBatch(values: List[Datapoint]): Array[Byte] = {
+    Streams.byteArray { out =>
+      Using.resource(Json.newSmileGenerator(out)) { gen =>
+        PublishPayloads.encodeCompactBatch(gen, values)
+      }
+    }
+  }
+
+  private def decodeList(data: Array[Byte]): List[Datapoint] = {
+    Using.resource(Json.newSmileParser(new ByteArrayInputStream(data))) { parser =>
+      PublishPayloads.decodeList(parser)
+    }
+  }
+
+  private def encodeList(values: List[Datapoint]): Array[Byte] = {
+    Streams.byteArray { out =>
+      Using.resource(Json.newSmileGenerator(out)) { gen =>
+        PublishPayloads.encodeList(gen, values)
+      }
+    }
+  }
+
+  private val encodedBatch = encodeBatch(datapoints)
+
+  private val encodedCompactBatch = encodeCompactBatch(datapoints)
+
+  private val encodedList = encodeList(datapoints)
+
+  @Benchmark
+  def decodeBatch(bh: Blackhole): Unit = {
+    val consumer = new BlackholePublishConsumer(bh)
+    decodeBatch(encodedBatch).foreach { d =>
+      consumer.consume(d.id, d.tags, d.timestamp, d.value)
+    }
+  }
+
+  @Benchmark
+  def decodeCompactBatch(bh: Blackhole): Unit = {
+    val consumer = new BlackholePublishConsumer(bh)
+    decodeCompactBatch(encodedCompactBatch, consumer)
+  }
+
+  @Benchmark
+  def decodeList(bh: Blackhole): Unit = {
+    val consumer = new BlackholePublishConsumer(bh)
+    decodeList(encodedList).foreach { d =>
+      consumer.consume(d.id, d.tags, d.timestamp, d.value)
+    }
+  }
+
+  @Benchmark
+  def encodeBatch(bh: Blackhole): Unit = {
+    bh.consume(encodeBatch(datapoints))
+  }
+
+  @Benchmark
+  def encodeCompactBatch(bh: Blackhole): Unit = {
+    bh.consume(encodeCompactBatch(datapoints))
+  }
+
+  @Benchmark
+  def encodeList(bh: Blackhole): Unit = {
+    bh.consume(encodeList(datapoints))
+  }
+}
+
+object PublishPayloadsBench {
+
+  class BlackholePublishConsumer(bh: Blackhole) extends PublishConsumer {
+
+    override def consume(
+      id: ItemId,
+      tags: Map[String, String],
+      timestamp: Long,
+      value: Double
+    ): Unit = {
+      bh.consume(id)
+      bh.consume(tags)
+      bh.consume(timestamp)
+      bh.consume(value)
+    }
+  }
+}

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
@@ -27,10 +27,6 @@ import com.netflix.atlas.akka.CustomDirectives._
 import com.netflix.atlas.akka.DiagnosticMessage
 import com.netflix.atlas.akka.WebApi
 import com.netflix.atlas.core.model.Datapoint
-import com.netflix.atlas.core.model.TaggedItem
-import com.netflix.atlas.core.util.Interner
-import com.netflix.atlas.core.util.SmallHashMap
-import com.netflix.atlas.core.util.Streams
 import com.netflix.atlas.core.validation.Rule
 import com.netflix.atlas.core.validation.ValidationResult
 import com.netflix.atlas.json.Json
@@ -39,7 +35,6 @@ import com.netflix.iep.config.ConfigManager
 import com.typesafe.scalalogging.StrictLogging
 
 import scala.concurrent.Promise
-import scala.util.Using
 
 class PublishApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi with StrictLogging {
 
@@ -107,145 +102,46 @@ class PublishApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi w
 
 object PublishApi {
 
-  import com.netflix.atlas.json.JsonParserHelper._
-
   type TagMap = Map[String, String]
 
-  private final val maxPermittedTags = ApiSettings.maxPermittedTags
-
-  private def decodeTags(parser: JsonParser, commonTags: TagMap, intern: Boolean): TagMap = {
-    val strInterner = Interner.forStrings
-    val b = new SmallHashMap.Builder[String, String](2 * maxPermittedTags)
-    if (commonTags != null) b.addAll(commonTags)
-    foreachField(parser) {
-      case key =>
-        val value = parser.nextTextValue()
-        if (value != null) {
-          if (intern)
-            b.add(strInterner.intern(key), strInterner.intern(value))
-          else
-            b.add(key, value)
-        }
-    }
-    if (intern) TaggedItem.internTagsShallow(b.compact) else b.result
-  }
-
-  private def getValue(parser: JsonParser): Double = {
-    import com.fasterxml.jackson.core.JsonToken._
-    parser.nextToken() match {
-      case START_ARRAY        => nextDouble(parser)
-      case VALUE_NUMBER_FLOAT => parser.getValueAsDouble()
-      case VALUE_STRING       => java.lang.Double.valueOf(parser.getText())
-      case t                  => fail(parser, s"expected VALUE_NUMBER_FLOAT but received $t")
-    }
-  }
-
-  private def decode(parser: JsonParser, commonTags: TagMap, intern: Boolean): Datapoint = {
-    var tags: TagMap = null
-    var timestamp: Long = -1L
-    var value: Double = Double.NaN
-    foreachField(parser) {
-      case "tags"      => tags = decodeTags(parser, commonTags, intern)
-      case "timestamp" => timestamp = nextLong(parser)
-      case "value"     => value = nextDouble(parser)
-      case "start"     => timestamp = nextLong(parser) // Legacy support
-      case "values"    => value = getValue(parser)
-      case _ => // Ignore unknown fields
-        parser.nextToken()
-        parser.skipChildren()
-    }
-    Datapoint(tags, timestamp, value)
-  }
-
   def decodeDatapoint(parser: JsonParser, intern: Boolean = false): Datapoint = {
-    decode(parser, null, intern)
+    PublishPayloads.decodeDatapoint(parser, intern)
   }
 
   def decodeDatapoint(json: String): Datapoint = {
-    val parser = Json.newJsonParser(json)
-    try decodeDatapoint(parser)
-    finally parser.close()
+    PublishPayloads.decodeDatapoint(json)
   }
 
   def decodeBatch(json: String): List[Datapoint] = {
-    val parser = Json.newJsonParser(json)
-    try decodeBatch(parser)
-    finally parser.close()
+    PublishPayloads.decodeBatch(json)
   }
 
   def decodeBatch(parser: JsonParser, intern: Boolean = false): List[Datapoint] = {
-    var tags: Map[String, String] = null
-    var metrics: List[Datapoint] = null
-    var tagsLoadedFirst = false
-    foreachField(parser) {
-      case "tags" => tags = decodeTags(parser, null, intern)
-      case "metrics" =>
-        tagsLoadedFirst = (tags != null)
-        val builder = List.newBuilder[Datapoint]
-        foreachItem(parser) { builder += decode(parser, tags, intern) }
-        metrics = builder.result()
-    }
-
-    // If the tags were loaded first they got merged with the datapoints while parsing. Otherwise
-    // they need to be merged here.
-    if (tagsLoadedFirst || tags == null) {
-      if (metrics == null) Nil else metrics
-    } else {
-      metrics.map(d => d.copy(tags = d.tags ++ tags))
-    }
+    PublishPayloads.decodeBatch(parser, intern)
   }
 
   def decodeList(parser: JsonParser, intern: Boolean = false): List[Datapoint] = {
-    val builder = List.newBuilder[Datapoint]
-    foreachItem(parser) {
-      builder += decode(parser, null, intern)
-    }
-    builder.result()
+    PublishPayloads.decodeList(parser, intern)
   }
 
   def decodeList(json: String): List[Datapoint] = {
-    val parser = Json.newJsonParser(json)
-    try decodeList(parser)
-    finally parser.close()
-  }
-
-  private def encodeTags(gen: JsonGenerator, tags: Map[String, String]): Unit = {
-    gen.writeObjectFieldStart("tags")
-    tags.foreachEntry(gen.writeStringField)
-    gen.writeEndObject()
+    PublishPayloads.decodeList(json)
   }
 
   def encodeDatapoint(gen: JsonGenerator, d: Datapoint): Unit = {
-    gen.writeStartObject()
-    encodeTags(gen, d.tags)
-    gen.writeNumberField("timestamp", d.timestamp)
-    gen.writeNumberField("value", d.value)
-    gen.writeEndObject()
+    PublishPayloads.encodeDatapoint(gen, d)
   }
 
   def encodeDatapoint(d: Datapoint): String = {
-    Streams.string { w =>
-      Using.resource(Json.newJsonGenerator(w)) { gen =>
-        encodeDatapoint(gen, d)
-      }
-    }
+    PublishPayloads.encodeDatapoint(d)
   }
 
   def encodeBatch(gen: JsonGenerator, tags: Map[String, String], values: List[Datapoint]): Unit = {
-    gen.writeStartObject()
-    encodeTags(gen, tags)
-    gen.writeArrayFieldStart("metrics")
-    values.foreach(v => encodeDatapoint(gen, v))
-    gen.writeEndArray()
-    gen.writeEndObject()
+    PublishPayloads.encodeBatch(gen, tags, values)
   }
 
   def encodeBatch(tags: Map[String, String], values: List[Datapoint]): String = {
-    Streams.string { w =>
-      Using.resource(Json.newJsonGenerator(w)) { gen =>
-        encodeBatch(gen, tags, values)
-      }
-    }
+    PublishPayloads.encodeBatch(tags, values)
   }
 
   case class PublishRequest(

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishConsumer.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishConsumer.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.webapi
+
+import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.core.model.ItemId
+
+trait PublishConsumer {
+
+  def consume(id: ItemId, tags: Map[String, String], timestamp: Long, value: Double): Unit
+}
+
+object PublishConsumer {
+
+  /**
+    * Returns a new consumer that will accumulate the values into a list of data points.
+    */
+  def datapointList: ListPublishConsumer = {
+    new ListPublishConsumer
+  }
+
+  class ListPublishConsumer extends PublishConsumer {
+    private val builder = List.newBuilder[Datapoint]
+
+    def consume(id: ItemId, tags: Map[String, String], timestamp: Long, value: Double): Unit = {
+      builder += Datapoint(tags, timestamp, value)
+    }
+
+    def toList: List[Datapoint] = {
+      builder.result()
+    }
+  }
+}

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishPayloads.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishPayloads.scala
@@ -1,0 +1,409 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.webapi
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.JsonToken
+import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.core.model.ItemId
+import com.netflix.atlas.core.model.TaggedItem
+import com.netflix.atlas.core.util.Interner
+import com.netflix.atlas.core.util.RefIntHashMap
+import com.netflix.atlas.core.util.SmallHashMap
+import com.netflix.atlas.core.util.SortedTagMap
+import com.netflix.atlas.core.util.Streams
+import com.netflix.atlas.json.Json
+
+import scala.util.Using
+
+object PublishPayloads {
+
+  import com.netflix.atlas.json.JsonParserHelper._
+
+  type TagMap = Map[String, String]
+
+  // Maximum size of arrays allocated based on input data. This is used as a sanity
+  // check in case a bad payload comes in with a really large size for an array that
+  // could exhaust memory.
+  private final val maxArraySize = 100_000
+
+  // Maximum number of tags allowed. This will be used to help pre-size buffers when
+  // processing tag data.
+  private final val maxPermittedTags = ApiSettings.maxPermittedTags
+
+  private def decodeTags(parser: JsonParser, commonTags: TagMap, intern: Boolean): TagMap = {
+    val strInterner = Interner.forStrings
+    val b = new SmallHashMap.Builder[String, String](2 * maxPermittedTags)
+    if (commonTags != null) b.addAll(commonTags)
+    foreachField(parser) {
+      case key =>
+        val value = parser.nextTextValue()
+        if (value != null) {
+          if (intern)
+            b.add(strInterner.intern(key), strInterner.intern(value))
+          else
+            b.add(key, value)
+        }
+    }
+    if (intern) TaggedItem.internTagsShallow(b.compact) else b.result
+  }
+
+  private def getValue(parser: JsonParser): Double = {
+    import com.fasterxml.jackson.core.JsonToken._
+    parser.nextToken() match {
+      case START_ARRAY        => nextDouble(parser)
+      case VALUE_NUMBER_FLOAT => parser.getValueAsDouble()
+      case VALUE_STRING       => java.lang.Double.valueOf(parser.getText())
+      case t                  => fail(parser, s"expected VALUE_NUMBER_FLOAT but received $t")
+    }
+  }
+
+  private def decode(parser: JsonParser, commonTags: TagMap, intern: Boolean): Datapoint = {
+    var tags: TagMap = null
+    var timestamp: Long = -1L
+    var value: Double = Double.NaN
+    foreachField(parser) {
+      case "tags"      => tags = decodeTags(parser, commonTags, intern)
+      case "timestamp" => timestamp = nextLong(parser)
+      case "value"     => value = nextDouble(parser)
+      case "start"     => timestamp = nextLong(parser) // Legacy support
+      case "values"    => value = getValue(parser)
+      case _ => // Ignore unknown fields
+        parser.nextToken()
+        parser.skipChildren()
+    }
+    Datapoint(tags, timestamp, value)
+  }
+
+  /**
+    * Parse a single datapoint.
+    *
+    * @param parser
+    *     Parser for JSON input.
+    * @param intern
+    *     If true, then strings and the final tag map will be interned as the data is being
+    *     parsed.
+    */
+  def decodeDatapoint(parser: JsonParser, intern: Boolean = false): Datapoint = {
+    decode(parser, null, intern)
+  }
+
+  /**
+    * Parse a single datapoint.
+    */
+  def decodeDatapoint(json: String): Datapoint = {
+    val parser = Json.newJsonParser(json)
+    try decodeDatapoint(parser)
+    finally parser.close()
+  }
+
+  /**
+    * Parse batch of datapoints encoded as an object. Common tags to all datapoints can be
+    * placed at the top level to avoid repetition.
+    *
+    * @param parser
+    *     Parser for JSON input.
+    * @param intern
+    *     If true, then strings and the final tag map will be interned as the data is being
+    *     parsed.
+    */
+  def decodeBatch(parser: JsonParser, intern: Boolean = false): List[Datapoint] = {
+    var tags: Map[String, String] = null
+    var metrics: List[Datapoint] = null
+    var tagsLoadedFirst = false
+    foreachField(parser) {
+      case "tags" => tags = decodeTags(parser, null, intern)
+      case "metrics" =>
+        tagsLoadedFirst = (tags != null)
+        val builder = List.newBuilder[Datapoint]
+        foreachItem(parser) { builder += decode(parser, tags, intern) }
+        metrics = builder.result()
+    }
+
+    // If the tags were loaded first they got merged with the datapoints while parsing. Otherwise
+    // they need to be merged here.
+    if (tagsLoadedFirst || tags == null) {
+      if (metrics == null) Nil else metrics
+    } else {
+      metrics.map(d => d.copy(tags = d.tags ++ tags))
+    }
+  }
+
+  /**
+    * Parse batch of datapoints encoded as an object. Common tags to all datapoints can be
+    * placed at the top level to avoid repetition.
+    */
+  def decodeBatch(json: String): List[Datapoint] = {
+    val parser = Json.newJsonParser(json)
+    try decodeBatch(parser)
+    finally parser.close()
+  }
+
+  private def nextArraySize(parser: JsonParser): Int = {
+    val size = nextInt(parser)
+    if (size > maxArraySize) {
+      throw new IllegalArgumentException(
+        s"requested buffer size exceeds limit ($size > $maxArraySize)"
+      )
+    }
+    size
+  }
+
+  /**
+    * Batch format that is less repetitive for string data and more efficient to process
+    * than the normal batch format encoded as an object. Data is encoded as a flattened
+    * array with the following structure:
+    *
+    * ```
+    * [
+    *   size of string table,
+    *   ... strings in table...,
+    *
+    *   number of datapoints,
+    *   foreach datapoint:
+    *     id computed based on tags,
+    *     number of tags,
+    *     foreach tag:
+    *       int for key position in string table,
+    *       int for value position in string table,
+    *     timestamp,
+    *     value,
+    * ]
+    * ```
+    *
+    * @param parser
+    *     Parser for JSON input.
+    * @param consumer
+    *     Consumer that will be called with each datapoint that is extracted from the input.
+    * @param intern
+    *     If true, then strings and the final tag map will be interned as the data is being
+    *     parsed.
+    */
+  def decodeCompactBatch(
+    parser: JsonParser,
+    consumer: PublishConsumer,
+    intern: Boolean = false
+  ): Unit = {
+    val strInterner = Interner.forStrings
+
+    requireNextToken(parser, JsonToken.START_ARRAY)
+    val table = new Array[String](nextArraySize(parser))
+    var i = 0
+    while (i < table.length) {
+      val s = nextString(parser)
+      table(i) = if (intern) strInterner.intern(s) else s
+      i += 1
+    }
+
+    val numDatapoints = nextInt(parser)
+    i = 0
+    while (i < numDatapoints) {
+      //parser.nextToken()
+      val idRaw = ItemId(nextString(parser))
+      val id = if (intern) TaggedItem.internId(idRaw) else idRaw
+
+      val numTags = nextArraySize(parser)
+      var j = 0
+      val builder = SortedTagMap.builder(numTags)
+      while (j < numTags) {
+        val k = table(nextInt(parser))
+        val v = table(nextInt(parser))
+        builder.add(k, v)
+        j += 1
+      }
+      val tags = if (intern) TaggedItem.internTagsShallow(builder.result()) else builder.result()
+
+      val timestamp = nextLong(parser)
+      val value = getValue(parser)
+
+      consumer.consume(id, tags, timestamp, value)
+      i += 1
+    }
+  }
+
+  /**
+    * Batch format that is less repetitive for string data and more efficient to process
+    * than the normal batch format encoded as an object.
+    */
+  def decodeCompactBatch(json: String): List[Datapoint] = {
+    val parser = Json.newJsonParser(json)
+    val consumer = PublishConsumer.datapointList
+    try decodeCompactBatch(parser, consumer)
+    finally parser.close()
+    consumer.toList
+  }
+
+  /**
+    * Parse batch of datapoints encoded as a list.
+    *
+    * @param parser
+    *     Parser for JSON input.
+    * @param intern
+    *     If true, then strings and the final tag map will be interned as the data is being
+    *     parsed.
+    */
+  def decodeList(parser: JsonParser, intern: Boolean = false): List[Datapoint] = {
+    val builder = List.newBuilder[Datapoint]
+    foreachItem(parser) {
+      builder += decode(parser, null, intern)
+    }
+    builder.result()
+  }
+
+  /**
+    * Parse batch of datapoints encoded as a list.
+    */
+  def decodeList(json: String): List[Datapoint] = {
+    val parser = Json.newJsonParser(json)
+    try decodeList(parser)
+    finally parser.close()
+  }
+
+  private def encodeTags(gen: JsonGenerator, tags: Map[String, String]): Unit = {
+    gen.writeObjectFieldStart("tags")
+    tags.foreachEntry(gen.writeStringField)
+    gen.writeEndObject()
+  }
+
+  def encodeDatapoint(gen: JsonGenerator, d: Datapoint): Unit = {
+    gen.writeStartObject()
+    encodeTags(gen, d.tags)
+    gen.writeNumberField("timestamp", d.timestamp)
+    gen.writeNumberField("value", d.value)
+    gen.writeEndObject()
+  }
+
+  def encodeDatapoint(d: Datapoint): String = {
+    Streams.string { w =>
+      Using.resource(Json.newJsonGenerator(w)) { gen =>
+        encodeDatapoint(gen, d)
+      }
+    }
+  }
+
+  /**
+    * Encode batch of datapoints.
+    */
+  def encodeBatch(gen: JsonGenerator, tags: TagMap, values: List[Datapoint]): Unit = {
+    gen.writeStartObject()
+    encodeTags(gen, tags)
+    gen.writeArrayFieldStart("metrics")
+    values.foreach(v => encodeDatapoint(gen, v))
+    gen.writeEndArray()
+    gen.writeEndObject()
+  }
+
+  /**
+    * Encode batch of datapoints.
+    */
+  def encodeBatch(tags: TagMap, values: List[Datapoint]): String = {
+    Streams.string { w =>
+      Using.resource(Json.newJsonGenerator(w)) { gen =>
+        encodeBatch(gen, tags, values)
+      }
+    }
+  }
+
+  private def encodeStringTable(
+    gen: JsonGenerator,
+    values: List[Datapoint]
+  ): RefIntHashMap[String] = {
+    val stringPositions = new RefIntHashMap[String](100)
+    values.foreach { value =>
+      value.tags.foreachEntry { (k, v) =>
+        stringPositions.putIfAbsent(k, stringPositions.size)
+        stringPositions.putIfAbsent(v, stringPositions.size)
+      }
+    }
+
+    val tmp = new Array[String](stringPositions.size)
+    stringPositions.foreach { (s, i) =>
+      tmp(i) = s
+    }
+    gen.writeNumber(tmp.length)
+    var i = 0
+    while (i < tmp.length) {
+      gen.writeString(tmp(i))
+      i += 1
+    }
+
+    stringPositions
+  }
+
+  /**
+    * Encode batch of datapoints as using compact format. See decodeCompactBatch method for
+    * details.
+    */
+  def encodeCompactBatch(gen: JsonGenerator, values: List[Datapoint]): Unit = {
+    gen.writeStartArray()
+
+    val table = encodeStringTable(gen, values)
+
+    gen.writeNumber(values.size)
+    values.foreach { value =>
+      // id
+      gen.writeString(value.id.toString)
+
+      // tags
+      gen.writeNumber(value.tags.size)
+      value.tags.foreachEntry { (k, v) =>
+        gen.writeNumber(table.get(k, -1))
+        gen.writeNumber(table.get(v, -1))
+      }
+
+      // timestamp
+      gen.writeNumber(value.timestamp)
+
+      // value
+      gen.writeNumber(value.value)
+    }
+
+    gen.writeEndArray()
+  }
+
+  /**
+    * Encode batch of datapoints as using compact format. See decodeCompactBatch method for
+    * details.
+    */
+  def encodeCompactBatch(values: List[Datapoint]): String = {
+    Streams.string { w =>
+      Using.resource(Json.newJsonGenerator(w)) { gen =>
+        encodeCompactBatch(gen, values)
+      }
+    }
+  }
+
+  /**
+    * Encode batch of datapoints as a list.
+    */
+  def encodeList(gen: JsonGenerator, values: List[Datapoint]): Unit = {
+    gen.writeStartArray()
+    values.foreach(v => encodeDatapoint(gen, v))
+    gen.writeEndArray()
+  }
+
+  /**
+    * Encode batch of datapoints as a list.
+    */
+  def encodeList(values: List[Datapoint]): String = {
+    Streams.string { w =>
+      Using.resource(Json.newJsonGenerator(w)) { gen =>
+        encodeList(gen, values)
+      }
+    }
+  }
+}

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishPayloadsSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishPayloadsSuite.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.webapi
+
+import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.core.util.SortedTagMap
+import munit.FunSuite
+
+import java.util.UUID
+import scala.util.Random
+
+class PublishPayloadsSuite extends FunSuite {
+
+  private val timestamp = 1636116180000L
+
+  private def datapoints(n: Int): List[Datapoint] = {
+    (0 until n).toList.map { i =>
+      val tags = SortedTagMap(
+        "name" -> "test",
+        "i"    -> i.toString,
+        "u"    -> UUID.randomUUID().toString
+      )
+      val value = i match {
+        case 0 => Double.NaN
+        case 1 => Double.MinValue
+        case 2 => Double.MaxValue
+        case 3 => Double.MinPositiveValue
+        case 4 => Double.NegativeInfinity
+        case 5 => Double.PositiveInfinity
+        case _ => Random.nextDouble()
+      }
+      Datapoint(tags, timestamp, value)
+    }
+  }
+
+  test("encode and decode empty batch") {
+    val input = datapoints(0)
+    val encoded = PublishPayloads.encodeBatch(Map.empty, input)
+    val decoded = PublishPayloads.decodeBatch(encoded)
+    assertEquals(decoded, input)
+  }
+
+  test("encode and decode batch") {
+    val input = datapoints(10)
+    val encoded = PublishPayloads.encodeBatch(Map.empty, input)
+    val decoded = PublishPayloads.decodeBatch(encoded)
+    assert(decoded.head.value.isNaN)
+    assertEquals(decoded.head.tags, input.head.tags)
+    assertEquals(decoded.tail, input.tail)
+  }
+
+  test("encode and decode empty compact batch") {
+    val input = datapoints(0)
+    val encoded = PublishPayloads.encodeCompactBatch(input)
+    val decoded = PublishPayloads.decodeCompactBatch(encoded)
+    assertEquals(decoded, input)
+  }
+
+  test("encode and decode compact batch") {
+    val input = datapoints(10)
+    val encoded = PublishPayloads.encodeCompactBatch(input)
+    val decoded = PublishPayloads.decodeCompactBatch(encoded)
+    assert(decoded.head.value.isNaN)
+    assertEquals(decoded.head.tags, input.head.tags)
+    assertEquals(decoded.tail, input.tail)
+  }
+
+  test("encode and decode empty list") {
+    val input = datapoints(0)
+    val encoded = PublishPayloads.encodeList(input)
+    val decoded = PublishPayloads.decodeList(encoded)
+    assertEquals(decoded, input)
+  }
+
+  test("encode and decode list") {
+    val input = datapoints(10)
+    val encoded = PublishPayloads.encodeList(input)
+    val decoded = PublishPayloads.decodeList(encoded)
+    assert(decoded.head.value.isNaN)
+    assertEquals(decoded.head.tags, input.head.tags)
+    assertEquals(decoded.tail, input.tail)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,7 @@ lazy val `atlas-eval` = project
 
 lazy val `atlas-jmh` = project
   .configure(BuildSettings.profile)
-  .dependsOn(`atlas-chart`, `atlas-core`, `atlas-eval`, `atlas-json`)
+  .dependsOn(`atlas-chart`, `atlas-core`, `atlas-eval`, `atlas-json`, `atlas-webapi`)
   .enablePlugins(pl.project13.scala.sbt.SbtJmh)
 
 lazy val `atlas-json` = project


### PR DESCRIPTION
Adds helper functions for a new publish format that is more
efficient to decode. In particular, it allows the id to be
sent along so it doesn't need to get recomputed and keeps the
strings up front so they are only interned once if there are
duplicate values.

This format is a bit more expensive to encode due to needing
to compute the string table. This change also Moves the helper
functions for encoding and decoding publish payloads to a
separate object.