### PR TITLE
json: fix double parsing for large integers

### DIFF
--- a/atlas-json/src/main/scala/com/netflix/atlas/json/JsonParserHelper.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/JsonParserHelper.scala
@@ -91,7 +91,7 @@ object JsonParserHelper {
   def nextDouble(parser: JsonParser): Double = {
     import com.fasterxml.jackson.core.JsonToken._
     parser.nextToken() match {
-      case VALUE_NUMBER_INT   => parser.getValueAsLong.toDouble
+      case VALUE_NUMBER_INT   => parser.getValueAsDouble
       case VALUE_NUMBER_FLOAT => parser.getValueAsDouble
       case VALUE_STRING       => java.lang.Double.parseDouble(parser.getText)
       case t                  => fail(parser, s"expected VALUE_NUMBER_FLOAT but received $t")

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/JsonParserHelperSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/JsonParserHelperSuite.scala
@@ -97,7 +97,7 @@ class JsonParserHelperSuite extends FunSuite {
 
   test("nextDouble: big integer") {
     val parser = Json.newJsonParser("""18446744073709552000""")
-    assertEquals(nextDouble(parser), 1.8446744073709552E19)
+    assertEquals(nextDouble(parser), 1.8446744073709552e19)
   }
 
   test("nextDouble: float") {

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/JsonParserHelperSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/JsonParserHelperSuite.scala
@@ -90,6 +90,26 @@ class JsonParserHelperSuite extends FunSuite {
     }
   }
 
+  test("nextDouble: integer") {
+    val parser = Json.newJsonParser("""42""")
+    assertEquals(nextDouble(parser), 42.0)
+  }
+
+  test("nextDouble: big integer") {
+    val parser = Json.newJsonParser("""18446744073709552000""")
+    assertEquals(nextDouble(parser), 1.8446744073709552E19)
+  }
+
+  test("nextDouble: float") {
+    val parser = Json.newJsonParser("""42.0""")
+    assertEquals(nextDouble(parser), 42.0)
+  }
+
+  test("nextDouble: string") {
+    val parser = Json.newJsonParser(""""42"""")
+    assertEquals(nextDouble(parser), 42.0)
+  }
+
   test("skipNext: empty object") {
     val parser = Json.newJsonParser("""[{}]""")
     assertEquals(parser.nextToken(), JsonToken.START_ARRAY)


### PR DESCRIPTION
Before when using `JsonParserHelper.nextDouble` if the raw encoded value looked like an integer type it would try to access it as a long, then convert the long to a double. This causes problems for larger integers that cannot fit within the bounds of a Java long. Now it will access it as a double.