### PR TITLE
flush meters when a time grouping is emitted

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
@@ -123,6 +123,9 @@ private[stream] class TimeGrouped(
         * so it can be used for a new time window.
         */
       private def flush(i: Int): Option[TimeGroup] = {
+        droppedOldUpdater.flush()
+        droppedFutureUpdater.flush()
+        bufferedUpdater.flush()
         val t = timestamps(i)
         val group = if (t > 0) Some(toTimeGroup(t, buf(i))) else None
         cutoffTime = t


### PR DESCRIPTION
When TimeGrouped flushes a finalized time grouping also have it explicitly flush the batch meter updaters. This avoids the counts potentially showing up much later due to a low rate.