### PR TITLE
dedup or clauses when normalizing

### DIFF
--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
@@ -360,6 +360,7 @@ object ExprApi {
             Query.And(q1, q2)
           }
       }
+      .distinct
       .sortWith(_.toString < _.toString) // order OR clauses
       .reduce { (q1, q2) =>
         Query.Or(q1, q2)

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
@@ -410,6 +410,12 @@ class ExprApiSuite extends MUnitRouteSuite {
     assertEquals(normalize(expr), List(expected))
   }
 
+  test("normalize duplicate or clauses") {
+    val expr = "name,a,:eq,name,b,:eq,:or,name,a,:eq,:or"
+    val expected = "name,a,:eq,name,b,:eq,:or,:sum"
+    assertEquals(normalize(expr), List(expected))
+  }
+
   test("normalize simplify query") {
     val input = "app,foo,:eq,name,cpuUser,:eq,:and,:true,:and,:sum"
     val expected = "app,foo,:eq,name,cpuUser,:eq,:and,:sum"


### PR DESCRIPTION
Update the expression normalization to dedup OR clauses if the conditions are the same.