### PR TITLE
allow image to be disabled for v2.json

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonCodec.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonCodec.scala
@@ -95,10 +95,12 @@ private[chart] object JsonCodec {
   // Writes out a pre-rendered image for the chart. This can be used
   // for partially dynamic views.
   private def writeGraphImage(gen: JsonGenerator, config: GraphDef): Unit = {
-    gen.writeStartObject()
-    gen.writeStringField("type", "graph-image")
-    gen.writeStringField("data", toDataUri(config))
-    gen.writeEndObject()
+    if (!config.renderingHints.contains("no-image")) {
+      gen.writeStartObject()
+      gen.writeStringField("type", "graph-image")
+      gen.writeStringField("data", toDataUri(config))
+      gen.writeEndObject()
+    }
   }
 
   private def toDataUri(config: GraphDef): String = {

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/GraphDef.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/GraphDef.scala
@@ -68,6 +68,10 @@ import com.netflix.atlas.core.model.TimeSeries
   * @param source
   *     Used to provide metadata for how the graph definition was created. For example the uri
   *     input by the user.
+  * @param themeName
+  *     Which theme to use for the chart, typically light or dark mode.
+  * @param renderingHints
+  *     Arbitrary hints passed to the rendering engine to adjust behavior.
   */
 case class GraphDef(
   plots: List[PlotDef],
@@ -87,11 +91,12 @@ case class GraphDef(
   stats: CollectorStats = CollectorStats.unknown,
   warnings: List[String] = Nil,
   source: Option[String] = None,
-  themeName: String = ChartSettings.defaultTheme
+  themeName: String = ChartSettings.defaultTheme,
+  renderingHints: Set[String] = Set.empty
 ) {
 
   /** Total number of lines for all plots. */
-  val numLines = plots.foldLeft(0) { (acc, p) =>
+  val numLines: Int = plots.foldLeft(0) { (acc, p) =>
     acc + p.data.size
   }
 

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/JsonCodecSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/JsonCodecSuite.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.chart
+
+import com.netflix.atlas.chart.model.GraphDef
+import com.netflix.atlas.chart.model.LineDef
+import com.netflix.atlas.chart.model.PlotDef
+import com.netflix.atlas.core.model.TimeSeries
+import munit.FunSuite
+
+import java.time.Instant
+
+class JsonCodecSuite extends FunSuite {
+
+  private def graphDef(hints: Set[String]): GraphDef = {
+    val step = 60_000L
+    GraphDef(
+      plots = List(PlotDef(List(LineDef(TimeSeries.noData(step))))),
+      startTime = Instant.ofEpochMilli(0L),
+      endTime = Instant.ofEpochMilli(step),
+      renderingHints = hints
+    )
+  }
+
+  test("rendering hint: none") {
+    val gdef = graphDef(Set.empty)
+    val str = JsonCodec.encode(gdef)
+    assert(str.contains(""""type":"graph-image""""))
+  }
+
+  test("rendering hint: no-image") {
+    val gdef = graphDef(Set("no-image"))
+    val str = JsonCodec.encode(gdef)
+    assert(!str.contains(""""type":"graph-image""""))
+  }
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/GraphConfig.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/GraphConfig.scala
@@ -136,7 +136,8 @@ case class GraphConfig(
       themeName = flags.theme,
       plots = plots,
       source = if (settings.metadataEnabled) Some(uri) else None,
-      warnings = warnings
+      warnings = warnings,
+      renderingHints = flags.hints
     )
 
     gdef = gdef.withVisionType(flags.vision)

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
@@ -78,6 +78,18 @@ case class Grapher(settings: DefaultSettings) {
   }
 
   /**
+    * Hints parameter is a comma separated set of strings that will be passed on to the
+    * rendering engine to optionally tune behavior.
+    */
+  private def processHints(hints: Option[String]): Set[String] = {
+    hints.toSeq
+      .flatMap(_.split(','))
+      .map(_.trim)
+      .filterNot(_.isEmpty)
+      .toSet
+  }
+
+  /**
     * Create a graph config from an Atlas URI.
     */
   def toGraphConfig(uri: Uri): GraphConfig = {
@@ -110,7 +122,8 @@ case class Grapher(settings: DefaultSettings) {
       vision = vision.getOrElse(VisionType.normal),
       palette = palette,
       theme = theme,
-      layout = Layout.create(params.get("layout").getOrElse("canvas"))
+      layout = Layout.create(params.get("layout").getOrElse("canvas")),
+      hints = processHints(params.get("hints"))
     )
 
     val q = params.get("q")

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/ImageFlags.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/ImageFlags.scala
@@ -31,5 +31,6 @@ case class ImageFlags(
   vision: VisionType,
   palette: String,
   theme: String,
-  layout: Layout
+  layout: Layout,
+  hints: Set[String]
 )

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GraphUriSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GraphUriSuite.scala
@@ -85,4 +85,34 @@ class GraphUriSuite extends FunSuite {
     val cfg = parseUri("/api/v1/graph?q=name,foo,:eq,:sum")
     assertEquals(cfg.flags.axes(0).newPlotDef().lower, PlotBound.AutoStyle)
   }
+
+  test("lower bound default") {
+    val cfg = parseUri("/api/v1/graph?q=name,foo,:eq,:sum")
+    assertEquals(cfg.flags.axes(0).newPlotDef().lower, PlotBound.AutoStyle)
+  }
+
+  test("hints: none") {
+    val cfg = parseUri("/api/v1/graph?q=name,foo,:eq,:sum")
+    assertEquals(cfg.flags.hints, Set.empty[String])
+  }
+
+  test("hints: empty") {
+    val cfg = parseUri("/api/v1/graph?q=name,foo,:eq,:sum&hints=")
+    assertEquals(cfg.flags.hints, Set.empty[String])
+  }
+
+  test("hints: single") {
+    val cfg = parseUri("/api/v1/graph?q=name,foo,:eq,:sum&hints=a")
+    assertEquals(cfg.flags.hints, Set("a"))
+  }
+
+  test("hints: multiple") {
+    val cfg = parseUri("/api/v1/graph?q=name,foo,:eq,:sum&hints=a,b,c")
+    assertEquals(cfg.flags.hints, Set("a", "b", "c"))
+  }
+
+  test("hints: multiple messy") {
+    val cfg = parseUri("/api/v1/graph?q=name,foo,:eq,:sum&hints=a,b,%20a%20%20,b,b,b,c")
+    assertEquals(cfg.flags.hints, Set("a", "b", "c"))
+  }
 }


### PR DESCRIPTION
The image rendering can be computationally expensive and increase the size of the payload quite a bit. For some cases it is desirable to use the `v2.json` format since it is similar to fetch and LWC, but the image is not needed. Alert processing is one example.

This change adds a `hints` URI parameter that can be used to pass arbitrary hints back to the rendering engine that is used. The `v2.json` engine has been updated to omit the image if a `no-image` hint is passed. In the future we may want to only include the image if requested, but that would be backwards incompatible and break some current usage.