### PR TITLE
fix `:cg` with non-grouped math aggregate

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -661,7 +661,7 @@ object MathExpr {
     }
   }
 
-  trait AggrMathExpr extends TimeSeriesExpr {
+  sealed trait AggrMathExpr extends TimeSeriesExpr {
 
     def name: String
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathGroupBySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathGroupBySuite.scala
@@ -307,4 +307,13 @@ class MathGroupBySuite extends FunSuite {
     val exprExplicit = eval(inputExplicit)
     assertEquals(expr.toString, exprExplicit.toString)
   }
+
+  test("cg with non-grouped math aggr") {
+    val input = "name,foo,:eq,:sum,(,a,),:by,5,:mul,:sum,(,b,),:cg"
+    val inputExplicit = "name,foo,:eq,:sum,(,a,b,),:by,5,:mul,:sum,(,b,),:by"
+
+    val expr = eval(input)
+    val exprExplicit = eval(inputExplicit)
+    assertEquals(expr.toString, exprExplicit.toString)
+  }
 }


### PR DESCRIPTION
If there was an aggregation of a group by result that
was not grouped, then it was not getting the common
grouping applied.