### PR TITLE
json: enable fast double operations

### DIFF
--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
@@ -66,6 +66,8 @@ object Json {
     .enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)
     .enable(StreamReadFeature.AUTO_CLOSE_SOURCE)
     .enable(StreamWriteFeature.AUTO_CLOSE_TARGET)
+    .enable(StreamReadFeature.USE_FAST_DOUBLE_PARSER)
+    .enable(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)
     .enable(JsonWriteFeature.WRITE_NAN_AS_STRINGS)
     .build()
 

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/JsonParserHelper.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/JsonParserHelper.scala
@@ -17,6 +17,7 @@ package com.netflix.atlas.json
 
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.core.JsonToken
+import com.fasterxml.jackson.core.io.doubleparser.FastDoubleParser
 
 object JsonParserHelper {
 
@@ -93,7 +94,7 @@ object JsonParserHelper {
     parser.nextToken() match {
       case VALUE_NUMBER_INT   => parser.getValueAsDouble
       case VALUE_NUMBER_FLOAT => parser.getValueAsDouble
-      case VALUE_STRING       => java.lang.Double.parseDouble(parser.getText)
+      case VALUE_STRING       => FastDoubleParser.parseDouble(parser.getText)
       case t                  => fail(parser, s"expected VALUE_NUMBER_FLOAT but received $t")
     }
   }


### PR DESCRIPTION
Enable the fast double reading/writing that was added in jackson 2.14.0.