### PR TITLE
consistent normalization of line styles

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
@@ -33,6 +33,7 @@ case class StyleExpr(expr: TimeSeriesExpr, settings: Map[String, String]) extend
     // updates to the object.
     val vs = settings.toList.sortWith(_._1 > _._1).map {
       case ("sed", v) => v
+      case ("ls", v)  => s":$v"
       case (k, v)     => s"$v,:$k"
     }
     if (vs.isEmpty) expr.toString else s"$expr,${vs.mkString(",")}"

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
@@ -323,9 +323,12 @@ object ExprApi {
       val rewritten = normalizeStat(expr).rewrite {
         case q: Query => sort(q)
       }
-      // Remove explicit :const, it can be determined from implicit conversion
-      // and adds visual clutter
-      rewritten.toString.replace(",:const", "")
+      // Remove explicit :const and :line, it can be determined from implicit conversion
+      // and add visual clutter
+      rewritten
+        .toString
+        .replace(",:const", "")
+        .replace(",:line", "")
     }
   }
 

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
@@ -325,8 +325,7 @@ object ExprApi {
       }
       // Remove explicit :const and :line, it can be determined from implicit conversion
       // and add visual clutter
-      rewritten
-        .toString
+      rewritten.toString
         .replace(",:const", "")
         .replace(",:line", "")
     }

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
@@ -461,6 +461,27 @@ class ExprApiSuite extends MUnitRouteSuite {
     val expected = "name,cpuUser,:eq,:sum,foo$(name)$(abc) bar$(def)baz,:legend"
     assertEquals(normalize(expr), List(expected))
   }
+
+  test("normalize :line") {
+    val expr = "app,foo,:eq,name,cpuUser,:eq,:and,:sum,(,stack,),:by"
+    assertEquals(normalize(expr), List(expr))
+    assertEquals(normalize(s"$expr,:line"), List(expr))
+  }
+
+  test("normalize :stack") {
+    val expr = "app,foo,:eq,name,cpuUser,:eq,:and,:sum,(,stack,),:by,:stack"
+    assertEquals(normalize(expr), List(expr))
+  }
+
+  test("normalize :area") {
+    val expr = "app,foo,:eq,name,cpuUser,:eq,:and,:sum,(,stack,),:by,:area"
+    assertEquals(normalize(expr), List(expr))
+  }
+
+  test("normalize :vspan") {
+    val expr = "app,foo,:eq,name,cpuUser,:eq,:and,:sum,(,stack,),:by,:vspan"
+    assertEquals(normalize(expr), List(expr))
+  }
 }
 
 object ExprApiSuite {


### PR DESCRIPTION
Updates the normalization behavior so that expressions that use the default line style or `:line` explicitly will be the same after normalization. For other line styles use the simple name rather than `:ls` as it is more familiar to users.