### PR TITLE
rename classes with Akka in the name

### DIFF
--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/PekkoHttpClient.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/PekkoHttpClient.scala
@@ -24,12 +24,12 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 /**
-  * A wrapper used for simple unit testing of Akka HTTP calls.
+  * A wrapper used for simple unit testing of Pekko HTTP calls.
   */
-trait AkkaHttpClient {
+trait PekkoHttpClient {
 
   /**
-    * See pekko.http.scaladsl.Http
+    * See org.apache.pekko.http.scaladsl.Http
     */
   def singleRequest(request: HttpRequest): Future[HttpResponse]
 
@@ -41,9 +41,10 @@ trait AkkaHttpClient {
   * @param name
   *     The name to use for access logging and metrics.
   * @param system
-  *     The Akka system.
+  *     The actor system.
   */
-class DefaultAkkaHttpClient(name: String)(implicit val system: ActorSystem) extends AkkaHttpClient {
+class DefaultPekkoHttpClient(name: String)(implicit val system: ActorSystem)
+    extends PekkoHttpClient {
 
   private implicit val ec: ExecutionContext = system.dispatcher
 

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/StreamOps.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/StreamOps.scala
@@ -43,7 +43,7 @@ import com.typesafe.scalalogging.StrictLogging
 import scala.concurrent.duration.FiniteDuration
 
 /**
-  * Utility functions for commonly used operations on Akka streams. Most of these are for
+  * Utility functions for commonly used operations on Pekko streams. Most of these are for
   * the purpose of getting additional instrumentation into the behavior of the stream.
   */
 object StreamOps extends StrictLogging {

--- a/atlas-spring-pekko/src/main/scala/com/netflix/atlas/pekko/PekkoConfiguration.scala
+++ b/atlas-spring-pekko/src/main/scala/com/netflix/atlas/pekko/PekkoConfiguration.scala
@@ -32,7 +32,7 @@ import java.util.Optional
   * are available for `com.typesafe.config.Config` and `com.netflix.spectator.api.Registry`.
   */
 @Configuration
-class AkkaConfiguration {
+class PekkoConfiguration {
 
   @Bean
   def actorSystemService(config: Optional[Config]): ActorSystemService = {

--- a/atlas-spring-pekko/src/test/scala/com/netflix/atlas/pekko/PekkoConfigurationSuite.scala
+++ b/atlas-spring-pekko/src/test/scala/com/netflix/atlas/pekko/PekkoConfigurationSuite.scala
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 
 import scala.util.Using
 
-class AkkaConfigurationSuite extends FunSuite {
+class PekkoConfigurationSuite extends FunSuite {
 
   private val testCfg = ConfigFactory.parseString("""
       |atlas.pekko.name = test


### PR DESCRIPTION
Rename to use Pekko for better consistency and making it easier to automate the transition of other projects that pull in these classes. Allows for easier search and replace to migrate.