### PR TITLE
eval: support simple legends for streaming data

### DIFF
--- a/atlas-eval/src/main/resources/reference.conf
+++ b/atlas-eval/src/main/resources/reference.conf
@@ -32,6 +32,11 @@ atlas.eval {
 
     // Which version of the LWC server API to use
     lwcapi-version = 2
+
+    // If set to true, then it will try to generate a simple legend for the set of expressions
+    // on the graph. By default the legend will just summarize the expression which is often
+    // long and hard to read for users.
+    simple-legends-enabled = true
   }
 
   graph {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/SimpleLegends.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/SimpleLegends.scala
@@ -26,7 +26,7 @@ import com.typesafe.scalalogging.StrictLogging
   * Helper to analyze a set of expressions and try to automatically set a reasonable
   * human readable legend.
   */
-private[graph] object SimpleLegends extends StrictLogging {
+object SimpleLegends extends StrictLogging {
 
   def generate(exprs: List[StyleExpr]): List[StyleExpr] = {
     try {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
@@ -24,6 +24,7 @@ import com.netflix.atlas.core.model.ModelExtractors
 import com.netflix.atlas.core.model.StatefulExpr
 import com.netflix.atlas.core.model.StyleExpr
 import com.netflix.atlas.core.stacklang.Interpreter
+import com.netflix.atlas.eval.graph.SimpleLegends
 import com.netflix.atlas.eval.stream.Evaluator.DataSource
 import com.netflix.atlas.eval.stream.Evaluator.DataSources
 import com.netflix.atlas.eval.util.HostRewriter
@@ -35,11 +36,15 @@ private[stream] class ExprInterpreter(config: Config) {
 
   private val hostRewriter = new HostRewriter(config.getConfig("atlas.eval.host-rewrite"))
 
+  // Use simple legends for expressions
+  private val simpleLegendsEnabled: Boolean = config.getBoolean("atlas.eval.stream.simple-legends-enabled")
+
   def eval(expr: String): List[StyleExpr] = {
-    interpreter.execute(expr).stack.map {
+    val exprs = interpreter.execute(expr).stack.map {
       case ModelExtractors.PresentationType(t) => t
       case v                                   => throw new MatchError(v)
     }
+    if (simpleLegendsEnabled) SimpleLegends.generate(exprs) else exprs
   }
 
   def eval(uri: Uri): List[StyleExpr] = {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
@@ -37,7 +37,8 @@ private[stream] class ExprInterpreter(config: Config) {
   private val hostRewriter = new HostRewriter(config.getConfig("atlas.eval.host-rewrite"))
 
   // Use simple legends for expressions
-  private val simpleLegendsEnabled: Boolean = config.getBoolean("atlas.eval.stream.simple-legends-enabled")
+  private val simpleLegendsEnabled: Boolean =
+    config.getBoolean("atlas.eval.stream.simple-legends-enabled")
 
   def eval(expr: String): List[StyleExpr] = {
     val exprs = interpreter.execute(expr).stack.map {

--- a/atlas-eval/src/test/resources/application.conf
+++ b/atlas-eval/src/test/resources/application.conf
@@ -24,5 +24,9 @@ atlas {
     graph {
       simple-legends-enabled = false
     }
+
+    stream {
+      simple-legends-enabled = false
+    }
   }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
@@ -61,6 +61,8 @@ object TestContext {
       |  expression-limit = 50000
       |
       |  ignored-tag-keys = []
+      |
+      |  simple-legends-enabled = false
       |}
       |
       |atlas.eval.host-rewrite {


### PR DESCRIPTION
To make streaming data more consistent with the backends allow simple legends to be used. Defaults to true, but can be disabled if needed.