### PR TITLE
lwc: model object for event

### DIFF
--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEvent.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEvent.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwc.events
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.netflix.atlas.json.Json
+
+import java.io.StringWriter
+import scala.util.Using
+
+/**
+  * Represents an event that should be published via an LWC stream. Defines how to
+  * extract values and encode the raw event object.
+  */
+trait LwcEvent {
+
+  /** Raw event object that is being considered. */
+  def rawEvent: Any
+
+  /**
+    * Extract a tag value for a given key. Returns `null` if there is no value for
+    * the key or the value is not a string. By default it will delegate to `extractValue`
+    * to ensure the two are consistent.
+    */
+  def tagValue(key: String): String = {
+    extractValue(key) match {
+      case v: String => v
+      case _         => null
+    }
+  }
+
+  /**
+    * Extract a value from the raw event for a given key. This method should be consistent
+    * with the `tagValue` method for keys that can be considered tags.
+    */
+  def extractValue(key: String): Any
+
+  /** Encode the raw event as JSON. */
+  def encode(gen: JsonGenerator): Unit
+
+  /**
+    * Encode the raw event as an array representing a row in a table.
+    *
+    * @param columns
+    *     Keys to use with `extractValue` for selecting the value of the
+    *     column.
+    * @param gen
+    *     Generator for the JSON output.
+    */
+  def encodeAsRow(columns: List[String], gen: JsonGenerator): Unit
+
+  /** Return a JSON representation of the raw event. */
+  def toJson: String = {
+    Using.resource(new StringWriter) { w =>
+      Using.resource(Json.newJsonGenerator(w)) { gen =>
+        encode(gen)
+      }
+      w.toString
+    }
+  }
+
+  /** Return a JSON representation of a row generated from the raw event. */
+  def toJson(columns: List[String]): String = {
+    Using.resource(new StringWriter) { w =>
+      Using.resource(Json.newJsonGenerator(w)) { gen =>
+        encodeAsRow(columns, gen)
+      }
+      w.toString
+    }
+  }
+}
+
+object LwcEvent {
+
+  /**
+    * Wrap an object as an LWC event.
+    *
+    * @param rawEvent
+    *     Raw event object to wrap.
+    * @param extractor
+    *     Function to extract a value from the raw event. Returns null if there is no
+    *     value associated with the key.
+    * @return
+    *     Wrapped event to process with LWC.
+    */
+  def apply(rawEvent: Any, extractor: String => Any): LwcEvent = {
+    BasicLwcEvent(rawEvent, extractor)
+  }
+
+  private case class BasicLwcEvent(rawEvent: Any, extractor: String => Any) extends LwcEvent {
+
+    override def extractValue(key: String): Any = extractor(key)
+
+    override def encode(gen: JsonGenerator): Unit = {
+      Json.encode(gen, rawEvent)
+    }
+
+    override def encodeAsRow(columns: List[String], gen: JsonGenerator): Unit = {
+      gen.writeStartArray()
+      encodeColumns(columns, gen)
+      gen.writeEndArray()
+    }
+
+    @scala.annotation.tailrec
+    private def encodeColumns(columns: List[String], gen: JsonGenerator): Unit = {
+      if (columns.nonEmpty) {
+        Json.encode(gen, extractValue(columns.head))
+        encodeColumns(columns.tail, gen)
+      }
+    }
+  }
+}

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/LwcEventSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/LwcEventSuite.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwc.events
+
+import com.netflix.atlas.core.util.SortedTagMap
+import munit.FunSuite
+
+class LwcEventSuite extends FunSuite {
+
+  import LwcEventSuite._
+
+  private val sampleSpan: Span = {
+    Span(SortedTagMap("app" -> "www", "node" -> "i-123"), 42L)
+  }
+
+  private val sampleLwcEvent: LwcEvent = LwcEvent(sampleSpan, extractSpanValue(sampleSpan))
+
+  test("tagValue: exists") {
+    assertEquals(sampleLwcEvent.tagValue("app"), "www")
+    assertEquals(sampleLwcEvent.tagValue("node"), "i-123")
+  }
+
+  test("tagValue: missing") {
+    assertEquals(sampleLwcEvent.tagValue("foo"), null)
+  }
+
+  test("tagValue: wrong type") {
+    assertEquals(sampleLwcEvent.tagValue("duration"), null)
+  }
+
+  test("extractValue: exists") {
+    assertEquals(sampleLwcEvent.extractValue("app"), "www")
+    assertEquals(sampleLwcEvent.extractValue("node"), "i-123")
+    assertEquals(sampleLwcEvent.extractValue("duration"), 42L)
+  }
+
+  test("extractValue: missing") {
+    assertEquals(sampleLwcEvent.extractValue("foo"), null)
+  }
+
+  test("toJson: raw event") {
+    val expected = """{"tags":{"app":"www","node":"i-123"},"duration":42}"""
+    assertEquals(sampleLwcEvent.toJson, expected)
+  }
+
+  test("toJson: row no columns") {
+    val expected = """[]"""
+    assertEquals(sampleLwcEvent.toJson(List.empty), expected)
+  }
+
+  test("toJson: row nested object") {
+    val expected = """[42,{"app":"www","node":"i-123"}]"""
+    assertEquals(sampleLwcEvent.toJson(List("duration", "tags")), expected)
+  }
+
+  test("toJson: row simple") {
+    val expected = """[42,"www"]"""
+    assertEquals(sampleLwcEvent.toJson(List("duration", "app")), expected)
+  }
+}
+
+object LwcEventSuite {
+
+  case class Span(tags: Map[String, String], duration: Long)
+
+  def extractSpanValue(span: Span)(key: String): Any = {
+    key match {
+      case "tags"     => span.tags
+      case "duration" => span.duration
+      case k          => span.tags.getOrElse(k, null)
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ lazy val atlas = project.in(file("."))
     `atlas-jmh`,
     `atlas-json`,
     `atlas-lwcapi`,
+    `atlas-lwc-events`,
     `atlas-postgres`,
     `atlas-spring-akka`,
     `atlas-spring-eval`,
@@ -98,6 +99,13 @@ lazy val `atlas-lwcapi` = project
     Dependencies.akkaTestkit % "test",
     Dependencies.akkaHttpTestkit % "test",
     Dependencies.akkaStreamTestkit % "test"
+  ))
+
+lazy val `atlas-lwc-events` = project
+  .configure(BuildSettings.profile)
+  .dependsOn(`atlas-akka`, `atlas-core`, `atlas-json`)
+  .settings(libraryDependencies ++= Seq(
+    Dependencies.iepDynConfig
   ))
 
 lazy val `atlas-postgres` = project


### PR DESCRIPTION
Initial model object representing an arbitrary event to process with LWC. The raw event would typically be a log, span, or trace. The `LwcEvent` type would define how to extract data and encode the event without putting any restrictions on the structure so that LWC is agnostic to the event model and so we can avoid expensive conversions when processing.