### PR TITLE
avoid lambda allocation for lock

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/InternMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/InternMap.scala
@@ -123,18 +123,12 @@ class ConcurrentInternMap[K <: AnyRef](newMap: => InternMap[K], concurrencyLevel
     if (i < 0) -1 * i else i
   }
 
-  private def lock[R](key: K)(f: InternMap[K] => R): R = {
-    val i = index(key)
+  def intern(k: K): K = {
+    val i = index(k)
     locks(i).lock()
-    try f(segments(i))
+    try segments(i).intern(k)
     finally {
       locks(i).unlock()
-    }
-  }
-
-  def intern(k: K): K = {
-    lock(k) { m =>
-      m.intern(k)
     }
   }
 


### PR DESCRIPTION
Update ConcurrentInternMap to make intern call more
efficient. In particular, it will no longer use create
a lambda instance on each call.