### PR TITLE
lwc: update operator validation

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -183,7 +183,7 @@ private[stream] class StreamContext(
     * Emit an error to the sources where the number of input
     * or intermediate datapoints exceed for an expression.
     */
-  def logDatapointsExceeded(timestamp: Long, dataExpr: DataExpr) = {
+  def logDatapointsExceeded(timestamp: Long, dataExpr: DataExpr): Unit = {
     val diagnosticMessage = DiagnosticMessage.error(
       s"expression: $dataExpr exceeded the configured max input datapoints limit" +
       s" '$maxInputDatapointsPerExpression' or max intermediate" +


### PR DESCRIPTION
Exclude operators that are confusing when used in a
streaming context. Specifically:

- `integral`: accumulates the value over the life of
  the evaluation. For a streaming evaluation the user
  has no way to know the time window it has been
  accumulating the value over.
- _Filters_: all filtering operators rely on statistics
  from the evaluation context to select the results.
  For streaming evaluation, that context is always a
  single step interval. Filtering is best left to the
  consumer of the data.