### PR TITLE
add option to disable CORS

### DIFF
--- a/atlas-akka/src/main/resources/reference.conf
+++ b/atlas-akka/src/main/resources/reference.conf
@@ -40,6 +40,11 @@ atlas.akka {
 
   # Options for the behavior of the default request handler
   request-handler {
+    # Should the CORS handler be added? In some cases when proxying requests
+    # it can be desirable to disable to avoid having multiple places trying
+    # to process CORS headers.
+    cors = true
+
     # Should it automatically handle compression of responses and decompressing
     # requests?
     compression = true

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/RequestHandler.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/RequestHandler.scala
@@ -112,6 +112,10 @@ object RequestHandler extends StrictLogging {
         .distinct
     }
 
+    val corsEnabled: Boolean = {
+      config.getBoolean("atlas.akka.request-handler.cors")
+    }
+
     val handleCompression: Boolean = {
       config.getBoolean("atlas.akka.request-handler.compression")
     }
@@ -181,7 +185,10 @@ object RequestHandler extends StrictLogging {
         accessLog(settings.diagnosticHeaders) { close }
 
     // Add CORS headers to all responses
-    cors(settings.corsHostPatterns) { log }
+    if (settings.corsEnabled)
+      cors(settings.corsHostPatterns) { log }
+    else
+      log
   }
 
   /**

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerNoCompressionSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerNoCompressionSuite.scala
@@ -44,6 +44,7 @@ class RequestHandlerNoCompressionSuite extends MUnitRouteSuite {
       |atlas.akka.cors-host-patterns = []
       |atlas.akka.diagnostic-headers = []
       |atlas.akka.request-handler {
+      |  cors = false
       |  compression = false
       |  access-log = false
       |  close-probability = 0.0
@@ -115,6 +116,13 @@ class RequestHandlerNoCompressionSuite extends MUnitRouteSuite {
     Post("/jsonparse", content).addHeader(gzipHeader) ~> routes ~> check {
       assertEquals(response.status, StatusCodes.OK)
       assertEquals(responseAs[String], "foo")
+    }
+  }
+
+  test("cors preflight") {
+    // With CORS disabled there shouldn't be a route to handle the OPTIONS request
+    Options("/api/v2/ip") ~> routes ~> check {
+      assertEquals(response.status, StatusCodes.NotFound)
     }
   }
 }

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/RequestHandlerSuite.scala
@@ -49,6 +49,7 @@ class RequestHandlerSuite extends MUnitRouteSuite {
       |  }
       |]
       |atlas.akka.request-handler {
+      |  cors = true
       |  compression = true
       |  access-log = true
       |  close-probability = 0.0


### PR DESCRIPTION
If we are proxying to another server that already supports CORS, then having multiple layers adding the CORS headers can cause problems.