### PR TITLE
ensure map keys are deduped

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/SortedTagMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/SortedTagMapSuite.scala
@@ -72,6 +72,24 @@ class SortedTagMapSuite extends FunSuite {
     assertEquals(m.toList, pairs)
   }
 
+  test("apply: array with duplicates") {
+    val actual = SortedTagMap(Array("a", "1", "b", "2", "a", "3"))
+    val expected = SortedTagMap("a" -> "3", "b" -> "2")
+    assertEquals(actual, expected)
+  }
+
+  test("apply: varargs tuples with duplicates") {
+    val actual = SortedTagMap("a" -> "1", "b" -> "2", "a" -> "3")
+    val expected = SortedTagMap("a" -> "3", "b" -> "2")
+    assertEquals(actual, expected)
+  }
+
+  test("apply: varargs tuples with duplicates") {
+    val actual = SortedTagMap(List("a" -> "1", "b" -> "2", "a" -> "3"))
+    val expected = SortedTagMap("a" -> "3", "b" -> "2")
+    assertEquals(actual, expected)
+  }
+
   test("equals") {
     val input = scala.util.Random.shuffle(pairs)
     val actual: Map[String, String] = SortedTagMap(input)
@@ -98,6 +116,13 @@ class SortedTagMapSuite extends FunSuite {
     val expected = SortedTagMap(input)
     assertEquals(actual, expected)
     assert(actual.isInstanceOf[SortedTagMap])
+  }
+
+  test("updates: combining maps") {
+    val m1 = SortedTagMap("a" -> "1", "b" -> "2", "c" -> "3")
+    val m2 = SortedTagMap("a" -> "4", "b" -> "5", "d" -> "6")
+    val expected = SortedTagMap("a" -> "4", "b" -> "5", "c" -> "3", "d" -> "6")
+    assertEquals(m1 ++ m2, expected)
   }
 
   @scala.annotation.tailrec
@@ -188,6 +213,28 @@ class SortedTagMapSuite extends FunSuite {
     val b = SortedTagMap(Array("a", "1", "b", "2", "c", "3"))
     assert(a.compareTo(b) < 0)
     assert(b.compareTo(a) > 0)
+  }
+
+  test("builder: duplicates result") {
+    val m1 = SortedTagMap("a" -> "1", "b" -> "2", "c" -> "3")
+    val m2 = SortedTagMap("a" -> "4", "b" -> "5", "d" -> "6")
+    val actual = SortedTagMap.builder()
+      .addAll(m1)
+      .addAll(m2)
+      .result()
+    val expected = SortedTagMap("a" -> "4", "b" -> "5", "c" -> "3", "d" -> "6")
+    assertEquals(actual, expected)
+  }
+
+  test("builder: duplicates compact") {
+    val m1 = SortedTagMap("a" -> "1", "b" -> "2", "c" -> "3")
+    val m2 = SortedTagMap("a" -> "4", "b" -> "5", "d" -> "6")
+    val actual = SortedTagMap.builder()
+      .addAll(m1)
+      .addAll(m2)
+      .result()
+    val expected = SortedTagMap("a" -> "4", "b" -> "5", "c" -> "3", "d" -> "6")
+    assertEquals(actual, expected)
   }
 
   test("builder: compact result") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/SortedTagMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/SortedTagMapSuite.scala
@@ -79,7 +79,7 @@ class SortedTagMapSuite extends FunSuite {
   }
 
   test("apply: varargs tuples with duplicates") {
-    val actual = SortedTagMap("a" -> "1", "b" -> "2", "a" -> "3")
+    val actual = SortedTagMap("a"   -> "1", "b" -> "2", "a" -> "3")
     val expected = SortedTagMap("a" -> "3", "b" -> "2")
     assertEquals(actual, expected)
   }
@@ -119,8 +119,8 @@ class SortedTagMapSuite extends FunSuite {
   }
 
   test("updates: combining maps") {
-    val m1 = SortedTagMap("a" -> "1", "b" -> "2", "c" -> "3")
-    val m2 = SortedTagMap("a" -> "4", "b" -> "5", "d" -> "6")
+    val m1 = SortedTagMap("a"       -> "1", "b" -> "2", "c" -> "3")
+    val m2 = SortedTagMap("a"       -> "4", "b" -> "5", "d" -> "6")
     val expected = SortedTagMap("a" -> "4", "b" -> "5", "c" -> "3", "d" -> "6")
     assertEquals(m1 ++ m2, expected)
   }
@@ -218,7 +218,8 @@ class SortedTagMapSuite extends FunSuite {
   test("builder: duplicates result") {
     val m1 = SortedTagMap("a" -> "1", "b" -> "2", "c" -> "3")
     val m2 = SortedTagMap("a" -> "4", "b" -> "5", "d" -> "6")
-    val actual = SortedTagMap.builder()
+    val actual = SortedTagMap
+      .builder()
       .addAll(m1)
       .addAll(m2)
       .result()
@@ -229,7 +230,8 @@ class SortedTagMapSuite extends FunSuite {
   test("builder: duplicates compact") {
     val m1 = SortedTagMap("a" -> "1", "b" -> "2", "c" -> "3")
     val m2 = SortedTagMap("a" -> "4", "b" -> "5", "d" -> "6")
-    val actual = SortedTagMap.builder()
+    val actual = SortedTagMap
+      .builder()
       .addAll(m1)
       .addAll(m2)
       .result()


### PR DESCRIPTION
Fixes SortedTagMap to address some update patterns
that could result in duplicate keys.