### PR TITLE
add unmarshaller for use with entity

### DIFF
--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/CustomDirectivesSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/CustomDirectivesSuite.scala
@@ -71,6 +71,12 @@ class CustomDirectivesSuite extends MUnitRouteSuite {
                   val entity = HttpEntity(MediaTypes.`application/json`, Json.encode(message))
                   complete(HttpResponse(status = StatusCodes.OK, entity = entity))
                 }
+              } ~
+              put {
+                entity(CustomDirectives.jsonUnmarshaller[Message]) { message =>
+                  val entity = HttpEntity(MediaTypes.`application/json`, Json.encode(message))
+                  complete(HttpResponse(status = StatusCodes.OK, entity = entity))
+                }
               }
             } ~
             path("json-parser") {
@@ -192,10 +198,27 @@ class CustomDirectivesSuite extends MUnitRouteSuite {
     }
   }
 
+  test("json put") {
+    val msg = Message("foo", "bar baz")
+    Put("/json", Json.encode(msg)) ~> endpoint.routes ~> check {
+      val expected = Json.decode[Message](responseAs[String])
+      assertEquals(expected, msg)
+    }
+  }
+
   test("smile post") {
     val msg = Message("foo", "bar baz")
     val entity = HttpEntity(CustomMediaTypes.`application/x-jackson-smile`, Json.smileEncode(msg))
     Post("/json", entity) ~> endpoint.routes ~> check {
+      val expected = Json.decode[Message](responseAs[String])
+      assertEquals(expected, msg)
+    }
+  }
+
+  test("smile put") {
+    val msg = Message("foo", "bar baz")
+    val entity = HttpEntity(CustomMediaTypes.`application/x-jackson-smile`, Json.smileEncode(msg))
+    Put("/json", entity) ~> endpoint.routes ~> check {
       val expected = Json.decode[Message](responseAs[String])
       assertEquals(expected, msg)
     }


### PR DESCRIPTION
Adds `jsonUnmarshaller` method for getting an unmarshaller
that can be used with the default `entity` directive.