### PR TITLE
1.7.x: eval: fix aggr for group by with gauges

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
@@ -235,12 +235,13 @@ object AggrDatapoint {
     override def aggregate(datapoint: AggrDatapoint): Aggregator = {
       if (!checkLimits) {
         numInputDatapoints += 1
-        aggregators.get(datapoint.tags) match {
+        val tags = datapoint.tags - aggrTagKey
+        aggregators.get(tags) match {
           case Some(aggr) =>
             aggr.aggregate(datapoint)
           case None =>
             numIntermediateDatapoints += 1
-            aggregators.put(datapoint.tags, newAggregator(datapoint))
+            aggregators.put(tags, newAggregator(datapoint))
         }
       }
       this


### PR DESCRIPTION
The `atlas.aggr` key was included when grouping the datapoints which caused values for the same key to go to separate buckets.

Backport of #1555