### PR TITLE
Fix a bug regarding chained group by queries where an error was thrown

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -739,7 +739,7 @@ object MathExpr {
     private val dataGroups = expr.dataExprs.collect { case e: DataExpr.GroupBy => e }
     dataGroups.foreach { grp =>
       require(
-        grp.keys.containsSlice(keys),
+        keys.forall(key => grp.keys.contains(key)),
         s"(,${keys.mkString(",")},) is not a subset of (,${grp.keys.mkString(",")},)"
       )
     }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathGroupBySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathGroupBySuite.scala
@@ -87,6 +87,23 @@ class MathGroupBySuite extends FunSuite {
     assertEquals(rs, expected)
   }
 
+  test("(,name,mode,value,),:by,(,name,value,),:by") {
+    val input = List(
+      ts(1),
+      ts(2),
+      ts(3)
+    )
+    val rs = groupBy(input, List("name", "mode", "value"), List("name", "value"), MathExpr.Sum)
+    assertEquals(rs.size, 3)
+
+    val expected = List(
+      ts(1).withTags(Map("name" -> "test", "value" -> "1")).withLabel("(name=test value=1)"),
+      ts(2).withTags(Map("name" -> "test", "value" -> "2")).withLabel("(name=test value=2)"),
+      ts(3).withTags(Map("name" -> "test", "value" -> "3")).withLabel("(name=test value=3)")
+    )
+    assertEquals(rs, expected)
+  }
+
   test("(,name,mode,value,),:by,(,name,mode,),:by,(,name,),:by") {
     val input = List(
       ts(1),


### PR DESCRIPTION
if a subsequent key group was not a `slice` of the previous group but
was still a subset of that group. E.g.
`(,name,mode,value,),:by,(,name,value,),:by` would throw the error
despite `name` and `value` being present in the original group.