### PR TITLE
update eval library so it can be configured with explicit limits for expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ target
 *.iml
 *.ipr
 *.iws
+project
 
 # anything in .idea dirs
 .idea

--- a/atlas-eval/src/main/resources/reference.conf
+++ b/atlas-eval/src/main/resources/reference.conf
@@ -15,6 +15,9 @@ atlas.eval {
     // is too old
     num-buffers = 1
 
+    // Limit configured for expressions. Evaluation will be stopped if limit exceeds.
+    expression-limit = 40
+
     // Broad tag keys that should be ignored for the purposes of dropping expensive queries
     // that will be prohibitive to match. These are typically tags that will be applied to
     // everything within a given deployment scope.

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -78,6 +78,9 @@ private[stream] class StreamContext(
 
   def numBuffers: Int = config.getInt("num-buffers")
 
+  // Limit configured for expressions. Evaluation will be stopped if limit exceeds.
+  def expressionLimit: Int = Try(config.getInt("expression-limit")).getOrElse(Integer.MAX_VALUE)
+
   val interpreter = new ExprInterpreter(rootConfig)
 
   def findBackendForUri(uri: Uri): Backend = {

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -39,7 +39,7 @@ import com.netflix.atlas.eval.stream.Evaluator.MessageEnvelope
 import com.netflix.atlas.json.Json
 import com.netflix.atlas.json.JsonSupport
 import com.netflix.spectator.api.DefaultRegistry
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import nl.jqno.equalsverifier.EqualsVerifier
 import nl.jqno.equalsverifier.Warning
 import munit.FunSuite
@@ -65,10 +65,11 @@ class EvaluatorSuite extends FunSuite {
     Files.createDirectories(targetDir)
   }
 
-  def testPublisher(baseUri: String): Unit = {
+  def testPublisher(baseUri: String, bufferSize: Option[Int] = None): Unit = {
     import scala.concurrent.duration._
 
-    val evaluator = new Evaluator(config, registry, system)
+    val buffers = bufferSize.getOrElse(config.getInt("atlas.eval.stream.num-buffers"))
+    val evaluator = new Evaluator( config.withValue("atlas.eval.stream.num-buffers", ConfigValueFactory.fromAnyRef(buffers)), registry, system)
 
     val uri = s"$baseUri?q=name,jvm.gc.pause,:eq,:dist-max,(,nf.asg,nf.node,),:by"
     val future = Source
@@ -76,10 +77,11 @@ class EvaluatorSuite extends FunSuite {
       .toMat(Sink.seq[JsonSupport])(Keep.right)
       .run()
 
-    val messages = Await.result(future, 1.minute).collect {
+    val messages = Await.result(future, 100.minute).collect {
       case t: TimeSeriesMessage => t
     }
-    assertEquals(messages.size, 255) // Can vary depending on num buffers for evaluation
+    val expectedMessages = if(buffers > 1)  256 else 255
+    assertEquals(messages.size, expectedMessages) // Can vary depending on num buffers for evaluation
     assertEquals(messages.map(_.tags("nf.asg")).toSet.size, 3)
   }
 
@@ -123,6 +125,11 @@ class EvaluatorSuite extends FunSuite {
     testPublisher("resource:///gc-pause.dat")
   }
 
+  test("create publisher from resource uri with higher number of time buffers") {
+    //has enough buffers to retain an AggrDatapoint with an older timestamp than an earlier AggrDatapoint processed.
+    testPublisher("resource:///gc-pause.dat", Some(2))
+  }
+
   test("create publish, missing q parameter") {
     val evaluator = new Evaluator(config, registry, system)
 
@@ -139,6 +146,22 @@ class EvaluatorSuite extends FunSuite {
         )
       case v =>
         throw new MatchError(v)
+    }
+  }
+
+
+  test("create publish, for an expression with incoming data points exceeding the limit") {
+    val evaluator = new Evaluator(config.withValue("atlas.eval.stream.expression-limit", ConfigValueFactory.fromAnyRef(10)), registry, system)
+    val uri = "resource:///gc-pause.dat?q=name,jvm.gc.pause,:eq,:dist-max,(,nf.asg,nf.node,),:by"
+    val future = Source.fromPublisher(evaluator.createPublisher(uri)).runWith(Sink.seq)
+    val result = Await.result(future, scala.concurrent.duration.Duration.Inf)
+    result.foreach {
+      case DiagnosticMessage(t, msg, None) =>
+        assertEquals(t, "error")
+        assert(msg.startsWith("expression exceeded the configured limit '10' for timestamp"))
+      case timeSeriesMessage: TimeSeriesMessage =>
+        assertEquals(timeSeriesMessage.label, "NO DATA")
+      case _ =>
     }
   }
 

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
@@ -53,6 +53,8 @@ object TestContext {
       |
       |  num-buffers = 2
       |
+      |  expression-limit = 50000
+      |
       |  ignored-tag-keys = []
       |}
       |


### PR DESCRIPTION
### Changes in this pr:

1. update eval library so it can be configured with explicit limits for expressions with config parameter - `atlas.eval.stream.expression-limit`
2. if any expression within the streamContext exceeds the limit, then emit an error to all the datasources using this expression.
3. stop adding additional `AggrDataPoint` to the `Aggregator` corresponding to an expression when the number of raw data points for that expression coming in exceed the expression limit.
4. drop all `AggrDataPoint` corresponding to the expression within the `TimeGroup` before flushing if raw data points exceeds the configured limit. This is to avoid any user confusion that could be caused by keeping the data points until the limit is exceeded that results in incorrect data.
5. add tests

### Context:
https://github.com/Netflix/atlas/issues/1355

### Assumptions made this in this pr:
1. `eatlas.eval.stream.expression-limit` config parameter applies to all expressions. Could pattern match to apply the limit only to some expressions if we need to support that use case later.
 2. `TimeGrouped` seemed like the best place to check if an expression has data points that exceed the configured limit. As `TimeGrouped` maintains time buffers for every expression, the approach taken here is to stop adding any data points to the `Aggregator ` for an expression when the raw incoming data points exceed the configured limit for a specific timeStamp(floor of the step size of the stream context).
    a) Considering the `number of raw data points` instead of the number of data points after the aggregation for an expression within the buffer. This is to stop adding to the `Aggregator` earlier if raw data points exceed the limit which I think results in better memory utilization of the buffers.  If we were to instead use the number of data points after the aggregation, all data points could still be added(depending on the aggregation function and data) to the expression for a given timestamp until the buffer for that timestamp is to be flushed. Happy to change to use the number of data points after the aggregation if that's desired.
    b) drop all `AggrDataPoint` corresponding to the expression within the `TimeGroup` before flushing for FinalEvaluation, if raw data points exceeds the configured limit. This is to avoid any user confusion that could be caused by keeping the data points until the limit is exceeded that results in incorrect data. Also based on the implementation in this pr(considering the number of raw data points), we might be missing adding any values that come in after the limit is exceeded and might already be present in the aggregation results.
  c) Only the `AggrDataPoint`s in the  buffer for the expression corresponding to the timestamp that exceed the limit are dropped. Any other timestamps in the buffer for this expression might still have data if the number of raw data points are < the limit. This is to avoid completely stopping any future  evaluation of the expression because there was an intermittent spike in the data points in the past.
  
