### PR TITLE
lwc: indicate expr type for subscriptions

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/ExprType.java
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/ExprType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model;
+
+/** Indicates the type of expression for a subscription. */
+public enum ExprType {
+  /**
+   * Time series expression such as used with Atlas Graph API. Can also be used for analytics
+   * queries on top of event data.
+   */
+  TIME_SERIES,
+
+  /** Expression to select a set of events to be passed through. */
+  EVENTS,
+
+  /** Expression to select a set of traces to be passed through. */
+  TRACES;
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcExpression.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcExpression.scala
@@ -24,9 +24,12 @@ import com.netflix.atlas.json.JsonSupport
   *
   * @param expression
   *     Expression to subscribe to from LWCAPI.
+  * @param exprType
+  *     Indicates the type of expression for the subscription. This is typically determined
+  *     based on the endpoint used on the URI.
   * @param step
   *     The step size used for this stream of data.
   */
-case class LwcExpression(expression: String, step: Long) extends JsonSupport {
+case class LwcExpression(expression: String, exprType: ExprType, step: Long) extends JsonSupport {
   val `type`: String = "expression"
 }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -50,6 +50,7 @@ import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.eval.model.AggrDatapoint
 import com.netflix.atlas.eval.model.AggrValuesInfo
+import com.netflix.atlas.eval.model.ExprType
 import com.netflix.atlas.eval.model.LwcExpression
 import com.netflix.atlas.eval.model.LwcMessages
 import com.netflix.atlas.eval.model.TimeGroup
@@ -506,7 +507,7 @@ private[stream] abstract class EvaluatorImpl(
   private def toExprSet(dss: DataSources, interpreter: ExprInterpreter): Set[LwcExpression] = {
     dss.getSources.asScala.flatMap { dataSource =>
       interpreter.eval(Uri(dataSource.getUri)).map { expr =>
-        LwcExpression(expr.toString, dataSource.getStep.toMillis)
+        LwcExpression(expr.toString, ExprType.TIME_SERIES, dataSource.getStep.toMillis)
       }
     }.toSet
   }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcMessagesSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcMessagesSuite.scala
@@ -89,7 +89,15 @@ class LwcMessagesSuite extends FunSuite {
 
   test("batch: expression") {
     val expected = (0 until 10).map { i =>
-      LwcExpression("name,cpu,:eq,:max", i)
+      LwcExpression("name,cpu,:eq,:max", ExprType.TIME_SERIES, i)
+    }
+    val actual = LwcMessages.parseBatch(LwcMessages.encodeBatch(expected))
+    assertEquals(actual, expected.toList)
+  }
+
+  test("batch: events expression") {
+    val expected = (0 until 10).map { i =>
+      LwcExpression("name,cpu,:eq", ExprType.EVENTS, i)
     }
     val actual = LwcMessages.parseBatch(LwcMessages.encodeBatch(expected))
     assertEquals(actual, expected.toList)
@@ -152,7 +160,7 @@ class LwcMessagesSuite extends FunSuite {
     // compatibility with existing versions. To check for that this test loads a file
     // that has been pre-encoded.
     val expected = List(
-      LwcExpression("name,cpu,:eq,:max", 60_000),
+      LwcExpression("name,cpu,:eq,:max", ExprType.TIME_SERIES, 60_000),
       LwcSubscription(
         "name,cpu,:eq,:avg",
         List(
@@ -195,7 +203,7 @@ class LwcMessagesSuite extends FunSuite {
   private def randomObject(random: Random): AnyRef = {
     random.nextInt(6) match {
       case 0 =>
-        LwcExpression(randomString, randomStep(random))
+        LwcExpression(randomString, ExprType.TIME_SERIES, randomStep(random))
       case 1 =>
         val n = random.nextInt(10) + 1
         LwcSubscription(

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionMetadata.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionMetadata.scala
@@ -18,10 +18,12 @@ package com.netflix.atlas.lwcapi
 import com.fasterxml.jackson.annotation.JsonAlias
 import com.netflix.atlas.core.util.Hash
 import com.netflix.atlas.core.util.Strings
+import com.netflix.atlas.eval.model.ExprType
 import com.netflix.atlas.json.JsonSupport
 
 case class ExpressionMetadata(
   expression: String,
+  exprType: ExprType,
   @JsonAlias(Array("step")) frequency: Long = ApiSettings.defaultStep,
   id: String = ""
 ) extends JsonSupport
@@ -37,13 +39,13 @@ case class ExpressionMetadata(
 
 object ExpressionMetadata {
 
-  def apply(expression: String, step: Long): ExpressionMetadata = {
+  def apply(expression: String, exprType: ExprType, step: Long): ExpressionMetadata = {
     val f = if (step > 0) step else ApiSettings.defaultStep
-    new ExpressionMetadata(expression, f, computeId(expression, f))
+    new ExpressionMetadata(expression, exprType, f, computeId(expression, f))
   }
 
   def apply(expression: String): ExpressionMetadata = {
-    apply(expression, ApiSettings.defaultStep)
+    apply(expression, ExprType.TIME_SERIES, ApiSettings.defaultStep)
   }
 
   def computeId(e: String, f: Long): String = {

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionSplitter.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionSplitter.scala
@@ -23,6 +23,7 @@ import com.netflix.atlas.core.model.ModelExtractors
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.Query.KeyQuery
 import com.netflix.atlas.core.stacklang.Interpreter
+import com.netflix.atlas.eval.model.ExprType
 import com.netflix.spectator.ipc.ServerGroup
 import com.typesafe.config.Config
 
@@ -152,15 +153,19 @@ class ExpressionSplitter(config: Config) {
     }
   }
 
-  def split(expression: String, frequency: Long): List[Subscription] = {
+  def split(expression: String, exprType: ExprType, frequency: Long): List[Subscription] = {
     getFromCache(expression) match {
-      case Success(exprs: List[?]) => exprs.map(e => toSubscription(e, frequency))
+      case Success(exprs: List[?]) => exprs.map(e => toSubscription(e, exprType, frequency))
       case Failure(t)              => throw t
     }
   }
 
-  private def toSubscription(meta: DataExprMeta, frequency: Long): Subscription = {
-    Subscription(meta.compressedQuery, ExpressionMetadata(meta.exprString, frequency))
+  private def toSubscription(
+    meta: DataExprMeta,
+    exprType: ExprType,
+    frequency: Long
+  ): Subscription = {
+    Subscription(meta.compressedQuery, ExpressionMetadata(meta.exprString, exprType, frequency))
   }
 
   private def simplify(query: Query): Query = {

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
@@ -194,7 +194,7 @@ class SubscribeApi(
 
     expressions.foreach { expr =>
       try {
-        val splits = splitter.split(expr.expression, expr.frequency)
+        val splits = splitter.split(expr.expression, expr.exprType, expr.frequency)
 
         // Add any new expressions
         val (queue, addedSubs) = sm.subscribe(streamId, splits)

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/WebSocketSessionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/WebSocketSessionManager.scala
@@ -29,7 +29,6 @@ import akka.util.ByteString
 import com.netflix.atlas.akka.DiagnosticMessage
 import com.netflix.atlas.eval.model.LwcExpression
 import com.netflix.atlas.eval.model.LwcMessages
-import com.netflix.atlas.json.Json
 import com.netflix.atlas.json.JsonSupport
 import com.netflix.atlas.lwcapi.SubscribeApi.ErrorMsg
 import com.typesafe.scalalogging.StrictLogging
@@ -70,11 +69,11 @@ private[lwcapi] class WebSocketSessionManager(
       override def onPush(): Unit = {
         try {
           val lwcExpressions = grab(in) match {
-            case str: String     => Json.decode[List[LwcExpression]](str)
             case str: ByteString => LwcMessages.parseBatch(str).asInstanceOf[List[LwcExpression]]
             case v               => throw new MatchError(s"invalid type: ${v.getClass.getName}")
           }
-          val metadata = lwcExpressions.map(v => ExpressionMetadata(v.expression, v.step))
+          val metadata =
+            lwcExpressions.map(v => ExpressionMetadata(v.expression, v.exprType, v.step))
           // Update subscription here
           val errors = subscribeFunc(streamMeta.streamId, metadata).map { error =>
             DiagnosticMessage.error(s"[${error.expression}] ${error.message}")

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionMetadataSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionMetadataSuite.scala
@@ -17,6 +17,7 @@ package com.netflix.atlas.lwcapi
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException
+import com.netflix.atlas.eval.model.ExprType
 import com.netflix.atlas.json.Json
 import munit.FunSuite
 
@@ -24,17 +25,17 @@ class ExpressionMetadataSuite extends FunSuite {
 
   test("default frequency is applied") {
     val ret1 = ExpressionMetadata("this")
-    val ret2 = ExpressionMetadata("this", ApiSettings.defaultStep)
+    val ret2 = ExpressionMetadata("this", ExprType.TIME_SERIES, ApiSettings.defaultStep)
     assertEquals(ret1, ret2)
   }
 
   test("default id is applied") {
-    val ret1 = ExpressionMetadata("this", 5)
+    val ret1 = ExpressionMetadata("this", ExprType.TIME_SERIES, 5)
     assert(ret1.id.nonEmpty)
   }
 
   test("full params") {
-    val expr = ExpressionMetadata("test", 60000, "idHere")
+    val expr = ExpressionMetadata("test", ExprType.TIME_SERIES, 60000, "idHere")
     assertEquals(expr.expression, "test")
     assertEquals(expr.frequency, 60000L)
     assertEquals(expr.id, "idHere")
@@ -51,8 +52,8 @@ class ExpressionMetadataSuite extends FunSuite {
   }
 
   test("id computation considers frequency") {
-    val exp1 = ExpressionMetadata("test", 10000)
-    val exp2 = ExpressionMetadata("test", 20000)
+    val exp1 = ExpressionMetadata("test", ExprType.TIME_SERIES, 10000)
+    val exp2 = ExpressionMetadata("test", ExprType.TIME_SERIES, 20000)
     assert(exp1.id != exp2.id)
   }
 
@@ -106,22 +107,22 @@ class ExpressionMetadataSuite extends FunSuite {
   }
 
   test("renders as json") {
-    val expected = """{"expression":"this","frequency":99000,"id":"foo"}"""
-    val json = ExpressionMetadata("this", 99000, "foo").toJson
+    val expected = """{"expression":"this","exprType":"TIME_SERIES","frequency":99000,"id":"foo"}"""
+    val json = ExpressionMetadata("this", ExprType.TIME_SERIES, 99000, "foo").toJson
     assertEquals(expected, json)
   }
 
   test("renders as json with default frequency") {
     val expected =
-      "{\"expression\":\"this\",\"frequency\":60000,\"id\":\"fc3a081088771e05bdc3aa99ffd8770157dfe6ce\"}"
+      "{\"expression\":\"this\",\"exprType\":\"TIME_SERIES\",\"frequency\":60000,\"id\":\"fc3a081088771e05bdc3aa99ffd8770157dfe6ce\"}"
     val json = ExpressionMetadata("this").toJson
     assertEquals(expected, json)
   }
 
   test("renders as json with frequency of 0") {
     val expected =
-      "{\"expression\":\"this\",\"frequency\":60000,\"id\":\"fc3a081088771e05bdc3aa99ffd8770157dfe6ce\"}"
-    val json = ExpressionMetadata("this", 0).toJson
+      "{\"expression\":\"this\",\"exprType\":\"TIME_SERIES\",\"frequency\":60000,\"id\":\"fc3a081088771e05bdc3aa99ffd8770157dfe6ce\"}"
+    val json = ExpressionMetadata("this", ExprType.TIME_SERIES, 0).toJson
     assertEquals(expected, json)
   }
 
@@ -132,10 +133,16 @@ class ExpressionMetadataSuite extends FunSuite {
   }
 
   test("sorts") {
-    val source =
-      List(ExpressionMetadata("a", 2), ExpressionMetadata("z", 1), ExpressionMetadata("c", 3))
-    val expected =
-      List(ExpressionMetadata("a", 2), ExpressionMetadata("c", 3), ExpressionMetadata("z", 1))
+    val source = List(
+      ExpressionMetadata("a", ExprType.TIME_SERIES, 2),
+      ExpressionMetadata("z", ExprType.TIME_SERIES, 1),
+      ExpressionMetadata("c", ExprType.TIME_SERIES, 3)
+    )
+    val expected = List(
+      ExpressionMetadata("a", ExprType.TIME_SERIES, 2),
+      ExpressionMetadata("c", ExprType.TIME_SERIES, 3),
+      ExpressionMetadata("z", ExprType.TIME_SERIES, 1)
+    )
     assertEquals(expected, source.sorted)
   }
 }

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionSplitterSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionSplitterSuite.scala
@@ -16,6 +16,7 @@
 package com.netflix.atlas.lwcapi
 
 import com.netflix.atlas.core.model.Query
+import com.netflix.atlas.eval.model.ExprType
 import com.typesafe.config.ConfigFactory
 import munit.FunSuite
 
@@ -31,27 +32,27 @@ class ExpressionSplitterSuite extends FunSuite {
   private val splitter = new ExpressionSplitter(ConfigFactory.load())
 
   test("splits single expression into data expressions") {
-    val actual = splitter.split(query1, frequency1)
+    val actual = splitter.split(query1, ExprType.TIME_SERIES, frequency1)
     val expected = List(
-      Subscription(matchList1, ExpressionMetadata(ds1a, frequency1)),
-      Subscription(matchList1, ExpressionMetadata(ds1b, frequency1))
+      Subscription(matchList1, ExpressionMetadata(ds1a, ExprType.TIME_SERIES, frequency1)),
+      Subscription(matchList1, ExpressionMetadata(ds1b, ExprType.TIME_SERIES, frequency1))
     ).reverse
     assertEquals(actual, expected)
   }
 
   test("splits compound expression into data expressions") {
     val expr = query1 + "," + query1
-    val actual = splitter.split(expr, frequency1)
+    val actual = splitter.split(expr, ExprType.TIME_SERIES, frequency1)
     val expected = List(
-      Subscription(matchList1, ExpressionMetadata(ds1a, frequency1)),
-      Subscription(matchList1, ExpressionMetadata(ds1b, frequency1))
+      Subscription(matchList1, ExpressionMetadata(ds1a, ExprType.TIME_SERIES, frequency1)),
+      Subscription(matchList1, ExpressionMetadata(ds1b, ExprType.TIME_SERIES, frequency1))
     ).reverse
     assertEquals(actual, expected)
   }
 
   test("throws IAE for invalid expressions") {
     val msg = intercept[IllegalArgumentException] {
-      splitter.split("foo", frequency1)
+      splitter.split("foo", ExprType.TIME_SERIES, frequency1)
     }
     assertEquals(msg.getMessage, "expression is invalid")
   }
@@ -59,7 +60,7 @@ class ExpressionSplitterSuite extends FunSuite {
   test("throws IAE for expressions with offset") {
     val expr = "name,foo,:eq,:sum,PT168H,:offset"
     val msg = intercept[IllegalArgumentException] {
-      splitter.split(expr, frequency1)
+      splitter.split(expr, ExprType.TIME_SERIES, frequency1)
     }
     assertEquals(msg.getMessage, s":offset not supported for streaming evaluation [[$expr]]")
   }
@@ -67,7 +68,7 @@ class ExpressionSplitterSuite extends FunSuite {
   test("throws IAE for expressions with style offset") {
     val expr = "name,foo,:eq,:sum,(,0h,1w,),:offset"
     val msg = intercept[IllegalArgumentException] {
-      splitter.split(expr, frequency1)
+      splitter.split(expr, ExprType.TIME_SERIES, frequency1)
     }
     val badExpr = "name,foo,:eq,:sum,PT168H,:offset"
     assertEquals(msg.getMessage, s":offset not supported for streaming evaluation [[$badExpr]]")

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiJsonSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiJsonSuite.scala
@@ -17,6 +17,7 @@ package com.netflix.atlas.lwcapi
 
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException
+import com.netflix.atlas.eval.model.ExprType
 import com.netflix.atlas.json.Json
 import com.netflix.atlas.lwcapi.SubscribeApi.*
 import munit.FunSuite
@@ -25,8 +26,8 @@ class SubscribeApiJsonSuite extends FunSuite {
 
   test("encode and decode loop") {
     val expressions: List[ExpressionMetadata] = List(
-      ExpressionMetadata("this", 1234, "idGoesHere"),
-      ExpressionMetadata("that", 4321, "idGoesHereToo")
+      ExpressionMetadata("this", ExprType.TIME_SERIES, 1234, "idGoesHere"),
+      ExpressionMetadata("that", ExprType.TIME_SERIES, 4321, "idGoesHereToo")
     )
     val original = SubscribeRequest("sid", expressions)
     val json = original.toJson

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
@@ -21,6 +21,7 @@ import akka.http.scaladsl.testkit.WSProbe
 import com.netflix.atlas.akka.DiagnosticMessage
 import com.netflix.atlas.akka.RequestHandler
 import com.netflix.atlas.akka.testkit.MUnitRouteSuite
+import com.netflix.atlas.eval.model.ExprType
 import com.netflix.atlas.eval.model.LwcDatapoint
 import com.netflix.atlas.eval.model.LwcExpression
 import com.netflix.atlas.eval.model.LwcHeartbeat
@@ -61,7 +62,7 @@ class SubscribeApiSuite extends MUnitRouteSuite {
       assert(isWebSocketUpgrade)
 
       // Send list of expressions to subscribe to
-      val exprs = List(LwcExpression("name,disk,:eq,:avg", 60000))
+      val exprs = List(LwcExpression("name,disk,:eq,:avg", ExprType.TIME_SERIES, 60000))
       client.sendMessage(LwcMessages.encodeBatch(exprs))
 
       // Look for subscription messages, one for sum and one for count

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.lwcapi
 
+import com.netflix.atlas.eval.model.ExprType
 import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.ManualClock
@@ -29,7 +30,7 @@ class SubscriptionManagerSuite extends FunSuite {
 
   private def sub(expr: String): Subscription = {
     val splitter = new ExpressionSplitter(config)
-    splitter.split(expr, 60).head
+    splitter.split(expr, ExprType.TIME_SERIES, 60).head
   }
 
   test("subscribe, unsubscribe, and get work") {

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/WebSocketSessionManagerSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/WebSocketSessionManagerSuite.scala
@@ -19,6 +19,10 @@ import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import com.netflix.atlas.eval.model.ExprType
+import com.netflix.atlas.eval.model.LwcExpression
+import com.netflix.atlas.eval.model.LwcMessages
 import com.netflix.atlas.json.JsonSupport
 import com.netflix.atlas.lwcapi.SubscribeApi.ErrorMsg
 import munit.FunSuite
@@ -33,8 +37,8 @@ class WebSocketSessionManagerSuite extends FunSuite {
 
   test("subscribe - one by one") {
     val subscriptionList = List(
-      """[{"expression": "name,a,:eq,:sum", "step": 10000}]""",
-      """[{"expression": "name,b,:eq", "step": 5000}]"""
+      LwcMessages.encodeBatch(List(LwcExpression("name,a,:eq,:sum", ExprType.TIME_SERIES, 10000))),
+      LwcMessages.encodeBatch(List(LwcExpression("name,b,:eq", ExprType.TIME_SERIES, 5000)))
     )
 
     val subsCollector = ArrayBuffer[List[ExpressionMetadata]]()
@@ -46,16 +50,16 @@ class WebSocketSessionManagerSuite extends FunSuite {
     assertEquals(
       subsCollector.toList,
       List(
-        List(ExpressionMetadata("name,a,:eq,:sum", 10000)),
-        List(ExpressionMetadata("name,b,:eq", 5000))
+        List(ExpressionMetadata("name,a,:eq,:sum", ExprType.TIME_SERIES, 10000)),
+        List(ExpressionMetadata("name,b,:eq", ExprType.TIME_SERIES, 5000))
       )
     )
   }
 
   test("subscribe - ignore bad subscription") {
     val subscriptionList = List(
-      """Bad Expression""",
-      """[{"expression": "name,b,:eq", "step": 5000}]"""
+      ByteString("""Bad Expression"""),
+      LwcMessages.encodeBatch(List(LwcExpression("name,b,:eq", ExprType.TIME_SERIES, 5000)))
     )
     val subsCollector = ArrayBuffer[List[ExpressionMetadata]]()
     val subFunc = createSubscribeFunc(subsCollector)
@@ -66,13 +70,13 @@ class WebSocketSessionManagerSuite extends FunSuite {
     assertEquals(
       subsCollector.toList,
       List(
-        List(ExpressionMetadata("name,b,:eq", 5000))
+        List(ExpressionMetadata("name,b,:eq", ExprType.TIME_SERIES, 5000))
       )
     )
   }
 
   private def run(
-    data: List[String],
+    data: List[ByteString],
     registerFunc: StreamMetadata => (QueueHandler, Source[JsonSupport, NotUsed]),
     subscribeFunc: (String, List[ExpressionMetadata]) => List[ErrorMsg]
   ): List[String] = {


### PR DESCRIPTION
In preparation for supporting event and trace data flowing through indicate an expression type on the messages to setup the subscription. For backwards compatiblity, the time series type will be used if there is not an explicit type set on the messages.