### PR TITLE
fix common grouping for aggr helpers

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -475,7 +475,7 @@ object MathVocabulary extends Vocabulary {
 
     private def addCommonKeys(expr: TimeSeriesExpr, keys: List[String]): TimeSeriesExpr = {
       val newExpr = expr.rewrite {
-        case nr: NamedRewrite =>
+        case nr @ MathExpr.NamedRewrite(_, _: Query, _, _, _) =>
           nr.copy(evalExpr = addCommonKeys(nr.evalExpr, keys))
         case af: AggregateFunction =>
           DataExpr.GroupBy(af, keys)


### PR DESCRIPTION
Updates the rewrite used for math functions that behave
like aggregation functions, e.g. `:avg`, so that the
rewrite works correctly when the display expression is
a `Query`. Before it would always apply the rewrite to
just the eval expression which could lead to a different
and sometimes broken expression if reinterpreted from
the display expression.