### PR TITLE
eval: improve offset validation

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
@@ -58,6 +58,10 @@ private[stream] class ExprInterpreter(config: Config) {
         case op: FilterExpr                    => invalidOperator(op); op
         case op: DataExpr if !op.offset.isZero => invalidOperator(op); op
       }
+
+      // Double check all data expressions do not have an offset. In some cases for named rewrites
+      // the check above may not detect the offset.
+      result.expr.dataExprs.filterNot(_.offset.isZero).foreach(invalidOperator)
     }
 
     // Perform host rewrites based on the Atlas hostname

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -502,6 +502,14 @@ class EvaluatorSuite extends FunSuite {
     invalidOperator("offset", "name,jvm.gc.pause,:eq,:sum,1w,:offset")
   }
 
+  test("validate: unsupported operation `:offset` with math") {
+    invalidOperator("offset", "name,a,:eq,:sum,:dup,1w,:offset,:div")
+  }
+
+  test("validate: unsupported operation `:offset` with named rewrite and math") {
+    invalidOperator("offset", "name,a,:eq,:sum,:sdes-slower,:dup,1w,:offset,:div")
+  }
+
   test("validate: unsupported operation `:integral`") {
     invalidOperator("integral", "name,jvm.gc.pause,:eq,:sum,:integral")
   }


### PR DESCRIPTION
Check each data expression to catch some uses of named rewrites where the offset is not available on the display expression.