### PR TITLE
remove redundant clauses when normalizing

### DIFF
--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
@@ -416,6 +416,12 @@ class ExprApiSuite extends MUnitRouteSuite {
     assertEquals(normalize(expr), List(expected))
   }
 
+  test("normalize, remove redundant clauses") {
+    val expr = "name,a,:eq,:sum,b,:has,c,:has,:or,:cq,b,:has,c,:has,:or,:cq"
+    val expected = "b,:has,name,a,:eq,:and,c,:has,name,a,:eq,:and,:or,:sum"
+    assertEquals(normalize(expr), List(expected))
+  }
+
   test("normalize simplify query") {
     val input = "app,foo,:eq,name,cpuUser,:eq,:and,:true,:and,:sum"
     val expected = "app,foo,:eq,name,cpuUser,:eq,:and,:sum"


### PR DESCRIPTION
In some cases with tooling a `:cq` can get applied multiple times. If the common query condition has an OR clause, then that will get expanded with the cross product when computing the DNF. As a result, the normalized query resulting from applying a `:cq` once would differ from applying the same `:cq` multiple times. This change removes redundant clauses from the normalized OR set to avoid the discrepancy. Redundant means that the removed clause will not change the result since another branch of the OR would have matched.