### PR TITLE
Add the HEATMAP line style.

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/graphics/TimeSeriesGraph.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/graphics/TimeSeriesGraph.scala
@@ -17,7 +17,6 @@ package com.netflix.atlas.chart.graphics
 
 import java.awt.BasicStroke
 import java.awt.Graphics2D
-
 import com.netflix.atlas.chart.GraphConstants
 import com.netflix.atlas.chart.model.GraphDef
 import com.netflix.atlas.chart.model.LineStyle
@@ -119,6 +118,9 @@ case class TimeSeriesGraph(graphDef: GraphDef) extends Element with FixedHeight 
             case LineStyle.AREA  => TimeSeriesArea(style, line.data.data, timeAxis, axis)
             case LineStyle.VSPAN => TimeSeriesSpan(style, line.data.data, timeAxis)
             case LineStyle.STACK => TimeSeriesStack(style, line.data.data, timeAxis, axis, offsets)
+            case LineStyle.HEATMAP =>
+              // no-op for now.
+              new Element { def draw(g: Graphics2D, x1: Int, y1: Int, x2: Int, y2: Int) = () }
           }
 
           lineElement.draw(g, x1 + leftOffset, y1, x2 - rightOffset, chartEnd)

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/DataDef.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/DataDef.scala
@@ -52,6 +52,8 @@ sealed trait DataDef {
   *     Width of the stroke when rendering the line. Has no effect for styles other than LINE.
   * @param legendStats
   *     Summary stats for the data in the line.
+  * @param palette
+  *     An optional link to a palette override for this line..
   */
 case class LineDef(
   data: TimeSeries,
@@ -60,7 +62,8 @@ case class LineDef(
   color: Color = Color.RED,
   lineStyle: LineStyle = LineStyle.LINE,
   lineWidth: Float = 1.0f,
-  legendStats: SummaryStats = SummaryStats.empty
+  legendStats: SummaryStats = SummaryStats.empty,
+  palette: Option[Palette] = None
 ) extends DataDef {
 
   def label: String = data.label

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/DataDef.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/DataDef.scala
@@ -52,8 +52,6 @@ sealed trait DataDef {
   *     Width of the stroke when rendering the line. Has no effect for styles other than LINE.
   * @param legendStats
   *     Summary stats for the data in the line.
-  * @param palette
-  *     An optional link to a palette override for this line..
   */
 case class LineDef(
   data: TimeSeries,
@@ -62,8 +60,7 @@ case class LineDef(
   color: Color = Color.RED,
   lineStyle: LineStyle = LineStyle.LINE,
   lineWidth: Float = 1.0f,
-  legendStats: SummaryStats = SummaryStats.empty,
-  palette: Option[Palette] = None
+  legendStats: SummaryStats = SummaryStats.empty
 ) extends DataDef {
 
   def label: String = data.label

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/HeatmapDef.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/HeatmapDef.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.chart.model
+
+import com.netflix.atlas.chart.model.PlotBound.AutoStyle
+
+/**
+  * A configuration used to compute and optionally plot a heatmap.
+  *
+  * @param colorScale
+  *   The color scale to use for counts within a cell.
+  * @param upper
+  *   An optional upper boundary for the cell count.
+  * @param lower
+  *   An optional lower boundary for the cell count.
+  * @param palette
+  *   An optional palette to use for the heatmap
+  * @param legend
+  *   A string to use for the legend.
+  */
+case class HeatmapDef(
+  colorScale: Scale = Scale.LINEAR,
+  upper: PlotBound = AutoStyle,
+  lower: PlotBound = AutoStyle,
+  palette: Option[Palette] = None,
+  legend: Option[String] = None
+)

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/LineStyle.java
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/LineStyle.java
@@ -19,5 +19,5 @@ package com.netflix.atlas.chart.model;
  * Line styles for how to render an time series.
  */
 public enum LineStyle {
-  LINE, AREA, STACK, VSPAN
+  LINE, AREA, STACK, VSPAN, HEATMAP
 }

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/PlotDef.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/model/PlotDef.scala
@@ -38,6 +38,8 @@ import com.netflix.atlas.chart.model.PlotBound.Explicit
   *     Lower limit for the axis.
   * @param tickLabelMode
   *     Mode to use for displaying tick labels.
+  * @param heatmapDef
+  *     Optional heatmap settings for the plot.
   */
 case class PlotDef(
   data: List[DataDef],
@@ -46,7 +48,8 @@ case class PlotDef(
   scale: Scale = Scale.LINEAR,
   upper: PlotBound = AutoStyle,
   lower: PlotBound = AutoStyle,
-  tickLabelMode: TickLabelMode = TickLabelMode.DECIMAL
+  tickLabelMode: TickLabelMode = TickLabelMode.DECIMAL,
+  heatmapDef: Option[HeatmapDef] = None
 ) {
 
   import java.lang.{Double => JDouble}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Axis.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Axis.scala
@@ -16,12 +16,14 @@
 package com.netflix.atlas.eval.graph
 
 import com.netflix.atlas.chart.model.DataDef
+import com.netflix.atlas.chart.model.HeatmapDef
 import com.netflix.atlas.chart.model.LineDef
+import com.netflix.atlas.chart.model.Palette
 import com.netflix.atlas.chart.model.PlotBound
-import com.netflix.atlas.chart.model.PlotBound.AutoStyle
 import com.netflix.atlas.chart.model.PlotDef
 import com.netflix.atlas.chart.model.Scale
 import com.netflix.atlas.chart.model.TickLabelMode
+import com.netflix.atlas.chart.model.PlotBound.AutoStyle
 import com.netflix.atlas.core.util.Strings
 
 case class Axis(
@@ -33,7 +35,12 @@ case class Axis(
   tickLabels: Option[String] = None,
   palette: Option[String] = None,
   sort: Option[String] = None,
-  order: Option[String] = None
+  order: Option[String] = None,
+  heatmapScale: Option[String] = None,
+  heatmapUpper: Option[String] = None,
+  heatmapLower: Option[String] = None,
+  heatmapPalette: Option[String] = None,
+  heatmapLegend: Option[String] = None
 ) {
 
   val tickLabelMode: TickLabelMode = {
@@ -59,7 +66,16 @@ case class Axis(
       ylabel = label,
       scale = Scale.fromName(scale.getOrElse("linear")),
       axisColor = if (multiY) data.headOption.map(_.color) else None,
-      tickLabelMode = tickLabelMode
+      tickLabelMode = tickLabelMode,
+      heatmapDef = Some(
+        HeatmapDef(
+          heatmapScale.fold[Scale](Scale.LINEAR)(Scale.fromName(_)),
+          heatmapUpper.fold[PlotBound](AutoStyle)(v => PlotBound(v)),
+          heatmapLower.fold[PlotBound](AutoStyle)(v => PlotBound(v)),
+          heatmapPalette.fold[Option[Palette]](None)(p => Some(Palette.create(p))),
+          heatmapLegend
+        )
+      )
     )
   }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GrapherSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GrapherSuite.scala
@@ -554,6 +554,13 @@ class GrapherSuite extends FunSuite {
     assertEquals(config.query, "a,b,:foo")
     assert(config.parsedQuery.isFailure)
   }
+
+  test("heatmap and stack not allowed") {
+    val uri = "/api/v1/graph?q=a,b,:eq,heatmap,:ls,a,b,:eq,stack,:ls"
+    intercept[IllegalArgumentException] {
+      grapher.evalAndRender(Uri(uri), db)
+    }
+  }
 }
 
 object GrapherSuite {


### PR DESCRIPTION
Add the HeatmapDef class used to configure heatmaps globaly for a graph. Add a palette option to the LineDef class for use by heatmaps. Parse the HeatmapDef in Grapher.scala and pass it to the Axis and then PlotDef.
Throw an exception if a user attempts to plot a heatmap and stacked lines on the same axis.
Select a color or palette for use in heatmaps in Grapher.scala. If no style or heatmap settings are provided, the heatmap grabs a color based on the order of the expression and uses alpha transparencies for the color scale. Remaining expressions use the rest of the palette as normal. If the user specifies a color for the expression, that color is used with alphas and no colors are taken from the main palette. If a palette is specified for heatmaps, that palette is used for the color scale.