### PR TITLE
fix shard lookup for Integer.MIN_VALUE

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Shards.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Shards.scala
@@ -147,13 +147,13 @@ object Shards {
 
     /** Return the instance that should receive the data associated with `id`. */
     def instanceForId(id: BigInteger): T = {
-      val i = math.abs(id.intValue())
+      val i = nonNegative(id.intValue())
       instanceForIndex(i)
     }
 
     /** Return the instance that should receive the data associated with `id`. */
     def instanceForId(id: ItemId): T = {
-      val i = math.abs(id.intValue)
+      val i = nonNegative(id.intValue)
       instanceForIndex(i)
     }
 
@@ -176,7 +176,7 @@ object Shards {
 
     /** Return true if this instance should include data for `id`. */
     def containsId(id: BigInteger): Boolean = {
-      val i = math.abs(id.intValue())
+      val i = nonNegative(id.intValue())
       containsIndex(i)
     }
 
@@ -196,7 +196,7 @@ object Shards {
 
     /** Return the instances that should receive the data associated with `id`. */
     def instancesForId(id: BigInteger): List[T] = {
-      val i = math.abs(id.intValue())
+      val i = nonNegative(id.intValue())
       instancesForIndex(i)
     }
 
@@ -208,5 +208,13 @@ object Shards {
         group.instances((i / groups.length) % group.size)
       }
     }
+  }
+
+  /**
+    * Returns the absolute value for the number unless it is Integer.MIN_VALUE, in which case
+    * it will return 0.
+    */
+  private[util] def nonNegative(v: Int): Int = {
+    math.abs(v) & 0x7fffffff
   }
 }


### PR DESCRIPTION
Before it was relying on `abs` to get a non-negative value
for computing an index to the array. This breaks when the
int value of the id is `Integer.MIN_VALUE`. Update it to
explicitly clear the sign bit to ensure the value will
always be non-negative.