### PR TITLE
1. update eval library so it can be configured with explicit limits for expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ target
 *.iml
 *.ipr
 *.iws
+project
 
 # anything in .idea dirs
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ target
 *.iml
 *.ipr
 *.iws
-project
 
 # anything in .idea dirs
 .idea

--- a/atlas-eval/src/main/resources/reference.conf
+++ b/atlas-eval/src/main/resources/reference.conf
@@ -15,9 +15,6 @@ atlas.eval {
     // is too old
     num-buffers = 1
 
-    // Limit configured for expressions. Evaluation will be stopped if limit exceeds.
-    expression-limit = 40
-
     // Broad tag keys that should be ignored for the purposes of dropping expensive queries
     // that will be prohibitive to match. These are typically tags that will be applied to
     // everything within a given deployment scope.

--- a/atlas-eval/src/main/resources/reference.conf
+++ b/atlas-eval/src/main/resources/reference.conf
@@ -15,6 +15,9 @@ atlas.eval {
     // is too old
     num-buffers = 1
 
+    // Limit configured for expressions. Evaluation will be stopped if limit exceeds.
+    expression-limit = 40
+
     // Broad tag keys that should be ignored for the purposes of dropping expensive queries
     // that will be prohibitive to match. These are typically tags that will be applied to
     // everything within a given deployment scope.

--- a/atlas-eval/src/main/resources/reference.conf
+++ b/atlas-eval/src/main/resources/reference.conf
@@ -15,6 +15,13 @@ atlas.eval {
     // is too old
     num-buffers = 1
 
+    limits {
+      // Maximum number of raw input datapoints for a data expr. Defaults to Integer.MaxValue
+      max-input-datapoints = 2147483647
+      // Maximum number of datapoints resulting from a group by. Defaults to Integer.MaxValue
+      max-intermediate-datapoints = 2147483647
+    }
+
     // Broad tag keys that should be ignored for the purposes of dropping expensive queries
     // that will be prohibitive to match. These are typically tags that will be applied to
     // everything within a given deployment scope.

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
@@ -34,6 +34,7 @@ import com.netflix.atlas.core.model.StyleExpr
 import com.netflix.atlas.core.model.TimeSeries
 import com.netflix.atlas.core.util.IdentityMap
 import com.netflix.atlas.eval.model.AggrDatapoint
+import com.netflix.atlas.eval.model.AggrDatapoint.Aggregator
 import com.netflix.atlas.eval.model.TimeGroup
 import com.netflix.atlas.eval.model.TimeSeriesMessage
 import com.netflix.atlas.eval.stream.Evaluator.DataSources
@@ -46,15 +47,20 @@ import scala.collection.mutable
   * Takes the set of data sources and time grouped partial aggregates as input and performs
   * the final evaluation step.
   *
-  * @param interpreter
+  * @param context
   *     Used for evaluating the expressions.
   */
-private[stream] class FinalExprEval(interpreter: ExprInterpreter)
+private[stream] class FinalExprEval(context: StreamContext)
     extends GraphStage[FlowShape[AnyRef, Source[MessageEnvelope, NotUsed]]]
     with StrictLogging {
 
   private val in = Inlet[AnyRef]("FinalExprEval.in")
   private val out = Outlet[Source[MessageEnvelope, NotUsed]]("FinalExprEval.out")
+  private val interpreter = context.interpreter
+  private val maxInputDatapointsPerExpression = context.maxInputDatapointsPerExpression
+
+  private val maxIntermediateDatapointsPerExpression =
+    context.maxIntermediateDatapointsPerExpression
 
   override val shape: FlowShape[AnyRef, Source[MessageEnvelope, NotUsed]] = FlowShape(in, out)
 
@@ -170,7 +176,24 @@ private[stream] class FinalExprEval(interpreter: ExprInterpreter)
 
         val dataExprToDatapoints = noData ++ groupedDatapoints.map {
             case (k, vs) =>
-              k -> AggrDatapoint.aggregate(vs.values).map(_.toTimeSeries)
+              val aggregator = AggrDatapoint.aggregate(
+                vs.values,
+                maxInputDatapointsPerExpression,
+                maxIntermediateDatapointsPerExpression,
+                context.registry
+              )
+              val timeSeries: List[TimeSeries] = aggregator match {
+                case aggr: Some[Aggregator] =>
+                  val maxInputOrIntermediateDatapointsExceeded =
+                    aggr.get.maxInputOrIntermediateDatapointsExceeded
+                  if (maxInputOrIntermediateDatapointsExceeded) {
+                    context.logDatapointsExceeded(timestamp, k)
+                    List()
+                  } else aggr.get.datapoints.map(_.toTimeSeries)
+                case _ => List()
+              }
+
+              k -> timeSeries
           }
 
         // Collect input and intermediate data size per DataSource

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -78,8 +78,12 @@ private[stream] class StreamContext(
 
   def numBuffers: Int = config.getInt("num-buffers")
 
-  // Limit configured for expressions. Evaluation will be stopped if limit exceeds.
-  def expressionLimit: Int = Try(config.getInt("expression-limit")).getOrElse(Integer.MAX_VALUE)
+  // Maximum number of raw input data points for a data expr.
+  def maxInputDatapointsPerExpression: Int = config.getInt("limits.max-input-datapoints")
+
+  // Maximum number of datapoints resulting from a group by for a data expr.
+  def maxIntermediateDatapointsPerExpression: Int =
+    config.getInt("limits.max-intermediate-datapoints")
 
   val interpreter = new ExprInterpreter(rootConfig)
 
@@ -173,6 +177,20 @@ private[stream] class StreamContext(
       val msg = s"rejected expensive query [$query], narrow the scope to a specific app or name"
       throw new IllegalArgumentException(msg)
     }
+  }
+
+  /**
+    * Emit an error to the sources where the number of input
+    * or intermediate datapoints exceed for an expression.
+    */
+  def logDatapointsExceeded(timestamp: Long, dataExpr: DataExpr) = {
+    val diagnosticMessage = DiagnosticMessage.error(
+      s"expression: $dataExpr exceeded the configured max input datapoints limit" +
+      s" '$maxInputDatapointsPerExpression' or max intermediate" +
+      s" datapoints limit '$maxIntermediateDatapointsPerExpression'" +
+      s" for timestamp '$timestamp}"
+    )
+    log(dataExpr, diagnosticMessage)
   }
 
   /**

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -78,6 +78,9 @@ private[stream] class StreamContext(
 
   def numBuffers: Int = config.getInt("num-buffers")
 
+  // Limit configured for expressions. Evaluation will be stopped if limit exceeds.
+  def expressionLimit: Int = Try(config.getInt("expression-limit")).getOrElse(Integer.MAX_VALUE)
+
   val interpreter = new ExprInterpreter(rootConfig)
 
   def findBackendForUri(uri: Uri): Backend = {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
@@ -23,6 +23,7 @@ import akka.stream.stage.GraphStage
 import akka.stream.stage.GraphStageLogic
 import akka.stream.stage.InHandler
 import akka.stream.stage.OutHandler
+import com.netflix.atlas.akka.DiagnosticMessage
 import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.eval.model.AggrDatapoint
 import com.netflix.atlas.eval.model.AggrValuesInfo
@@ -51,6 +52,7 @@ private[stream] class TimeGrouped(
     * for a new time that would evict the buffer with the minimum time.
     */
   private val numBuffers = context.numBuffers
+  private val expressionLimit = context.expressionLimit
 
   private val in = Inlet[AggrDatapoint]("TimeGrouped.in")
   private val out = Outlet[TimeGroup]("TimeGrouped.out")
@@ -97,8 +99,18 @@ private[stream] class TimeGrouped(
       private def aggregate(i: Int, v: AggrDatapoint): Unit = {
         if (!v.isHeartbeat) {
           buf(i).get(v.expr) match {
-            case Some(aggr) => aggr.aggregate(v)
-            case None       => buf(i).put(v.expr, AggrDatapoint.newAggregator(v))
+            case Some(aggr) => {
+              // drop the data points if an expression exceeds the configured limit within the time buffer and stop any final evaluation of this expression.
+              // emit an error to all data sources that use this particular data expression.
+              if (aggr.numRawDatapoints > expressionLimit) {
+                // emit an error to the source
+                val diagnosticMessage = DiagnosticMessage.error(
+                  s"expression exceeded the configured limit '$expressionLimit' for timestamp '${timestamps(i)}"
+                )
+                context.log(v.expr, diagnosticMessage)
+              } else aggr.aggregate(v)
+            }
+            case None => buf(i).put(v.expr, AggrDatapoint.newAggregator(v))
           }
         }
       }
@@ -115,10 +127,14 @@ private[stream] class TimeGrouped(
       }
 
       private def toTimeGroup(ts: Long, aggrMap: AggrMap): TimeGroup = {
+        val aggregateMapWithExpressionLimits =
+          aggrMap.filter(t => t._2.numRawDatapoints < expressionLimit).toMap
         TimeGroup(
           ts,
           step,
-          aggrMap.map(t => t._1 -> AggrValuesInfo(t._2.datapoints, t._2.numRawDatapoints)).toMap
+          aggregateMapWithExpressionLimits
+            .map(t => t._1 -> AggrValuesInfo(t._2.datapoints, t._2.numRawDatapoints))
+            .toMap
         )
       }
 

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -40,6 +40,7 @@ import com.netflix.atlas.json.Json
 import com.netflix.atlas.json.JsonSupport
 import com.netflix.spectator.api.DefaultRegistry
 import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigValueFactory
 import nl.jqno.equalsverifier.EqualsVerifier
 import nl.jqno.equalsverifier.Warning
 import munit.FunSuite
@@ -65,10 +66,15 @@ class EvaluatorSuite extends FunSuite {
     Files.createDirectories(targetDir)
   }
 
-  def testPublisher(baseUri: String): Unit = {
+  def testPublisher(baseUri: String, bufferSize: Option[Int] = None): Unit = {
     import scala.concurrent.duration._
 
-    val evaluator = new Evaluator(config, registry, system)
+    val buffers = bufferSize.getOrElse(config.getInt("atlas.eval.stream.num-buffers"))
+    val evaluator = new Evaluator(
+      config.withValue("atlas.eval.stream.num-buffers", ConfigValueFactory.fromAnyRef(buffers)),
+      registry,
+      system
+    )
 
     val uri = s"$baseUri?q=name,jvm.gc.pause,:eq,:dist-max,(,nf.asg,nf.node,),:by"
     val future = Source
@@ -79,7 +85,9 @@ class EvaluatorSuite extends FunSuite {
     val messages = Await.result(future, 1.minute).collect {
       case t: TimeSeriesMessage => t
     }
-    assertEquals(messages.size, 255) // Can vary depending on num buffers for evaluation
+
+    val expectedMessages = if (buffers > 1) 256 else 255
+    assertEquals(messages.size, expectedMessages) // Can vary depending on num buffers for evaluation
     assertEquals(messages.map(_.tags("nf.asg")).toSet.size, 3)
   }
 
@@ -123,6 +131,11 @@ class EvaluatorSuite extends FunSuite {
     testPublisher("resource:///gc-pause.dat")
   }
 
+  test("create publisher from resource uri with higher number of time buffers") {
+    //has enough buffers to retain an AggrDatapoint with an older timestamp than an earlier AggrDatapoint processed.
+    testPublisher("resource:///gc-pause.dat", Some(2))
+  }
+
   test("create publish, missing q parameter") {
     val evaluator = new Evaluator(config, registry, system)
 
@@ -139,6 +152,25 @@ class EvaluatorSuite extends FunSuite {
         )
       case v =>
         throw new MatchError(v)
+    }
+  }
+
+  test("create publish, for an expression with incoming data points exceeding the limit") {
+    val evaluator = new Evaluator(
+      config.withValue("atlas.eval.stream.expression-limit", ConfigValueFactory.fromAnyRef(10)),
+      registry,
+      system
+    )
+    val uri = "resource:///gc-pause.dat?q=name,jvm.gc.pause,:eq,:dist-max,(,nf.asg,nf.node,),:by"
+    val future = Source.fromPublisher(evaluator.createPublisher(uri)).runWith(Sink.seq)
+    val result = Await.result(future, scala.concurrent.duration.Duration.Inf)
+    result.foreach {
+      case DiagnosticMessage(t, msg, None) =>
+        assertEquals(t, "error")
+        assert(msg.startsWith("expression exceeded the configured limit '10' for timestamp"))
+      case timeSeriesMessage: TimeSeriesMessage =>
+        assertEquals(timeSeriesMessage.label, "NO DATA")
+      case _ =>
     }
   }
 

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -157,7 +157,10 @@ class EvaluatorSuite extends FunSuite {
 
   test("create publish, for an expression with incoming data points exceeding the limit") {
     val evaluator = new Evaluator(
-      config.withValue("atlas.eval.stream.expression-limit", ConfigValueFactory.fromAnyRef(10)),
+      config.withValue(
+        "atlas.eval.stream.limits.max-input-datapoints",
+        ConfigValueFactory.fromAnyRef(10)
+      ),
       registry,
       system
     )
@@ -171,7 +174,9 @@ class EvaluatorSuite extends FunSuite {
         assertEquals(t, "error")
         assert(
           msg.startsWith(
-            "expression: statistic,max,:eq,name,jvm.gc.pause,:eq,:and,:max,(,nf.asg,nf.node,),:by exceeded the configured limit '10' for timestamp"
+            "expression: statistic,max,:eq,name,jvm.gc.pause,:eq,:and,:max,(,nf.asg,nf.node,),:by" +
+            " exceeded the configured max input datapoints limit '10' or max intermediate" +
+            " datapoints limit '2147483647' for timestamp"
           )
         )
         numberOfDiagnosticMessages += 1

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
@@ -53,6 +53,11 @@ object TestContext {
       |
       |  num-buffers = 2
       |
+      |  limits {
+      |    max-input-datapoints = 50000
+      |    max-intermediate-datapoints = 10000000
+      |  }
+      |
       |  expression-limit = 50000
       |
       |  ignored-tag-keys = []

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
@@ -53,6 +53,8 @@ object TestContext {
       |
       |  num-buffers = 2
       |
+      |  expression-limit = 50000
+      |
       |  ignored-tag-keys = []
       |}
       |

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
@@ -124,16 +124,16 @@ class TimeGroupedSuite extends FunSuite {
     count("buffered") -> (count("dropped-old") + count("dropped-future"))
   }
 
-  test("drop events for an expression that exceed the limit") {
+  test("drop events for an expression that exceed the number of input datapoints limit") {
     val n = 60000
     val expr = DataExpr.Max(Query.True)
     val data = (0 until n).toList.map { i =>
       AggrDatapoint(10, 10, expr, "test", Map.empty, i)
     }
 
-    val before = count("dropped-limit-exceeded")
+    val before = count("dropped-datapoints-limit-exceeded")
     val groups = run(data)
-    val after = count("dropped-limit-exceeded")
+    val after = count("dropped-datapoints-limit-exceeded")
 
     assertEquals(groups, List(timeGroup(10, Nil)))
     assertEquals(before, 0L)
@@ -346,31 +346,6 @@ class TimeGroupedSuite extends FunSuite {
           AggrDatapoint(10, 10, expr, "test", Map("category" -> "odd"), n * n)
         ),
         2 * n
-      )
-    )
-
-    val groups = run(data)
-    assertEquals(groups, List(TimeGroup(10, step, expected)))
-  }
-
-  test("group by aggregate with additional tags: count") {
-    val expr: DataExpr = DataExpr.GroupBy(DataExpr.Count(Query.True), List("category"))
-    val data = List(
-      AggrDatapoint(10, 10, expr, "test", Map("category" -> "even", "blah" -> "a"), 0),
-      AggrDatapoint(10, 10, expr, "test", Map("category" -> "odd", "blah"  -> "b"), 1),
-      AggrDatapoint(10, 10, expr, "test", Map("category" -> "even", "blah" -> "c"), 2),
-      AggrDatapoint(10, 10, expr, "test", Map("category" -> "odd", "blah"  -> "d"), 3)
-    )
-
-    val expected = Map(
-      expr -> AggrValuesInfo(
-        List(
-          AggrDatapoint(10, 10, expr, "test", Map("category" -> "even", "blah" -> "a"), 0),
-          AggrDatapoint(10, 10, expr, "test", Map("category" -> "odd", "blah"  -> "b"), 1),
-          AggrDatapoint(10, 10, expr, "test", Map("category" -> "even", "blah" -> "c"), 2),
-          AggrDatapoint(10, 10, expr, "test", Map("category" -> "odd", "blah"  -> "d"), 3)
-        ),
-        4
       )
     )
 

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
@@ -130,8 +130,14 @@ class TimeGroupedSuite extends FunSuite {
     val data = (0 until n).toList.map { i =>
       AggrDatapoint(10, 10, expr, "test", Map.empty, i)
     }
+
+    val before = count("dropped-limit-exceeded")
     val groups = run(data)
+    val after = count("dropped-limit-exceeded")
+
     assertEquals(groups, List(timeGroup(10, Nil)))
+    assertEquals(before, 0L)
+    assertEquals(after, 10000L)
   }
 
   test("late events dropped") {

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
@@ -124,6 +124,16 @@ class TimeGroupedSuite extends FunSuite {
     count("buffered") -> (count("dropped-old") + count("dropped-future"))
   }
 
+  test("drop events for an expression that exceed the limit") {
+    val n = 60000
+    val expr = DataExpr.Max(Query.True)
+    val data = (0 until n).toList.map { i =>
+      AggrDatapoint(10, 10, expr, "test", Map.empty, i)
+    }
+    val groups = run(data)
+    assertEquals(groups, List(timeGroup(10, Nil)))
+  }
+
   test("late events dropped") {
     val data = List(
       datapoint(20, 1),
@@ -330,6 +340,31 @@ class TimeGroupedSuite extends FunSuite {
           AggrDatapoint(10, 10, expr, "test", Map("category" -> "odd"), n * n)
         ),
         2 * n
+      )
+    )
+
+    val groups = run(data)
+    assertEquals(groups, List(TimeGroup(10, step, expected)))
+  }
+
+  test("group by aggregate with additional tags: count") {
+    val expr: DataExpr = DataExpr.GroupBy(DataExpr.Count(Query.True), List("category"))
+    val data = List(
+      AggrDatapoint(10, 10, expr, "test", Map("category" -> "even", "blah" -> "a"), 0),
+      AggrDatapoint(10, 10, expr, "test", Map("category" -> "odd", "blah"  -> "b"), 1),
+      AggrDatapoint(10, 10, expr, "test", Map("category" -> "even", "blah" -> "c"), 2),
+      AggrDatapoint(10, 10, expr, "test", Map("category" -> "odd", "blah"  -> "d"), 3)
+    )
+
+    val expected = Map(
+      expr -> AggrValuesInfo(
+        List(
+          AggrDatapoint(10, 10, expr, "test", Map("category" -> "even", "blah" -> "a"), 0),
+          AggrDatapoint(10, 10, expr, "test", Map("category" -> "odd", "blah"  -> "b"), 1),
+          AggrDatapoint(10, 10, expr, "test", Map("category" -> "even", "blah" -> "c"), 2),
+          AggrDatapoint(10, 10, expr, "test", Map("category" -> "odd", "blah"  -> "d"), 3)
+        ),
+        4
       )
     )
 


### PR DESCRIPTION
### Changes in this pr:
1. update eval library so it can be configured with explicit limits for expressions with config parameter - `atlas.eval.stream.expression-limit`
2. if any expression within the streamContext exceeds the limit, then emit an error to all the datasources using this expression.
3. stop adding additional `AggrDataPoint` to the Aggregator corresponding to an expression when the number of raw data points for that expression coming in exceed the expression limit.
4. drop all `AggrDataPoint` corresponding to the expression within the `TimeGroup` before flushing if raw data points exceeds the configured limit. This is to avoid any user confusion that could be caused by keeping the data points until the limit is exceeded that results in incorrect data.
5. add tests


### Context:
#1355


### Assumptions made this in this pr:
1. `atlas.eval.stream.expression-limit` config parameter applies to all expressions. Could pattern match to apply the limit only to some expressions if we need to support that use case later.
2. `TimeGrouped` seemed like the best place to check if an expression has data points that exceed the configured limit. As TimeGrouped maintains time buffers for every expression, the approach taken here is to stop adding any data points to the Aggregator for an expression when the raw incoming data points exceed the configured limit for a specific timeStamp(floor of the step size of the stream context).
     a) Considering the number of `raw data points` instead of the number of data points after the aggregation for an expression within the buffer. This is to stop adding to the Aggregator earlier if raw data points exceed the limit which I think results in better memory utilization of the buffers. If we were to instead use the number of data points after the aggregation, all data points could still be added(depending on the aggregation function and data) to the expression for a given timestamp until the buffer for that timestamp is to be flushed. Happy to change to use the number of data points after the aggregation if that's desired.
     b) drop all `AggrDataPoint` corresponding to the expression within the `TimeGroup` before flushing for FinalEvaluation, if raw data points exceeds the configured limit. This is to avoid any user confusion that could be caused by keeping the data points until the limit is exceeded that results in incorrect data. Also based on the implementation in this pr(considering the number of raw data points), we might be missing adding any values that come in after the limit is exceeded and might already be present in the aggregation results. 
   c) Only the `AggrDataPoint`s in the buffer for the expression corresponding to the timestamp that exceed the limit are dropped. Any other timestamps in the buffer for this expression might still have data if the number of raw data points are < the limit. This is to avoid completely stopping any future evaluation of the expression because there was an intermittent spike in the data points in the past.



