### PR TITLE
use absolute path for golden image

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/util/GraphAssertions.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/util/GraphAssertions.scala
@@ -33,6 +33,11 @@ class GraphAssertions(goldenDir: String, targetDir: String, assert: (Any, Any) =
 
   PngImage.useAntiAliasing = false
 
+  private val absoluteGoldenDir = {
+    val dir = new File(goldenDir)
+    dir.getAbsolutePath
+  }
+
   private def getInputStream(file: String): InputStream = {
     new FileInputStream(new File(s"$goldenDir/$file"))
   }
@@ -65,7 +70,7 @@ class GraphAssertions(goldenDir: String, targetDir: String, assert: (Any, Any) =
                 <table border="1">
                   <tr><th>Golden</th><th>Test</th><th>Diff</th></tr>
                   <tr valign="top">
-                    <td><img src="${goldenDir + '/' + f.getName}"/></td>
+                    <td><img src="${absoluteGoldenDir + '/' + f.getName}"/></td>
                     <td><img src="${f.getName}"/></td>
                     ${if (diffImg.isFile)
               s"""<td><img src="${s"diff_${f.getName}"}"/></td>"""


### PR DESCRIPTION
When generating the HTML report for image tests, use the
absolute path for the golden image. This avoids missing
images in the report if the working directory for rendering
the page differs.