### PR TITLE
lwc: keep input to TimeGrouped batched

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcMessages.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcMessages.scala
@@ -296,7 +296,12 @@ object LwcMessages {
         data(i + 1) = parser.nextTextValue()
         i += 2
       }
-      SortedTagMap.createUnsafe(data, data.length)
+      // The map should be sorted from the server side, so we can avoid resorting
+      // here. Force the hash to be computed and cached as soon as possible so it
+      // can be done on the compute pool for parsing.
+      val tags = SortedTagMap.createUnsafe(data, data.length)
+      tags.hashCode
+      tags
     }
   }
 

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapoint.scala
@@ -66,7 +66,7 @@ private[stream] class LwcToAggrDatapoint(context: StreamContext)
           push(out, datapoints)
       }
 
-      private def updateState(sub: LwcSubscription): Unit  = {
+      private def updateState(sub: LwcSubscription): Unit = {
         sub.metrics.foreach { m =>
           if (!state.contains(m.id)) {
             state.put(m.id, m)

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapoint.scala
@@ -35,12 +35,12 @@ import com.netflix.atlas.eval.model.LwcSubscription
   * [[AggrDatapoint]]s that can be used for evaluation.
   */
 private[stream] class LwcToAggrDatapoint(context: StreamContext)
-    extends GraphStage[FlowShape[AnyRef, AggrDatapoint]] {
+    extends GraphStage[FlowShape[List[AnyRef], List[AggrDatapoint]]] {
 
-  private val in = Inlet[AnyRef]("LwcToAggrDatapoint.in")
-  private val out = Outlet[AggrDatapoint]("LwcToAggrDatapoint.out")
+  private val in = Inlet[List[AnyRef]]("LwcToAggrDatapoint.in")
+  private val out = Outlet[List[AggrDatapoint]]("LwcToAggrDatapoint.out")
 
-  override val shape: FlowShape[AnyRef, AggrDatapoint] = FlowShape(in, out)
+  override val shape: FlowShape[List[AnyRef], List[AggrDatapoint]] = FlowShape(in, out)
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
     new GraphStageLogic(shape) with InHandler with OutHandler {
@@ -51,37 +51,36 @@ private[stream] class LwcToAggrDatapoint(context: StreamContext)
       private var nextSource: Int = 0
 
       override def onPush(): Unit = {
-        grab(in) match {
+        val builder = List.newBuilder[AggrDatapoint]
+        grab(in).foreach {
           case sb: LwcSubscription      => updateState(sb)
-          case dp: LwcDatapoint         => pushDatapoint(dp)
+          case dp: LwcDatapoint         => builder ++= pushDatapoint(dp)
           case dg: LwcDiagnosticMessage => pushDiagnosticMessage(dg)
-          case hb: LwcHeartbeat         => pushHeartbeat(hb)
-          case _                        => pull(in)
+          case hb: LwcHeartbeat         => builder += pushHeartbeat(hb)
+          case _                        =>
         }
+        val datapoints = builder.result()
+        if (datapoints.isEmpty)
+          pull(in)
+        else
+          push(out, datapoints)
       }
 
-      private def updateState(sub: LwcSubscription): Unit = {
+      private def updateState(sub: LwcSubscription): Unit  = {
         sub.metrics.foreach { m =>
           if (!state.contains(m.id)) {
             state.put(m.id, m)
           }
         }
-        pull(in)
       }
 
-      private def pushDatapoint(dp: LwcDatapoint): Unit = {
-        state.get(dp.id) match {
-          case Some(sub) =>
-            // TODO, put in source, for now make it random to avoid dedup
-            nextSource += 1
-            val expr = sub.expr
-            val step = sub.step
-            push(
-              out,
-              AggrDatapoint(dp.timestamp, step, expr, nextSource.toString, dp.tags, dp.value)
-            )
-          case None =>
-            pull(in)
+      private def pushDatapoint(dp: LwcDatapoint): Option[AggrDatapoint] = {
+        state.get(dp.id).map { sub =>
+          // TODO, put in source, for now make it random to avoid dedup
+          nextSource += 1
+          val expr = sub.expr
+          val step = sub.step
+          AggrDatapoint(dp.timestamp, step, expr, nextSource.toString, dp.tags, dp.value)
         }
       }
 
@@ -89,11 +88,10 @@ private[stream] class LwcToAggrDatapoint(context: StreamContext)
         state.get(diagMsg.id).foreach { sub =>
           context.log(sub.expr, diagMsg.message)
         }
-        pull(in)
       }
 
-      private def pushHeartbeat(hb: LwcHeartbeat): Unit = {
-        push(out, AggrDatapoint.heartbeat(hb.timestamp, hb.step))
+      private def pushHeartbeat(hb: LwcHeartbeat): AggrDatapoint = {
+        AggrDatapoint.heartbeat(hb.timestamp, hb.step)
       }
 
       override def onPull(): Unit = {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
@@ -132,8 +132,7 @@ private[stream] class TimeGrouped(
 
       private def toTimeGroup(ts: Long, aggrMap: AggrMap): TimeGroup = {
         import scala.jdk.CollectionConverters._
-        val aggregateMapForExpWithinLimits = aggrMap
-          .asScala
+        val aggregateMapForExpWithinLimits = aggrMap.asScala
           .filter {
             case (expr, aggr) if aggr.limitExceeded =>
               context.logDatapointsExceeded(ts, expr)

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
@@ -38,9 +38,9 @@ import com.netflix.atlas.eval.model.TimeGroup
   */
 private[stream] class TimeGrouped(
   context: StreamContext
-) extends GraphStage[FlowShape[AggrDatapoint, TimeGroup]] {
+) extends GraphStage[FlowShape[List[AggrDatapoint], List[TimeGroup]]] {
 
-  type AggrMap = scala.collection.mutable.AnyRefMap[DataExpr, AggrDatapoint.Aggregator]
+  type AggrMap = java.util.HashMap[DataExpr, AggrDatapoint.Aggregator]
 
   /**
     * Number of time buffers to maintain. The buffers are stored in a rolling array
@@ -60,10 +60,10 @@ private[stream] class TimeGrouped(
     context.registry
   )
 
-  private val in = Inlet[AggrDatapoint]("TimeGrouped.in")
-  private val out = Outlet[TimeGroup]("TimeGrouped.out")
+  private val in = Inlet[List[AggrDatapoint]]("TimeGrouped.in")
+  private val out = Outlet[List[TimeGroup]]("TimeGrouped.out")
 
-  override val shape: FlowShape[AggrDatapoint, TimeGroup] = FlowShape(in, out)
+  override val shape: FlowShape[List[AggrDatapoint], List[TimeGroup]] = FlowShape(in, out)
 
   private val metricName = "atlas.eval.datapoints"
   private val registry = context.registry
@@ -109,9 +109,11 @@ private[stream] class TimeGrouped(
         */
       private def aggregate(i: Int, v: AggrDatapoint): Unit = {
         if (!v.isHeartbeat) {
-          buf(i).get(v.expr) match {
-            case Some(aggr) => aggr.aggregate(v)
-            case None       => buf(i).put(v.expr, AggrDatapoint.newAggregator(v, aggrSettings))
+          val aggr = buf(i).get(v.expr)
+          if (aggr == null) {
+            buf(i).put(v.expr, AggrDatapoint.newAggregator(v, aggrSettings))
+          } else {
+            aggr.aggregate(v)
           }
         }
       }
@@ -120,15 +122,18 @@ private[stream] class TimeGrouped(
         * Push the most recently completed time group to the next stage and reset the buffer
         * so it can be used for a new time window.
         */
-      private def flush(i: Int): Unit = {
+      private def flush(i: Int): Option[TimeGroup] = {
         val t = timestamps(i)
-        if (t > 0) push(out, toTimeGroup(t, buf(i))) else pull(in)
+        val group = if (t > 0) Some(toTimeGroup(t, buf(i))) else None
         cutoffTime = t
         buf(i) = new AggrMap
+        group
       }
 
       private def toTimeGroup(ts: Long, aggrMap: AggrMap): TimeGroup = {
+        import scala.jdk.CollectionConverters._
         val aggregateMapForExpWithinLimits = aggrMap
+          .asScala
           .filter {
             case (expr, aggr) if aggr.limitExceeded =>
               context.logDatapointsExceeded(ts, expr)
@@ -145,29 +150,33 @@ private[stream] class TimeGrouped(
       }
 
       override def onPush(): Unit = {
-        val v = grab(in)
-        val t = v.timestamp
-        val now = clock.wallTime()
-        step = v.step
-        if (t > now) {
-          droppedFutureUpdater.increment()
-          pull(in)
-        } else if (t <= cutoffTime) {
-          droppedOldUpdater.increment()
-          pull(in)
-        } else {
-          bufferedUpdater.increment()
-          val i = findBuffer(t)
-          if (i >= 0) {
-            aggregate(i, v)
-            pull(in)
+        val builder = List.newBuilder[TimeGroup]
+        grab(in).foreach { v =>
+          val t = v.timestamp
+          val now = clock.wallTime()
+          step = v.step
+          if (t > now) {
+            droppedFutureUpdater.increment()
+          } else if (t <= cutoffTime) {
+            droppedOldUpdater.increment()
           } else {
-            val pos = -i - 1
-            flush(pos)
-            aggregate(pos, v)
-            timestamps(pos) = t
+            bufferedUpdater.increment()
+            val i = findBuffer(t)
+            if (i >= 0) {
+              aggregate(i, v)
+            } else {
+              val pos = -i - 1
+              builder ++= flush(pos)
+              aggregate(pos, v)
+              timestamps(pos) = t
+            }
           }
         }
+        val groups = builder.result()
+        if (groups.isEmpty)
+          pull(in)
+        else
+          push(out, groups)
       }
 
       override def onPull(): Unit = {
@@ -190,8 +199,8 @@ private[stream] class TimeGrouped(
 
       private def flushPending(): Unit = {
         if (pending.nonEmpty && isAvailable(out)) {
-          push(out, pending.head)
-          pending = pending.tail
+          push(out, pending)
+          pending = Nil
         }
         if (pending.isEmpty) {
           completeStage()

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
@@ -85,7 +85,9 @@ class LwcToAggrDatapointSuite extends FunSuite {
     val future = Source(data)
       .map(ByteString.apply)
       .map(LwcMessages.parse)
+      .map(msg => List(msg))
       .via(new LwcToAggrDatapoint(context))
+      .flatMapConcat(Source.apply)
       .runWith(Sink.seq[AggrDatapoint])
     Await.result(future, Duration.Inf).toList
   }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
@@ -54,7 +54,8 @@ class TimeGroupedSuite extends FunSuite {
   }
 
   private def run(data: List[AggrDatapoint]): List[TimeGroup] = {
-    val future = Source.single(data)
+    val future = Source
+      .single(data)
       .via(new TimeGrouped(context))
       .flatMapConcat(Source.apply)
       .runFold(List.empty[TimeGroup])((acc, g) => g :: acc)

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
@@ -54,8 +54,9 @@ class TimeGroupedSuite extends FunSuite {
   }
 
   private def run(data: List[AggrDatapoint]): List[TimeGroup] = {
-    val future = Source(data)
+    val future = Source.single(data)
       .via(new TimeGrouped(context))
+      .flatMapConcat(Source.apply)
       .runFold(List.empty[TimeGroup])((acc, g) => g :: acc)
     result(future)
   }


### PR DESCRIPTION
Refactors the stream from parsing the messages from lwcapi to the TimeGrouped stage to keep the datapoints batched. This significantly reduces the number of messages passed between the stream stages and achieve a higher throughput.

Also creates a dedicated thread pool to use for parsing the messages as that is the most time consuming step.