### PR TITLE
lwcapi: list streams if path ends with `/`

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamsApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamsApi.scala
@@ -34,14 +34,14 @@ class StreamsApi @Inject() (sm: StreamSubscriptionManager) extends WebApi {
 
   def routes: Route = {
     endpointPathPrefix("api" / "v1" / "streams") {
+      pathEndOrSingleSlash {
+        complete(Json.encode(sm.streamSummaries.map(_.metadata)))
+      } ~
       path(Remaining) { streamId =>
         sm.streamSummary(streamId) match {
           case Some(summary) => complete(Json.encode(summary))
           case None          => complete(notFound(streamId))
         }
-      } ~
-      pathEnd {
-        complete(Json.encode(sm.streamSummaries.map(_.metadata)))
       }
     }
   }


### PR DESCRIPTION
Update the matching logic to list for the end of the path
or a single slash. Before it would try to use an empty string
as the id which can be confusing.