### PR TITLE
1.7 - eval: ensure exprs are resent on reconnect

### DIFF
--- a/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
+++ b/atlas-akka/src/test/scala/com/netflix/atlas/akka/StreamOpsSuite.scala
@@ -252,4 +252,24 @@ class StreamOpsSuite extends FunSuite {
     val vs = Await.result(future, Duration.Inf)
     assertEquals(vs, List(1, 1, 2, 2))
   }
+
+  test("repeatLastReceived, steady updates") {
+    val input = List(1, 1, 2, 3, 3, 3, 4, 5, 6, 6, 7, 1)
+    val future = Source(input)
+      .via(StreamOps.repeatLastReceived(30.seconds))
+      .runWith(Sink.seq[Int])
+    val vs = Await.result(future, Duration.Inf)
+    assertEquals(vs, input)
+  }
+
+  test("repeatLastReceived") {
+    val future = Source
+      .repeat(1)
+      .via(StreamOps.unique())
+      .via(StreamOps.repeatLastReceived(1.millis))
+      .take(10)
+      .runWith(Sink.seq[Int])
+    val vs = Await.result(future, Duration.Inf)
+    assertEquals(vs, (0 until 10).map(_ => 1).toList)
+  }
 }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -477,6 +477,12 @@ private[stream] abstract class EvaluatorImpl(
           )
         )
       }
+      // Repeat the last received element which will be the data map with the set
+      // expressions to subscribe to. In the event of a connection failure the cluster
+      // group by step will automatically reconnect, but the data message needs to be
+      // resent. This ensures the most recent set of subscriptions will go out at a
+      // regular cadence.
+      .via(StreamOps.repeatLastReceived(5.seconds))
       .via(ClusterOps.groupBy(createGroupByContext(context)))
       .mapAsync(parsingNumThreads) { msg =>
         // This step is placed after merge of streams so there is a single


### PR DESCRIPTION
If the websocket to an lwcapi node fails and needs to reconnect, then the message with the set of expressions needs to be resent. Before this would only happen when there was a change in either the set of remote instances or the set of expressions. With this change, the set of expressions will get repeated every 5s so it will get resent on a reconnect.

Note, the websocket sub-flow already has some deduping if there is no change, so the additional overhead during normal operations is minimal. If there is a failure, then the sub-flow will get restarted and the state for the `unique` operator will get reset allowing the repeated expression message through.

Backport of #1557.