### PR TITLE
enable fanout on the publisher

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
@@ -161,7 +161,7 @@ class SubscribeApi @Inject() (
     // Create queue to allow messages coming into /evaluate to be passed to this stream
     val (queue, pub) = StreamOps
       .blockingQueue[Seq[JsonSupport]](registry, "SubscribeApi", queueSize)
-      .toMat(Sink.asPublisher(false))(Keep.both)
+      .toMat(Sink.asPublisher(true))(Keep.both)
       .run()
 
     // Send initial setup messages


### PR DESCRIPTION
In some cases there will be multiple subscriptions. If
a downstream fails it will still get propagated and
cleanup the resources that came into the queue.