### PR TITLE
optimize result tags computation

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/AggregateCollector.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/AggregateCollector.scala
@@ -123,11 +123,11 @@ abstract class SimpleAggregateCollector extends AggregateCollector {
 
     blocks.foreach { b =>
       if (valueMask != null) {
-        val v = buffer.aggrBlock(tags, b, aggr, ConsolidationFunction.Sum, multiple, op)
+        val v = buffer.aggrBlock(b, aggr, ConsolidationFunction.Sum, multiple, op)
         buffer.valueMask(valueMask, b, multiple)
         valueCount += v
       } else {
-        val v = buffer.aggrBlock(tags, b, aggr, cf, multiple, op)
+        val v = buffer.aggrBlock(b, aggr, cf, multiple, op)
         valueCount += v
       }
     }
@@ -286,7 +286,7 @@ class AllAggregateCollector extends LimitedAggregateCollector {
     }
 
     blocks.foreach { b =>
-      val v = buffer.aggrBlock(tags, b, aggr, cf, multiple, op)
+      val v = buffer.aggrBlock(b, aggr, cf, multiple, op)
       valueCount += v
     }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/AggregateCollectorSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/AggregateCollectorSuite.scala
@@ -149,7 +149,7 @@ class AggregateCollectorSuite extends FunSuite {
       newTaggedBuffer(Map("a" -> "4", "b" -> "2", "c" -> "7"), 5.0)
     )
     val expected = List(
-      newTaggedBuffer(Map("b" -> "2"), 9.0),
+      newTaggedBuffer(Map("a" -> "1", "b" -> "2"), 9.0),
       newTaggedBuffer(Map("a" -> "3", "b" -> "3"), 2.0)
     )
     val by = DataExpr.GroupBy(DataExpr.Sum(Query.False), List("b"))


### PR DESCRIPTION
A long time ago the tag set was made deterministic based on the query expression where it only includes tags with an exact match or that are listed in the group by. As a result, it isn't necessary to compute the intersection of dimensions while aggregating the matching time series.