### PR TITLE
fix cg with custom averages

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -475,8 +475,10 @@ object MathVocabulary extends Vocabulary {
 
     private def addCommonKeys(expr: TimeSeriesExpr, keys: List[String]): TimeSeriesExpr = {
       val newExpr = expr.rewrite {
+        case nr @ MathExpr.NamedRewrite(_, _: Query, e, _, _) if e.isGrouped =>
+          nr.copy(evalExpr = addCommonKeys(e, keys))
         case nr @ MathExpr.NamedRewrite(_, _: Query, _, _, _) =>
-          nr.copy(evalExpr = addCommonKeys(nr.evalExpr, keys))
+          nr.groupBy(keys)
         case af: AggregateFunction =>
           DataExpr.GroupBy(af, keys)
         case e: DataExpr.GroupBy =>

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/NamedRewriteSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/NamedRewriteSuite.scala
@@ -16,7 +16,6 @@
 package com.netflix.atlas.core.model
 
 import java.time.Duration
-
 import com.netflix.atlas.core.stacklang.Interpreter
 import com.typesafe.config.ConfigFactory
 import munit.FunSuite
@@ -268,6 +267,24 @@ class NamedRewriteSuite extends FunSuite {
     val exprs = rawEval("name,a,:eq,:avg,:list,(,(,c,),:cg,),:each")
     val exprs2 = rawEval(exprs.mkString(","))
     val expected = rawEval("name,a,:eq,:avg,(,c,),:by")
+    assertEquals(exprs, expected)
+    assertEquals(exprs2, expected)
+  }
+
+  test("named rewrite, custom avg and cg") {
+    val q = "name,foo,:eq"
+    val exprs = rawEval(s"$q,(,a,b,),:by,$q,:node-avg,:lt,:sum,(,a,),:by,(,c,),:cg")
+    val exprs2 = rawEval(exprs.mkString(","))
+    val expected = rawEval(s"$q,(,a,b,c,),:by,$q,:node-avg,(,c,),:by,:lt,(,a,c,),:by")
+    assertEquals(exprs, expected)
+    assertEquals(exprs2, expected)
+  }
+
+  test("named rewrite, des and cg") {
+    val q = "name,foo,:eq"
+    val exprs = rawEval(s"$q,(,a,),:by,:des-fast,(,b,),:cg")
+    val exprs2 = rawEval(exprs.mkString(","))
+    val expected = rawEval(s"$q,(,a,b,),:by,:des-fast")
     assertEquals(exprs, expected)
     assertEquals(exprs2, expected)
   }


### PR DESCRIPTION
The subset check for nested grouping would check all
data expressions. If the underlying expression was
combined with binary operations with the grouping for
one side being a subset of the other, then a subsequent
grouping operation could fail the check. Now it checks
based on the final grouping of the pre-aggregate.