### PR TITLE
avoid calling sort for SortedTagMap

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/ItemIdCalculator.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/ItemIdCalculator.scala
@@ -70,6 +70,7 @@ class ItemIdCalculator {
           iter.nextEntry()
           pos += 2
         }
+        ArrayHelper.sortPairs(pairs, length)
       case _ =>
         var pos = 0
         tags.foreachEntry { (k, v) =>
@@ -77,9 +78,9 @@ class ItemIdCalculator {
           pairs(pos + 1) = v
           pos += 2
         }
+        ArrayHelper.sortPairs(pairs, length)
     }
 
-    ArrayHelper.sortPairs(pairs, length)
     pairs
   }
 


### PR DESCRIPTION
When computing the id from a tag map, avoid making the sort call when a SortedTagMap is used. That type will already be sorted so it is not necessary.