### PR TITLE
remove usage of javax annotations

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/ActorService.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/ActorService.scala
@@ -15,8 +15,6 @@
  */
 package com.netflix.atlas.akka
 
-import javax.inject.Inject
-import javax.inject.Singleton
 import akka.actor.Actor
 import akka.actor.ActorSystem
 import akka.actor.Props
@@ -33,8 +31,7 @@ import java.lang.reflect.Type
   * Exposes actor system as service for healthcheck and proper shutdown. Additional
   * actors to start up can be specified using the `atlas.akka.actors` property.
   */
-@Singleton
-class ActorService @Inject() (
+class ActorService(
   system: ActorSystem,
   config: Config,
   registry: Registry,

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/HealthcheckApi.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/HealthcheckApi.scala
@@ -15,8 +15,6 @@
  */
 package com.netflix.atlas.akka
 
-import javax.inject.Provider
-
 import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.model.MediaTypes
@@ -28,10 +26,12 @@ import com.netflix.atlas.json.Json
 import com.netflix.iep.service.ServiceManager
 import com.typesafe.scalalogging.StrictLogging
 
+import java.util.function.Supplier
+
 /**
   * Healthcheck endpoint based on health status of the ServiceManager.
   */
-class HealthcheckApi(serviceManagerProvider: Provider[ServiceManager])
+class HealthcheckApi(serviceManagerSupplier: Supplier[ServiceManager])
     extends WebApi
     with StrictLogging {
 
@@ -46,7 +46,7 @@ class HealthcheckApi(serviceManagerProvider: Provider[ServiceManager])
     }
   }
 
-  private def serviceManager: ServiceManager = serviceManagerProvider.get
+  private def serviceManager: ServiceManager = serviceManagerSupplier.get
 
   private def summary: String = {
     import scala.jdk.CollectionConverters._

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/WebServer.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/WebServer.scala
@@ -15,8 +15,6 @@
  */
 package com.netflix.atlas.akka
 
-import javax.inject.Inject
-import javax.inject.Singleton
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.Http.ServerBinding
@@ -48,8 +46,7 @@ import scala.concurrent.duration.Duration
   * @param system
   *     Instance of the actor system.
   */
-@Singleton
-class WebServer @Inject() (
+class WebServer(
   config: Config,
   classFactory: ClassFactory,
   registry: Registry,

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/HealthcheckApiSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/HealthcheckApiSuite.scala
@@ -16,7 +16,6 @@
 package com.netflix.atlas.akka
 
 import java.util.concurrent.atomic.AtomicBoolean
-import javax.inject.Provider
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import com.netflix.atlas.akka.testkit.MUnitRouteSuite
@@ -25,15 +24,17 @@ import com.netflix.iep.service.Service
 import com.netflix.iep.service.ServiceManager
 import com.netflix.iep.service.State
 
+import java.util.function.Supplier
+
 class HealthcheckApiSuite extends MUnitRouteSuite {
 
   import scala.concurrent.duration._
 
-  implicit val routeTestTimeout = RouteTestTimeout(5.second)
+  private implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(5.second)
 
   private val serviceHealth = new AtomicBoolean(false)
 
-  val services = new java.util.HashSet[Service]
+  private val services = new java.util.HashSet[Service]
 
   services.add(new Service {
 
@@ -44,13 +45,13 @@ class HealthcheckApiSuite extends MUnitRouteSuite {
     override def isHealthy: Boolean = serviceHealth.get()
   })
 
-  val serviceManager = new ServiceManager(services)
+  private val serviceManager = new ServiceManager(services)
 
-  val provider = new Provider[ServiceManager] {
+  private val supplier = new Supplier[ServiceManager] {
 
     override def get(): ServiceManager = serviceManager
   }
-  val endpoint = new HealthcheckApi(provider)
+  private val endpoint = new HealthcheckApi(supplier)
 
   test("/healthcheck pre-start") {
     serviceHealth.set(false)

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionApi.scala
@@ -15,7 +15,6 @@
  */
 package com.netflix.atlas.lwcapi
 
-import javax.inject.Inject
 import akka.actor.ActorRefFactory
 import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.model.HttpHeader
@@ -44,7 +43,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.util.Using
 
-case class ExpressionApi @Inject() (
+case class ExpressionApi(
   sm: StreamSubscriptionManager,
   registry: Registry,
   implicit val actorRefFactory: ActorRefFactory

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StartupDelayService.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StartupDelayService.scala
@@ -19,14 +19,13 @@ import com.netflix.iep.service.AbstractService
 import com.netflix.spectator.api.Registry
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
-import javax.inject.Inject
 
 /**
   * Service that will report as unhealthy for a configured window after startup. This is
   * used to allow clients that will stream data time to connect before marking the instance
   * as UP so that clients publishing data will send to the instance.
   */
-class StartupDelayService @Inject() (registry: Registry, config: Config)
+class StartupDelayService(registry: Registry, config: Config)
     extends AbstractService
     with StrictLogging {
 

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamSubscriptionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamSubscriptionManager.scala
@@ -17,15 +17,13 @@ package com.netflix.atlas.lwcapi
 
 import com.netflix.spectator.api.Registry
 
-import javax.inject.Inject
-
 /**
   * Subclass of [[SubscriptionManager]] that uses a source queue for the handler. In some cases
   * with dependency injection erasure can cause problems with generic types. This class
   * is just to avoid those issues for the main use-cases where we need to inject a version
   * that needs a source queue.
   */
-class StreamSubscriptionManager @Inject() (registry: Registry)
+class StreamSubscriptionManager(registry: Registry)
     extends SubscriptionManager[QueueHandler](registry) {
 
   /**

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamsApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamsApi.scala
@@ -24,13 +24,11 @@ import com.netflix.atlas.akka.DiagnosticMessage
 import com.netflix.atlas.akka.WebApi
 import com.netflix.atlas.json.Json
 
-import javax.inject.Inject
-
 /**
   * Provides a summary of the current streams. This is to aide in debugging and can be
   * disabled without impacting the service.
   */
-class StreamsApi @Inject() (sm: StreamSubscriptionManager) extends WebApi {
+class StreamsApi(sm: StreamSubscriptionManager) extends WebApi {
 
   def routes: Route = {
     endpointPathPrefix("api" / "v1" / "streams") {

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
@@ -42,13 +42,12 @@ import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
 
 import java.io.ByteArrayOutputStream
-import javax.inject.Inject
 import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
 import scala.util.control.NonFatal
 
-class SubscribeApi @Inject() (
+class SubscribeApi(
   config: Config,
   registry: Registry,
   sm: StreamSubscriptionManager,

--- a/atlas-spring-webapi/src/main/scala/com/netflix/atlas/webapi/WebApiConfiguration.scala
+++ b/atlas-spring-webapi/src/main/scala/com/netflix/atlas/webapi/WebApiConfiguration.scala
@@ -16,7 +16,6 @@
 package com.netflix.atlas.webapi
 
 import com.netflix.atlas.core.db.Database
-import com.netflix.atlas.webapi.DatabaseProvider
 import com.netflix.iep.service.ClassFactory
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
@@ -32,13 +31,13 @@ import java.util.Optional
 class WebApiConfiguration {
 
   @Bean
-  def databaseProvider(config: Optional[Config], factory: ClassFactory): DatabaseProvider = {
+  def databaseSupplier(config: Optional[Config], factory: ClassFactory): DatabaseSupplier = {
     val c = config.orElseGet(() => ConfigFactory.load())
-    new DatabaseProvider(c, factory)
+    new DatabaseSupplier(c, factory)
   }
 
   @Bean
-  def database(provider: DatabaseProvider): Database = {
+  def database(provider: DatabaseSupplier): Database = {
     provider.get()
   }
 }

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/DatabaseSupplier.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/DatabaseSupplier.scala
@@ -22,8 +22,7 @@ import com.typesafe.config.Config
 
 import java.util.function.Supplier
 
-class DatabaseSupplier(config: Config, classFactory: ClassFactory)
-    extends Supplier[Database] {
+class DatabaseSupplier(config: Config, classFactory: ClassFactory) extends Supplier[Database] {
 
   private val db = {
     import scala.compat.java8.FunctionConverters._

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/DatabaseSupplier.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/DatabaseSupplier.scala
@@ -16,20 +16,14 @@
 package com.netflix.atlas.webapi
 
 import java.lang.reflect.Type
-import javax.inject.Inject
-import javax.inject.Provider
-import javax.inject.Singleton
-
 import com.netflix.atlas.core.db.Database
 import com.netflix.iep.service.ClassFactory
 import com.typesafe.config.Config
 
-/**
-  * Created by brharrington on 7/20/16.
-  */
-@Singleton
-class DatabaseProvider @Inject() (config: Config, classFactory: ClassFactory)
-    extends Provider[Database] {
+import java.util.function.Supplier
+
+class DatabaseSupplier(config: Config, classFactory: ClassFactory)
+    extends Supplier[Database] {
 
   private val db = {
     import scala.compat.java8.FunctionConverters._

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,6 @@ lazy val `atlas-akka` = project
     Dependencies.akkaSlf4j,
     Dependencies.akkaStream,
     Dependencies.iepService,
-    Dependencies.jsr250,
     Dependencies.spectatorIpc,
     Dependencies.akkaHttp,
     Dependencies.typesafeConfig,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -51,7 +51,6 @@ object Dependencies {
   val jacksonScala      = "com.fasterxml.jackson.module" %% "jackson-module-scala" % jackson
   val jacksonSmile      = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-smile" % jackson
   val jol               = "org.openjdk.jol" % "jol-core" % "0.16"
-  val jsr250            = "javax.annotation" % "jsr250-api" % "1.0"
   val jsr305            = "com.google.code.findbugs" % "jsr305" % "3.0.2"
   val log4jApi          = "org.apache.logging.log4j" % "log4j-api" % log4j
   val log4jCore         = "org.apache.logging.log4j" % "log4j-core" % log4j


### PR DESCRIPTION
These have been moved to jakarta in later versions. With the way we are using Spring, the annotations are not necessary.