### PR TITLE
adjust log settings for akka

### DIFF
--- a/atlas-akka/src/main/resources/reference.conf
+++ b/atlas-akka/src/main/resources/reference.conf
@@ -100,7 +100,10 @@ atlas.akka {
 }
 
 akka {
+  # Sometimes see timeouts related to logging, maybe related to something about M1 Macs
+  logger-startup-timeout = 30s
   loggers = ["akka.event.slf4j.Slf4jLogger"]
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
   loglevel = "INFO"
   actor {
     debug {


### PR DESCRIPTION
Helps to avoid timeout during logging initialization.