### PR TITLE
lwc: remove some monitorFlow steps

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
@@ -35,12 +35,9 @@ import com.netflix.atlas.eval.model.TimeGroup
   *
   * @param context
   *     Shared context for the evaluation stream.
-  * @param max
-  *     Maximum number of items that can be accumulated for a given time.
   */
 private[stream] class TimeGrouped(
-  context: StreamContext,
-  max: Int
+  context: StreamContext
 ) extends GraphStage[FlowShape[AggrDatapoint, TimeGroup]] {
 
   type AggrMap = scala.collection.mutable.AnyRefMap[DataExpr, AggrDatapoint.Aggregator]

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
@@ -55,7 +55,7 @@ class TimeGroupedSuite extends FunSuite {
 
   private def run(data: List[AggrDatapoint]): List[TimeGroup] = {
     val future = Source(data)
-      .via(new TimeGrouped(context, 10))
+      .via(new TimeGrouped(context))
       .runFold(List.empty[TimeGroup])((acc, g) => g :: acc)
     result(future)
   }


### PR DESCRIPTION
When processing data with a high input volume the
`ConnectionSources`, `InputLines`, and `LwcDatapoints` monitors would have a high throughput and the same number of elements flowing through. This change removes two of them so there is now just `InputLines`. This helps reduce overhead in the hot path.