### PR TITLE
fix compile and test errors on scala3

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
@@ -64,9 +64,10 @@ class MemoryDatabase(registry: Registry, config: Config) extends Database {
 
   private val stats = new IndexStats(registry)
 
-  val index = new BatchUpdateTagIndex[BlockStoreItem](registry, { items =>
-    new CachingTagIndex(new RoaringTagIndex(items, stats))
-  })
+  val index: BatchUpdateTagIndex[BlockStoreItem] =
+    new BatchUpdateTagIndex[BlockStoreItem](registry, { items =>
+      new CachingTagIndex(new RoaringTagIndex(items, stats))
+    })
 
   // If the last update time for the index is older than the rebuild age force an update
   private val rebuildAge = config.getDuration("rebuild-frequency", TimeUnit.MILLISECONDS)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
@@ -294,8 +294,8 @@ object Query {
 
     def matchesAny(tags: Map[String, List[String]]): Boolean = {
       tags match {
-        case ts: SmallHashMap[String, List[String]] =>
-          val vs = ts.getOrNull(k)
+        case ts: SmallHashMap[String, _] =>
+          val vs = ts.getOrNull(k).asInstanceOf[List[String]]
           vs != null && vs.exists(check)
         case _ =>
           tags.get(k).exists(_.exists(check))

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleVocabulary.scala
@@ -71,7 +71,7 @@ object StyleVocabulary extends Vocabulary {
 
     protected def executor: PartialFunction[List[Any], List[Any]] = {
       case (v: String) :: PresentationType(t) :: s =>
-        t.copy(settings = t.settings + (name -> v)) :: s
+        t.copy(settings = t.settings + (this.name -> v)) :: s
     }
 
     override def signature: String = "TimeSeriesExpr String -- StyleExpr"

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
@@ -70,7 +70,7 @@ object SmallHashMap {
 
     def addAll(m: Map[K, V]): Builder[K, V] = {
       m match {
-        case sm: SmallHashMap[K, V] =>
+        case sm: SmallHashMap[_, _] =>
           var i = 0
           while (i < sm.data.length) {
             val k = sm.data(i).asInstanceOf[K]

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathGroupBySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathGroupBySuite.scala
@@ -51,7 +51,7 @@ class MathGroupBySuite extends FunSuite {
       ts(2),
       ts(3)
     )
-    val rs = groupBy(input, List("name"), List("name"), MathExpr.Sum)
+    val rs = groupBy(input, List("name"), List("name"), MathExpr.Sum.apply)
     assertEquals(rs.size, 1)
 
     val expected = ts(6).withTags(Map("name" -> "test")).withLabel("(name=test)")
@@ -66,7 +66,7 @@ class MathGroupBySuite extends FunSuite {
     )
 
     val e = intercept[IllegalArgumentException] {
-      groupBy(input, List("name"), List("foo"), MathExpr.Sum)
+      groupBy(input, List("name"), List("foo"), MathExpr.Sum.apply)
     }
     assertEquals(e.getMessage, "requirement failed: (,foo,) is not a subset of (,name,)")
   }
@@ -77,7 +77,7 @@ class MathGroupBySuite extends FunSuite {
       ts(2),
       ts(3)
     )
-    val rs = groupBy(input, List("name", "mode"), List("mode"), MathExpr.Sum)
+    val rs = groupBy(input, List("name", "mode"), List("mode"), MathExpr.Sum.apply)
     assertEquals(rs.size, 2)
 
     val expected = List(
@@ -93,7 +93,8 @@ class MathGroupBySuite extends FunSuite {
       ts(2),
       ts(3)
     )
-    val rs = groupBy(input, List("name", "mode", "value"), List("name", "value"), MathExpr.Sum)
+    val rs =
+      groupBy(input, List("name", "mode", "value"), List("name", "value"), MathExpr.Sum.apply)
     assertEquals(rs.size, 3)
 
     val expected = List(
@@ -149,7 +150,7 @@ class MathGroupBySuite extends FunSuite {
       ts(2),
       ts(3)
     )
-    val rs = groupBy(input, List("value", "mode"), List("mode"), MathExpr.Count)
+    val rs = groupBy(input, List("value", "mode"), List("mode"), MathExpr.Count.apply)
     assertEquals(rs.size, 2)
 
     val expected = List(

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
@@ -228,7 +228,7 @@ class TimeSeriesExprSuite extends FunSuite {
       test(s"eval global: $prg") {
         val c = interpreter.execute(prg)
         assertEquals(c.stack.size, 1)
-        val expr = c.stack.collect { case ModelExtractors.TimeSeriesType(t) => t } head
+        val expr = c.stack.collect { case ModelExtractors.TimeSeriesType(t) => t }.head
         val rs = expr.eval(p.ctxt, p.input)
         assertEquals(rs.expr, expr)
         assertEquals(bounded(rs.data, p.ctxt), bounded(p.output, p.ctxt))
@@ -239,7 +239,7 @@ class TimeSeriesExprSuite extends FunSuite {
           test(s"eval incremental $label: $prg") {
             val c = interpreter.execute(prg)
             assertEquals(c.stack.size, 1)
-            val expr = c.stack.collect { case ModelExtractors.TimeSeriesType(t) => t } head
+            val expr = c.stack.collect { case ModelExtractors.TimeSeriesType(t) => t }.head
             val rs = expr.eval(p.ctxt, p.input)
             val ctxts = p.ctxt.partition(step, ChronoUnit.MINUTES)
             var state = Map.empty[StatefulExpr, Any]
@@ -273,7 +273,7 @@ class TimeSeriesExprSuite extends FunSuite {
       test(s"eval global: $prg") {
         val c = interpreter.execute(prg)
         assertEquals(c.stack.size, 1)
-        val expr = c.stack.collect { case ModelExtractors.PresentationType(t) => t } head
+        val expr = c.stack.collect { case ModelExtractors.PresentationType(t) => t }.head
         val rs = expr.expr.eval(p.ctxt, p.input)
         assertEquals(rs.expr, expr.expr)
         assertEquals(bounded(rs.data, p.ctxt), bounded(p.output, p.ctxt))

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/InterpreterSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/InterpreterSuite.scala
@@ -136,8 +136,11 @@ class InterpreterSuite extends FunSuite {
   }
 
   test("typeSummary: Primitive") {
-    // Why do all of these get coerced to doubles?
-    assertEquals(Interpreter.typeSummary(List(42, 42.0, 42L)), "[Double,Double,Double]")
+    // scala 2.x: List(42, 4.0, 42L) will coerce all the values to Double. explicit Any
+    // annotation needed to get expected values.
+    //
+    // scala 3.x: List(42, 4.0, 42L) works as expected with no type annotation
+    assertEquals(Interpreter.typeSummary(List[Any](42, 42.0, 42L)), "[Long,Double,Integer]")
     assertEquals(Interpreter.typeSummary(42 :: 42.0 :: 42L :: Nil), "[Long,Double,Integer]")
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/RefIntHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/RefIntHashMapSuite.scala
@@ -147,7 +147,7 @@ class RefIntHashMapSuite extends FunSuite {
     (0 until 10000).foreach { i =>
       val v = Random.nextInt()
       imap.put(v.toLong, i)
-      jmap.put(v, i)
+      jmap.put(v.toLong, i)
     }
     assertEquals(jmap.toMap, imap.toMap)
     assertEquals(jmap.size, imap.size)


### PR DESCRIPTION
Fixes some minor issues that cause compile errors on
scala3 for atlas-core. The atlas-core project now
compiles and all tests pass except for AlgoStateSuite
due to issues with atlas-json.