### PR TITLE
avoid recomputing id after parsing

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Datapoint.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Datapoint.scala
@@ -51,6 +51,10 @@ case class Datapoint(
   def apply(t: Long): Double = {
     if (t == timestamp) value else Double.NaN
   }
+
+  def toTuple: DatapointTuple = {
+    DatapointTuple(id, tags, timestamp, value)
+  }
 }
 
 object Datapoint {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DatapointTuple.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DatapointTuple.scala
@@ -13,14 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.atlas.core.norm
+package com.netflix.atlas.core.model
 
-import com.netflix.atlas.core.model.ItemId
+/**
+  * Simple tuple representing a datapoint. Can be used in place of [[Datapoint]] when
+  * the use-case does not require a [[TimeSeries]]. The id must be pre-computed for the
+  * tuple where it cannot be passed in an will be computed on first access for [[Datapoint]].
+  */
+case class DatapointTuple(id: ItemId, tags: Map[String, String], timestamp: Long, value: Double) {
 
-class UpdateValueFunction(id: ItemId, tags: Map[String, String], updateF: UpdateFunction)
-    extends ValueFunction {
-
-  def apply(timestamp: Long, value: Double): Unit = {
-    updateF(id, tags, timestamp, value)
+  def toDatapoint: Datapoint = {
+    Datapoint(tags, timestamp, value)
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/norm/package.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/norm/package.scala
@@ -13,14 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.atlas.core.norm
+package com.netflix.atlas.core
 
 import com.netflix.atlas.core.model.ItemId
 
-class UpdateValueFunction(id: ItemId, tags: Map[String, String], updateF: UpdateFunction)
-    extends ValueFunction {
-
-  def apply(timestamp: Long, value: Double): Unit = {
-    updateF(id, tags, timestamp, value)
-  }
+package object norm {
+  type UpdateFunction = (ItemId, Map[String, String], Long, Double) => Unit
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
@@ -53,10 +53,11 @@ class MemoryDatabaseSuite extends FunSuite {
 
   private def addData(name: String, values: Double*): Unit = {
     val tags = Map("name" -> name)
+    val id = TaggedItem.computeId(tags)
     val data = values.toList.zipWithIndex.map {
       case (v, i) =>
         clock.setWallTime(i * step)
-        Datapoint(tags, i * step, v)
+        DatapointTuple(id, tags, i * step, v)
     }
     db.update(data)
     db.index.rebuildIndex()
@@ -64,10 +65,11 @@ class MemoryDatabaseSuite extends FunSuite {
 
   private def addRollupData(name: String, values: Double*): Unit = {
     val tags = Map("name" -> name)
+    val id = TaggedItem.computeId(tags)
     val data = values.toList.zipWithIndex.map {
       case (v, i) =>
         clock.setWallTime(i * step)
-        Datapoint(tags, i * step, v)
+        DatapointTuple(id, tags, i * step, v)
     }
     data.foreach(db.rollup)
     db.index.rebuildIndex()

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/webapi/PublishPayloadsBench.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/webapi/PublishPayloadsBench.scala
@@ -16,6 +16,7 @@
 package com.netflix.atlas.webapi
 
 import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.core.model.DatapointTuple
 import com.netflix.atlas.core.model.ItemId
 import com.netflix.atlas.core.util.SortedTagMap
 import com.netflix.atlas.core.util.Streams
@@ -65,19 +66,17 @@ class PublishPayloadsBench {
   private val datapoints = {
     (0 until 10_000).toList.map { i =>
       val tags = SortedTagMap(tagMap + ("i" -> i.toString))
-      val datapoint = Datapoint(tags, 1636116180000L, Math.PI)
-      datapoint.id // lazy val, force it early
-      datapoint
+      Datapoint(tags, 1636116180000L, Math.PI).toTuple
     }
   }
 
-  private def decodeBatch(data: Array[Byte]): List[Datapoint] = {
+  private def decodeBatch(data: Array[Byte]): List[DatapointTuple] = {
     Using.resource(Json.newSmileParser(new ByteArrayInputStream(data))) { parser =>
       PublishPayloads.decodeBatch(parser)
     }
   }
 
-  private def encodeBatch(values: List[Datapoint]): Array[Byte] = {
+  private def encodeBatch(values: List[DatapointTuple]): Array[Byte] = {
     Streams.byteArray { out =>
       Using.resource(Json.newSmileGenerator(out)) { gen =>
         PublishPayloads.encodeBatch(gen, Map.empty, values)
@@ -91,7 +90,7 @@ class PublishPayloadsBench {
     }
   }
 
-  private def encodeCompactBatch(values: List[Datapoint]): Array[Byte] = {
+  private def encodeCompactBatch(values: List[DatapointTuple]): Array[Byte] = {
     Streams.byteArray { out =>
       Using.resource(Json.newSmileGenerator(out)) { gen =>
         PublishPayloads.encodeCompactBatch(gen, values)
@@ -99,13 +98,13 @@ class PublishPayloadsBench {
     }
   }
 
-  private def decodeList(data: Array[Byte]): List[Datapoint] = {
+  private def decodeList(data: Array[Byte]): List[DatapointTuple] = {
     Using.resource(Json.newSmileParser(new ByteArrayInputStream(data))) { parser =>
       PublishPayloads.decodeList(parser)
     }
   }
 
-  private def encodeList(values: List[Datapoint]): Array[Byte] = {
+  private def encodeList(values: List[DatapointTuple]): Array[Byte] = {
     Streams.byteArray { out =>
       Using.resource(Json.newSmileGenerator(out)) { gen =>
         PublishPayloads.encodeList(gen, values)

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishConsumer.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishConsumer.scala
@@ -15,7 +15,7 @@
  */
 package com.netflix.atlas.webapi
 
-import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.core.model.DatapointTuple
 import com.netflix.atlas.core.model.ItemId
 
 trait PublishConsumer {
@@ -33,13 +33,13 @@ object PublishConsumer {
   }
 
   class ListPublishConsumer extends PublishConsumer {
-    private val builder = List.newBuilder[Datapoint]
+    private val builder = List.newBuilder[DatapointTuple]
 
     def consume(id: ItemId, tags: Map[String, String], timestamp: Long, value: Double): Unit = {
-      builder += Datapoint(tags, timestamp, value)
+      builder += DatapointTuple(id, tags, timestamp, value)
     }
 
-    def toList: List[Datapoint] = {
+    def toList: List[DatapointTuple] = {
       builder.result()
     }
   }

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishApiSuite.scala
@@ -22,7 +22,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import com.netflix.atlas.akka.RequestHandler
 import com.netflix.atlas.akka.testkit.MUnitRouteSuite
-import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.core.model.DatapointTuple
 import com.netflix.atlas.webapi.PublishApi.FailureMessage
 import com.netflix.atlas.webapi.PublishApi.PublishRequest
 
@@ -67,7 +67,7 @@ class PublishApiSuite extends MUnitRouteSuite {
       }"""
     Post("/api/v1/publish", json) ~> routes ~> check {
       assertEquals(response.status, StatusCodes.OK)
-      assertEquals(lastUpdate, PublishApi.decodeBatch(json))
+      assertEquals(lastUpdate, PublishPayloads.decodeBatch(json))
     }
   }
 
@@ -103,7 +103,7 @@ class PublishApiSuite extends MUnitRouteSuite {
       }"""
     Post("/api/v1/publish", json) ~> routes ~> check {
       assertEquals(response.status, StatusCodes.Accepted)
-      assertEquals(lastUpdate, PublishApi.decodeBatch(json).tail)
+      assertEquals(lastUpdate, PublishPayloads.decodeBatch(json).tail)
     }
   }
 
@@ -200,14 +200,14 @@ class PublishApiSuite extends MUnitRouteSuite {
       }"""
     Post("/api/v1/publish-fast", json) ~> routes ~> check {
       assertEquals(response.status, StatusCodes.OK)
-      assertEquals(lastUpdate, PublishApi.decodeBatch(json))
+      assertEquals(lastUpdate, PublishPayloads.decodeBatch(json))
     }
   }
 }
 
 object PublishApiSuite {
 
-  @volatile var lastUpdate: List[Datapoint] = Nil
+  @volatile var lastUpdate: List[DatapointTuple] = Nil
 
   class TestActor extends Actor {
 

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishPayloadsSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishPayloadsSuite.scala
@@ -16,6 +16,7 @@
 package com.netflix.atlas.webapi
 
 import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.core.model.DatapointTuple
 import com.netflix.atlas.core.util.SortedTagMap
 import munit.FunSuite
 
@@ -26,7 +27,7 @@ class PublishPayloadsSuite extends FunSuite {
 
   private val timestamp = 1636116180000L
 
-  private def datapoints(n: Int): List[Datapoint] = {
+  private def datapoints(n: Int): List[DatapointTuple] = {
     (0 until n).toList.map { i =>
       val tags = SortedTagMap(
         "name" -> "test",
@@ -42,7 +43,7 @@ class PublishPayloadsSuite extends FunSuite {
         case 5 => Double.PositiveInfinity
         case _ => Random.nextDouble()
       }
-      Datapoint(tags, timestamp, value)
+      Datapoint(tags, timestamp, value).toTuple
     }
   }
 


### PR DESCRIPTION
Update the flow from parsing publish messages to storage
so that the id does not need to be recomputed.