### PR TITLE
lwcapi: only update subscription list on changes

### DIFF
--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
@@ -73,9 +73,11 @@ class SubscriptionManagerSuite extends FunSuite {
 
     val exp1 = sub("name,exp1,:eq")
     sm.subscribe(meta.streamId, exp1)
+    sm.regenerateQueryIndex()
     assertEquals(sm.subscriptions, List(exp1))
 
     assert(!sm.register(meta, 1))
+    sm.regenerateQueryIndex()
     assertEquals(sm.subscriptions, List(exp1))
   }
 
@@ -86,6 +88,7 @@ class SubscriptionManagerSuite extends FunSuite {
 
     val subs = List(sub("name,exp1,:eq"), sub("name,exp2,:eq"))
     sm.subscribe(meta.streamId, subs)
+    sm.regenerateQueryIndex()
 
     assertEquals(sm.subscriptions.toSet, subs.toSet)
   }
@@ -98,6 +101,7 @@ class SubscriptionManagerSuite extends FunSuite {
     val s = sub("name,exp1,:eq")
     sm.subscribe(meta.streamId, s)
     sm.subscribe(meta.streamId, s)
+    sm.regenerateQueryIndex()
 
     assertEquals(sm.subscriptions, List(s))
   }
@@ -112,6 +116,7 @@ class SubscriptionManagerSuite extends FunSuite {
     val s = sub("name,exp1,:eq")
     sm.subscribe(a.streamId, s)
     sm.subscribe(b.streamId, s)
+    sm.regenerateQueryIndex()
 
     assertEquals(sm.subscriptions, List(s))
     assertEquals(sm.subscriptionsForStream(a.streamId), List(s))


### PR DESCRIPTION
Creating the full list of of all subscriptions can be expensive when there are a lot of expressions. Update it to only be done when there are changes the same as the query index update.