### PR TITLE
add span-time-series operator

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/CustomVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/CustomVocabulary.scala
@@ -78,15 +78,18 @@ import com.typesafe.config.Config
   *       `:\$name`.
   *     - `base-query`: query for the denominator.
   *     - `keys`: tag keys that are available for use on the denominator.
+  *
+  * @param dependencies
+  *     Other vocabularies to depend on, defaults to the `StyleVocabulary`.
   */
-class CustomVocabulary(config: Config) extends Vocabulary {
+class CustomVocabulary(config: Config, dependencies: List[Vocabulary] = List(StyleVocabulary)) extends Vocabulary {
 
   import CustomVocabulary.*
   import scala.jdk.CollectionConverters.*
 
   val name: String = "custom"
 
-  val dependsOn: List[Vocabulary] = List(StyleVocabulary)
+  val dependsOn: List[Vocabulary] = dependencies
 
   val words: List[Word] = {
     val vocab = config.getConfig("atlas.core.vocabulary")

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/CustomVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/CustomVocabulary.scala
@@ -82,7 +82,8 @@ import com.typesafe.config.Config
   * @param dependencies
   *     Other vocabularies to depend on, defaults to the `StyleVocabulary`.
   */
-class CustomVocabulary(config: Config, dependencies: List[Vocabulary] = List(StyleVocabulary)) extends Vocabulary {
+class CustomVocabulary(config: Config, dependencies: List[Vocabulary] = List(StyleVocabulary))
+    extends Vocabulary {
 
   import CustomVocabulary.*
   import scala.jdk.CollectionConverters.*

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TraceQuery.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TraceQuery.scala
@@ -39,5 +39,8 @@ object TraceQuery {
   case class Child(q1: Query, q2: Query) extends TraceQuery
 
   /** Filter to select the set of spans from a trace to forward as events. */
-  case class SpanFilter(q: TraceQuery, f: DataExpr) extends Expr
+  case class SpanFilter(q: TraceQuery, f: Query) extends Expr
+
+  /** Time series based on data from a set of matching traces. */
+  case class SpanTimeSeries(q: TraceQuery, expr: StyleExpr) extends Expr
 }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/ExprType.java
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/ExprType.java
@@ -17,15 +17,19 @@ package com.netflix.atlas.eval.model;
 
 /** Indicates the type of expression for a subscription. */
 public enum ExprType {
+
+  /** Expression to select a set of events to be passed through. */
+  EVENTS,
+
   /**
    * Time series expression such as used with Atlas Graph API. Can also be used for analytics
    * queries on top of event data.
    */
   TIME_SERIES,
 
-  /** Expression to select a set of events to be passed through. */
-  EVENTS,
-
   /** Expression to select a set of traces to be passed through. */
-  TRACES
+  TRACE_EVENTS,
+
+  /** Time series expression based on data extraced from traces. */
+  TRACE_TIME_SERIES
 }

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/AbstractLwcEventClient.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/AbstractLwcEventClient.scala
@@ -66,7 +66,7 @@ abstract class AbstractLwcEventClient extends LwcEventClient {
 
     // Trace pass-through
     traceHandlers = subscriptions.tracePassThrough.map { sub =>
-      sub -> ExprUtils.parseTraceQuery(sub.expression)
+      sub -> ExprUtils.parseTraceEventsQuery(sub.expression)
     }.toMap
 
     index = idx
@@ -125,7 +125,7 @@ abstract class AbstractLwcEventClient extends LwcEventClient {
   override def processTrace(trace: Seq[LwcEvent.Span]): Unit = {
     traceHandlers.foreachEntry { (sub, filter) =>
       if (TraceMatcher.matches(filter.q, trace)) {
-        val filtered = trace.filter(event => ExprUtils.matches(filter.f.query, event.tagValue))
+        val filtered = trace.filter(event => ExprUtils.matches(filter.f, event.tagValue))
         if (filtered.nonEmpty) {
           submit(sub.id, LwcEvent.Events(filtered))
         }

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/ExprUtilsSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/ExprUtilsSuite.scala
@@ -18,6 +18,7 @@ package com.netflix.atlas.lwc.events
 import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.EventExpr
 import com.netflix.atlas.core.model.Query
+import com.netflix.atlas.core.model.StyleExpr
 import com.netflix.atlas.core.model.TraceQuery
 import munit.FunSuite
 
@@ -53,9 +54,9 @@ class ExprUtilsSuite extends FunSuite {
   test("trace: simple query") {
     val expected = TraceQuery.SpanFilter(
       TraceQuery.Simple(Query.Equal("app", "foo")),
-      DataExpr.All(Query.True)
+      Query.True
     )
-    assertEquals(ExprUtils.parseTraceQuery("app,foo,:eq"), expected)
+    assertEquals(ExprUtils.parseTraceEventsQuery("app,foo,:eq"), expected)
   }
 
   test("trace: complex") {
@@ -64,21 +65,21 @@ class ExprUtilsSuite extends FunSuite {
         Query.Equal("app", "foo"),
         Query.Equal("app", "bar")
       ),
-      DataExpr.All(Query.Equal("app", "foo"))
+      Query.Equal("app", "foo")
     )
     val expr = "app,foo,:eq,app,bar,:eq,:child,app,foo,:eq,:span-filter"
-    assertEquals(ExprUtils.parseTraceQuery(expr), expected)
+    assertEquals(ExprUtils.parseTraceEventsQuery(expr), expected)
   }
 
   test("trace: analytics") {
-    val expected = TraceQuery.SpanFilter(
+    val expected = TraceQuery.SpanTimeSeries(
       TraceQuery.Child(
         Query.Equal("app", "foo"),
         Query.Equal("app", "bar")
       ),
-      DataExpr.Sum(Query.Equal("app", "foo"))
+      StyleExpr(DataExpr.Sum(Query.Equal("app", "foo")), Map.empty)
     )
-    val expr = "app,foo,:eq,app,bar,:eq,:child,app,foo,:eq,:sum,:span-filter"
-    assertEquals(ExprUtils.parseTraceQuery(expr), expected)
+    val expr = "app,foo,:eq,app,bar,:eq,:child,app,foo,:eq,:sum,:span-time-series"
+    assertEquals(ExprUtils.parseTraceTimeSeriesQuery(expr), expected)
   }
 }

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/TraceMatcherSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/TraceMatcherSuite.scala
@@ -58,37 +58,37 @@ class TraceMatcherSuite extends FunSuite {
   }
 
   test("simple") {
-    checkMatch(ExprUtils.parseTraceQuery("app,a,:eq").q, true)
-    checkMatch(ExprUtils.parseTraceQuery("app,z,:eq").q, false)
+    checkMatch(ExprUtils.parseTraceEventsQuery("app,a,:eq").q, true)
+    checkMatch(ExprUtils.parseTraceEventsQuery("app,z,:eq").q, false)
   }
 
   test("span-and") {
-    val q1 = ExprUtils.parseTraceQuery("app,a,:eq,app,e,:eq,:span-and").q
+    val q1 = ExprUtils.parseTraceEventsQuery("app,a,:eq,app,e,:eq,:span-and").q
     checkMatch(q1, true)
 
-    val q2 = ExprUtils.parseTraceQuery("app,a,:eq,app,z,:eq,:span-and").q
+    val q2 = ExprUtils.parseTraceEventsQuery("app,a,:eq,app,z,:eq,:span-and").q
     checkMatch(q2, false)
   }
 
   test("span-or") {
-    val q1 = ExprUtils.parseTraceQuery("app,a,:eq,app,e,:eq,:span-or").q
+    val q1 = ExprUtils.parseTraceEventsQuery("app,a,:eq,app,e,:eq,:span-or").q
     checkMatch(q1, true)
 
-    val q2 = ExprUtils.parseTraceQuery("app,a,:eq,app,z,:eq,:span-or").q
+    val q2 = ExprUtils.parseTraceEventsQuery("app,a,:eq,app,z,:eq,:span-or").q
     checkMatch(q2, true)
 
-    val q3 = ExprUtils.parseTraceQuery("app,y,:eq,app,z,:eq,:span-or").q
+    val q3 = ExprUtils.parseTraceEventsQuery("app,y,:eq,app,z,:eq,:span-or").q
     checkMatch(q3, false)
   }
 
   test("child") {
-    val q1 = ExprUtils.parseTraceQuery("app,a,:eq,app,c,:eq,:child").q
+    val q1 = ExprUtils.parseTraceEventsQuery("app,a,:eq,app,c,:eq,:child").q
     checkMatch(q1, true)
 
-    val q2 = ExprUtils.parseTraceQuery("app,c,:eq,app,e,:eq,:child").q
+    val q2 = ExprUtils.parseTraceEventsQuery("app,c,:eq,app,e,:eq,:child").q
     checkMatch(q2, true)
 
-    val q3 = ExprUtils.parseTraceQuery("app,a,:eq,app,e,:eq,:child").q
+    val q3 = ExprUtils.parseTraceEventsQuery("app,a,:eq,app,e,:eq,:child").q
     checkMatch(q3, false)
   }
 }


### PR DESCRIPTION
Just using span-filter for both pass-through and time series use-cases on traces creates some ambiguity for some use-cases in particular with implicit conversions.