### PR TITLE
1.6: fix shard lookup for Integer.MIN_VALUE

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Shards.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Shards.scala
@@ -144,7 +144,7 @@ object Shards {
 
     /** Return the instance that should receive the data associated with `id`. */
     def instanceForId(id: BigInteger): T = {
-      val i = math.abs(id.intValue())
+      val i = nonNegative(id.intValue())
       instanceForIndex(i)
     }
 
@@ -164,7 +164,7 @@ object Shards {
 
     /** Return true if this instance should include data for `id`. */
     def containsId(id: BigInteger): Boolean = {
-      val i = math.abs(id.intValue())
+      val i = nonNegative(id.intValue())
       containsIndex(i)
     }
 
@@ -184,7 +184,7 @@ object Shards {
 
     /** Return the instances that should receive the data associated with `id`. */
     def instancesForId(id: BigInteger): List[T] = {
-      val i = math.abs(id.intValue())
+      val i = nonNegative(id.intValue())
       instancesForIndex(i)
     }
 
@@ -196,5 +196,13 @@ object Shards {
         group.instances((i / groups.length) % group.size)
       }
     }
+  }
+
+  /**
+    * Returns the absolute value for the number unless it is Integer.MIN_VALUE, in which case
+    * it will return 0.
+    */
+  private[util] def nonNegative(v: Int): Int = {
+    math.abs(v) & 0x7fffffff
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/ShardsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/ShardsSuite.scala
@@ -15,9 +15,12 @@
  */
 package com.netflix.atlas.core.util
 
-import java.util.UUID
+import com.netflix.atlas.core.model.ItemId
 
 import org.scalatest.FunSuite
+
+import java.util.UUID
+import java.util.Random
 
 class ShardsSuite extends FunSuite {
 
@@ -93,6 +96,15 @@ class ShardsSuite extends FunSuite {
       assert(max - avg <= threshold)
       assert(avg - min <= threshold)
     }
+  }
+
+  test("intValue of bigint is Integer.MIN_VALUE") {
+    // Verify it doesn't fail with:
+    // java.lang.IllegalArgumentException: requirement failed: index cannot be negative
+    val id = ItemId("016adce025b0485b9f581d071961de1480000000").toBigInteger
+    val groups = createGroups(10, 10)
+    val mapper = Shards.mapper(groups)
+    mapper.instanceForId(id)
   }
 
   test("uneven groups") {
@@ -228,5 +240,24 @@ class ShardsSuite extends FunSuite {
     var sum = 0
     counts.foreach((_, v) => sum += v)
     assert(sum >= 20000 + 20000 / 3)
+  }
+
+  test("nonNegative max") {
+    assert(Shards.nonNegative(Integer.MAX_VALUE) === Integer.MAX_VALUE)
+  }
+
+  test("nonNegative min") {
+    assert(Shards.nonNegative(Integer.MIN_VALUE) === 0)
+  }
+
+  test("nonNegative random") {
+    val r = new Random()
+    (0 until 10000).foreach { i =>
+      val v = r.nextInt()
+      assert(Shards.nonNegative(v) >= 0)
+      if (v != Integer.MIN_VALUE) {
+        assert(Shards.nonNegative(v) === math.abs(v))
+      }
+    }
   }
 }


### PR DESCRIPTION
Back port of #1452.

Before it was relying on `abs` to get a non-negative value
for computing an index to the array. This breaks when the
int value of the id is `Integer.MIN_VALUE`. Update it to
explicitly clear the sign bit to ensure the value will
always be non-negative.