### PR TITLE
core: no data for aggr of empty group by

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -690,8 +690,9 @@ object MathExpr {
     def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
       val rs = expr.eval(context, data)
       val ts =
-        if (rs.data.isEmpty) Nil
-        else {
+        if (rs.data.isEmpty) {
+          List(TimeSeries.noData(context.step))
+        } else {
           val aggr = aggregator(context.start, context.end)
           rs.data.foreach(aggr.update)
           val t = aggr.result()

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
@@ -120,7 +120,7 @@ class TimeSeriesExprSuite extends FunSuite {
     ":true,(,name,),:by,:avg"      -> const(ts(unknownTag, "(name=unknown / count(NO TAGS))", 5)),
     ":true,(,foo,),:by"            -> const(Nil),
     ":false,(,name,),:by"          -> const(Nil),
-    "n,:has,(,n,),:by,4,:div,:sum" -> const(Nil),
+    "n,:has,(,n,),:by,4,:div,:sum" -> const(ts(Map("name" -> "NO_DATA"), "NO DATA", Double.NaN)),
     "NaN,NaN,:add"                 -> const(ts(Map("name" -> "NaN"), "(NaN + NaN)", Double.NaN)),
     "NaN,1.0,:add"                 -> const(ts(Map("name" -> "NaN"), "(NaN + 1.0)", 1.0)),
     "1.0,NaN,:add"                 -> const(ts(Map("name" -> "1.0"), "(1.0 + NaN)", 1.0)),
@@ -184,7 +184,7 @@ class TimeSeriesExprSuite extends FunSuite {
     ":true,1w,:offset"   -> const(ts(unknownTag, "name=unknown (offset=1w)", 55)),
     ":true,5,:add,1w,:offset"    -> const(ts(unknownTag, "(name=unknown (offset=1w) + 5.0)", 60)),
     "issue,283,:eq"              -> const(ts(Map("issue" -> "283"), "NO DATA", Double.NaN)),
-    ":false,(,name,),:by,:count" -> const(Nil),
+    ":false,(,name,),:by,:count" -> const(ts(Map("name" -> "NO_DATA"), "NO DATA", Double.NaN)),
     ":true,(,name,),:by,:stddev" -> const(
       ts(Map.empty[String, String], stddevLegend("NO TAGS"), 3.1622776601683795)
     ),


### PR DESCRIPTION
Make the behavior of using an aggregate on an empty group by result consistent with aggregate on an empty query result.