### PR TITLE
make default dstype consistent

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/TimeSeriesBuffer.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/TimeSeriesBuffer.scala
@@ -35,7 +35,7 @@ object TimeSeriesBuffer {
     start: Long,
     vs: Array[Double]
   ): TimeSeriesBuffer = {
-    new TimeSeriesBuffer(tags, new ArrayTimeSeq(dsType(tags), start / step * step, step, vs))
+    new TimeSeriesBuffer(tags, new ArrayTimeSeq(DsType(tags), start / step * step, step, vs))
   }
 
   def apply(tags: Map[String, String], step: Long, start: Long, end: Long): TimeSeriesBuffer = {
@@ -44,7 +44,7 @@ object TimeSeriesBuffer {
 
     val size = (e - s).toInt + 1
     val buffer = ArrayHelper.fill(size, Double.NaN)
-    new TimeSeriesBuffer(tags, new ArrayTimeSeq(dsType(tags), s * step, step, buffer))
+    new TimeSeriesBuffer(tags, new ArrayTimeSeq(DsType(tags), s * step, step, buffer))
   }
 
   def apply(
@@ -65,11 +65,7 @@ object TimeSeriesBuffer {
       fill(block, buffer, step, s, e, aggr)
     }
 
-    new TimeSeriesBuffer(tags, new ArrayTimeSeq(dsType(tags), start, step, buffer))
-  }
-
-  private def dsType(tags: Map[String, String]): DsType = {
-    DsType(tags.getOrElse(TagKey.dsType, "gauge"))
+    new TimeSeriesBuffer(tags, new ArrayTimeSeq(DsType(tags), start, step, buffer))
   }
 
   private def fill(

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/TimeSeriesBuffer.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/TimeSeriesBuffer.scala
@@ -21,7 +21,6 @@ import com.netflix.atlas.core.model.ConsolidationFunction
 import com.netflix.atlas.core.model.DsType
 import com.netflix.atlas.core.model.LazyTaggedItem
 import com.netflix.atlas.core.model.MapStepTimeSeq
-import com.netflix.atlas.core.model.TagKey
 import com.netflix.atlas.core.model.TimeSeq
 import com.netflix.atlas.core.model.TimeSeries
 import com.netflix.atlas.core.util.ArrayHelper
@@ -504,7 +503,7 @@ final class TimeSeriesBuffer(var tags: Map[String, String], val data: ArrayTimeS
         buffer(i) = buf.getValue(start + i * step)
         i += 1
       }
-      new TimeSeriesBuffer(tags, new ArrayTimeSeq(DsType.Gauge, start / step * step, step, buffer))
+      new TimeSeriesBuffer(tags, new ArrayTimeSeq(dsType, start / step * step, step, buffer))
     }
   }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DsType.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DsType.scala
@@ -21,10 +21,8 @@ object DsType {
 
   def apply(key: String): DsType = {
     key match {
-      case "counter" => Rate
-      case "rate"    => Rate
       case "gauge"   => Gauge
-      case _         => Gauge
+      case _         => Rate  // counter, rate, sum
     }
   }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DsType.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DsType.scala
@@ -21,8 +21,8 @@ object DsType {
 
   def apply(key: String): DsType = {
     key match {
-      case "gauge"   => Gauge
-      case _         => Rate  // counter, rate, sum
+      case "gauge" => Gauge
+      case _       => Rate // counter, rate, sum
     }
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
@@ -90,11 +90,11 @@ class MemoryDatabaseSuite extends FunSuite {
   }
 
   private def ts(label: String, mul: Int, values: Double*): TimeSeries = {
-    TimeSeries(Map.empty, label, new ArrayTimeSeq(DsType.Gauge, 0L, mul * step, values.toArray))
+    TimeSeries(Map.empty, label, new ArrayTimeSeq(DsType.Rate, 0L, mul * step, values.toArray))
   }
 
   private def ts(name: String, label: String, mul: Int, values: Double*): TimeSeries = {
-    val seq = new ArrayTimeSeq(DsType.Gauge, 0L, mul * step, values.toArray)
+    val seq = new ArrayTimeSeq(DsType.Rate, 0L, mul * step, values.toArray)
     TimeSeries(Map("name" -> name, "foo" -> "bar"), label, seq)
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/TimeSeriesBufferSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/TimeSeriesBufferSuite.scala
@@ -509,16 +509,30 @@ class TimeSeriesBufferSuite extends FunSuite {
     assertEquals(b.consolidate(5, ConsolidationFunction.Avg), b5)
   }
 
-  test("normalize") {
+  test("normalize rate") {
     val start = 1366746900000L
     val b1 = TimeSeriesBuffer(emptyTags, 60000, start, Array(1.0, 2.0, 3.0, 4.0, 5.0))
-    val b1e = TimeSeriesBuffer(emptyTags, 120000, start, Array(1.0, 2.5, 4.5))
+    val b1e = TimeSeriesBuffer(emptyTags, 120000, start, Array(0.5, 2.5, 4.5))
     assertEquals(b1.normalize(60000, start, 5), b1)
     assertEquals(b1.normalize(120000, start, 3), b1e)
 
     val b2 = TimeSeriesBuffer(emptyTags, 120000, start, Array(3.0, 7.0))
     val b2e =
       TimeSeriesBuffer(emptyTags, 60000, start, Array(3.0, 7.0, 7.0, Double.NaN, Double.NaN))
+    assertEquals(b2.normalize(60000, start, 5), b2e)
+  }
+
+  test("normalize gauge") {
+    val start = 1366746900000L
+    val tags = Map(TagKey.dsType -> "gauge")
+    val b1 = TimeSeriesBuffer(tags, 60000, start, Array(1.0, 2.0, 3.0, 4.0, 5.0))
+    val b1e = TimeSeriesBuffer(tags, 120000, start, Array(1.0, 2.5, 4.5))
+    assertEquals(b1.normalize(60000, start, 5), b1)
+    assertEquals(b1.normalize(120000, start, 3), b1e)
+
+    val b2 = TimeSeriesBuffer(tags, 120000, start, Array(3.0, 7.0))
+    val b2e =
+      TimeSeriesBuffer(tags, 60000, start, Array(3.0, 7.0, 7.0, Double.NaN, Double.NaN))
     assertEquals(b2.normalize(60000, start, 5), b2e)
   }
 


### PR DESCRIPTION
This change makes the default dstype consistently
rate for both apply methods of DsType as well as
matching the behavior for the publish path when
feeding data into the normalization cache.