### PR TITLE
drop use of scala reflection for atlas-core

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -65,7 +65,6 @@ object Dependencies {
   val scalaLibrary      = "org.scala-lang" % "scala-library"
   val scalaLibraryAll   = "org.scala-lang" % "scala-library-all"
   val scalaLogging      = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4"
-  val scalaReflect      = "org.scala-lang" % "scala-reflect" % scala
   val slf4jApi          = "org.slf4j" % "slf4j-api" % slf4j
   val slf4jLog4j        = "org.slf4j" % "slf4j-log4j12" % slf4j
   val slf4jSimple       = "org.slf4j" % "slf4j-simple" % slf4j


### PR DESCRIPTION
Scala reflection libraries were removed in scala 3.
The only usage was for loading rule instances based on
a config entry. This can be done easily enough with the
normal java reflection.