### PR TITLE
support presentation metadata for fetch

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonCodec.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/JsonCodec.scala
@@ -51,7 +51,7 @@ import scala.util.Using
   * `plot-metadata` that corresponds to all lines on a given axis. The plot has an id that
   * will be referenced when the line data is emitted.
   */
-private[chart] object JsonCodec {
+object JsonCodec {
 
   import com.netflix.atlas.json.JsonParserHelper.*
   private val factory = new JsonFactory()
@@ -120,7 +120,7 @@ private[chart] object JsonCodec {
     s"data:image/png;base64,$encoded"
   }
 
-  private def writeGraphDefMetadata(gen: JsonGenerator, config: GraphDef): Unit = {
+  def writeGraphDefMetadata(gen: JsonGenerator, config: GraphDef): Unit = {
     gen.writeStartObject()
     gen.writeStringField("type", "graph-metadata")
     gen.writeNumberField("startTime", config.startTime.toEpochMilli)
@@ -170,7 +170,7 @@ private[chart] object JsonCodec {
     gen.writeEndObject()
   }
 
-  private def writePlotDefMetadata(gen: JsonGenerator, plot: PlotDef, id: Int): Unit = {
+  def writePlotDefMetadata(gen: JsonGenerator, plot: PlotDef, id: Int): Unit = {
     gen.writeStartObject()
     gen.writeStringField("type", "plot-metadata")
     gen.writeNumberField("id", id)

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
@@ -366,7 +366,7 @@ case class Grapher(settings: DefaultSettings) {
 
           val lineDefs = labelledTS.sortWith(_._1.label < _._1.label).map {
             case (t, stats) =>
-              val lineStyle = s.lineStyle.fold(dfltStyle)(s => LineStyle.valueOf(s.toUpperCase))
+              val lineStyle = s.lineStyle.fold(dfltStyle)(LineStyle.parse)
               val color = s.color.fold {
                 val c = lineStyle match {
                   case LineStyle.HEATMAP =>
@@ -393,7 +393,7 @@ case class Grapher(settings: DefaultSettings) {
                 query = Some(s.toString),
                 groupByKeys = s.expr.finalGrouping,
                 color = color,
-                lineStyle = s.lineStyle.fold(dfltStyle)(s => LineStyle.valueOf(s.toUpperCase)),
+                lineStyle = s.lineStyle.fold(dfltStyle)(LineStyle.parse),
                 lineWidth = s.lineWidth,
                 legendStats = stats
               )

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/ImageFlags.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/ImageFlags.scala
@@ -33,4 +33,16 @@ case class ImageFlags(
   theme: String,
   layout: Layout,
   hints: Set[String]
-)
+) {
+
+  def presentationMetadataEnabled: Boolean = {
+    hints.contains("presentation-metadata")
+  }
+
+  def axisPalette(settings: DefaultSettings, index: Int): String = {
+    axes.get(index) match {
+      case Some(axis) => axis.palette.getOrElse(settings.primaryPalette(theme))
+      case None       => settings.primaryPalette(theme)
+    }
+  }
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LineStyleMetadata.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LineStyleMetadata.scala
@@ -13,17 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.atlas.chart.model;
+package com.netflix.atlas.eval.model
 
-import java.util.Locale;
+import com.netflix.atlas.chart.model.LineStyle
+
+import java.awt.Color
 
 /**
- * Line styles for how to render a time series.
- */
-public enum LineStyle {
-  LINE, AREA, STACK, VSPAN, HEATMAP;
-
-  public static LineStyle parse(String lineStyle) {
-    return valueOf(lineStyle.toUpperCase(Locale.US));
-  }
-}
+  * Metadata for presentation details related to how to render the line.
+  *
+  * @param plot
+  *     Identifies which axis the line should be associated with.
+  * @param color
+  *     Color to use for rendering the line.
+  * @param lineStyle
+  *     How to render the line (line, stack, area, etc).
+  * @param lineWidth
+  *     Width of the stroke when rendering the line.
+  */
+case class LineStyleMetadata(plot: Int, color: Color, lineStyle: LineStyle, lineWidth: Float)

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/TimeSeriesMessageSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/TimeSeriesMessageSuite.scala
@@ -28,7 +28,8 @@ class TimeSeriesMessageSuite extends FunSuite {
     step = 60000L,
     label = "test",
     tags = Map("name" -> "sps", "cluster" -> "www"),
-    data = ArrayData(Array(42.0))
+    data = ArrayData(Array(42.0)),
+    None
   )
 
   test("json encoding with empty group by") {


### PR DESCRIPTION
Adds initial support for presentation metadata when using fetch API. It will force hashed palette selection as not all data is known in advance. It is off by default to keep data sizes smaller. To enable the user would need to specify a hint of `presentation-metadata`.