### PR TITLE
standalone: adjust log levels

### DIFF
--- a/atlas-standalone/src/main/resources/log4j2.xml
+++ b/atlas-standalone/src/main/resources/log4j2.xml
@@ -9,7 +9,7 @@
     </Console>
   </Appenders>
   <Loggers>
-    <Logger name="com.netflix.spectator" level="debug"/>
+    <Logger name="com.netflix.spectator" level="info"/>
     <Root level="info">
       <AppenderRef ref="STDERR"/>
     </Root>


### PR DESCRIPTION
Set spectator to info to reduce log noise when running the demo app.