### PR TITLE
lwcapi: remove the /v1/subscribe endpoint

### DIFF
--- a/atlas-eval/src/main/resources/reference.conf
+++ b/atlas-eval/src/main/resources/reference.conf
@@ -31,7 +31,7 @@ atlas.eval {
     ]
 
     // Which version of the LWC server API to use
-    lwcapi-version = 1
+    lwcapi-version = 2
   }
 
   graph {

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
@@ -26,7 +26,6 @@ import com.netflix.atlas.eval.model.LwcExpression
 import com.netflix.atlas.eval.model.LwcHeartbeat
 import com.netflix.atlas.eval.model.LwcMessages
 import com.netflix.atlas.eval.model.LwcSubscription
-import com.netflix.atlas.json.Json
 import com.netflix.spectator.api.NoopRegistry
 import com.typesafe.config.ConfigFactory
 
@@ -51,45 +50,6 @@ class SubscribeApiSuite extends MUnitRouteSuite {
   //
   // Subscribe websocket
   //
-
-  private def parse(msg: Message): AnyRef = {
-    LwcMessages.parse(msg.asTextMessage.getStrictText)
-  }
-
-  test("subscribe websocket") {
-    val client = WSProbe()
-    WS("/api/v1/subscribe/111", client.flow) ~> routes ~> check {
-      assert(isWebSocketUpgrade)
-
-      // Send list of expressions to subscribe to
-      val exprs = List(LwcExpression("name,cpu,:eq,:avg", 60000))
-      client.sendMessage(Json.encode(exprs))
-
-      // Look for subscription messages, one for sum and one for count
-      var subscriptions = List.empty[LwcSubscription]
-      while (subscriptions.size < 2) {
-        parse(client.expectMessage()) match {
-          case _: DiagnosticMessage =>
-          case sub: LwcSubscription => subscriptions = sub :: subscriptions
-          case h: LwcHeartbeat      => assertEquals(h.step, 60000L)
-          case v                    => throw new MatchError(v)
-        }
-      }
-
-      // Verify subscription is in the manager, push a message to the queue check that it
-      // is received by the client
-      assertEquals(subscriptions.flatMap(_.metrics).size, 2)
-      subscriptions.flatMap(_.metrics).foreach { m =>
-        val tags = Map("name" -> "cpu")
-        val datapoint = LwcDatapoint(60000, m.id, tags, 42.0)
-        val handlers = sm.handlersForSubscription(m.id)
-        assertEquals(handlers.size, 1)
-        handlers.head.offer(Seq(datapoint))
-
-        assertEquals(parse(client.expectMessage()), datapoint)
-      }
-    }
-  }
 
   private def parseBatch(msg: Message): List[AnyRef] = {
     LwcMessages.parseBatch(msg.asBinaryMessage.getStrictData)


### PR DESCRIPTION
This was an earlier version that relied used unbatched
text messages for passing the data and was much less
efficient. It is no longer in use internally.