### PR TITLE
use sorted map when decoding tags

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/SortedTagMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/SortedTagMap.scala
@@ -133,6 +133,14 @@ final class SortedTagMap private (private val data: Array[String], private val l
   }
 
   /**
+    * Returns the size of the backing array. Since the array has keys and values, the array
+    * size will be twice the number of tuples it can hold.
+    */
+  private[util] def backingArraySize: Int = {
+    data.length
+  }
+
+  /**
     * Overridden to get better performance.
     */
   override def hashCode: Int = {
@@ -355,6 +363,19 @@ object SortedTagMap {
       val map = createUnsafe(buf, pos)
       buf = null
       map
+    }
+
+    /**
+      * Same as result except that it will ensure the backing array is sized to exactly
+      * fit the data.
+      */
+    def compact(): SortedTagMap = {
+      if (pos < buf.length) {
+        val tmp = new Array[String](pos)
+        System.arraycopy(buf, 0, tmp, 0, pos)
+        buf = tmp
+      }
+      result()
     }
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/SortedTagMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/SortedTagMapSuite.scala
@@ -190,6 +190,32 @@ class SortedTagMapSuite extends FunSuite {
     assert(b.compareTo(a) > 0)
   }
 
+  test("builder: compact result") {
+    val expected = SortedTagMap
+      .builder(50)
+      .add("a", "1")
+      .add("b", "2")
+      .result()
+    val actual = SortedTagMap
+      .builder(50)
+      .add("a", "1")
+      .add("b", "2")
+      .compact()
+    assertEquals(actual, expected)
+    assertEquals(actual.backingArraySize, 4)
+  }
+
+  test("builder: compact result, no change") {
+    val expected = SortedTagMap("a" -> "1", "b" -> "2")
+    val actual = SortedTagMap
+      .builder(2)
+      .add("a", "1")
+      .add("b", "2")
+      .compact()
+    assertEquals(actual, expected)
+    assertEquals(actual.backingArraySize, 4)
+  }
+
   test("equals contract") {
     val a = SortedTagMap(Array("a", "1", "b", "2"))
     val b = SortedTagMap(Array("a", "1", "b", "2", "c", "3"))


### PR DESCRIPTION
This is typically more efficient overall as it avoids
the need to sort multiple times later on. For example,
in publish the sort is needed for computing the ids
and then ends up getting performed again to encode
as a compact batch.