### PR TITLE
incremental expression evaluation

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
@@ -22,6 +22,7 @@ import com.netflix.atlas.core.index.CachingTagIndex
 import com.netflix.atlas.core.index.IndexStats
 import com.netflix.atlas.core.index.RoaringTagIndex
 import com.netflix.atlas.core.index.TagQuery
+import com.netflix.atlas.core.model.AggregateCollector
 import com.netflix.atlas.core.model.Block
 import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.DatapointTuple
@@ -30,6 +31,7 @@ import com.netflix.atlas.core.model.EvalContext
 import com.netflix.atlas.core.model.ItemId
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.TimeSeries
+import com.netflix.atlas.core.model.TimeSeriesBuffer
 import com.netflix.spectator.api.Registry
 import com.netflix.spectator.api.Spectator
 import com.typesafe.config.Config

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/AggregateCollector.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/AggregateCollector.scala
@@ -13,13 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.atlas.core.db
+package com.netflix.atlas.core.model
 
-import com.netflix.atlas.core.model.Block
-import com.netflix.atlas.core.model.CollectorStats
-import com.netflix.atlas.core.model.CollectorStatsBuilder
-import com.netflix.atlas.core.model.ConsolidationFunction
-import com.netflix.atlas.core.model.DataExpr
+import com.netflix.atlas.core.db.Limits
 import com.netflix.atlas.core.util.Math
 
 object AggregateCollector {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/IncrementalEvaluator.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/IncrementalEvaluator.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.atlas.core.util.IdentityMap
+
+/**
+  * Evaluator that can be used to incrementally process compute the final results
+  * with a bounded memory use. Input data must be supplied in order based on the
+  * keys in the `orderBy` set. Stateful operations will have to maintain state and
+  * thus will result in a much higher memory usage.
+  */
+trait IncrementalEvaluator {
+
+  /**
+    * Set of keys in the order needed for evaluation.
+    */
+  def orderBy: List[String]
+
+  /**
+    * Update the evaluation with a time series that is associated with the specified
+    * data expression. Any results that are already complete will be returned.
+    */
+  def update(dataExpr: DataExpr, ts: TimeSeries): List[TimeSeries]
+
+  /**
+    * When the input has been fully processed, flush should be called to get the final
+    * results for the evaluation.
+    */
+  def flush(): List[TimeSeries]
+
+  /**
+    * Expression state resulting from the evaluation.
+    */
+  def state: Map[StatefulExpr, Any]
+
+  /**
+    * Return a new evaluator that will apply the mapping function to the output of
+    * this evaluator.
+    */
+  def map(f: TimeSeries => TimeSeries): IncrementalEvaluator = {
+    val self = this
+    new IncrementalEvaluator {
+      override def orderBy: List[String] = self.orderBy
+
+      override def update(dataExpr: DataExpr, ts: TimeSeries): List[TimeSeries] = {
+        self.update(dataExpr, ts).map(f)
+      }
+
+      override def flush(): List[TimeSeries] = {
+        self.flush().map(f)
+      }
+
+      override def state: Map[StatefulExpr, Any] = self.state
+    }
+  }
+}
+
+object IncrementalEvaluator {
+
+  /** Create a simple evaluator for a static set of data. */
+  def apply(data: List[TimeSeries]): IncrementalEvaluator = {
+    new IncrementalEvaluator {
+      override def orderBy: List[String] = Nil
+
+      override def update(dataExpr: DataExpr, ts: TimeSeries): List[TimeSeries] = Nil
+
+      override def flush(): List[TimeSeries] = data
+
+      override def state: Map[StatefulExpr, Any] = IdentityMap.empty
+    }
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -1145,8 +1145,10 @@ object MathVocabulary extends Vocabulary {
       case DoubleListType(pcts) :: DataExprType(t) :: stack =>
         // Percentile always needs sum aggregate type, if others are used convert to sum
         val expr = t match {
-          case af: AggregateFunction => DataExpr.GroupBy(toSum(af), List(TagKey.percentile))
-          case by: DataExpr.GroupBy  => DataExpr.GroupBy(toSum(by.af), TagKey.percentile :: by.keys)
+          case af: AggregateFunction =>
+            DataExpr.GroupBy(toSum(af), List(TagKey.percentile))
+          case by: DataExpr.GroupBy =>
+            DataExpr.GroupBy(toSum(by.af), by.keys.appended(TagKey.percentile))
           case _ =>
             throw new IllegalArgumentException(":percentiles can only be used with :sum and :by")
         }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TimeSeriesBuffer.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TimeSeriesBuffer.scala
@@ -13,16 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.atlas.core.db
+package com.netflix.atlas.core.model
 
-import com.netflix.atlas.core.model.ArrayTimeSeq
-import com.netflix.atlas.core.model.Block
-import com.netflix.atlas.core.model.ConsolidationFunction
-import com.netflix.atlas.core.model.DsType
-import com.netflix.atlas.core.model.LazyTaggedItem
-import com.netflix.atlas.core.model.MapStepTimeSeq
-import com.netflix.atlas.core.model.TimeSeq
-import com.netflix.atlas.core.model.TimeSeries
 import com.netflix.atlas.core.util.ArrayHelper
 import com.netflix.atlas.core.util.Math
 
@@ -176,7 +168,7 @@ final class TimeSeriesBuffer(var tags: Map[String, String], val data: ArrayTimeS
   }
 
   /** Aggregate the data from the block into this buffer. */
-  private[db] def aggrBlock(
+  private[model] def aggrBlock(
     blkTags: Map[String, String],
     block: Block,
     aggr: Int,
@@ -208,7 +200,7 @@ final class TimeSeriesBuffer(var tags: Map[String, String], val data: ArrayTimeS
   }
 
   /** Aggregate the data from the block into this buffer. */
-  private[db] def valueMask(mask: JBitSet, block: Block, multiple: Int): Unit = {
+  private[model] def valueMask(mask: JBitSet, block: Block, multiple: Int): Unit = {
     val blkStep = step / multiple
     val s = start / blkStep
     val e = values.length * multiple + s - 1
@@ -226,7 +218,7 @@ final class TimeSeriesBuffer(var tags: Map[String, String], val data: ArrayTimeS
     }
   }
 
-  private[db] def average(mask: JBitSet, multiple: Int): Unit = {
+  private[model] def average(mask: JBitSet, multiple: Int): Unit = {
     val end = values.length * multiple
     var count = 0
     var i = 0

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/AggregateCollectorSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/AggregateCollectorSuite.scala
@@ -13,13 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.atlas.core.db
+package com.netflix.atlas.core.model
 
-import com.netflix.atlas.core.model.ArrayTimeSeq
-import com.netflix.atlas.core.model.CollectorStats
-import com.netflix.atlas.core.model.DataExpr
-import com.netflix.atlas.core.model.DsType
-import com.netflix.atlas.core.model.Query
 import munit.FunSuite
 
 class AggregateCollectorSuite extends FunSuite {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/FinalGroupingSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/FinalGroupingSuite.scala
@@ -66,7 +66,7 @@ class FinalGroupingSuite extends FunSuite {
 
   test("data group by with percentiles") {
     val expr = "name,sps,:eq,(,app,),:by,(,50,),:percentiles"
-    val expected = List("percentile", "app")
+    val expected = List("app", "percentile")
     assertEquals(eval(expr), expected)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/PercentilesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/PercentilesSuite.scala
@@ -347,8 +347,6 @@ class PercentilesSuite extends FunSuite {
     val expr = MathExpr.Percentiles(by, List(50.0))
     val input = Map[DataExpr, List[TimeSeries]](by -> List(TimeSeries.noData(step)))
     val ts = expr.eval(context, input).data
-    assertEquals(ts.size, 1)
-    assertEquals(ts.head.tags, Map("name" -> "NO_DATA"))
-    assertEquals(ts.head.label, "NO DATA")
+    assertEquals(ts.size, 0)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesBufferSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesBufferSuite.scala
@@ -13,18 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.atlas.core.db
+package com.netflix.atlas.core.model
 
-import com.netflix.atlas.core.model.ArrayBlock
-import com.netflix.atlas.core.model.ArrayTimeSeq
-import com.netflix.atlas.core.model.Block
-import com.netflix.atlas.core.model.ConsolidationFunction
-import com.netflix.atlas.core.model.ConstantBlock
-import com.netflix.atlas.core.model.DsType
 import com.netflix.atlas.core.util.Math
+import munit.FunSuite
 import nl.jqno.equalsverifier.EqualsVerifier
 import nl.jqno.equalsverifier.Warning
-import munit.FunSuite
 
 class TimeSeriesBufferSuite extends FunSuite {
 


### PR DESCRIPTION
Add method for TimeSeriesExpr to get a evaluator that can
be used to incrementally process a set of time series
without needing to have the entire set in memory. This
depends on being able to read the data in a given order
so that expressions can be processed and ensure a grouped
output time series is complete without needing to wait
for the entire dataset to be processed.