### PR TITLE
fix memory leak for failed streams

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/QueueHandler.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/QueueHandler.scala
@@ -48,8 +48,10 @@ class QueueHandler(streamMeta: StreamMetadata, queue: StreamOps.SourceQueue[Seq[
   }
 
   def complete(): Unit = {
-    logger.debug(s"queue complete for $id")
-    queue.complete()
+    if (queue.isOpen) {
+      logger.debug(s"queue complete for $id")
+      queue.complete()
+    }
   }
 
   override def toString: String = s"QueueHandler($id)"


### PR DESCRIPTION
The BroadcastHub doesn't complete if there are still items
pending. When the subscriber failed, the failure wasn't
propagated up since the BroadcastHub can have another
subscriber come along later. Change it to use a publisher
with no fanout, this will fail along with the connected
downstream.