### PR TITLE
update normalize behavior for UI

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterExpr.scala
@@ -24,9 +24,21 @@ trait FilterExpr extends TimeSeriesExpr
 
 object FilterExpr {
 
-  case class Stat(expr: TimeSeriesExpr, stat: String) extends FilterExpr {
+  /**
+    * Represents a basic summary stat for an input time series.
+    *
+    * @param expr
+    *     Input expression to compute the stat over.
+    * @param stat
+    *     Which summary stat to compute.
+    * @param str
+    *     Optional string representation of the expression. Used for common-cases of helper
+    *     functions to avoid duplication of the original expression.
+    */
+  case class Stat(expr: TimeSeriesExpr, stat: String, str: Option[String] = None)
+      extends FilterExpr {
 
-    override def toString: String = s"$expr,$stat,:stat"
+    override def toString: String = str.getOrElse(s"$expr,$stat,:stat")
 
     def dataExprs: List[DataExpr] = expr.dataExprs
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterVocabulary.scala
@@ -220,7 +220,7 @@ object FilterVocabulary extends Vocabulary {
 
     private def rewriteStatExprs(t1: TimeSeriesExpr, t2: TimeSeriesExpr): TimeSeriesExpr = {
       val r = t2.rewrite {
-        case s: FilterExpr.StatExpr => FilterExpr.Stat(t1, s.name)
+        case s: FilterExpr.StatExpr => FilterExpr.Stat(t1, s.name, Some(s.toString))
       }
       r.asInstanceOf[TimeSeriesExpr]
     }


### PR DESCRIPTION
Updates the behavior of normalize to reflect preferences of the UI team. In particular:

- It will not try to extract common query aspects into a `:cq` clause.
- The helpers for filtering based on summary stats will be preserved rather than expanding.

/cc @nathfisher 