### PR TITLE
Add `:starts` and `:ends` predicate filters for compatibility with in…

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/QueryVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/QueryVocabulary.scala
@@ -41,6 +41,8 @@ object QueryVocabulary extends Vocabulary {
     Regex,
     RegexIgnoreCase,
     Contains,
+    Starts,
+    Ends,
     In,
     And,
     Or,
@@ -361,6 +363,63 @@ object QueryVocabulary extends Vocabulary {
 
     override def examples: List[String] =
       List("name,request", "result,error")
+  }
+
+  case object Starts extends KeyValueWord {
+
+    override def name: String = "starts"
+
+    def newInstance(k: String, v: String): Query = Query.Regex(k, PatternUtils.escape(v))
+
+    override def summary: String =
+      """
+        |Query expression that matches time series with a value that starts with the given
+        |sequence of characters. This version is case sensitive.
+        |
+        |Suppose you have four time series:
+        |
+        |* `name=http.requests, status=200, nf.app=server`
+        |* `name=sys.cpu, type=user, nf.app=foo`
+        |* `name=sys.cpu, type=user, nf.app=bar`
+        |* `name=sys.cpu, type=user, nf.app=foobar`
+        |
+        |The query `nf.app,bar,:starts` would match series with "bar" at the beginning of
+        |the string:
+        |
+        |* `name=sys.cpu, type=user, nf.app=bar`
+      """.stripMargin.trim
+
+    override def examples: List[String] =
+      List("name,req", "result,err")
+  }
+
+  case object Ends extends KeyValueWord {
+
+    override def name: String = "ends"
+
+    def newInstance(k: String, v: String): Query = Query.Regex(k, s".*${PatternUtils.escape(v)}$$")
+
+    override def summary: String =
+      """
+        |Query expression that matches time series with a value that ends with the given
+        |sequence of characters. This version is case sensitive.
+        |
+        |Suppose you have four time series:
+        |
+        |* `name=http.requests, status=200, nf.app=server`
+        |* `name=sys.cpu, type=user, nf.app=foo`
+        |* `name=sys.cpu, type=user, nf.app=bar`
+        |* `name=sys.cpu, type=user, nf.app=foobar`
+        |
+        |The query `nf.app,bar,:ends` would match series with "bar" at the end of
+        |the string:
+        |
+        |* `name=sys.cpu, type=user, nf.app=bar`
+        |* `name=sys.cpu, type=user, nf.app=foobar`
+      """.stripMargin.trim
+
+    override def examples: List[String] =
+      List("name,error", "result,failed")
   }
 
   case object In extends SimpleWord {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
@@ -33,7 +33,7 @@ class ModelExtractorsSuite extends FunSuite {
   }
 
   completionTest("name", 8)
-  completionTest("name,sps", 20)
+  completionTest("name,sps", 22)
   completionTest("name,sps,:eq", 20)
   completionTest("name,sps,:eq,app,foo,:eq", 41)
   completionTest("name,sps,:eq,app,foo,:eq,:and,(,asg,)", 12)

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/QueryVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/QueryVocabularySuite.scala
@@ -46,4 +46,35 @@ class QueryVocabularySuite extends FunSuite {
     assert(!q.matches(Map("foo" -> "my $var. [work-in progress]")))
   }
 
+  test("starts, prefix and escape") {
+    val exp = interpreter.execute("a,[foo],:starts").stack(0)
+    assertEquals(exp.asInstanceOf[Regex].pattern.prefix(), "[foo]")
+    assertEquals(exp.asInstanceOf[Regex].pattern.toString, "^\\[foo\\]")
+  }
+
+  test("starts, matches escaped") {
+    val q = interpreter
+      .execute("foo,my $var.,:starts")
+      .stack(0)
+      .asInstanceOf[Regex]
+    assert(q.matches(Map("foo" -> "my $var.")))
+    assert(!q.matches(Map("foo" -> "initialize my $var. [work-in-progress], not a range")))
+    assert(q.matches(Map("foo" -> "my $var. [work-in progress]")))
+  }
+
+  test("ends, suffix and escape") {
+    val exp = interpreter.execute("a,[foo],:ends").stack(0)
+    assertEquals(exp.asInstanceOf[Regex].pattern.prefix(), null)
+    assertEquals(exp.asInstanceOf[Regex].pattern.toString, ".*\\[foo\\]$")
+  }
+
+  test("ends, matches escaped") {
+    val q = interpreter
+      .execute("foo,my $var.,:ends")
+      .stack(0)
+      .asInstanceOf[Regex]
+    assert(q.matches(Map("foo" -> "my $var.")))
+    assert(!q.matches(Map("foo" -> "initialize my $var. [work-in-progress], not a range")))
+    assert(!q.matches(Map("foo" -> "my $var. [work-in progress]")))
+  }
 }


### PR DESCRIPTION
…ternal

logging queries.