### PR TITLE
lwc: use SortedTagMap for data points

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/util/SortedTagMapDeserializer.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/util/SortedTagMapDeserializer.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.util
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.netflix.atlas.core.util.SortedTagMap
+
+/**
+  * Custom deserializer for tag maps to go directly to `SortedTagMap` type. It is assumed
+  * that each tag map should have a relatively small number of entries.
+  *
+  * @param initSize
+  *     The initial size to use for the maps.
+  */
+class SortedTagMapDeserializer(initSize: Int) extends JsonDeserializer[SortedTagMap] {
+
+  /** Default constructor so it can be used with the annotations. */
+  def this() = this(10)
+
+  override def deserialize(p: JsonParser, ctxt: DeserializationContext): SortedTagMap = {
+    val builder = SortedTagMap.builder(initSize)
+    var k = p.nextFieldName()
+    while (k != null) {
+      val v = p.nextTextValue()
+      builder.add(k, v)
+      k = p.nextFieldName()
+    }
+    builder.result()
+  }
+}

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/util/SortedTagMapDeserializerSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/util/SortedTagMapDeserializerSuite.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.util
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.netflix.atlas.core.util.SortedTagMap
+import munit.FunSuite
+
+class SortedTagMapDeserializerSuite extends FunSuite {
+
+  private val mapper = {
+    val module = new SimpleModule()
+      .addDeserializer(classOf[SortedTagMap], new SortedTagMapDeserializer(2))
+    new ObjectMapper().registerModule(module)
+  }
+
+  private def parse(json: String): SortedTagMap = {
+    mapper.readValue(json, classOf[SortedTagMap])
+  }
+
+  test("empty") {
+    val json =
+      """
+        |{}
+        |""".stripMargin
+    val actual = parse(json)
+    assertEquals(actual, SortedTagMap.empty)
+  }
+
+  test("one") {
+    val json =
+      """
+        |{
+        |  "a": "1"
+        |}
+        |""".stripMargin
+    val actual = parse(json)
+    assertEquals(actual, SortedTagMap("a" -> "1"))
+  }
+
+  test("many") {
+    val json =
+      """
+        |{
+        |  "d": "4",
+        |  "c": "3",
+        |  "b": "2",
+        |  "a": "1"
+        |}
+        |""".stripMargin
+    val actual = parse(json)
+    assertEquals(actual, SortedTagMap("a" -> "1", "b" -> "2", "c" -> "3", "d" -> "4"))
+  }
+}

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/EvaluateApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/EvaluateApi.scala
@@ -82,8 +82,9 @@ object EvaluateApi {
 
   case class Item(
     id: String,
-    @JsonDeserialize(using = classOf[SortedTagMapDeserializer]) tags: SortedTagMap,
-    value: Double)
+    @JsonDeserialize(`using` = classOf[SortedTagMapDeserializer]) tags: SortedTagMap,
+    value: Double
+  )
 
   case class EvaluateRequest(
     timestamp: Long,

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/EvaluateApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/EvaluateApi.scala
@@ -20,10 +20,13 @@ import akka.http.scaladsl.model.RemoteAddress
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.netflix.atlas.akka.CustomDirectives._
 import com.netflix.atlas.akka.WebApi
+import com.netflix.atlas.core.util.SortedTagMap
 import com.netflix.atlas.eval.model.LwcDatapoint
 import com.netflix.atlas.eval.model.LwcDiagnosticMessage
+import com.netflix.atlas.eval.util.SortedTagMapDeserializer
 import com.netflix.atlas.json.JsonSupport
 import com.netflix.spectator.api.Registry
 import com.typesafe.scalalogging.StrictLogging
@@ -77,9 +80,10 @@ class EvaluateApi(registry: Registry, sm: StreamSubscriptionManager)
 
 object EvaluateApi {
 
-  type TagMap = Map[String, String]
-
-  case class Item(id: String, tags: TagMap, value: Double)
+  case class Item(
+    id: String,
+    @JsonDeserialize(using = classOf[SortedTagMapDeserializer]) tags: SortedTagMap,
+    value: Double)
 
   case class EvaluateRequest(
     timestamp: Long,

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/EvaluateApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/EvaluateApiSuite.scala
@@ -19,6 +19,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import com.netflix.atlas.akka.DiagnosticMessage
 import com.netflix.atlas.akka.testkit.MUnitRouteSuite
+import com.netflix.atlas.core.util.SortedTagMap
 import com.netflix.atlas.eval.model.LwcDiagnosticMessage
 import com.netflix.atlas.lwcapi.EvaluateApi._
 import com.netflix.spectator.api.NoopRegistry
@@ -40,7 +41,7 @@ class EvaluateApiSuite extends MUnitRouteSuite {
   }
 
   test("post metrics") {
-    val metrics = List(Item("abc", Map("a" -> "1"), 42.0))
+    val metrics = List(Item("abc", SortedTagMap("a" -> "1"), 42.0))
     val json = EvaluateRequest(1234L, metrics, Nil).toJson
     Post("/lwc/api/v1/evaluate", json) ~> endpoint.routes ~> check {
       assertEquals(response.status, StatusCodes.OK)


### PR DESCRIPTION
The main advantage is that for eval it can just quickly copy into an array without all the hashing and extra space in the hash array to avoid collisions.

Note, this change is safe to roll out as long as the lwcapi service is pushed first.