### PR TITLE
sanitize id parameter on graph URIs

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
@@ -42,6 +42,7 @@ import com.netflix.atlas.core.model.TimeSeries
 import com.netflix.atlas.core.util.Features
 import com.netflix.atlas.core.util.Strings
 import com.netflix.atlas.core.util.UnitPrefix
+import com.netflix.atlas.eval.util.IdParamSanitizer
 import com.typesafe.config.Config
 
 import java.util.Locale
@@ -71,7 +72,7 @@ case class Grapher(settings: DefaultSettings) {
         .find(_.is("origin"))
         .flatMap(h => Cors.normalizedOrigin(h.value()))
         .getOrElse("default")
-      config.copy(isBrowser = isBrowser, id = origin)
+      config.copy(isBrowser = isBrowser, id = IdParamSanitizer.sanitize(origin))
     } else {
       config.copy(isBrowser = isBrowser)
     }
@@ -107,7 +108,7 @@ case class Grapher(settings: DefaultSettings) {
     */
   def toGraphConfig(uri: Uri): GraphConfig = {
     val params = uri.query()
-    val id = params.get("id").getOrElse("default")
+    val id = IdParamSanitizer.sanitize(params.get("id").getOrElse("default"))
 
     val features = params
       .get("features")

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/util/IdParamSanitizer.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/util/IdParamSanitizer.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.util
+
+import java.util.Locale
+import java.util.regex.Pattern
+
+/** Helper to sanitize the id parameter value. */
+object IdParamSanitizer {
+
+  private val pattern = Pattern.compile("[0-9a-f]{8}|[0-9]{3}|[0-9][.][0-9]|:");
+
+  /**
+    * Sanitize id parameter value.
+    *
+    * @param id
+    *     Value for the parameter.
+    * @return
+    *     Sanitized value. If the input contains something that looks like UUIDs, IP addresses,
+    *     instance ids, or arbitrary numbers, then it will return the value `default` instead.
+    */
+  def sanitize(id: String): String = {
+    val lowerId = id.toLowerCase(Locale.US)
+    if (pattern.matcher(lowerId).find())
+      "default"
+    else
+      lowerId
+  }
+}

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/util/IdParamSanitizerSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/util/IdParamSanitizerSuite.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.util
+
+import munit.FunSuite
+
+import java.util.UUID
+
+class IdParamSanitizerSuite extends FunSuite {
+
+  test("allowed") {
+    assertEquals("foo", IdParamSanitizer.sanitize("foo"))
+    assertEquals("foo", IdParamSanitizer.sanitize("Foo"))
+    assertEquals("foo2", IdParamSanitizer.sanitize("Foo2"))
+    assertEquals("foobarbaz", IdParamSanitizer.sanitize("FooBarBaz"))
+    assertEquals("foo_bar-baz", IdParamSanitizer.sanitize("Foo_Bar-Baz"))
+    assertEquals("foo.bar.baz", IdParamSanitizer.sanitize("Foo.Bar.Baz"))
+  }
+
+  test("uuid") {
+    val str = UUID.randomUUID().toString
+    assertEquals("default", IdParamSanitizer.sanitize(str))
+  }
+
+  test("instance id") {
+    val str = String.format("i-%08x", 1234567890)
+    assertEquals("default", IdParamSanitizer.sanitize(str))
+  }
+
+  test("ipv4") {
+    val str = "1.2.3.4"
+    assertEquals("default", IdParamSanitizer.sanitize(str))
+  }
+
+  test("ipv6") {
+    val str = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+    assertEquals("default", IdParamSanitizer.sanitize(str))
+  }
+
+  test("ipv6 local") {
+    val str = "::1"
+    assertEquals("default", IdParamSanitizer.sanitize(str))
+  }
+
+  test("arbitrary number") {
+    val str = "foo-12345"
+    assertEquals("default", IdParamSanitizer.sanitize(str))
+  }
+}


### PR DESCRIPTION
Adds a utility to do some basic sanitization. First the it is normalized to lower case. Second it will be checked for some common patterns for arbitrary high cardinality values that should not be used, but sometimes are and maps those to the default bucket.