### PR TITLE
Handle :cg after style expressions

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -463,6 +463,9 @@ object MathVocabulary extends Vocabulary {
       case StringListType(_) :: TimeSeriesType(_) :: _ =>
         // Default data or math aggregate group by applied across math operations
         true
+      case StringListType(_) :: PresentationType(_) :: _ =>
+        // Handle :cg after presentation operators
+        true
     }
 
     private def mergeKeys(ks1: List[String], ks2: List[String]): List[String] = {
@@ -488,6 +491,8 @@ object MathVocabulary extends Vocabulary {
     override protected def executor: PartialFunction[List[Any], List[Any]] = {
       case StringListType(keys) :: TimeSeriesType(t) :: stack =>
         addCommonKeys(t, keys) :: stack
+      case StringListType(keys) :: PresentationType(e) :: stack =>
+        StyleExpr(addCommonKeys(e.expr, keys), e.settings) :: stack
     }
 
     override def summary: String =

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/CustomVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/CustomVocabularySuite.scala
@@ -143,4 +143,21 @@ class CustomVocabularySuite extends FunSuite {
       eval("name,(,a,b,c,),:in,app,beacon,:eq,:and,:node-avg,(,name,asg,),:by")
     }
   }
+
+  test("cg after style") {
+    val context = interpreter.execute("foo,1,:eq,$foo,:legend,(,bar,),:cg")
+    val context2 = interpreter.execute("foo,1,:eq,(,bar,),:by,$foo,:legend")
+    assertEquals(context.stack, context2.stack)
+  }
+
+  test("cg after complex expression including style") {
+    val complexExpr = "name,cpu,:eq,(,node,),:by,80,:gt,15,:rolling-count,10,:gt" +
+      ",$node,:legend,region,east,:eq,:cq,(,region,),:cg"
+    val context = interpreter.execute(complexExpr)
+
+    val complexExprExplicit = "name,cpu,:eq,region,east,:eq,:and,(,node,region,),:by," +
+      "80,:gt,15,:rolling-count,10,:gt,$node,:legend"
+    val context2 = interpreter.execute(complexExprExplicit)
+    assertEquals(context.stack, context2.stack)
+  }
 }


### PR DESCRIPTION
This makes expressions like the following work:

```
foo,a,:eq,$foo,:legend,(,bar,),:cg

name,cpu,:eq,(,node,),:by,80,:gt,15,:rolling-count,10,:gt,
  $node,:legend,region,east,:eq,:cq,(,region,),:cg
```

Previously we would get a match error since we were only expecting math
expressions but since we want to have tools blindly add `:cg` to
arbitrary expressions, we need to handle expressions that include style words