### PR TITLE
reduce allocations for ItemId.toString

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/ItemId.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/ItemId.scala
@@ -56,14 +56,14 @@ class ItemId private (private val data: Array[Byte], private val hc: Int)
   }
 
   override def toString: String = {
-    val buffer = new StringBuilder
+    val buffer = new java.lang.StringBuilder(data.length * 2)
     var i = 0
     while (i < data.length) {
       val unsigned = java.lang.Byte.toUnsignedInt(data(i))
       buffer.append(ItemId.hexValueForByte(unsigned))
       i += 1
     }
-    buffer.toString()
+    buffer.toString
   }
 
   def toBigInteger: BigInteger = new BigInteger(1, data)

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/model/ItemIdToString.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/model/ItemIdToString.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.util.Random
+
+/**
+  * ```
+  * > jmh:run -prof gc -prof stack -wi 5 -i 10 -f1 -t1 .*ItemIdToString.*
+  * ...
+  * Benchmark                             Mode  Cnt        Score       Error   Units
+  * runToString                          thrpt   10  6502790.539 ± 84203.781   ops/s
+  * runToString:·gc.alloc.rate           thrpt   10     1275.402 ±    16.731  MB/sec
+  * runToString:·gc.alloc.rate.norm      thrpt   10      216.000 ±     0.001    B/op
+  * ```
+  */
+@State(Scope.Thread)
+class ItemIdToString {
+
+  private val id = ItemId(Random.nextBytes(20))
+
+  @Benchmark
+  def runToString(bh: Blackhole): Unit = {
+    bh.consume(id.toString)
+  }
+}


### PR DESCRIPTION
Initialize capacity for the builder to avoid a resize while filling the buffer. Reduces allocations for the sample benchmark from 440 B/op to 216 B/op.