### PR TITLE
add method to decode direct to datapoints

### DIFF
--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishPayloadsSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishPayloadsSuite.scala
@@ -94,4 +94,13 @@ class PublishPayloadsSuite extends FunSuite {
     assertEquals(decoded.head.tags, input.head.tags)
     assertEquals(decoded.tail, input.tail)
   }
+
+  test("datapoints: encode and decode batch") {
+    val input = datapoints(10)
+    val encoded = PublishPayloads.encodeBatch(Map.empty, input)
+    val decoded = PublishPayloads.decodeBatchDatapoints(encoded)
+    assert(decoded.head.value.isNaN)
+    assertEquals(decoded.head.tags, input.head.tags)
+    assertEquals(decoded.tail, input.tail.map(_.toDatapoint))
+  }
 }


### PR DESCRIPTION
Update PublishPayloads to have a helper to decode batches
direct to datapoints. This can be useful where the id is
not needed to avoid having to compute it.