### PR TITLE
fix performance of limit check

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
@@ -144,7 +144,7 @@ private[stream] class TimeGrouped(
           ts,
           step,
           aggregateMapForExpWithinLimits
-            .map(t => t._1 -> AggrValuesInfo(t._2.datapoints, t._2.numRawDatapoints))
+            .map(t => t._1 -> AggrValuesInfo(t._2.datapoints, t._2.numInputDatapoints))
         )
       }
 

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
@@ -73,7 +73,7 @@ class FinalExprEvalSuite extends FunSuite {
       .map(t => {
         val aggr =
           AggrDatapoint.aggregate(t._2.toList, Integer.MAX_VALUE, Integer.MAX_VALUE, registry).get
-        t._1 -> AggrValuesInfo(aggr.datapoints, aggr.numRawDatapoints)
+        t._1 -> AggrValuesInfo(aggr.datapoints, aggr.numInputDatapoints)
       })
     TimeGroup(timestamp, step, values)
   }


### PR DESCRIPTION
For group by it was calling `datapoints.size` which is a
linear operation and maps the values resulting in a lot
of allocations. This changes the intermediate size check
to be a constant time operation.