### PR TITLE
lwc: add client interface for processing events

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/EventExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/EventExpr.scala
@@ -16,9 +16,21 @@
 package com.netflix.atlas.core.model
 
 /** Base type for event expressions. */
-sealed trait EventExpr extends Expr
+sealed trait EventExpr extends Expr {
+
+  /** Query to determine if an event should be matched. */
+  def query: Query
+}
 
 object EventExpr {
+
+  /**
+    * Specifies to just pass through the raw event if they match the query.
+    *
+    * @param query
+    *     Query to determine if an event should be matched.
+    */
+  case class Raw(query: Query) extends EventExpr
 
   /**
     * Expression that specifies how to map an event to a simple row with the specified columns.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/ModelExtractors.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/ModelExtractors.scala
@@ -86,6 +86,15 @@ object ModelExtractors {
     }
   }
 
+  case object EventExprType {
+
+    def unapply(value: Any): Option[EventExpr] = value match {
+      case e: EventExpr => Some(e)
+      case q: Query     => Some(EventExpr.Raw(q))
+      case _            => None
+    }
+  }
+
   case object TraceQueryType {
 
     def unapply(value: Any): Option[TraceQuery] = value match {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TraceQuery.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TraceQuery.scala
@@ -36,8 +36,8 @@ object TraceQuery {
     * Matches if the trace has a span that matches `q1` with a direct child span that
     * matches `q2`.
     */
-  case class Child(q1: TraceQuery, q2: TraceQuery) extends TraceQuery
+  case class Child(q1: Query, q2: Query) extends TraceQuery
 
   /** Filter to select the set of spans from a trace to forward as events. */
-  case class SpanFilter(q: TraceQuery, f: Query) extends Expr
+  case class SpanFilter(q: TraceQuery, f: DataExpr) extends Expr
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TraceVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TraceVocabularySuite.scala
@@ -63,8 +63,8 @@ class TraceVocabularySuite extends FunSuite {
   test("child") {
     val q = parseTraceQuery("app,foo,:eq,app,bar,:eq,:child")
     val expected = TraceQuery.Child(
-      TraceQuery.Simple(Query.Equal("app", "foo")),
-      TraceQuery.Simple(Query.Equal("app", "bar"))
+      Query.Equal("app", "foo"),
+      Query.Equal("app", "bar")
     )
     assertEquals(q, expected)
   }
@@ -73,10 +73,10 @@ class TraceVocabularySuite extends FunSuite {
     val q = parseFilter("app,foo,:eq,app,bar,:eq,:child,app,foo,:eq,:span-filter")
     val expected = TraceQuery.SpanFilter(
       TraceQuery.Child(
-        TraceQuery.Simple(Query.Equal("app", "foo")),
-        TraceQuery.Simple(Query.Equal("app", "bar"))
+        Query.Equal("app", "foo"),
+        Query.Equal("app", "bar")
       ),
-      Query.Equal("app", "foo")
+      DataExpr.All(Query.Equal("app", "foo"))
     )
     assertEquals(q, expected)
   }

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/AbstractLwcEventClient.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/AbstractLwcEventClient.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwc.events
+
+import com.netflix.atlas.core.model.DataExpr
+import com.netflix.atlas.core.model.EventExpr
+import com.netflix.atlas.core.model.Query
+import com.netflix.atlas.core.model.TraceQuery
+import com.netflix.atlas.core.util.SortedTagMap
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spectator.atlas.impl.QueryIndex
+
+abstract class AbstractLwcEventClient extends LwcEventClient {
+
+  import AbstractLwcEventClient._
+
+  @volatile private var index: QueryIndex[EventHandler] = QueryIndex.newInstance(new NoopRegistry)
+
+  @volatile private var traceHandlers: Map[Subscription, TraceQuery.SpanFilter] = Map.empty
+
+  protected def sync(subscriptions: Subscriptions): Unit = {
+    val idx = QueryIndex.newInstance[EventHandler](new NoopRegistry)
+
+    // Pass-through events
+    subscriptions.passThrough.foreach { sub =>
+      val expr = ExprUtils.parseEventExpr(sub.expression)
+      val q = removeValueClause(expr.query)
+      val handler = expr match {
+        case EventExpr.Raw(_)       => EventHandler(sub, e => List(e))
+        case EventExpr.Table(_, cs) => EventHandler(sub, e => List(LwcEvent.Row(e, cs)))
+      }
+      idx.add(q, handler)
+    }
+
+    // Analytics based on events
+    subscriptions.analytics.foreach { sub =>
+      val expr = ExprUtils.parseDataExpr(sub.expression)
+      val q = removeValueClause(expr.query)
+      val queryTags = Query.tags(expr.query)
+      val handler = EventHandler(
+        sub,
+        event => {
+          val tags = groupTags(expr, event)
+          tags.fold(List.empty[LwcEvent]) { ts =>
+            val tags = ts ++ queryTags
+            val v = dataValue(tags, event)
+            List(DatapointEvent(sub.id, SortedTagMap(tags), event.timestamp, v))
+          }
+        }
+      )
+      idx.add(q, handler)
+    }
+
+    // Trace pass-through
+    traceHandlers = subscriptions.tracePassThrough.map { sub =>
+      sub -> ExprUtils.parseTraceQuery(sub.expression)
+    }.toMap
+
+    index = idx
+  }
+
+  private def removeValueClause(query: Query): SpectatorQuery = {
+    val q = query
+      .rewrite {
+        case kq: Query.KeyQuery if kq.k == "value" => Query.True
+      }
+      .asInstanceOf[Query]
+    ExprUtils.toSpectatorQuery(Query.simplify(q, ignore = true))
+  }
+
+  private def groupTags(expr: DataExpr, event: LwcEvent): Option[Map[String, String]] = {
+    val tags = Map.newBuilder[String, String]
+    val it = expr.finalGrouping.iterator
+    while (it.hasNext) {
+      val k = it.next()
+      val v = event.tagValue(k)
+      if (v == null)
+        return None
+      else
+        tags += k -> v
+    }
+    Some(tags.result())
+  }
+
+  private def dataValue(tags: Map[String, String], event: LwcEvent): Double = {
+    tags.get("value").fold(1.0) { v =>
+      event.extractValue(v) match {
+        case b: Boolean if b => 1.0
+        case _: Boolean      => 0.0
+        case n: Byte         => n.toDouble
+        case n: Short        => n.toDouble
+        case n: Int          => n.toDouble
+        case n: Long         => n.toDouble
+        case n: Float        => n.toDouble
+        case n: Double       => n
+        case n: Number       => n.doubleValue()
+        case _               => 1.0
+      }
+    }
+  }
+
+  override def process(event: LwcEvent): Unit = {
+    index.forEachMatch(k => event.tagValue(k), h => handleMatch(event, h))
+  }
+
+  private def handleMatch(event: LwcEvent, handler: EventHandler): Unit = {
+    handler.mapper(event).foreach { e =>
+      submit(handler.subscription.id, e)
+    }
+  }
+
+  override def processTrace(trace: Seq[LwcEvent.Span]): Unit = {
+    traceHandlers.foreachEntry { (sub, filter) =>
+      if (TraceMatcher.matches(filter.q, trace)) {
+        val filtered = trace.filter(event => ExprUtils.matches(filter.f.query, event.tagValue))
+        if (filtered.nonEmpty) {
+          submit(sub.id, LwcEvent.Events(filtered))
+        }
+      }
+    }
+  }
+}
+
+object AbstractLwcEventClient {
+
+  private case class EventHandler(subscription: Subscription, mapper: LwcEvent => List[LwcEvent])
+}

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/DatapointEvent.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/DatapointEvent.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwc.events
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.netflix.atlas.json.Json
+
+/**
+  * Event that represents a time series data point generated from the events.
+  *
+  * @param id
+  *     Id for the associated subscription.
+  * @param tags
+  *     Tags for the data point.
+  * @param timestamp
+  *     Timestamp for the data point.
+  * @param value
+  *     Value for the data point.
+  */
+case class DatapointEvent(id: String, tags: Map[String, String], timestamp: Long, value: Double)
+    extends LwcEvent {
+
+  override def rawEvent: Any = this
+
+  override def extractValue(key: String): Any = {
+    tags.getOrElse(key, null)
+  }
+
+  override def encode(gen: JsonGenerator): Unit = {
+    Json.encode(gen, this)
+  }
+
+  override def encodeAsRow(columns: List[String], gen: JsonGenerator): Unit = {
+    gen.writeStartArray()
+    encodeColumns(columns, gen)
+    gen.writeEndArray()
+  }
+
+  @scala.annotation.tailrec
+  private def encodeColumns(columns: List[String], gen: JsonGenerator): Unit = {
+    if (columns.nonEmpty) {
+      Json.encode(gen, extractValue(columns.head))
+      encodeColumns(columns.tail, gen)
+    }
+  }
+}

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/ExprUtils.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/ExprUtils.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwc.events
+
+import com.netflix.atlas.core.model.DataExpr
+import com.netflix.atlas.core.model.DataVocabulary
+import com.netflix.atlas.core.model.EventExpr
+import com.netflix.atlas.core.model.EventVocabulary
+import com.netflix.atlas.core.model.ModelExtractors
+import com.netflix.atlas.core.model.Query
+import com.netflix.atlas.core.model.TraceQuery
+import com.netflix.atlas.core.model.TraceVocabulary
+import com.netflix.atlas.core.stacklang.Interpreter
+import com.netflix.spectator.atlas.impl.Parser
+
+/**
+  * Helper functions for working with expressions.
+  */
+private[events] object ExprUtils {
+
+  import ModelExtractors._
+
+  private val dataInterpreter = Interpreter(DataVocabulary.allWords)
+
+  /** Parse a single data expression. */
+  def parseDataExpr(str: String): DataExpr = {
+    dataInterpreter.execute(str).stack match {
+      case DataExprType(e) :: Nil => e
+      case _                      => throw new IllegalArgumentException(str)
+    }
+  }
+
+  private val eventInterpreter = Interpreter(EventVocabulary.allWords)
+
+  /** Parse a single event expression. */
+  def parseEventExpr(str: String): EventExpr = {
+    eventInterpreter.execute(str).stack match {
+      case EventExprType(e) :: Nil => e
+      case _                       => throw new IllegalArgumentException(str)
+    }
+  }
+
+  private val traceInterpreter = Interpreter(TraceVocabulary.allWords)
+
+  private def matchAllSpans(q: TraceQuery): TraceQuery.SpanFilter = {
+    TraceQuery.SpanFilter(q, DataExpr.All(Query.True))
+  }
+
+  /** Parse a single trace query expression. */
+  def parseTraceQuery(str: String): TraceQuery.SpanFilter = {
+    traceInterpreter.execute(str).stack match {
+      case TraceQueryType(q) :: Nil          => matchAllSpans(q)
+      case (f: TraceQuery.SpanFilter) :: Nil => f
+      case _                                 => throw new IllegalArgumentException(str)
+    }
+  }
+
+  /** Convert from Atlas query model to Spectator to use with a QueryIndex. */
+  def toSpectatorQuery(query: Query): SpectatorQuery = {
+    Parser.parseQuery(query.toString)
+  }
+
+  /**
+    * Check if a query matches based on tags provided by a function.
+    *
+    * @param query
+    *     Query to use for matching against the set of tags.
+    * @param tags
+    *     Function that returns the value for a given key. If there is no mapping
+    *     for a given key, then it should return `null`.
+    */
+  def matches(query: Query, tags: String => String): Boolean = {
+    query match {
+      case Query.True             => true
+      case Query.False            => false
+      case q: Query.HasKey        => tags(q.k) != null
+      case q: Query.KeyValueQuery => check(q, tags)
+      case Query.And(q1, q2)      => matches(q1, tags) && matches(q2, tags)
+      case Query.Or(q1, q2)       => matches(q1, tags) || matches(q2, tags)
+      case Query.Not(q)           => !matches(q, tags)
+    }
+  }
+
+  private def check(q: Query.KeyValueQuery, tags: String => String): Boolean = {
+    val v = tags(q.k)
+    v != null && q.check(v)
+  }
+}

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEvent.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEvent.scala
@@ -131,4 +131,65 @@ object LwcEvent {
       }
     }
   }
+
+  /**
+    * Wraps an event and converts it to a row.
+    *
+    * @param event
+    *     Event to wrap.
+    * @param columns
+    *     Columsn to project into the rwo.
+    */
+  case class Row(event: LwcEvent, columns: List[String]) extends LwcEvent {
+
+    override def rawEvent: Any = event.rawEvent
+
+    override def timestamp: Long = event.timestamp
+
+    override def tagValue(key: String): String = event.tagValue(key)
+
+    override def extractValue(key: String): Any = event.extractValue(key)
+
+    override def encode(gen: JsonGenerator): Unit = {
+      event.encodeAsRow(columns, gen)
+    }
+
+    override def encodeAsRow(columns: List[String], gen: JsonGenerator): Unit = {
+      event.encodeAsRow(columns, gen)
+    }
+  }
+
+  /** Wraps a sequence of events into an event that can be submitted. */
+  case class Events(seq: Seq[LwcEvent]) extends LwcEvent {
+
+    require(seq.nonEmpty, "event sequence cannot be empty")
+
+    override def rawEvent: Any = seq
+
+    override def timestamp: Long = seq.head.timestamp
+
+    override def tagValue(key: String): String = null
+
+    override def extractValue(key: String): Any = null
+
+    override def encode(gen: JsonGenerator): Unit = {
+      gen.writeStartArray()
+      seq.foreach(_.encode(gen))
+      gen.writeEndArray()
+    }
+
+    override def encodeAsRow(columns: List[String], gen: JsonGenerator): Unit = {
+      throw new UnsupportedOperationException()
+    }
+  }
+
+  /** Represents a span event that makes up a trace. */
+  trait Span extends LwcEvent {
+
+    /** Return the id for this span. */
+    def spanId: String
+
+    /** Returns the id for the parent or `null` if it is the root span. */
+    def parentId: String
+  }
 }

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEventClient.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEventClient.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwc.events
+
+import com.netflix.atlas.json.Json
+
+import java.io.StringWriter
+import scala.util.Using
+
+// TODO
+// - spring based configuration
+
+/**
+  * Client for processing events to make available via LWC stream.
+  */
+trait LwcEventClient {
+
+  /**
+    * Submit an event for a given subscription.
+    *
+    * @param id
+    *     Id of the subscription that should receive the event.
+    * @param event
+    *     Event to submit to the subscription.
+    */
+  def submit(id: String, event: LwcEvent): Unit
+
+  /** Process event for the stream. */
+  def process(event: LwcEvent): Unit
+
+  /**
+    * Process a trace for the stream.
+    *
+    * @param trace
+    *     The trace is modelled as a sequence of spans as the trace graph can be costly
+    *     to construct as part of the ingestion pipeline.
+    */
+  def processTrace(trace: Seq[LwcEvent.Span]): Unit
+}
+
+object LwcEventClient {
+
+  /**
+    * Create a new local client that forwards the results to the consumer function. This
+    * is mostly used for testing and debugging.
+    *
+    * @param subscriptions
+    *     Set of subscriptions to match with the events.
+    * @param consumer
+    *     Function that will receive the output.
+    * @return
+    *     Client instance.
+    */
+  def apply(subscriptions: Subscriptions, consumer: String => Unit): LwcEventClient = {
+    new LocalLwcEventClient(subscriptions, consumer)
+  }
+
+  private class LocalLwcEventClient(subscriptions: Subscriptions, consumer: String => Unit)
+      extends AbstractLwcEventClient {
+
+    sync(subscriptions)
+
+    override def submit(id: String, event: LwcEvent): Unit = {
+      Using.resource(new StringWriter()) { w =>
+        Using.resource(Json.newJsonGenerator(w)) { gen =>
+          gen.writeStartObject()
+          gen.writeStringField("id", id)
+          gen.writeFieldName("event")
+          event.encode(gen)
+          gen.writeEndObject()
+        }
+        consumer(s"data: ${w.toString}")
+      }
+    }
+  }
+}

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/Subscription.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/Subscription.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwc.events
+
+/**
+  * Subscription to receive data.
+  *
+  * @param id
+  *     Id used to pair the received data with a given consumer.
+  * @param step
+  *     Step size for the subscription when mapped into a time series.
+  * @param expression
+  *     Expression for matching events and mapping into the expected output.
+  */
+case class Subscription(id: String, step: Long, expression: String)

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/Subscriptions.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/Subscriptions.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwc.events
+
+/**
+  * Set of subscriptions to receive event data.
+  *
+  * @param passThrough
+  *     Subscriptions looking for the raw events to be passed through.
+  * @param analytics
+  *     Subscriptions that should be mapped into time series.
+  * @param tracePassThrough
+  *     Trace subscriptions looking for the trace spans to be passed through.
+  * @param traceAnalytics
+  *     Trace subscriptions that should map the selected spans into time-series.
+  */
+case class Subscriptions(
+  passThrough: List[Subscription] = Nil,
+  analytics: List[Subscription] = Nil,
+  tracePassThrough: List[Subscription] = Nil,
+  traceAnalytics: List[Subscription] = Nil
+)

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/TraceMatcher.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/TraceMatcher.scala
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwc.events
+
+import com.netflix.atlas.core.model.Query
+import com.netflix.atlas.core.model.TraceQuery
+
+/**
+  * Re-usable matcher to determine if a trace query matches a sequence of spans.
+  */
+trait TraceMatcher {
+
+  /** Update the matcher by checking the given span. */
+  def check(event: LwcEvent.Span): Unit
+
+  /**
+    * Returns true if the trace query matches. Should only be called after all the spans
+    * have been checked.
+    */
+  def matches: Boolean
+
+  /** Reset the matcher so it can be re-used. */
+  def reset(): Unit
+}
+
+object TraceMatcher {
+
+  /**
+    * Check if a trace query matches the trace.
+    *
+    * @param query
+    *     Expression for whether a trace should be selected.
+    * @param trace
+    *     Set of spans that are part of a call tree.
+    * @return
+    *     True if the query matches the trace.
+    */
+  def matches(query: TraceQuery, trace: Seq[LwcEvent.Span]): Boolean = {
+    val matcher = apply(query)
+    trace.foreach(matcher.check)
+    matcher.matches
+  }
+
+  /** Construct a new matcher for the trace query. */
+  def apply(query: TraceQuery): TraceMatcher = {
+    query match {
+      case TraceQuery.Child(q1, q2)   => new ChildMatcher(q1, q2)
+      case TraceQuery.SpanAnd(q1, q2) => new SpanAndMatcher(apply(q1), apply(q2))
+      case TraceQuery.SpanOr(q1, q2)  => new SpanOrMatcher(apply(q1), apply(q2))
+      case TraceQuery.Simple(q)       => new SimpleMatcher(q)
+    }
+  }
+
+  private class SimpleMatcher(query: Query) extends TraceMatcher {
+
+    private var matched: Boolean = false
+
+    override def check(event: LwcEvent.Span): Unit = {
+      matched = matched || ExprUtils.matches(query, event.tagValue)
+    }
+
+    override def matches: Boolean = matched
+
+    override def reset(): Unit = {
+      matched = false
+    }
+  }
+
+  private class SpanAndMatcher(m1: TraceMatcher, m2: TraceMatcher) extends TraceMatcher {
+
+    override def check(event: LwcEvent.Span): Unit = {
+      m1.check(event)
+      m2.check(event)
+    }
+
+    override def matches: Boolean = m1.matches && m2.matches
+
+    override def reset(): Unit = {
+      m1.reset()
+      m2.reset()
+    }
+  }
+
+  private class SpanOrMatcher(m1: TraceMatcher, m2: TraceMatcher) extends TraceMatcher {
+
+    override def check(event: LwcEvent.Span): Unit = {
+      m1.check(event)
+      m2.check(event)
+    }
+
+    override def matches: Boolean = m1.matches || m2.matches
+
+    override def reset(): Unit = {
+      m1.reset()
+      m2.reset()
+    }
+  }
+
+  private class ChildMatcher(parent: Query, child: Query) extends TraceMatcher {
+
+    private val parentSpanIds = collection.mutable.HashSet.empty[String]
+    private val childParentIds = collection.mutable.HashSet.empty[String]
+
+    private var matched = false
+
+    override def check(event: LwcEvent.Span): Unit = {
+      if (matched)
+        return
+
+      if (ExprUtils.matches(parent, event.tagValue)) {
+        val id = event.spanId
+        if (childParentIds.contains(id)) {
+          matched = true
+          return
+        } else {
+          parentSpanIds.add(id)
+        }
+      }
+
+      if (ExprUtils.matches(child, event.tagValue)) {
+        val id = event.parentId
+        if (parentSpanIds.contains(id)) {
+          matched = true
+          return
+        } else {
+          childParentIds.add(id)
+        }
+      }
+    }
+
+    override def matches: Boolean = matched
+
+    override def reset(): Unit = {
+      parentSpanIds.clear()
+      childParentIds.clear()
+      matched = false
+    }
+  }
+}

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/package.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/package.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwc
+
+package object events {
+
+  type SpectatorQuery = com.netflix.spectator.atlas.impl.Query
+}

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/ExprUtilsSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/ExprUtilsSuite.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwc.events
+
+import com.netflix.atlas.core.model.DataExpr
+import com.netflix.atlas.core.model.EventExpr
+import com.netflix.atlas.core.model.Query
+import com.netflix.atlas.core.model.TraceQuery
+import munit.FunSuite
+
+class ExprUtilsSuite extends FunSuite {
+
+  test("data: ok") {
+    val expected = DataExpr.Sum(Query.Equal("app", "foo"))
+    assertEquals(ExprUtils.parseDataExpr("app,foo,:eq,:sum"), expected)
+  }
+
+  test("data: invalid") {
+    intercept[IllegalArgumentException] {
+      ExprUtils.parseDataExpr("app,foo,:eq,:sum,1")
+    }
+  }
+
+  test("event: raw") {
+    val expected = EventExpr.Raw(Query.Equal("app", "foo"))
+    assertEquals(ExprUtils.parseEventExpr("app,foo,:eq"), expected)
+  }
+
+  test("event: table") {
+    val expected = EventExpr.Table(Query.Equal("app", "foo"), List("app"))
+    assertEquals(ExprUtils.parseEventExpr("app,foo,:eq,(,app,),:table"), expected)
+  }
+
+  test("event: invalid") {
+    intercept[IllegalArgumentException] {
+      ExprUtils.parseEventExpr("app,foo,:eq,1")
+    }
+  }
+
+  test("trace: simple query") {
+    val expected = TraceQuery.SpanFilter(
+      TraceQuery.Simple(Query.Equal("app", "foo")),
+      DataExpr.All(Query.True)
+    )
+    assertEquals(ExprUtils.parseTraceQuery("app,foo,:eq"), expected)
+  }
+
+  test("trace: complex") {
+    val expected = TraceQuery.SpanFilter(
+      TraceQuery.Child(
+        Query.Equal("app", "foo"),
+        Query.Equal("app", "bar")
+      ),
+      DataExpr.All(Query.Equal("app", "foo"))
+    )
+    val expr = "app,foo,:eq,app,bar,:eq,:child,app,foo,:eq,:span-filter"
+    assertEquals(ExprUtils.parseTraceQuery(expr), expected)
+  }
+
+  test("trace: analytics") {
+    val expected = TraceQuery.SpanFilter(
+      TraceQuery.Child(
+        Query.Equal("app", "foo"),
+        Query.Equal("app", "bar")
+      ),
+      DataExpr.Sum(Query.Equal("app", "foo"))
+    )
+    val expr = "app,foo,:eq,app,bar,:eq,:child,app,foo,:eq,:sum,:span-filter"
+    assertEquals(ExprUtils.parseTraceQuery(expr), expected)
+  }
+}

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/LwcEventClientSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/LwcEventClientSuite.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwc.events
+
+import com.netflix.atlas.core.util.SortedTagMap
+import munit.FunSuite
+
+class LwcEventClientSuite extends FunSuite {
+
+  import LwcEventSuite._
+
+  private val sampleSpan: TestEvent = {
+    TestEvent(SortedTagMap("app" -> "www", "node" -> "i-123"), 42L)
+  }
+
+  private val sampleLwcEvent: LwcEvent = LwcEvent(sampleSpan, extractSpanValue(sampleSpan))
+
+  test("pass-through") {
+    val subs = Subscriptions(passThrough =
+      List(
+        Subscription("1", 60000, "app,foo,:eq"),
+        Subscription("2", 60000, "app,www,:eq")
+      )
+    )
+    val output = List.newBuilder[String]
+    val client = LwcEventClient(subs, output.addOne)
+    client.process(sampleLwcEvent)
+    assertEquals(
+      List("""data: {"id":"2","event":{"tags":{"app":"www","node":"i-123"},"duration":42}}"""),
+      output.result()
+    )
+  }
+
+  test("analytics, basic aggregate") {
+    val subs = Subscriptions(analytics =
+      List(
+        Subscription("1", 60000, "app,foo,:eq,:sum"),
+        Subscription("2", 60000, "app,www,:eq,:sum")
+      )
+    )
+    val output = List.newBuilder[String]
+    val client = LwcEventClient(subs, output.addOne)
+    client.process(sampleLwcEvent)
+    val vs = output.result()
+    assertEquals(1, vs.size)
+    assert(vs.forall(_.contains(""""tags":{"app":"www"}""")))
+    assert(vs.forall(_.contains(""""value":1.0""")))
+  }
+
+  test("analytics, basic aggregate extract value") {
+    val subs = Subscriptions(analytics =
+      List(
+        Subscription("1", 60000, "app,www,:eq,value,duration,:eq,:and,:sum")
+      )
+    )
+    val output = List.newBuilder[String]
+    val client = LwcEventClient(subs, output.addOne)
+    client.process(sampleLwcEvent)
+    val vs = output.result()
+    assertEquals(1, vs.size)
+    assert(vs.forall(_.contains(""""tags":{"app":"www","value":"duration"}""")))
+    assert(vs.forall(_.contains(""""value":42.0""")))
+  }
+
+  test("analytics, group by") {
+    val subs = Subscriptions(analytics =
+      List(
+        Subscription("1", 60000, "app,foo,:eq,:sum,(,node,),:by"),
+        Subscription("2", 60000, "app,www,:eq,:sum,(,node,),:by")
+      )
+    )
+    val output = List.newBuilder[String]
+    val client = LwcEventClient(subs, output.addOne)
+    client.process(sampleLwcEvent)
+    val vs = output.result()
+    assertEquals(1, vs.size)
+    assert(vs.forall(_.contains(""""tags":{"app":"www","node":"i-123"}""")))
+    assert(vs.forall(_.contains(""""value":1.0""")))
+  }
+
+  test("analytics, group by missing key") {
+    val subs = Subscriptions(analytics =
+      List(
+        Subscription("1", 60000, "app,www,:eq,:sum,(,foo,),:by")
+      )
+    )
+    val output = List.newBuilder[String]
+    val client = LwcEventClient(subs, output.addOne)
+    client.process(sampleLwcEvent)
+    assert(output.result().isEmpty)
+  }
+}

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/LwcEventSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/LwcEventSuite.scala
@@ -22,8 +22,8 @@ class LwcEventSuite extends FunSuite {
 
   import LwcEventSuite._
 
-  private val sampleSpan: Span = {
-    Span(SortedTagMap("app" -> "www", "node" -> "i-123"), 42L)
+  private val sampleSpan: TestEvent = {
+    TestEvent(SortedTagMap("app" -> "www", "node" -> "i-123"), 42L)
   }
 
   private val sampleLwcEvent: LwcEvent = LwcEvent(sampleSpan, extractSpanValue(sampleSpan))
@@ -74,9 +74,9 @@ class LwcEventSuite extends FunSuite {
 
 object LwcEventSuite {
 
-  case class Span(tags: Map[String, String], duration: Long)
+  case class TestEvent(tags: Map[String, String], duration: Long)
 
-  def extractSpanValue(span: Span)(key: String): Any = {
+  def extractSpanValue(span: TestEvent)(key: String): Any = {
     key match {
       case "tags"     => span.tags
       case "duration" => span.duration

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/TraceMatcherSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/TraceMatcherSuite.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwc.events
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.netflix.atlas.core.model.TraceQuery
+import com.netflix.atlas.json.Json
+import munit.FunSuite
+
+import scala.util.Random
+
+class TraceMatcherSuite extends FunSuite {
+
+  import TraceMatcherSuite._
+
+  private def mkSpan(
+    app: String,
+    spanId: String,
+    parentId: String,
+    start: Long,
+    duration: Long
+  ): TestSpan = {
+    TestSpan(
+      Map("app" -> app),
+      spanId,
+      parentId,
+      start,
+      duration
+    )
+  }
+
+  private val sampleTrace = List(
+    mkSpan("a", "1", null, 0L, 100L),
+    mkSpan("b", "2", "1", 1L, 25L),
+    mkSpan("c", "3", "1", 5L, 90L),
+    mkSpan("d", "4", "1", 15L, 50L),
+    mkSpan("e", "5", "3", 8L, 50L),
+    mkSpan("f", "6", "3", 55L, 20L)
+  )
+
+  private def checkMatch(query: TraceQuery, shouldMatch: Boolean): Unit = {
+    assertEquals(TraceMatcher.matches(query, sampleTrace), shouldMatch)
+    assertEquals(TraceMatcher.matches(query, sampleTrace.reverse), shouldMatch)
+    assertEquals(TraceMatcher.matches(query, Random.shuffle(sampleTrace)), shouldMatch)
+  }
+
+  test("simple") {
+    checkMatch(ExprUtils.parseTraceQuery("app,a,:eq").q, true)
+    checkMatch(ExprUtils.parseTraceQuery("app,z,:eq").q, false)
+  }
+
+  test("span-and") {
+    val q1 = ExprUtils.parseTraceQuery("app,a,:eq,app,e,:eq,:span-and").q
+    checkMatch(q1, true)
+
+    val q2 = ExprUtils.parseTraceQuery("app,a,:eq,app,z,:eq,:span-and").q
+    checkMatch(q2, false)
+  }
+
+  test("span-or") {
+    val q1 = ExprUtils.parseTraceQuery("app,a,:eq,app,e,:eq,:span-or").q
+    checkMatch(q1, true)
+
+    val q2 = ExprUtils.parseTraceQuery("app,a,:eq,app,z,:eq,:span-or").q
+    checkMatch(q2, true)
+
+    val q3 = ExprUtils.parseTraceQuery("app,y,:eq,app,z,:eq,:span-or").q
+    checkMatch(q3, false)
+  }
+
+  test("child") {
+    val q1 = ExprUtils.parseTraceQuery("app,a,:eq,app,c,:eq,:child").q
+    checkMatch(q1, true)
+
+    val q2 = ExprUtils.parseTraceQuery("app,c,:eq,app,e,:eq,:child").q
+    checkMatch(q2, true)
+
+    val q3 = ExprUtils.parseTraceQuery("app,a,:eq,app,e,:eq,:child").q
+    checkMatch(q3, false)
+  }
+}
+
+object TraceMatcherSuite {
+
+  case class TestSpan(
+    tags: Map[String, String],
+    spanId: String,
+    parentId: String,
+    timestamp: Long,
+    duration: Long
+  ) extends LwcEvent.Span {
+
+    override def rawEvent: Any = this
+
+    override def extractValue(key: String): Any = tags.getOrElse(key, null)
+
+    override def encode(gen: JsonGenerator): Unit = {
+      Json.encode(gen, this)
+    }
+
+    override def encodeAsRow(columns: List[String], gen: JsonGenerator): Unit = {
+      throw new UnsupportedOperationException()
+    }
+  }
+}

--- a/atlas-spring-lwc-events/src/main/resources/reference.conf
+++ b/atlas-spring-lwc-events/src/main/resources/reference.conf
@@ -1,0 +1,16 @@
+
+atlas.lwc.events {
+
+  // Sample subscription. Step is optional.
+  // {
+  //   id = "foo"
+  //   step = 60s
+  //   subscription = "app,foo,:eq,:sum"
+  // }
+  subscriptions {
+    pass-through = []
+    analytics = []
+    trace-pass-through = []
+    trace-analytics = []
+  }
+}

--- a/atlas-spring-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEventConfiguration.scala
+++ b/atlas-spring-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEventConfiguration.scala
@@ -1,0 +1,40 @@
+package com.netflix.atlas.lwc.events
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+import java.util.Optional
+
+@Configuration
+class LwcEventConfiguration {
+
+  import scala.jdk.CollectionConverters._
+
+  @Bean
+  def lwcEventClient(config: Optional[Config]): LwcEventClient = {
+    val c = config.orElseGet(() => ConfigFactory.load())
+    val logger = LoggerFactory.getLogger(classOf[LwcEventClient])
+    val subs = toSubscriptions(c)
+    LwcEventClient(subs, logger.info)
+  }
+
+  private def toSubscriptions(config: Config): Subscriptions = {
+    val cfg = config.getConfig("atlas.lwc.events.subscriptions")
+    Subscriptions(
+      passThrough = toSubscriptions(cfg.getConfigList("pass-through")),
+      analytics = toSubscriptions(cfg.getConfigList("analytics")),
+      tracePassThrough = toSubscriptions(cfg.getConfigList("trace-pass-through")),
+      traceAnalytics = toSubscriptions(cfg.getConfigList("trace-analytics"))
+    )
+  }
+
+  private def toSubscriptions(configs: java.util.List[_ <: Config]): List[Subscription] = {
+    configs.asScala.toList.map { c =>
+      val step = if (c.hasPath("step")) c.getDuration("step").toMillis else 60_000L
+      Subscription(c.getString("id"), step, c.getString("expression"))
+    }
+  }
+}

--- a/atlas-spring-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/LwcEventConfigurationSuite.scala
+++ b/atlas-spring-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/LwcEventConfigurationSuite.scala
@@ -1,0 +1,18 @@
+package com.netflix.atlas.lwc.events
+
+import munit.FunSuite
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+
+import scala.util.Using
+
+class LwcEventConfigurationSuite extends FunSuite {
+
+  test("load module") {
+    Using.resource(new AnnotationConfigApplicationContext()) { context =>
+      context.scan("com.netflix")
+      context.refresh()
+      context.start()
+      assert(context.getBean(classOf[LwcEventClient]) != null)
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,8 @@ lazy val `atlas-lwc-events` = project
   .configure(BuildSettings.profile)
   .dependsOn(`atlas-akka`, `atlas-core`, `atlas-json`)
   .settings(libraryDependencies ++= Seq(
-    Dependencies.iepDynConfig
+    Dependencies.iepDynConfig,
+    Dependencies.spectatorAtlas
   ))
 
 lazy val `atlas-postgres` = project
@@ -133,6 +134,14 @@ lazy val `atlas-spring-eval` = project
 lazy val `atlas-spring-lwcapi` = project
   .configure(BuildSettings.profile)
   .dependsOn(`atlas-spring-akka`, `atlas-lwcapi`)
+  .settings(libraryDependencies ++= Seq(
+    Dependencies.iepSpring,
+    Dependencies.springContext
+  ))
+
+lazy val `atlas-spring-lwc-events` = project
+  .configure(BuildSettings.profile)
+  .dependsOn(`atlas-lwc-events`)
   .settings(libraryDependencies ++= Seq(
     Dependencies.iepSpring,
     Dependencies.springContext

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
     val log4j      = "2.20.0"
     val scala      = "2.13.10"
     val slf4j      = "1.7.36"
-    val spectator  = "1.6.1"
+    val spectator  = "1.6.2"
     val spring     = "6.0.7"
 
     val crossScala = Seq(scala)


### PR DESCRIPTION
Adds `LwcEventClient` that can be used as part of an event ingestion workflow to make events available to an LWC stream. The current setup just supports a statically configured set of subscriptions for verifying the interface and testing the performance overhead.