### PR TITLE
ignore heartbeat for dropped old

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
@@ -157,7 +157,9 @@ private[stream] class TimeGrouped(
           if (t > now) {
             droppedFutureUpdater.increment()
           } else if (t <= cutoffTime) {
-            droppedOldUpdater.increment()
+            if (!v.isHeartbeat) {
+              droppedOldUpdater.increment()
+            }
           } else {
             bufferedUpdater.increment()
             val i = findBuffer(t)


### PR DESCRIPTION
The heartbeat just ensures the stream keeps moving even if there is no data. It is expected to be delayed from the actual flow a bit.