### PR TITLE
add expression to v2.json output

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonCodec.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonCodec.scala
@@ -202,6 +202,9 @@ private[chart] object JsonCodec {
     writeColor(gen, line.color)
     gen.writeStringField("lineStyle", line.lineStyle.name())
     gen.writeNumberField("lineWidth", line.lineWidth)
+    line.query.foreach { q =>
+      gen.writeStringField("query", q)
+    }
     if (line.groupByKeys.nonEmpty) {
       gen.writeArrayFieldStart("groupByKeys")
       line.groupByKeys.foreach(gen.writeString)
@@ -387,6 +390,7 @@ private[chart] object JsonCodec {
   private def toLineDef(gdef: GraphDef, node: JsonNode): LineDef = {
     LineDef(
       data = toTimeSeries(gdef, node),
+      query = Option(node.get("query")).map(_.asText()),
       groupByKeys = toStringList(node.get("groupByKeys")),
       color = toColor(node.get("color")),
       lineStyle = LineStyle.valueOf(node.get("lineStyle").asText()),

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/DataDef.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/DataDef.scala
@@ -38,6 +38,10 @@ sealed trait DataDef {
   *
   * @param data
   *     Time series with the underlying data to render.
+  * @param query
+  *     Expression for the time series. Note, the same expression can result in many time
+  *     series when using group by. For matching the data for a particular time series the
+  *     id field should be used.
   * @param groupByKeys
   *     Set of keys used in the final grouping for the time series.
   * @param color
@@ -51,6 +55,7 @@ sealed trait DataDef {
   */
 case class LineDef(
   data: TimeSeries,
+  query: Option[String] = None,
   groupByKeys: List[String] = Nil,
   color: Color = Color.RED,
   lineStyle: LineStyle = LineStyle.LINE,
@@ -80,7 +85,7 @@ case class HSpanDef(v1: Double, v2: Double, color: Color, labelOpt: Option[Strin
 
   def label: String = labelOpt.getOrElse(s"span from $v1 to $v2")
 
-  def withColor(c: Color) = copy(color = c)
+  def withColor(c: Color): HSpanDef = copy(color = c)
 }
 
 /**
@@ -100,7 +105,7 @@ case class VSpanDef(t1: Instant, t2: Instant, color: Color, labelOpt: Option[Str
 
   def label: String = labelOpt.getOrElse(s"span from $t1 to $t2")
 
-  def withColor(c: Color) = copy(color = c)
+  def withColor(c: Color): VSpanDef = copy(color = c)
 }
 
 /**
@@ -113,5 +118,5 @@ case class VSpanDef(t1: Instant, t2: Instant, color: Color, labelOpt: Option[Str
   */
 case class MessageDef(label: String, color: Color = Color.BLACK) extends DataDef {
 
-  def withColor(c: Color) = copy(color = c)
+  def withColor(c: Color): MessageDef = copy(color = c)
 }

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/PngGraphEngineSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/PngGraphEngineSuite.scala
@@ -103,7 +103,7 @@ abstract class PngGraphEngineSuite extends FunSuite {
   }
 
   def simpleSeriesDef(min: Double, max: Double): LineDef = {
-    LineDef(simpleWave(min, max))
+    LineDef(simpleWave(min, max), query = Some(s"$min,$max"))
   }
 
   def simpleSeriesDef(max: Double): LineDef = {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
@@ -354,6 +354,7 @@ case class Grapher(settings: DefaultSettings) {
 
               LineDef(
                 data = t,
+                query = Some(s.expr.toString),
                 groupByKeys = s.expr.finalGrouping,
                 color = color,
                 lineStyle = s.lineStyle.fold(dfltStyle)(s => LineStyle.valueOf(s.toUpperCase)),


### PR DESCRIPTION
Update the `v2.json` format to include the query expression for the lines. This makes it more consistent with the time series messages used with fetch and LWC.