### PR TITLE
use server group parser instead of frigga

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
@@ -19,9 +19,9 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import com.netflix.atlas.core.index.QueryIndex
-import com.netflix.frigga.Names
 import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.Registry
+import com.netflix.spectator.ipc.ServerGroup
 import com.typesafe.scalalogging.StrictLogging
 
 import scala.jdk.CollectionConverters._
@@ -233,13 +233,13 @@ class SubscriptionManager[T](registry: Registry) extends StrictLogging {
     * that are checked locally on the node.
     */
   def subscriptionsForCluster(cluster: String): List[Subscription] = {
-    val name = Names.parseName(cluster)
+    val group = ServerGroup.parse(cluster)
     val tags = Map.newBuilder[String, String]
-    tags += ("nf.cluster" -> name.getCluster)
-    if (name.getApp != null)
-      tags += ("nf.app" -> name.getApp)
-    if (name.getStack != null)
-      tags += ("nf.stack" -> name.getStack)
+    tags += ("nf.cluster" -> group.cluster)
+    if (group.app != null)
+      tags += ("nf.app" -> group.app)
+    if (group.stack != null)
+      tags += ("nf.stack" -> group.stack)
     queryIndex.matchingEntries(tags.result())
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,6 @@ lazy val `atlas-lwcapi` = project
   .dependsOn(`atlas-akka`, `atlas-akka-testkit` % "test", `atlas-core`, `atlas-eval`, `atlas-json`)
   .settings(libraryDependencies ++= Seq(
     Dependencies.iepNflxEnv,
-    Dependencies.frigga,
     Dependencies.akkaTestkit % "test",
     Dependencies.akkaHttpTestkit % "test",
     Dependencies.akkaStreamTestkit % "test"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,6 @@ object Dependencies {
   val caffeine          = "com.github.ben-manes.caffeine" % "caffeine" % "2.9.3"
   val datasketches      = "org.apache.datasketches" % "datasketches-java" % "3.1.0"
   val equalsVerifier    = "nl.jqno.equalsverifier" % "equalsverifier" % "3.9"
-  val frigga            = "com.netflix.frigga" % "frigga" % "0.25.0"
   val guiceCoreBase     = "com.google.inject" % "guice"
   val guiceMultiBase    = "com.google.inject.extensions" % "guice-multibindings"
   val iepGuice          = "com.netflix.iep" % "iep-guice" % iep


### PR DESCRIPTION
The spectator server group parser is more performant
and used with other observability tooling.