### PR TITLE
grapher: use id parameter if present

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
@@ -94,7 +94,7 @@ case class Grapher(settings: DefaultSettings) {
     */
   def toGraphConfig(uri: Uri): GraphConfig = {
     val params = uri.query()
-    val id = "default"
+    val id = params.get("id").getOrElse("default")
 
     val features = params
       .get("features")

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GrapherSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GrapherSuite.scala
@@ -554,6 +554,18 @@ class GrapherSuite extends FunSuite {
     assertEquals(config.query, "a,b,:foo")
     assert(config.parsedQuery.isFailure)
   }
+
+  test("recognize id parameter") {
+    val uri = Uri("/api/v1/graph?q=a,b,:eq&id=foo")
+    val config = grapher.toGraphConfig(uri)
+    assertEquals(config.id, "foo")
+  }
+
+  test("default id if parameter is not present") {
+    val uri = Uri("/api/v1/graph?q=a,b,:eq")
+    val config = grapher.toGraphConfig(uri)
+    assertEquals(config.id, "default")
+  }
 }
 
 object GrapherSuite {


### PR DESCRIPTION
Before it would always set it to `default` when processing the URI and the caller would have to set it to another value later. To get better consistency, recognize the id parameter when present. The caller can still override with additional logic if desirable.