### PR TITLE
improve error message for invalid theme

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/DefaultSettings.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/DefaultSettings.scala
@@ -68,11 +68,18 @@ case class DefaultSettings(root: Config, config: Config) {
   /** Default theme to use for the chart. */
   val theme: String = config.getString("theme")
 
+  private def themeConfig(theme: String): Config = {
+    if (config.hasPath(theme))
+      config.getConfig(theme)
+    else
+      throw new IllegalArgumentException(s"invalid theme: $theme")
+  }
+
   /** Default palette name to use. */
-  def primaryPalette(theme: String): String = config.getString(s"$theme.palette.primary")
+  def primaryPalette(theme: String): String = themeConfig(theme).getString("palette.primary")
 
   /** Default palette name to use for lines with an offset. */
-  def offsetPalette(theme: String): String = config.getString(s"$theme.palette.offset")
+  def offsetPalette(theme: String): String = themeConfig(theme).getString(s"palette.offset")
 
   /** Resolve color for a given theme. */
   def resolveColor(theme: String, color: String): Color = {

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GraphUriSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GraphUriSuite.scala
@@ -95,6 +95,13 @@ class GraphUriSuite extends FunSuite {
     assertEquals(cfg.flags.axes(0).newPlotDef().lower, PlotBound.AutoStyle)
   }
 
+  test("invalid theme") {
+    val e = intercept[IllegalArgumentException] {
+      parseUri("/api/v1/graph?q=name,foo,:eq,:sum&theme=foo")
+    }
+    assertEquals(e.getMessage, "invalid theme: foo")
+  }
+
   test("hints: none") {
     val cfg = parseUri("/api/v1/graph?q=name,foo,:eq,:sum")
     assertEquals(cfg.flags.hints, Set.empty[String])


### PR DESCRIPTION
If an invalid theme name was requested, it was returning a 500 with a confusing error message. It will now return a 400 and indicate the theme is invalid.