### PR TITLE
fix condition for close probability

### DIFF
--- a/atlas-akka/src/main/scala/com/netflix/atlas/akka/CustomDirectives.scala
+++ b/atlas-akka/src/main/scala/com/netflix/atlas/akka/CustomDirectives.scala
@@ -431,9 +431,9 @@ object CustomDirectives {
       mapResponseHeaders { headers =>
         val random = ThreadLocalRandom.current()
         if (random.nextDouble() < probability)
-          headers
-        else
           headers.prepended(closeHeader)
+        else
+          headers
       }
     }
   }


### PR DESCRIPTION
Swaps the body for the condition so it matches expectations. Before it was doing the opposite, so setting to 0.1 would close ~90% of connections rather than ~10%.