### PR TITLE
log4j 2.15.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     val iep        = "3.0.9"
     val guice      = "5.0.1"
     val jackson    = "2.13.0"
-    val log4j      = "2.14.1"
+    val log4j      = "2.15.0"
     val scala      = "2.13.7"
     val slf4j      = "1.7.32"
     val spectator  = "1.0.7"


### PR DESCRIPTION
Pull in latest version for fix to [CVE-2021-44228].

[CVE-2021-44228]: https://nvd.nist.gov/vuln/detail/CVE-2021-44228