### PR TITLE
add endpoint to strip query clauses

### DIFF
--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
@@ -183,6 +183,60 @@ class ExprApiSuite extends MUnitRouteSuite {
     assertEquals(data, List(":true", "name,:has", "name,sps,:eq"))
   }
 
+  testGet("/api/v1/expr/strip?q=name,sps,:eq") {
+    assertEquals(response.status, StatusCodes.OK)
+    val data = Json.decode[List[String]](responseAs[String])
+    assertEquals(data, List("name,sps,:eq,:sum"))
+  }
+
+  testGet("/api/v1/expr/strip?q=name,sps,:eq,foo,bar,:eq,:and&k=foo") {
+    assertEquals(response.status, StatusCodes.OK)
+    val data = Json.decode[List[String]](responseAs[String])
+    assertEquals(data, List("name,sps,:eq,:sum"))
+  }
+
+  testGet("/api/v1/expr/strip?q=name,sps,:eq,foo,bar,:eq,:and&k=foo") {
+    assertEquals(response.status, StatusCodes.OK)
+    val data = Json.decode[List[String]](responseAs[String])
+    assertEquals(data, List("name,sps,:eq,:sum"))
+  }
+
+  testGet("/api/v1/expr/strip?q=name,sps,:eq,foo,bar,:eq,:and&k=foo&k=name") {
+    assertEquals(response.status, StatusCodes.OK)
+    val data = Json.decode[List[String]](responseAs[String])
+    assertEquals(data, List(":true,:sum"))
+  }
+
+  testGet("/api/v1/expr/strip?q=name,sps,:eq,foo,bar,:eq,:and,:dist-avg&k=foo") {
+    assertEquals(response.status, StatusCodes.OK)
+    val data = Json.decode[List[String]](responseAs[String])
+    assertEquals(data, List("name,sps,:eq,:dist-avg"))
+  }
+
+  testGet("/api/v1/expr/strip?q=name,sps,:eq,foo,bar,:eq,:not,:and,:dist-avg&k=foo") {
+    assertEquals(response.status, StatusCodes.OK)
+    val data = Json.decode[List[String]](responseAs[String])
+    assertEquals(data, List("name,sps,:eq,:dist-avg"))
+  }
+
+  testGet("/api/v1/expr/strip?q=name,sps,:eq,foo,bar,:re,:and,:dist-avg&k=foo") {
+    assertEquals(response.status, StatusCodes.OK)
+    val data = Json.decode[List[String]](responseAs[String])
+    assertEquals(data, List("name,sps,:eq,:dist-avg"))
+  }
+
+  testGet("/api/v1/expr/strip?q=name,sps,:eq,foo,:has,:and,:dist-avg&k=foo") {
+    assertEquals(response.status, StatusCodes.OK)
+    val data = Json.decode[List[String]](responseAs[String])
+    assertEquals(data, List("name,sps,:eq,:dist-avg"))
+  }
+
+  testGet("/api/v1/expr/strip?q=name,sps,:eq,foo,:has,:or,:dist-avg&k=foo") {
+    assertEquals(response.status, StatusCodes.OK)
+    val data = Json.decode[List[String]](responseAs[String])
+    assertEquals(data, List(":true,:dist-avg"))
+  }
+
   import Query._
 
   private def normalize(expr: String): List[String] = {


### PR DESCRIPTION
Adds an endpoint to the expr API that can be used to
strip query clauses that for specific keys. The main
use-case is for taking a specific sample query and
removing scoping clauses to get a base expression for
use in a template.

/cc @nathfisher 