### PR TITLE
add graph config to data request

### DIFF
--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
@@ -57,14 +57,18 @@ class GraphApi(config: Config, implicit val actorRefFactory: ActorRefFactory) ex
 
 object GraphApi {
 
-  case class DataRequest(context: EvalContext, exprs: List[DataExpr])
+  case class DataRequest(
+    context: EvalContext,
+    exprs: List[DataExpr],
+    config: Option[GraphConfig] = None
+  )
 
   object DataRequest {
 
     def apply(config: GraphConfig): DataRequest = {
       val dataExprs = config.exprs.flatMap(_.expr.dataExprs)
       val deduped = dataExprs.distinct
-      DataRequest(config.evalContext, deduped)
+      DataRequest(config.evalContext, deduped, Option(config))
     }
   }
 


### PR DESCRIPTION
This is sometimes useful to provide more context to the data layer such as passing through the query id.