### PR TITLE
avoid recomputing id on BlockStoreItem

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/BlockStoreItem.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/BlockStoreItem.scala
@@ -15,11 +15,12 @@
  */
 package com.netflix.atlas.core.db
 
-import com.netflix.atlas.core.model.LazyTaggedItem
+import com.netflix.atlas.core.model.ItemId
 import com.netflix.atlas.core.model.TaggedItem
 import com.netflix.atlas.core.model.TimeSeries
 
-case class BlockStoreItem(tags: Map[String, String], blocks: BlockStore) extends LazyTaggedItem {
+case class BlockStoreItem(id: ItemId, tags: Map[String, String], blocks: BlockStore)
+    extends TaggedItem {
 
   def label: String = TimeSeries.toLabel(tags)
 
@@ -33,7 +34,11 @@ object BlockStoreItem {
   private val metricInterner = InternMap.concurrent[BlockStoreItem](1000000)
 
   def create(tags: Map[String, String], blocks: BlockStore): BlockStoreItem = {
-    val m = new BlockStoreItem(tags, blocks)
+    create(TaggedItem.createId(tags), tags, blocks)
+  }
+
+  def create(id: ItemId, tags: Map[String, String], blocks: BlockStore): BlockStoreItem = {
+    val m = new BlockStoreItem(id, tags, blocks)
     metricInterner.intern(m)
   }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
@@ -121,7 +121,7 @@ class MemoryDatabase(registry: Registry, config: Config) extends Database {
   def update(id: ItemId, tags: Map[String, String], timestamp: Long, value: Double): Unit = {
     val blkStore = getOrCreateBlockStore(id)
     blkStore.update(timestamp, value)
-    index.update(BlockStoreItem.create(tags, blkStore))
+    index.update(BlockStoreItem.create(id, tags, blkStore))
   }
 
   def update(dp: DatapointTuple): Unit = {
@@ -135,7 +135,7 @@ class MemoryDatabase(registry: Registry, config: Config) extends Database {
   def rollup(dp: DatapointTuple): Unit = {
     val blkStore = getOrCreateBlockStore(dp.id)
     blkStore.update(dp.timestamp, dp.value, rollup = true)
-    index.update(BlockStoreItem.create(dp.tags, blkStore))
+    index.update(BlockStoreItem.create(dp.id, dp.tags, blkStore))
   }
 
   @scala.annotation.tailrec


### PR DESCRIPTION
Allow it to be set to avoid recomputing if it is already
available.