### PR TITLE
add specialized map for ref with double values

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/RefDoubleHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/RefDoubleHashMap.scala
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+/**
+  * Mutable reference to double map based on open-addressing. Primary use-case is
+  * computing an aggregate double value based on a key.
+  *
+  * @param capacity
+  *     Initial capacity guideline. The actual size of the underlying buffer
+  *     will be the next prime >= `capacity`. Default is 10.
+  */
+class RefDoubleHashMap[T <: AnyRef](capacity: Int = 10) {
+
+  private[this] var keys = newArray(capacity)
+  private[this] var values = new Array[Double](keys.length)
+  private[this] var used = 0
+  private[this] var cutoff = computeCutoff(keys.length)
+
+  // Set at 50% capacity to get reasonable tradeoff between performance and
+  // memory use. See IntIntMap benchmark.
+  private def computeCutoff(n: Int): Int = math.max(3, n / 2)
+
+  private def newArray(n: Int): Array[T] = {
+    ArrayHelper.newInstance[T](PrimeFinder.nextPrime(n))
+  }
+
+  private def resize(): Unit = {
+    val tmpKS = newArray(keys.length * 2)
+    val tmpVS = new Array[Double](tmpKS.length)
+    var i = 0
+    while (i < keys.length) {
+      val k = keys(i)
+      if (k != null) put(tmpKS, tmpVS, k, values(i))
+      i += 1
+    }
+    keys = tmpKS
+    values = tmpVS
+    cutoff = computeCutoff(tmpKS.length)
+  }
+
+  private def put(ks: Array[T], vs: Array[Double], k: T, v: Double): Boolean = {
+    var pos = Hash.absOrZero(k.hashCode()) % ks.length
+    var posV = ks(pos)
+    while (posV != null && posV != k) {
+      pos = (pos + 1) % ks.length
+      posV = ks(pos)
+    }
+    ks(pos) = k
+    vs(pos) = v
+    posV == null
+  }
+
+  /**
+    * Put a ref to integer pair into the map. The key, `k`, should not be
+    * equivalent to the `noData` value used for this map. If an entry with the
+    * same key already exists, then the value will be overwritten.
+    */
+  def put(k: T, v: Double): Unit = {
+    if (used >= cutoff) resize()
+    if (put(keys, values, k, v)) used += 1
+  }
+
+  /**
+    * Put ref to integer pair into the map if there is not already a mapping
+    * for `k`. Returns true if the value was inserted into the map.
+    */
+  def putIfAbsent(k: T, v: Double): Boolean = {
+    if (used >= cutoff) resize()
+    var pos = Hash.absOrZero(k.hashCode()) % keys.length
+    var posV = keys(pos)
+    while (posV != null && posV != k) {
+      pos = (pos + 1) % keys.length
+      posV = keys(pos)
+    }
+    if (posV != null) false
+    else {
+      keys(pos) = k
+      values(pos) = v
+      used += 1
+      true
+    }
+  }
+
+  /**
+    * Get the value associated with key, `k`. If no value is present, then the
+    * `dflt` value will be returned.
+    */
+  def get(k: T, dflt: Double): Double = {
+    var pos = Hash.absOrZero(k.hashCode()) % keys.length
+    while (true) {
+      val prev = keys(pos)
+      if (prev == null)
+        return dflt
+      else if (prev.equals(k))
+        return values(pos)
+      else
+        pos = (pos + 1) % keys.length
+    }
+    dflt
+  }
+
+  /**
+    * Add `amount` to the value associated with `k`. If the key is not already in the
+    * map a new entry will be created with a value of `amount`.
+    */
+  def add(k: T, amount: Double): Unit = {
+    if (used >= cutoff) resize()
+    var pos = Hash.absOrZero(k.hashCode()) % keys.length
+    while (true) {
+      val prev = keys(pos)
+      if (prev == null || prev == k) {
+        keys(pos) = k
+        values(pos) += amount
+        if (prev == null) used += 1
+        return
+      }
+      pos = (pos + 1) % keys.length
+    }
+  }
+
+  /**
+    * Compute max `amount` and the value associated with `k`. If the key is not already in
+    * the map a new entry will be created with a value of `amount`.
+    */
+  def max(k: T, amount: Double): Unit = {
+    if (used >= cutoff) resize()
+    var pos = Hash.absOrZero(k.hashCode()) % keys.length
+    while (true) {
+      val prev = keys(pos)
+      if (prev == null || prev == k) {
+        keys(pos) = k
+        if (prev == null) {
+          values(pos) = amount
+          used += 1
+        } else {
+          values(pos) = math.max(values(pos), amount)
+        }
+        return
+      }
+      pos = (pos + 1) % keys.length
+    }
+  }
+
+  /**
+    * Compute min `amount` and the value associated with `k`. If the key is not already in
+    * the map a new entry will be created with a value of `amount`.
+    */
+  def min(k: T, amount: Double): Unit = {
+    if (used >= cutoff) resize()
+    var pos = Hash.absOrZero(k.hashCode()) % keys.length
+    while (true) {
+      val prev = keys(pos)
+      if (prev == null || prev == k) {
+        keys(pos) = k
+        if (prev == null) {
+          values(pos) = amount
+          used += 1
+        } else {
+          values(pos) = math.min(values(pos), amount)
+        }
+        return
+      }
+      pos = (pos + 1) % keys.length
+    }
+  }
+
+  /** Execute `f` for each item in the set. */
+  def foreach(f: (T, Double) => Unit): Unit = {
+    var i = 0
+    while (i < keys.length) {
+      val k = keys(i)
+      if (k != null) f(k, values(i))
+      i += 1
+    }
+  }
+
+  /** Return the number of items in the set. This is a constant time operation. */
+  def size: Int = used
+
+  /** Apply a mapping function `f` and converts the result to an array. */
+  def mapToArray[R](buffer: Array[R])(f: (T, Double) => R): Array[R] = {
+    require(buffer.length == used, s"buffer.length (${buffer.length}) != size ($used)")
+    var i = 0
+    var j = 0
+    while (i < keys.length) {
+      val k = keys(i)
+      if (k != null) {
+        buffer(j) = f(k, values(i))
+        j += 1
+      }
+      i += 1
+    }
+    buffer
+  }
+
+  /** Converts this set to a Map[T, Int]. Used mostly for debugging and tests. */
+  def toMap: Map[T, Double] = {
+    val builder = Map.newBuilder[T, Double]
+    foreach { (k, v) =>
+      builder += k -> v
+    }
+    builder.result()
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/RefDoubleHashMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/RefDoubleHashMapSuite.scala
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import org.openjdk.jol.info.ClassLayout
+import org.openjdk.jol.info.GraphLayout
+import munit.FunSuite
+
+import scala.util.Random
+
+class RefDoubleHashMapSuite extends FunSuite {
+
+  import java.lang.{Long => JLong}
+
+  test("put") {
+    val m = new RefDoubleHashMap[JLong]
+    assertEquals(0, m.size)
+    m.put(11L, 42)
+    assertEquals(1, m.size)
+    assertEquals(Map(JLong.valueOf(11) -> 42.0), m.toMap)
+  }
+
+  test("putIfAbsent") {
+    val m = new RefDoubleHashMap[JLong]
+    assertEquals(0, m.size)
+    assert(m.putIfAbsent(11L, 42))
+    assertEquals(1, m.size)
+    assertEquals(Map(JLong.valueOf(11) -> 42.0), m.toMap)
+
+    assert(!m.putIfAbsent(11L, 43))
+    assertEquals(1, m.size)
+    assertEquals(Map(JLong.valueOf(11) -> 42.0), m.toMap)
+  }
+
+  test("get") {
+    val m = new RefDoubleHashMap[JLong]
+    assertEquals(m.get(42L, -1), -1.0)
+    m.put(11L, 27)
+    assertEquals(m.get(42L, -1), -1.0)
+    assertEquals(m.get(11L, -1), 27.0)
+  }
+
+  test("get - collisions") {
+    // Underlying capacity will be 11, next prime after 10, so 0 and multiples of 11
+    // will collide
+    val m = new RefDoubleHashMap[JLong]
+    m.put(0L, 0)
+    m.put(11L, 1)
+    m.put(22L, 2)
+    assertEquals(m.size, 3)
+    assertEquals(m.get(0L, -1), 0.0)
+    assertEquals(m.get(11L, -1), 1.0)
+    assertEquals(m.get(22L, -1), 2.0)
+  }
+
+  test("dedup") {
+    val m = new RefDoubleHashMap[JLong]
+    m.put(42L, 1)
+    assertEquals(Map(JLong.valueOf(42) -> 1.0), m.toMap)
+    assertEquals(1, m.size)
+    m.put(42L, 2)
+    assertEquals(Map(JLong.valueOf(42) -> 2.0), m.toMap)
+    assertEquals(1, m.size)
+  }
+
+  test("add") {
+    val m = new RefDoubleHashMap[JLong]
+    assertEquals(0, m.size)
+
+    m.add(42L, 1.0)
+    assertEquals(1, m.size)
+    assertEquals(Map(JLong.valueOf(42) -> 1.0), m.toMap)
+
+    m.add(42L, 1.0)
+    assertEquals(1, m.size)
+    assertEquals(Map(JLong.valueOf(42) -> 2.0), m.toMap)
+
+    m.add(42L, 7.0)
+    assertEquals(1, m.size)
+    assertEquals(Map(JLong.valueOf(42) -> 9.0), m.toMap)
+  }
+
+  test("add - collisions") {
+    // Underlying capacity will be 11, next prime after 10, so 0 and multiples of 11
+    // will collide
+    val m = new RefDoubleHashMap[JLong]
+    m.add(0L, 1.0)
+    m.add(11L, 1.0)
+    m.add(22L, 1.0)
+    assertEquals(m.size, 3)
+    m.foreach { (_, v) =>
+      assertEquals(v, 1.0)
+    }
+  }
+
+  test("max") {
+    val m = new RefDoubleHashMap[JLong]
+    assertEquals(0, m.size)
+
+    m.max(42L, 1.0)
+    assertEquals(1, m.size)
+    assertEquals(Map(JLong.valueOf(42) -> 1.0), m.toMap)
+
+    m.max(42L, 0.5)
+    assertEquals(1, m.size)
+    assertEquals(Map(JLong.valueOf(42) -> 1.0), m.toMap)
+
+    m.max(42L, 7.0)
+    assertEquals(1, m.size)
+    assertEquals(Map(JLong.valueOf(42) -> 7.0), m.toMap)
+  }
+
+  test("min") {
+    val m = new RefDoubleHashMap[JLong]
+    assertEquals(0, m.size)
+
+    m.min(42L, 1.0)
+    assertEquals(1, m.size)
+    assertEquals(Map(JLong.valueOf(42) -> 1.0), m.toMap)
+
+    m.min(42L, 0.5)
+    assertEquals(1, m.size)
+    assertEquals(Map(JLong.valueOf(42) -> 0.5), m.toMap)
+
+    m.min(42L, 7.0)
+    assertEquals(1, m.size)
+    assertEquals(Map(JLong.valueOf(42) -> 0.5), m.toMap)
+  }
+
+  test("mapToArray") {
+    val m = new RefDoubleHashMap[JLong]
+    m.add(0L, 1.0)
+    m.add(11L, 1.0)
+    m.add(22L, 1.0)
+    val data = m.mapToArray(new Array[Double](m.size)) { (k, v) =>
+      k + v
+    }
+    assertEquals(data.toList, List(1.0, 12.0, 23.0))
+  }
+
+  test("mapToArray -- invalid length") {
+    val m = new RefDoubleHashMap[JLong]
+    m.add(0L, 1.0)
+    m.add(11L, 1.0)
+    m.add(22L, 1.0)
+    intercept[IllegalArgumentException] {
+      m.mapToArray(new Array[Double](0)) { (k, v) =>
+        k + v
+      }
+    }
+  }
+
+  test("resize") {
+    val m = new RefDoubleHashMap[JLong]
+    (0 until 10000).foreach(i => m.put(i.toLong, i.toDouble))
+    assertEquals((0 until 10000).map(i => JLong.valueOf(i) -> i.toDouble).toMap, m.toMap)
+  }
+
+  test("resize - add") {
+    val m = new RefDoubleHashMap[JLong]
+    (0 until 10000).foreach(i => m.add(i.toLong, i.toDouble))
+    assertEquals((0 until 10000).map(i => JLong.valueOf(i) -> i.toDouble).toMap, m.toMap)
+  }
+
+  test("random") {
+    val jmap = new scala.collection.mutable.HashMap[JLong, Double]
+    val imap = new RefDoubleHashMap[JLong]
+    (0 until 10000).foreach { i =>
+      val v = Random.nextInt()
+      imap.put(v.toLong, i)
+      jmap.put(v.toLong, i)
+    }
+    assertEquals(jmap.toMap, imap.toMap)
+    assertEquals(jmap.size, imap.size)
+  }
+
+  test("memory per map") {
+    // Sanity check to verify if some change introduces more overhead per set
+    val bytes = ClassLayout.parseClass(classOf[RefDoubleHashMap[JLong]]).instanceSize()
+    assertEquals(bytes, 32L)
+  }
+
+  test("memory - 5 items") {
+    val imap = new RefDoubleHashMap[JLong]
+    val jmap = new java.util.HashMap[Long, Double](10)
+    (0 until 5).foreach { i =>
+      imap.put(i.toLong, i)
+      jmap.put(i, i)
+    }
+
+    val igraph = GraphLayout.parseInstance(imap)
+    // val jgraph = GraphLayout.parseInstance(jmap)
+
+    // println(igraph.toFootprint)
+    // println(jgraph.toFootprint)
+
+    // Only objects should be the key/value arrays and the map itself + 5 key objects
+    assertEquals(igraph.totalCount(), 8L)
+
+    // Sanity check size is < 400 bytes
+    assert(igraph.totalSize() <= 400)
+  }
+
+  test("memory - 10k items") {
+    val imap = new RefDoubleHashMap[JLong]
+    val jmap = new java.util.HashMap[Long, Double](10)
+    (0 until 10000).foreach { i =>
+      imap.put(i.toLong, i)
+      jmap.put(i, i)
+    }
+
+    val igraph = GraphLayout.parseInstance(imap)
+    // val jgraph = GraphLayout.parseInstance(jmap)
+
+    // println(igraph.toFootprint)
+    // println(jgraph.toFootprint)
+
+    // Only objects should be the key/value arrays and the map itself + 10000 key objects
+    assertEquals(igraph.totalCount(), 3L + 10000)
+
+    // Sanity check size is < 600kb
+    assert(igraph.totalSize() <= 600000)
+  }
+
+  test("negative absolute value") {
+    val s = new RefDoubleHashMap[RefDoubleHashMapSuite.MinHash]()
+    assertEquals(s.get(new RefDoubleHashMapSuite.MinHash, 0.0), 0.0)
+  }
+}
+
+object RefDoubleHashMapSuite {
+
+  class MinHash {
+
+    override def hashCode: Int = Integer.MIN_VALUE
+  }
+}


### PR DESCRIPTION
Primary use-case is computing an aggregate double value based on a key.