### PR TITLE
core: add check for infinite loops

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Context.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Context.scala
@@ -43,8 +43,11 @@ case class Context(
   variables: Map[String, Any],
   initialVariables: Map[String, Any] = Map.empty,
   frozenStack: List[Any] = Nil,
-  features: Features = Features.STABLE
+  features: Features = Features.STABLE,
+  callDepth: Int = 0
 ) {
+
+  require(callDepth >= 0, "call depth cannot be negative")
 
   /**
     * Remove the contents of the stack and push them onto the frozen stack. The variable
@@ -60,5 +63,15 @@ case class Context(
     */
   def unfreeze: Context = {
     copy(stack = stack ::: frozenStack, frozenStack = Nil)
+  }
+
+  /** Increase the call depth for detecting deeply nested calls. */
+  def incrementCallDepth: Context = {
+    copy(callDepth = callDepth + 1)
+  }
+
+  /** Decrease the call depth for detecting deeply nested calls. */
+  def decrementCallDepth: Context = {
+    copy(callDepth = callDepth - 1)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/LoopSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/LoopSuite.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.stacklang
+
+import munit.FunSuite
+
+class LoopSuite extends FunSuite {
+
+  private val interpreter = Interpreter(StandardVocabulary.allWords)
+
+  test("infinite loop: fcall recursion") {
+    val e = intercept[IllegalStateException] {
+      interpreter.execute("loop,(,loop,:fcall,),:set,loop,:fcall")
+    }
+    assertEquals(e.getMessage, "looping detected")
+  }
+
+  test("infinite loop: call recursion") {
+    val e = intercept[IllegalStateException] {
+      interpreter.execute("loop,(,loop,:get,:call,),:set,loop,:get,:call")
+    }
+    assertEquals(e.getMessage, "looping detected")
+  }
+
+  test("infinite loop: nested") {
+    val e = intercept[IllegalStateException] {
+      interpreter.execute("a,(,b,:fcall,),:set,b,(,c,:fcall,),:set,c,(,a,:fcall,),:set,a,:fcall")
+    }
+    assertEquals(e.getMessage, "looping detected")
+  }
+}


### PR DESCRIPTION
If the `:call` operator is used recursively it can result in an infinite loop. This change adds some sanity checks for the call depth to quickly fail in these cases and indicate that a loop was detected.