### PR TITLE
use CORS origin as id

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/Cors.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/Cors.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.akka
+
+import akka.http.scaladsl.model.Uri
+import com.netflix.iep.config.ConfigManager
+
+/** Helper functions for working with CORS requests.  */
+object Cors {
+
+  private val allowedHostPatterns = {
+    import scala.jdk.CollectionConverters._
+    ConfigManager.get().getStringList("atlas.akka.cors-host-patterns").asScala.toList
+  }
+
+  /**
+    * Return a normalized origin string with just the host name if the host is allowed based
+    * on the set of patterns configured in `atlas.akka.cors-host-patterns`.
+    */
+  def normalizedOrigin(origin: String): Option[String] = {
+    val originHostname = extractHostname(origin)
+    if (isOriginAllowed(allowedHostPatterns, originHostname)) Option(originHostname) else None
+  }
+
+  /**
+    * Check if the origin is allowed.
+    *
+    * @param hosts
+    *     Set of host patterns to allow.
+    * @param origin
+    *     Origin value normally extracted from the request headers.
+    * @return
+    *     True if the hostname is allowed based on the set of host patterns.
+    */
+  def isOriginAllowed(hosts: List[String], origin: String): Boolean = {
+    try {
+      val originHostname = extractHostname(origin)
+      checkOrigin(hosts, originHostname)
+    } catch {
+      case _: Exception =>
+        // If there is a failure processing the origin uri, then do not add CORS headers.
+        false
+    }
+  }
+
+  private def extractHostname(origin: String): String = {
+    if (origin.startsWith("http:") || origin.startsWith("https:"))
+      Uri(origin).authority.host.address()
+    else
+      origin
+  }
+
+  @scala.annotation.tailrec
+  private def checkOrigin(hosts: List[String], origin: String): Boolean = {
+    hosts match {
+      case h :: hs => checkOrigin(h, origin) || checkOrigin(hs, origin)
+      case Nil     => false
+    }
+  }
+
+  private def checkOrigin(host: String, origin: String): Boolean = {
+    (host == "*") || (host.startsWith(".") && origin.endsWith(host)) || (host == origin)
+  }
+}

--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/CustomDirectives.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/CustomDirectives.scala
@@ -27,7 +27,6 @@ import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.model.MediaType
 import akka.http.scaladsl.model.MediaTypes
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.server.Directive
 import akka.http.scaladsl.server.Directive0
@@ -174,9 +173,9 @@ object CustomDirectives {
     // Add the cors headers to anything with an origin, browser behavior seems to be mixed as to
     // which request headers we can expect to receive
     optionalHeaderValueByName("Origin").flatMap {
-      case None                                            => pass
-      case Some(origin) if !isOriginAllowed(hosts, origin) => pass
-      case Some(origin)                                    =>
+      case None                                                 => pass
+      case Some(origin) if !Cors.isOriginAllowed(hosts, origin) => pass
+      case Some(origin)                                         =>
         // '*' doesn't seem to work reliably so use requested origin if provided. If running from
         // a local file we typically see 'null'.
         val allow =
@@ -210,33 +209,6 @@ object CustomDirectives {
             respondWithHeaders(finalHeaders) & exposeHeaders
         }
     }
-  }
-
-  private def isOriginAllowed(hosts: List[String], origin: String): Boolean = {
-    try {
-      val originHostname =
-        if (origin.startsWith("http:") || origin.startsWith("https:"))
-          Uri(origin).authority.host.address()
-        else
-          origin
-      checkOrigin(hosts, originHostname)
-    } catch {
-      case e: Exception =>
-        // If there is a failure processing the origin uri, then do not add CORS headers.
-        false
-    }
-  }
-
-  @scala.annotation.tailrec
-  private def checkOrigin(hosts: List[String], origin: String): Boolean = {
-    hosts match {
-      case h :: hs => checkOrigin(h, origin) || checkOrigin(hs, origin)
-      case Nil     => false
-    }
-  }
-
-  private def checkOrigin(host: String, origin: String): Boolean = {
-    (host == "*") || (host.startsWith(".") && origin.endsWith(host)) || (host == origin)
   }
 
   /** Route for CORS handling pre-flight checks. */

--- a/atlas-akka/src/test/resources/application.conf
+++ b/atlas-akka/src/test/resources/application.conf
@@ -1,0 +1,5 @@
+
+atlas.akka.cors-host-patterns = [
+  "localhost",
+  ".netflix.com"
+]

--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/CorsSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/CorsSuite.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.akka
+
+import munit.FunSuite
+
+class CorsSuite extends FunSuite {
+
+  test("normalizedOrigin: allowed host") {
+    val origin = Cors.normalizedOrigin("https://foo.netflix.com/")
+    assertEquals(origin, Some("foo.netflix.com"))
+  }
+
+  test("normalizedOrigin: disallowed host") {
+    val origin = Cors.normalizedOrigin("https://foo.netflix.org/")
+    assertEquals(origin, None)
+  }
+
+  test("normalizedOrigin: disallowed ip") {
+    val origin = Cors.normalizedOrigin("https://123.45.67.89/")
+    assertEquals(origin, None)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ lazy val `atlas-akka` = project
     Dependencies.akkaActor,
     Dependencies.akkaSlf4j,
     Dependencies.akkaStream,
+    Dependencies.iepDynConfig,
     Dependencies.iepService,
     Dependencies.spectatorIpc,
     Dependencies.akkaHttp,


### PR DESCRIPTION
For requests coming from UIs that have an allowed origin host, use the origin as the default id. If one is explicitly specified via the uri parameter, then that will still be used.