### PR TITLE
track number of streams dropping data

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/QueueHandler.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/QueueHandler.scala
@@ -41,9 +41,9 @@ class QueueHandler(streamMeta: StreamMetadata, queue: StreamOps.SourceQueue[Seq[
     logger.trace(s"enqueuing message for $id: ${toJson(msgs)}")
     if (!queue.offer(msgs)) {
       logger.debug(s"failed to enqueue message for $id: ${toJson(msgs)}")
-      streamMeta.droppedMessages.addAndGet(msgs.size)
+      streamMeta.updateDropped(msgs.size)
     } else {
-      streamMeta.receivedMessages.addAndGet(msgs.size)
+      streamMeta.updateReceived(msgs.size)
     }
   }
 

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamSubscriptionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamSubscriptionManager.scala
@@ -15,10 +15,15 @@
  */
 package com.netflix.atlas.lwcapi
 
+import com.netflix.spectator.api.Registry
+
+import javax.inject.Inject
+
 /**
   * Subclass of [[SubscriptionManager]] that uses a source queue for the handler. In some cases
   * with dependency injection erasure can cause problems with generic types. This class
   * is just to avoid those issues for the main use-cases where we need to inject a version
   * that needs a source queue.
   */
-class StreamSubscriptionManager extends SubscriptionManager[QueueHandler]
+class StreamSubscriptionManager @Inject() (registry: Registry)
+    extends SubscriptionManager[QueueHandler](registry)

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/EvaluateApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/EvaluateApiSuite.scala
@@ -28,7 +28,7 @@ class EvaluateApiSuite extends MUnitRouteSuite {
 
   private implicit val routeTestTimeout = RouteTestTimeout(5.second)
 
-  private val sm = new StreamSubscriptionManager
+  private val sm = new StreamSubscriptionManager(new NoopRegistry)
   private val endpoint = new EvaluateApi(new NoopRegistry, sm)
 
   test("post empty payload") {

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
@@ -48,7 +48,7 @@ class ExpressionApiSuite extends MUnitRouteSuite {
       .run()
   )
 
-  private val sm = new StreamSubscriptionManager
+  private val sm = new StreamSubscriptionManager(new NoopRegistry)
   private val endpoint = ExpressionApi(sm, new NoopRegistry, system)
 
   private def unzip(bytes: Array[Byte]): String = {

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/StreamMetadataSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/StreamMetadataSuite.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwcapi
+
+import com.netflix.spectator.api.ManualClock
+import com.netflix.spectator.impl.StepLong
+import munit.FunSuite
+
+class StreamMetadataSuite extends FunSuite {
+
+  test("toJson") {
+    val clock = new ManualClock()
+    val step = 60_000L
+    val meta =
+      StreamMetadata("id", "addr", new StepLong(0, clock, step), new StepLong(0, clock, step))
+    meta.updateReceived(100)
+    meta.updateDropped(2)
+
+    // Move to next interval to ensure it is polling last completed interval
+    clock.setWallTime(step)
+    val expected =
+      """{"streamId":"id","remoteAddress":"addr","receivedMessages":100,"droppedMessages":2}"""
+    assertEquals(meta.toJson, expected)
+  }
+}

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
@@ -37,7 +37,7 @@ class SubscribeApiSuite extends MUnitRouteSuite {
   private implicit val routeTestTimeout = RouteTestTimeout(5.second)
 
   private val config = ConfigFactory.load()
-  private val sm = new StreamSubscriptionManager
+  private val sm = new StreamSubscriptionManager(new NoopRegistry)
   private val splitter = new ExpressionSplitter(config)
 
   private val api = new SubscribeApi(config, new NoopRegistry, sm, splitter, materializer)

--- a/atlas-module-lwcapi/src/main/scala/com/netflix/atlas/guice/LwcApiModule.scala
+++ b/atlas-module-lwcapi/src/main/scala/com/netflix/atlas/guice/LwcApiModule.scala
@@ -25,6 +25,7 @@ import com.netflix.atlas.lwcapi.ExpressionSplitter
 import com.netflix.atlas.lwcapi.StartupDelayService
 import com.netflix.iep.guice.LifecycleModule
 import com.netflix.iep.service.Service
+import com.netflix.spectator.api.Registry
 import com.typesafe.config.Config
 
 final class LwcApiModule extends AbstractModule {
@@ -45,8 +46,8 @@ final class LwcApiModule extends AbstractModule {
 
   @Provides
   @Singleton
-  protected def providesSubscriptionManager(): StreamSubscriptionManager = {
-    new StreamSubscriptionManager()
+  protected def providesSubscriptionManager(registry: Registry): StreamSubscriptionManager = {
+    new StreamSubscriptionManager(registry)
   }
 
   override def equals(obj: Any): Boolean = {


### PR DESCRIPTION
Updates the stream metadata to keep track of the number
of recently received and dropped messages rather than
the number overall. Currently this is done based on a
step interval. Adds a guage to show the number of streams
with a dimension indicating the state.