### PR TITLE
adjust consolidation behavior for rates

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/TimeSeriesBufferSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/TimeSeriesBufferSuite.scala
@@ -21,6 +21,7 @@ import com.netflix.atlas.core.model.Block
 import com.netflix.atlas.core.model.ConsolidationFunction
 import com.netflix.atlas.core.model.ConstantBlock
 import com.netflix.atlas.core.model.DsType
+import com.netflix.atlas.core.model.TagKey
 import com.netflix.atlas.core.util.Math
 import nl.jqno.equalsverifier.EqualsVerifier
 import nl.jqno.equalsverifier.Warning
@@ -488,6 +489,24 @@ class TimeSeriesBufferSuite extends FunSuite {
 
     val b5 = TimeSeriesBuffer(emptyTags, 300000, start, Array(15.0))
     assertEquals(b.consolidate(5, ConsolidationFunction.Sum), b5)
+  }
+
+  test("consolidate NaN, avg with a rate") {
+    val start = 1366746900000L
+    val tags = Map(TagKey.dsType -> "rate")
+    val b = TimeSeriesBuffer(tags, 60000, start, Array(1.0, 2.0, Double.NaN, 4.0, 5.0))
+
+    val b5 = TimeSeriesBuffer(tags, 300000, start, Array(12.0 / 5.0))
+    assertEquals(b.consolidate(5, ConsolidationFunction.Avg), b5)
+  }
+
+  test("consolidate NaN, avg with gauge") {
+    val start = 1366746900000L
+    val tags = Map(TagKey.dsType -> "gauge")
+    val b = TimeSeriesBuffer(tags, 60000, start, Array(1.0, 2.0, Double.NaN, 4.0, 5.0))
+
+    val b5 = TimeSeriesBuffer(tags, 300000, start, Array(12.0 / 4.0))
+    assertEquals(b.consolidate(5, ConsolidationFunction.Avg), b5)
   }
 
   test("normalize") {


### PR DESCRIPTION
Port an old internal fix to ensure we have consistent behavior. If the data source type is a rate, then treat NaN values as 0 as it means no activity measured for those intervals when consolidating. That means the avg will always be computed over the entire consolidated interval.

For gauges, the NaN values are ignored because to be consistent with values reported to the gauge. The
behavior of gauges is not impacted with this change.