### PR TITLE
eval: make model classes records

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/ExprType.java
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/ExprType.java
@@ -27,5 +27,5 @@ public enum ExprType {
   EVENTS,
 
   /** Expression to select a set of traces to be passed through. */
-  TRACES;
+  TRACES
 }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookup.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookup.scala
@@ -63,16 +63,16 @@ private[stream] class EurekaGroupsLookup(context: StreamContext, frequency: Fini
 
         // Create a list of sources, one for each distinct Eureka group that is needed
         // by one of the data sources
-        if (next.getSources.isEmpty) {
+        if (next.sources.isEmpty) {
           // If the Eureka based sources are empty, then just use an empty source to avoid
           // potential delays to shutting down when the upstream completes.
           lookupTickSwitch = None // No need to stop Source.single
           push(out, Source.single[SourcesAndGroups](DataSources.empty() -> Groups(List.empty)))
         } else {
-          val eurekaSources = next.getSources.asScala
+          val eurekaSources = next.sources.asScala
             .flatMap { s =>
               try {
-                Option(context.findEurekaBackendForUri(Uri(s.getUri)).eurekaUri)
+                Option(context.findEurekaBackendForUri(Uri(s.uri)).eurekaUri)
               } catch {
                 case e: Exception =>
                   val msg = DiagnosticMessage.error(e)

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
@@ -78,9 +78,9 @@ private[stream] class ExprInterpreter(config: Config) {
 
   def dataExprMap(ds: DataSources): Map[DataExpr, List[DataSource]] = {
     import scala.jdk.CollectionConverters.*
-    ds.getSources.asScala.toList
+    ds.sources.asScala.toList
       .flatMap { s =>
-        val exprs = eval(Uri(s.getUri)).flatMap(_.expr.dataExprs).distinct
+        val exprs = eval(Uri(s.uri)).flatMap(_.expr.dataExprs).distinct
         exprs.map(_ -> s)
       }
       .groupBy(_._1)

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
@@ -87,7 +87,7 @@ private[stream] class FinalExprEval(interpreter: ExprInterpreter)
       // Updates the recipients list
       private def handleDataSources(ds: DataSources): Unit = {
         import scala.jdk.CollectionConverters.*
-        val sources = ds.getSources.asScala.toList
+        val sources = ds.sources.asScala.toList
         step = ds.stepSize()
 
         // Get set of expressions before we update the list
@@ -100,14 +100,14 @@ private[stream] class FinalExprEval(interpreter: ExprInterpreter)
         recipients = sources
           .flatMap { s =>
             try {
-              val exprs = interpreter.eval(Uri(s.getUri))
+              val exprs = interpreter.eval(Uri(s.uri))
               // Reuse the previous evaluated expression if available. States for the stateful
               // expressions are maintained in an IdentityHashMap so if the instances change
               // the state will be reset.
-              exprs.map(e => previous.getOrElse(e, e) -> s.getId)
+              exprs.map(e => previous.getOrElse(e, e) -> s.id)
             } catch {
               case e: Exception =>
-                errors += new MessageEnvelope(s.getId, error(s.getUri, "invalid expression", e))
+                errors += new MessageEnvelope(s.id, error(s.uri, "invalid expression", e))
                 Nil
             }
           }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -134,7 +134,7 @@ private[stream] class StreamContext(
   def validate(input: DataSources): DataSources = {
     import scala.jdk.CollectionConverters.*
     val valid = new java.util.HashSet[DataSource]()
-    input.getSources.asScala.foreach { ds =>
+    input.sources.asScala.foreach { ds =>
       validateDataSource(ds) match {
         case Success(v) => valid.add(v)
         case Failure(e) => dsLogger(ds, DiagnosticMessage.error(e))
@@ -149,7 +149,7 @@ private[stream] class StreamContext(
     */
   def validateDataSource(ds: DataSource): Try[DataSource] = {
     Try {
-      val uri = Uri(ds.getUri)
+      val uri = Uri(ds.uri)
 
       // Check that expression is parseable and perform basic static analysis of DataExprs to
       // weed out expensive queries up front

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookupSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookupSuite.scala
@@ -99,7 +99,7 @@ class EurekaGroupsLookupSuite extends FunSuite {
     )
     val output = run(input)
     assertEquals(output.size, 1)
-    assertEquals(output.head._1.getSources.size(), 0)
+    assertEquals(output.head._1.sources.size(), 0)
     assertEquals(output.head._2.groups.size, 0)
   }
 

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -272,7 +272,7 @@ class EvaluatorSuite extends FunSuite {
     val oneCount = new AtomicInteger()
     val twoCount = new AtomicInteger()
     val sink = Sink.foreach[Evaluator.MessageEnvelope] { msg =>
-      msg.getId match {
+      msg.id match {
         case "one" => oneCount.incrementAndGet()
         case "two" => twoCount.incrementAndGet()
       }
@@ -300,7 +300,7 @@ class EvaluatorSuite extends FunSuite {
       .via(Flow.fromProcessor(() => evaluator.createStreamsProcessor()))
       .runWith(Sink.head)
     val result = Await.result(future, scala.concurrent.duration.Duration.Inf)
-    result.getMessage match {
+    result.message match {
       case DiagnosticMessage(t, msg, None) =>
         assertEquals(t, "error")
         assertEquals(msg, expectedMsg)
@@ -379,14 +379,14 @@ class EvaluatorSuite extends FunSuite {
     val result = Await.result(future, scala.concurrent.duration.Duration.Inf)
 
     val dsOne = result
-      .filter(env => env.getId == "one" && env.getMessage.isInstanceOf[TimeSeriesMessage])
-      .map(_.getMessage.asInstanceOf[TimeSeriesMessage])
+      .filter(env => env.id == "one" && env.message.isInstanceOf[TimeSeriesMessage])
+      .map(_.message.asInstanceOf[TimeSeriesMessage])
     assert(dsOne.forall(_.step == 5000))
     assertEquals(dsOne.size, 120)
 
     val dsTwo = result
-      .filter(env => env.getId == "two" && env.getMessage.isInstanceOf[TimeSeriesMessage])
-      .map(_.getMessage.asInstanceOf[TimeSeriesMessage])
+      .filter(env => env.id == "two" && env.message.isInstanceOf[TimeSeriesMessage])
+      .map(_.message.asInstanceOf[TimeSeriesMessage])
     assert(dsTwo.forall(_.step == 60000))
     assertEquals(dsTwo.size, 10)
   }
@@ -448,17 +448,17 @@ class EvaluatorSuite extends FunSuite {
 
   test("extractStepFromUri, step param not set") {
     val ds = newDataSource(None)
-    assertEquals(ds.getStep, Duration.ofMinutes(1))
+    assertEquals(ds.step, Duration.ofMinutes(1))
   }
 
   test("extractStepFromUri, 5s step") {
     val ds = newDataSource(Some("5s"))
-    assertEquals(ds.getStep, Duration.ofSeconds(5))
+    assertEquals(ds.step, Duration.ofSeconds(5))
   }
 
   test("extractStepFromUri, invalid step") {
     val ds = newDataSource(Some("abc"))
-    assertEquals(ds.getStep, Duration.ofMinutes(1))
+    assertEquals(ds.step, Duration.ofMinutes(1))
   }
 
   test("validate: ok") {
@@ -545,7 +545,7 @@ class EvaluatorSuite extends FunSuite {
 
   private def timeSeriesMessages(msgs: Seq[Evaluator.MessageEnvelope]): List[TimeSeriesMessage] = {
     msgs
-      .map(_.getMessage)
+      .map(_.message)
       .collect {
         case ts: TimeSeriesMessage => ts
       }
@@ -575,8 +575,8 @@ class EvaluatorSuite extends FunSuite {
 
     val msgs = runDatapointFlow(sources, sampleData(1, 10))
 
-    assertEquals(msgs.map(_.getId).distinct, List("test"))
-    assertEquals(msgs.count(_.getMessage.isInstanceOf[TimeSeriesMessage]), 1)
+    assertEquals(msgs.map(_.id).distinct, List("test"))
+    assertEquals(msgs.count(_.message.isInstanceOf[TimeSeriesMessage]), 1)
 
     val ts = timeSeriesMessages(msgs).head
     assertEquals(ts.tags, Map("name" -> "foo"))
@@ -613,8 +613,8 @@ class EvaluatorSuite extends FunSuite {
 
     val msgs = runDatapointFlow(sources, sampleData(1, 10))
 
-    assertEquals(msgs.map(_.getId).distinct, List("test"))
-    assertEquals(msgs.count(_.getMessage.isInstanceOf[TimeSeriesMessage]), 10)
+    assertEquals(msgs.map(_.id).distinct, List("test"))
+    assertEquals(msgs.count(_.message.isInstanceOf[TimeSeriesMessage]), 10)
 
     timeSeriesMessages(msgs).foreach { ts =>
       val expected = ts.tags("id").toDouble
@@ -637,8 +637,8 @@ class EvaluatorSuite extends FunSuite {
 
     val msgs = runDatapointFlow(sources, sampleData(1, 10))
 
-    assertEquals(msgs.map(_.getId).distinct, List("a", "b"))
-    assertEquals(msgs.count(_.getMessage.isInstanceOf[TimeSeriesMessage]), 2)
+    assertEquals(msgs.map(_.id).distinct.sorted, List("a", "b"))
+    assertEquals(msgs.count(_.message.isInstanceOf[TimeSeriesMessage]), 2)
 
     timeSeriesMessages(msgs).foreach { ts =>
       assertEquals(ts.data, ArrayData(Array(45.0)))
@@ -649,5 +649,11 @@ class EvaluatorSuite extends FunSuite {
     val ds = new Evaluator.DataSource("_", Duration.ofSeconds(42L), ":true")
     assertEquals(Json.encode(ds), """{"id":"_","step":42000,"uri":":true"}""")
     assertEquals(Json.decode[Evaluator.DataSource](Json.encode(ds)), ds)
+  }
+
+  test("DataSource serde, default step") {
+    val ds = new Evaluator.DataSource("_", Duration.ofSeconds(60L), ":true")
+    val json = """{"id":"_","uri":":true"}"""
+    assertEquals(Json.decode[Evaluator.DataSource](json), ds)
   }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
@@ -89,11 +89,11 @@ class FinalExprEvalSuite extends FunSuite {
     val output = run(input)
     assertEquals(output.size, 1)
     output.foreach { env =>
-      assertEquals(env.getId, "a")
+      assertEquals(env.id, "a")
 
       val msg = "invalid expression [[http://atlas/graph?q=foo,:time]]: " +
         "IllegalArgumentException: No enum constant java.time.temporal.ChronoField.foo"
-      assert(env.getMessage.toJson.contains(msg))
+      assert(env.message.toJson.contains(msg))
     }
   }
 
@@ -107,21 +107,21 @@ class FinalExprEvalSuite extends FunSuite {
 
     val tsMsgs = output.filter(isTimeSeries)
     assertEquals(tsMsgs.size, 1)
-    val (tsId, tsMsg) = tsMsgs.head.getId -> tsMsgs.head.getMessage.asInstanceOf[TimeSeriesMessage]
+    val (tsId, tsMsg) = tsMsgs.head.id -> tsMsgs.head.message.asInstanceOf[TimeSeriesMessage]
     assert(tsId == "a")
     assertEquals(tsMsg.label, "(NO DATA / NO DATA)")
 
   }
 
   private def isTimeSeries(messageEnvelope: MessageEnvelope): Boolean = {
-    messageEnvelope.getMessage match {
+    messageEnvelope.message match {
       case _: TimeSeriesMessage => true
       case _                    => false
     }
   }
 
   private def isEvalDataRate(messageEnvelope: MessageEnvelope): Boolean = {
-    messageEnvelope.getMessage match {
+    messageEnvelope.message match {
       case _: EvalDataRate => true
       case _               => false
     }
@@ -130,7 +130,7 @@ class FinalExprEvalSuite extends FunSuite {
   private def getAsEvalDataRate(
     env: MessageEnvelope
   ): EvalDataRate = {
-    env.getMessage.asInstanceOf[EvalDataRate]
+    env.message.asInstanceOf[EvalDataRate]
   }
 
   private def checkRate(
@@ -184,12 +184,12 @@ class FinalExprEvalSuite extends FunSuite {
     val expectedTimeseries = List(Double.NaN, 42.0, 43.0, 44.0)
     timeseries.zip(expectedTimeseries).foreach {
       case (env, expectedValue) =>
-        assertEquals(env.getId, "a")
-        val ts = env.getMessage.asInstanceOf[TimeSeriesMessage]
+        assertEquals(env.id, "a")
+        val ts = env.message.asInstanceOf[TimeSeriesMessage]
         checkValue(ts, expectedValue)
     }
 
-    val dataRateMsgs = output.filter(isEvalDataRate).filter(_.getId == "a")
+    val dataRateMsgs = output.filter(isEvalDataRate).filter(_.id == "a")
     assert(dataRateMsgs.size == 3)
     val expectedSizes = Array(
       Array(
@@ -249,12 +249,12 @@ class FinalExprEvalSuite extends FunSuite {
     val expectedTimeseries = List(Double.NaN, 42.0, 129.0, 87.0)
     timeseries.zip(expectedTimeseries).foreach {
       case (env, expectedValue) =>
-        assertEquals(env.getId, "a")
-        val ts = env.getMessage.asInstanceOf[TimeSeriesMessage]
+        assertEquals(env.id, "a")
+        val ts = env.message.asInstanceOf[TimeSeriesMessage]
         checkValue(ts, expectedValue)
     }
 
-    val dataRateMsgs = output.filter(isEvalDataRate).filter(_.getId == "a")
+    val dataRateMsgs = output.filter(isEvalDataRate).filter(_.id == "a")
     assert(dataRateMsgs.size == 3)
     val expectedSizes = Array(
       Array(
@@ -319,14 +319,14 @@ class FinalExprEvalSuite extends FunSuite {
     val expectedTimeseries1 = scala.collection.mutable.Queue(42.0, 84.0, 44.0)
     val expectedTimeseries2 = scala.collection.mutable.Queue(Double.NaN, 45.0, 49.0)
     timeseries.foreach { env =>
-      val actual = env.getMessage.asInstanceOf[TimeSeriesMessage]
-      if (env.getId == "a")
+      val actual = env.message.asInstanceOf[TimeSeriesMessage]
+      if (env.id == "a")
         checkValue(actual, expectedTimeseries1.dequeue())
       else
         checkValue(actual, expectedTimeseries2.dequeue())
     }
 
-    val expr1DataRateMsgs = output.filter(isEvalDataRate).filter(_.getId == "a")
+    val expr1DataRateMsgs = output.filter(isEvalDataRate).filter(_.id == "a")
     assert(expr1DataRateMsgs.size == 3)
     val expr1ExpectedSizes = Array(
       Array(
@@ -358,7 +358,7 @@ class FinalExprEvalSuite extends FunSuite {
       )
     })
 
-    val expr2DataRateMsgs = output.filter(isEvalDataRate).filter(_.getId == "b")
+    val expr2DataRateMsgs = output.filter(isEvalDataRate).filter(_.id == "b")
     assert(expr2DataRateMsgs.size == 2)
     val expr2ExpectedSizes = Array(
       Array(
@@ -418,7 +418,7 @@ class FinalExprEvalSuite extends FunSuite {
     val timeseries = output.filter(isTimeSeries)
     assertEquals(timeseries.size, 4)
     timeseries.foreach { env =>
-      val ts = env.getMessage.asInstanceOf[TimeSeriesMessage]
+      val ts = env.message.asInstanceOf[TimeSeriesMessage]
       if (ts.tags("node") == "i-1") {
         assert(ts.start < 120000)
         checkValue(ts, 42.0)
@@ -428,7 +428,7 @@ class FinalExprEvalSuite extends FunSuite {
       }
     }
 
-    val dataRateMsgs = output.filter(isEvalDataRate).filter(_.getId == "a")
+    val dataRateMsgs = output.filter(isEvalDataRate).filter(_.id == "a")
     assert(dataRateMsgs.size == 3)
     val expectedSizes = Array(
       Array(
@@ -475,11 +475,11 @@ class FinalExprEvalSuite extends FunSuite {
 
     val output = run(input)
 
-    val timeseries = output.filter(_.getMessage.isInstanceOf[TimeSeriesMessage])
+    val timeseries = output.filter(_.message.isInstanceOf[TimeSeriesMessage])
     assertEquals(timeseries.size, 4)
     // tail to ignore initial no data entry
     timeseries.tail.foreach { env =>
-      val ts = env.getMessage.asInstanceOf[TimeSeriesMessage]
+      val ts = env.message.asInstanceOf[TimeSeriesMessage]
       assertEquals(ts.label, "legend for rps")
     }
   }
@@ -506,8 +506,8 @@ class FinalExprEvalSuite extends FunSuite {
     val expectedTimeseries = List(0.0, 0.0, 0.0, 0.0)
     timeseries.zip(expectedTimeseries).foreach {
       case (env, expectedValue) =>
-        assertEquals(env.getId, "a")
-        val ts = env.getMessage.asInstanceOf[TimeSeriesMessage]
+        assertEquals(env.id, "a")
+        val ts = env.message.asInstanceOf[TimeSeriesMessage]
         checkValue(ts, expectedValue)
     }
   }
@@ -536,8 +536,8 @@ class FinalExprEvalSuite extends FunSuite {
     val expectedTimeseries = List(Double.NaN, Double.NaN, -2.0, 0.0, -4.0)
     timeseries.zip(expectedTimeseries).foreach {
       case (env, expectedValue) =>
-        assertEquals(env.getId, "a")
-        val ts = env.getMessage.asInstanceOf[TimeSeriesMessage]
+        assertEquals(env.id, "a")
+        val ts = env.message.asInstanceOf[TimeSeriesMessage]
         checkValue(ts, expectedValue)
     }
   }
@@ -556,7 +556,7 @@ class FinalExprEvalSuite extends FunSuite {
     assertEquals(
       e.getMessage,
       "inconsistent step sizes, expected 60000, found 10000 " +
-        "on DataSource(b,PT10S,http://atlas/graph?q=name,rps,:eq,:sum)"
+        "on DataSource[id=b, step=PT10S, uri=http://atlas/graph?q=name,rps,:eq,:sum]"
     )
   }
 
@@ -583,8 +583,8 @@ class FinalExprEvalSuite extends FunSuite {
     val expectedTimeseries = List(0.0, 1.0, 1.0, 2.0, 1.0, 1.0, 0.0, 1.0)
     timeseries.zip(expectedTimeseries).foreach {
       case (env, expectedValue) =>
-        assertEquals(env.getId, "a")
-        val ts = env.getMessage.asInstanceOf[TimeSeriesMessage]
+        assertEquals(env.id, "a")
+        val ts = env.message.asInstanceOf[TimeSeriesMessage]
         checkValue(ts, expectedValue)
     }
   }
@@ -619,7 +619,7 @@ class FinalExprEvalSuite extends FunSuite {
     val timeseries = output.filter(isTimeSeries)
     assertEquals(timeseries.size, 8)
     timeseries.foreach { env =>
-      val ts = env.getMessage.asInstanceOf[TimeSeriesMessage]
+      val ts = env.message.asInstanceOf[TimeSeriesMessage]
       val v = getValue(ts)
       if (ts.label == "NO DATA")
         assert(v.isNaN)


### PR DESCRIPTION
Update the model classes used with `Evalutor` to be records now that the baseline is java 17.