### PR TITLE
lwc: use asg for matching exprs to a cluster

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionSplitter.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionSplitter.scala
@@ -189,9 +189,9 @@ class ExpressionSplitter(config: Config) {
         // Rewrite exact match for nf.asg to an exact match for the nf.cluster. When
         // fetching expressions for a cluster, this will allow expressions with only
         // a check for the asg to get filtered appropriately.
-        case Query.Equal("nf.asg", asg) =>
+        case q @ Query.Equal("nf.asg", asg) =>
           val cluster = ServerGroup.parse(asg).cluster()
-          Query.Equal("nf.cluster", cluster)
+          if (cluster == null) q else Query.Equal("nf.cluster", cluster)
       }
       .rewrite {
         case kq: KeyQuery if !keepKeys.contains(kq.k) => Query.True

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionSplitter.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionSplitter.scala
@@ -16,7 +16,6 @@
 package com.netflix.atlas.lwcapi
 
 import java.util.concurrent.TimeUnit
-
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.netflix.atlas.core.model.CustomVocabulary
 import com.netflix.atlas.core.model.DataExpr
@@ -24,6 +23,7 @@ import com.netflix.atlas.core.model.ModelExtractors
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.Query.KeyQuery
 import com.netflix.atlas.core.stacklang.Interpreter
+import com.netflix.spectator.ipc.ServerGroup
 import com.typesafe.config.Config
 
 import scala.util.Failure
@@ -184,8 +184,20 @@ class ExpressionSplitter(config: Config) {
   }
 
   private[lwcapi] def compress(expr: Query): Query = {
-    val tmp = expr.rewrite { case kq: KeyQuery if !keepKeys.contains(kq.k) => Query.True }
-    simplify(tmp.asInstanceOf[Query])
+    val query = expr
+      .rewrite {
+        // Rewrite exact match for nf.asg to an exact match for the nf.cluster. When
+        // fetching expressions for a cluster, this will allow expressions with only
+        // a check for the asg to get filtered appropriately.
+        case Query.Equal("nf.asg", asg) =>
+          val cluster = ServerGroup.parse(asg).cluster()
+          Query.Equal("nf.cluster", cluster)
+      }
+      .rewrite {
+        case kq: KeyQuery if !keepKeys.contains(kq.k) => Query.True
+      }
+      .asInstanceOf[Query]
+    simplify(query)
   }
 }
 

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionSplitterSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionSplitterSuite.scala
@@ -101,6 +101,11 @@ class ExpressionSplitterSuite extends FunSuite {
     assertEquals(ret, Query.Equal("nf.cluster", "skan"))
   }
 
+  test("compress with bad nf.asg value") {
+    val ret = splitter.compress(Query.Equal("nf.asg", "--v001"))
+    assertEquals(ret, Query.True)
+  }
+
   test("compress removes arbitrary other equal comparisons") {
     val ret = splitter.compress(Query.Equal("xxx", "skan"))
     assertEquals(ret, Query.True)

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionSplitterSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionSplitterSuite.scala
@@ -96,6 +96,11 @@ class ExpressionSplitterSuite extends FunSuite {
     assertEquals(ret, Query.Equal("nf.cluster", "skan"))
   }
 
+  test("compress adds cluster condition based on nf.asg") {
+    val ret = splitter.compress(Query.Equal("nf.asg", "skan-v001"))
+    assertEquals(ret, Query.Equal("nf.cluster", "skan"))
+  }
+
   test("compress removes arbitrary other equal comparisons") {
     val ret = splitter.compress(Query.Equal("xxx", "skan"))
     assertEquals(ret, Query.True)


### PR DESCRIPTION
Some expressions have an exact match for `nf.asg`, but do
not have conditions for `nf.app` or `nf.cluster`. This change
will parse the asg value based on the server group naming
rules and add a cluster restriction so that expressions for
a specific asg will only show when requesting data for the
cluster containing that asg.