### PR TITLE
Add a `:contains` predicate filter for compatibility with internal lo…

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
@@ -117,6 +117,10 @@ class MemoryDatabaseSuite extends FunSuite {
     assertEquals(exec("name,[ab]$,:re"), List(ts("sum(name~/^[ab]$/)", 1, 4.0, 4.0, 4.0)))
   }
 
+  test(":contains query") {
+    assertEquals(exec("name,a,:contains"), List(ts("sum(name~/^.*a/)", 1, 1.0, 2.0, 3.0)))
+  }
+
   test(":has query") {
     assertEquals(exec("name,:has"), List(ts("sum(has(name))", 1, 19.0, 22.0, 25.0)))
   }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
@@ -33,7 +33,7 @@ class ModelExtractorsSuite extends FunSuite {
   }
 
   completionTest("name", 8)
-  completionTest("name,sps", 19)
+  completionTest("name,sps", 20)
   completionTest("name,sps,:eq", 20)
   completionTest("name,sps,:eq,app,foo,:eq", 41)
   completionTest("name,sps,:eq,app,foo,:eq,:and,(,asg,)", 12)

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
@@ -233,7 +233,7 @@ class QuerySuite extends FunSuite {
   }
 
   test("matchesAny re with key match") {
-    val q = GreaterThan("foo", "b")
+    val q = Regex("foo", "b")
     assert(matchesAny(q, Map("foo" -> List("bar"), "bar"        -> List("foo"))))
     assert(matchesAny(q, Map("foo" -> List("foo", "bar"), "bar" -> List("foo"))))
     assert(matchesAny(q, Map("foo" -> List("bar", "baz"), "bar" -> List("foo"))))
@@ -650,4 +650,5 @@ class QuerySuite extends FunSuite {
     val q = Or(Equal("a", "1"), In("b", List("1", "2")))
     assertEquals(Query.expandInClauses(q, 1), List(q))
   }
+
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/QueryVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/QueryVocabularySuite.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.atlas.core.model.Query.Regex
+import com.netflix.atlas.core.stacklang.Interpreter
+import munit.FunSuite
+
+class QueryVocabularySuite extends FunSuite {
+
+  val interpreter = new Interpreter(QueryVocabulary.allWords)
+
+  test("contains, escape") {
+    var exp = interpreter.execute("a,^$.?*+[](){}\\#&!%,:contains").stack(0)
+    assertEquals(
+      exp.asInstanceOf[Regex].pattern.toString,
+      ".*\\^\\$\\.\\?\\*\\+\\[\\]\\(\\)\\{\\}\\\\#&!%"
+    )
+    exp = interpreter.execute("a,space and ~,:contains").stack(0)
+    assertEquals(
+      exp.asInstanceOf[Regex].pattern.toString,
+      ".*space\\u0020and\\u0020~"
+    )
+  }
+
+  test("contains, matches escaped") {
+    val q = interpreter
+      .execute("foo,my $var. [work-in-progress],:contains")
+      .stack(0)
+      .asInstanceOf[Regex]
+    assert(q.matches(Map("foo" -> "my $var. [work-in-progress]")))
+    assert(q.matches(Map("foo" -> "initialize my $var. [work-in-progress], not a range")))
+    assert(!q.matches(Map("foo" -> "my $var. [work-in progress]")))
+  }
+
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
@@ -52,6 +52,7 @@ class TimeSeriesExprSuite extends FunSuite {
     "name,1,:eq"                 -> const(ts(Map("name" -> "1"), 1)),
     "name,1,:re"                 -> const(ts(unknownTag, 11)),
     "name,2,:re"                 -> const(ts(unknownTag, 2)),
+    "name,2,:contains"           -> const(ts(unknownTag, 2)),
     "name,(,1,10,),:in"          -> const(ts(unknownTag, 11)),
     "name,1,:eq,name,10,:eq,:or" -> const(ts(unknownTag, 11)),
     ":true,:abs"                 -> const(ts(unknownTag, "abs(name=unknown)", 55.0)),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
     val log4j      = "2.18.0"
     val scala      = "2.13.8"
     val slf4j      = "1.7.36"
-    val spectator  = "1.3.7"
+    val spectator  = "1.3.8"
     val spring     = "5.3.22"
 
     val crossScala = Seq(scala)


### PR DESCRIPTION
…g queries.

Not meant to be used for metrics as it executes a full scan. Bump Spectator to 1.3.8