### PR TITLE
reduce allocations for datapoint aggregators

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
@@ -105,8 +105,8 @@ object AggrDatapoint {
       * Counter for tracking number of datapoints that are dropped due to exceeding the
       * configured limits.
       */
-    val droppedCounter: Counter = registry.counter(
-      "atlas.eval.datapoints", "id", "dropped-datapoints-limit-exceeded")
+    val droppedCounter: Counter =
+      registry.counter("atlas.eval.datapoints", "id", "dropped-datapoints-limit-exceeded")
   }
 
   /**
@@ -130,7 +130,7 @@ object AggrDatapoint {
     /** Returns true if any of the configured limits have been exceeded. */
     def limitExceeded: Boolean = {
       numInputDatapoints >= settings.maxInputDatapoints ||
-        numIntermediateDatapoints >= settings.maxIntermediateDatapoints
+      numIntermediateDatapoints >= settings.maxIntermediateDatapoints
     }
 
     /**

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
@@ -24,7 +24,7 @@ import com.netflix.atlas.core.model.Datapoint
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.TimeSeries
 import com.netflix.atlas.core.util.Math
-import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spectator.api.Counter
 import com.netflix.spectator.api.Registry
 
 /**
@@ -86,39 +86,60 @@ object AggrDatapoint {
   }
 
   /**
+    * Common settings for aggregators.
+    *
+    * @param maxInputDatapoints
+    *     Limit for the number of input datapoints.
+    * @param maxIntermediateDatapoints
+    *     Limit for the number of intermediate datapoints.
+    * @param registry
+    *     Registry used for reporting metrics related to the aggregation behavior.
+    */
+  case class AggregatorSettings(
+    maxInputDatapoints: Int,
+    maxIntermediateDatapoints: Int,
+    registry: Registry
+  ) {
+
+    /**
+      * Counter for tracking number of datapoints that are dropped due to exceeding the
+      * configured limits.
+      */
+    val droppedCounter: Counter = registry.counter(
+      "atlas.eval.datapoints", "id", "dropped-datapoints-limit-exceeded")
+  }
+
+  /**
     * Base trait for an aggregator that can efficiently combine the datapoints as they
     * arrive using the aggregation function for the data expression associated with the
     * datapoint. The caller should ensure that all datapoints passed to a given aggregator
     * instance have the same data expression.
     */
-  trait Aggregator {
-    protected[this] var inputDatapointCounter = 0
-    protected[this] var exceedsMaxInputOrIntermediateDatapoints = false
-    protected[this] var inputDatapointsLimit = Integer.MAX_VALUE
-    protected[this] var intermediateDatapointsLimit = Integer.MAX_VALUE
+  abstract class Aggregator(settings: AggregatorSettings) {
+    var numInputDatapoints = 0
+    var numIntermediateDatapoints = 0
 
-    protected[this] var counter =
-      new NoopRegistry().counter("atlas.eval.datapoints", "id", "dropped-datapoints-limit-exceeded")
-    def maxInputOrIntermediateDatapointsExceeded: Boolean = exceedsMaxInputOrIntermediateDatapoints
-
-    protected[this] def inputOrIntermediateDatapointsAtLimitOrExceeded: Boolean = {
-      val datapointsLimitExceeded =
-        numInputDatapoints >= inputDatapointsLimit || numIntermediateDatapoints >= intermediateDatapointsLimit
+    protected[this] def checkLimits: Boolean = {
+      val datapointsLimitExceeded = limitExceeded
       if (datapointsLimitExceeded) {
-        counter.increment()
-        exceedsMaxInputOrIntermediateDatapoints = true
+        settings.droppedCounter.increment()
       }
       datapointsLimitExceeded
     }
 
-    def numInputDatapoints: Int = inputDatapointCounter
+    /** Returns true if any of the configured limits have been exceeded. */
+    def limitExceeded: Boolean = {
+      numInputDatapoints >= settings.maxInputDatapoints ||
+        numIntermediateDatapoints >= settings.maxIntermediateDatapoints
+    }
 
-    def numIntermediateDatapoints: Int = 1
-
-    // drop the data points if the number of input/intermediate datapoints exceed the configured
-    // limit for an aggregator
+    /**
+      * Add datapoint to the aggregate. It may get dropped if configured limits have
+      * been exceeded.
+      */
     def aggregate(datapoint: AggrDatapoint): Aggregator
 
+    /** Final set of aggregate datapoints. */
     def datapoints: List[AggrDatapoint]
   }
 
@@ -130,20 +151,17 @@ object AggrDatapoint {
   private class SimpleAggregator(
     init: AggrDatapoint,
     op: (Double, Double) => Double,
-    maxInputDatapoints: Int,
-    maxIntermediateDatapoints: Int,
-    registry: Registry
-  ) extends Aggregator {
+    settings: AggregatorSettings
+  ) extends Aggregator(settings) {
+
     private var value = init.value
-    inputDatapointCounter += 1
-    inputDatapointsLimit = maxInputDatapoints
-    intermediateDatapointsLimit = maxIntermediateDatapoints
-    counter = registry.counter("atlas.eval.datapoints", "id", "dropped-datapoints-limit-exceeded")
+    numInputDatapoints += 1
+    numIntermediateDatapoints = 1
 
     override def aggregate(datapoint: AggrDatapoint): Aggregator = {
-      if (!inputOrIntermediateDatapointsAtLimitOrExceeded) {
+      if (!checkLimits) {
         value = op(value, datapoint.value)
-        inputDatapointCounter += 1
+        numInputDatapoints += 1
       }
       this
     }
@@ -157,46 +175,29 @@ object AggrDatapoint {
     * Group the datapoints by the tags and maintain a simple aggregator per distinct tag
     * set.
     */
-  private class GroupByAggregator(
-    maxInputDatapoints: Int,
-    maxIntermediateDatapoints: Int,
-    registry: Registry
-  ) extends Aggregator {
+  private class GroupByAggregator(settings: AggregatorSettings) extends Aggregator(settings) {
 
     private val aggregators =
       scala.collection.mutable.AnyRefMap.empty[Map[String, String], SimpleAggregator]
-    inputDatapointsLimit = maxInputDatapoints
-    intermediateDatapointsLimit = maxIntermediateDatapoints
-    counter = registry.counter("atlas.eval.datapoints", "id", "dropped-datapoints-limit-exceeded")
 
     private def newAggregator(datapoint: AggrDatapoint): SimpleAggregator = {
       datapoint.expr match {
         case GroupBy(af: AggregateFunction, _) =>
-          val aggregator = new SimpleAggregator(
-            datapoint,
-            aggrOp(af),
-            maxInputDatapoints,
-            maxIntermediateDatapoints,
-            registry
-          )
-          inputDatapointCounter += 1
+          val aggregator = new SimpleAggregator(datapoint, aggrOp(af), settings)
           aggregator
         case _ =>
           throw new IllegalArgumentException("datapoint is not for a grouped expression")
       }
     }
 
-    // This should be a constant time operation as it will be used to check the limit
-    // for incoming datapoints.
-    override def numIntermediateDatapoints: Int = aggregators.size
-
     override def aggregate(datapoint: AggrDatapoint): Aggregator = {
-      if (!inputOrIntermediateDatapointsAtLimitOrExceeded) {
+      if (!checkLimits) {
+        numInputDatapoints += 1
         aggregators.get(datapoint.tags) match {
           case Some(aggr) =>
-            inputDatapointCounter += 1
             aggr.aggregate(datapoint)
           case None =>
+            numIntermediateDatapoints += 1
             aggregators.put(datapoint.tags, newAggregator(datapoint))
         }
       }
@@ -211,23 +212,14 @@ object AggrDatapoint {
   /**
     * Do not perform aggregation. Keep track of all datapoints that have been received.
     */
-  private class AllAggregator(
-    maxInputDatapoints: Int,
-    maxIntermediateDatapoints: Int,
-    registry: Registry
-  ) extends Aggregator {
+  private class AllAggregator(settings: AggregatorSettings) extends Aggregator(settings) {
     private var values = List.empty[AggrDatapoint]
-    inputDatapointsLimit = maxInputDatapoints
-    intermediateDatapointsLimit = maxIntermediateDatapoints
-    counter = registry.counter("atlas.eval.datapoints", "id", "dropped-datapoints-limit-exceeded")
-
-    // For this operator all inputs will be outputs.
-    override def numIntermediateDatapoints: Int = inputDatapointCounter
 
     override def aggregate(datapoint: AggrDatapoint): Aggregator = {
-      if (!inputOrIntermediateDatapointsAtLimitOrExceeded) {
+      if (!checkLimits) {
         values = datapoint :: values
-        inputDatapointCounter += 1
+        numInputDatapoints += 1
+        numIntermediateDatapoints += 1
       }
       this
     }
@@ -239,27 +231,14 @@ object AggrDatapoint {
     * Create a new aggregator instance initialized with the specified datapoint. The
     * datapoint will already be applied and should not get re-added to the aggregation.
     */
-  def newAggregator(
-    datapoint: AggrDatapoint,
-    maxInputDatapoints: Int,
-    maxIntermediateDatapoints: Int,
-    registry: Registry
-  ): Aggregator = {
+  def newAggregator(datapoint: AggrDatapoint, settings: AggregatorSettings): Aggregator = {
     datapoint.expr match {
       case af: AggregateFunction =>
-        new SimpleAggregator(
-          datapoint,
-          aggrOp(af),
-          maxInputDatapoints,
-          maxIntermediateDatapoints,
-          registry
-        )
+        new SimpleAggregator(datapoint, aggrOp(af), settings)
       case _: GroupBy =>
-        new GroupByAggregator(maxInputDatapoints, maxIntermediateDatapoints, registry)
-          .aggregate(datapoint)
+        new GroupByAggregator(settings).aggregate(datapoint)
       case _: All =>
-        new AllAggregator(maxInputDatapoints, maxIntermediateDatapoints, registry)
-          .aggregate(datapoint)
+        new AllAggregator(settings).aggregate(datapoint)
     }
   }
 
@@ -277,16 +256,11 @@ object AggrDatapoint {
     * Aggregate intermediate aggregates from each source to get the final aggregate for
     * a given expression. All values are expected to be for the same data expression.
     */
-  def aggregate(
-    values: List[AggrDatapoint],
-    maxInputDatapoints: Int,
-    maxIntermediateDatapoints: Int,
-    registry: Registry
-  ): Option[Aggregator] = {
+  def aggregate(values: List[AggrDatapoint], settings: AggregatorSettings): Option[Aggregator] = {
     if (values.isEmpty) Option.empty
     else {
       val vs = dedup(values)
-      val aggr = newAggregator(vs.head, maxInputDatapoints, maxIntermediateDatapoints, registry)
+      val aggr = newAggregator(vs.head, settings)
       val aggregator = vs.tail
         .foldLeft(aggr) { (acc, d) =>
           acc.aggregate(d)

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
@@ -53,8 +53,10 @@ private[stream] class TimeGrouped(
   private val numBuffers = context.numBuffers
 
   private val maxInputDatapointsPerExpression = context.maxInputDatapointsPerExpression
+
   private val maxIntermediateDatapointsPerExpression =
     context.maxIntermediateDatapointsPerExpression
+
   private val aggrSettings = AggrDatapoint.AggregatorSettings(
     maxInputDatapointsPerExpression,
     maxIntermediateDatapointsPerExpression,

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
@@ -65,6 +65,10 @@ class FinalExprEvalSuite extends FunSuite {
     new DataSource(id, java.time.Duration.ofMillis(step), uri)
   }
 
+  private def settings(maxInput: Int, maxIntermediate: Int): AggrDatapoint.AggregatorSettings = {
+    AggrDatapoint.AggregatorSettings(maxInput, maxIntermediate, registry)
+  }
+
   private def group(i: Long, vs: AggrDatapoint*): TimeGroup = {
     val timestamp = i * step
     val values = vs
@@ -72,7 +76,7 @@ class FinalExprEvalSuite extends FunSuite {
       .groupBy(_.expr)
       .map(t => {
         val aggr =
-          AggrDatapoint.aggregate(t._2.toList, Integer.MAX_VALUE, Integer.MAX_VALUE, registry).get
+          AggrDatapoint.aggregate(t._2.toList, settings(Integer.MAX_VALUE, Integer.MAX_VALUE)).get
         t._1 -> AggrValuesInfo(aggr.datapoints, aggr.numInputDatapoints)
       })
     TimeGroup(timestamp, step, values)


### PR DESCRIPTION
Before the counter and associated id was being created
each time an aggregator instance was. Now it is part of
a settings object which can be reused. The aggregators
have also been refactored a bit to reduce code duplication.