### PR TITLE
LWC API: Move the termination watch to the root flow in order to catch

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/QueueHandler.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/QueueHandler.scala
@@ -50,7 +50,13 @@ class QueueHandler(streamMeta: StreamMetadata, queue: StreamOps.SourceQueue[Seq[
   def complete(): Unit = {
     if (queue.isOpen) {
       logger.debug(s"queue complete for $id")
-      queue.complete()
+      try {
+        queue.complete()
+      } catch {
+        // Thrown if the queue is already closed. Can happen when a websocket
+        // connects but doesn't send a message. See SubscribeApi#register
+        case _: IllegalStateException => // no-op
+      }
     }
   }
 

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/WebSocketSessionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/WebSocketSessionManager.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.lwcapi
 
+import akka.NotUsed
 import akka.stream.Attributes
 import akka.stream.FlowShape
 import akka.stream.Inlet
@@ -41,21 +42,21 @@ import scala.util.control.NonFatal
   */
 private[lwcapi] class WebSocketSessionManager(
   val streamMeta: StreamMetadata,
-  val registerFunc: StreamMetadata => (QueueHandler, Source[JsonSupport, Unit]),
+  val registerFunc: StreamMetadata => (QueueHandler, Source[JsonSupport, NotUsed]),
   val subscribeFunc: (String, List[ExpressionMetadata]) => List[ErrorMsg]
-) extends GraphStage[FlowShape[AnyRef, Source[JsonSupport, Unit]]]
+) extends GraphStage[FlowShape[AnyRef, Source[JsonSupport, NotUsed]]]
     with StrictLogging {
   private val in = Inlet[AnyRef]("WebSocketSessionManager.in")
-  private val out = Outlet[Source[JsonSupport, Unit]]("WebSocketSessionManager.out")
+  private val out = Outlet[Source[JsonSupport, NotUsed]]("WebSocketSessionManager.out")
 
-  override val shape: FlowShape[AnyRef, Source[JsonSupport, Unit]] = FlowShape(in, out)
+  override val shape: FlowShape[AnyRef, Source[JsonSupport, NotUsed]] = FlowShape(in, out)
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
     new GraphStageLogic(shape) with InHandler with OutHandler {
 
       var dataSourcePushed = false
       var queueHandler: QueueHandler = _
-      var dataSource: Source[JsonSupport, Unit] = _
+      var dataSource: Source[JsonSupport, NotUsed] = _
 
       setHandlers(in, out, this)
 

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/WebSocketSessionManagerSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/WebSocketSessionManagerSuite.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.lwcapi
 
+import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
@@ -72,7 +73,7 @@ class WebSocketSessionManagerSuite extends FunSuite {
 
   private def run(
     data: List[String],
-    registerFunc: StreamMetadata => (QueueHandler, Source[JsonSupport, Unit]),
+    registerFunc: StreamMetadata => (QueueHandler, Source[JsonSupport, NotUsed]),
     subscribeFunc: (String, List[ExpressionMetadata]) => List[ErrorMsg]
   ): List[String] = {
     val future = Source(data)
@@ -95,12 +96,12 @@ class WebSocketSessionManagerSuite extends FunSuite {
   }
 
   private def createNoopRegisterFunc()
-    : StreamMetadata => (QueueHandler, Source[JsonSupport, Unit]) = {
+    : StreamMetadata => (QueueHandler, Source[JsonSupport, NotUsed]) = {
     val noopQueueHandler = new QueueHandler(StreamMetadata(""), null) {
       override def offer(msgs: Seq[JsonSupport]): Unit = ()
       override def complete(): Unit = ()
     }
-    val noopSource = Source.empty[JsonSupport].mapMaterializedValue(_ => ())
+    val noopSource = Source.empty[JsonSupport].mapMaterializedValue(_ => (NotUsed))
     val noopRegisterFunc = (_: StreamMetadata) => (noopQueueHandler, noopSource)
 
     noopRegisterFunc


### PR DESCRIPTION
improperly terminated clients.
Also add a TODO about dealing with clients that connect and fail to send
a message wherein the queue shuts down after a timeout period and fails to
notify the rest of the flow.