### PR TITLE
monitor flow just after evaluation

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -292,9 +292,10 @@ private[stream] abstract class EvaluatorImpl(
       .flatMapConcat(s => Source(splitByStep(s)))
       .groupBy(Int.MaxValue, stepSize, allowClosedSubstreamRecreation = true)
       .via(new FinalExprEval(context.interpreter))
-      .flatMapConcat(s => s)
       .mergeSubstreams
-      .via(context.monitorFlow("12_OutputMessages"))
+      .via(context.monitorFlow("12_OutputSources"))
+      .flatMapConcat(s => s)
+      .via(context.monitorFlow("13_OutputMessages"))
       .via(new OnUpstreamFinish[MessageEnvelope](queue.complete()))
       .merge(logSrc, eagerComplete = false)
   }


### PR DESCRIPTION
Add a check to monitor the flow just after the final evaluation step and before flattening the messages. This helps show the overall delay for a downstream consumer which is more relevant than the delay for the indvidual messages.