### PR TITLE
core: fix toString for event and trace exprs

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/EventExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/EventExpr.scala
@@ -30,7 +30,10 @@ object EventExpr {
     * @param query
     *     Query to determine if an event should be matched.
     */
-  case class Raw(query: Query) extends EventExpr
+  case class Raw(query: Query) extends EventExpr {
+
+    override def toString: String = query.toString
+  }
 
   /**
     * Expression that specifies how to map an event to a simple row with the specified columns.
@@ -42,5 +45,7 @@ object EventExpr {
     */
   case class Table(query: Query, columns: List[String]) extends EventExpr {
     require(columns.nonEmpty, "set of columns cannot be empty")
+
+    override def toString: String = s"$query,(,${columns.mkString(",")},),:table"
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/EventExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/EventExpr.scala
@@ -44,6 +44,7 @@ object EventExpr {
     *     Set of columns to export into a row.
     */
   case class Table(query: Query, columns: List[String]) extends EventExpr {
+
     require(columns.nonEmpty, "set of columns cannot be empty")
 
     override def toString: String = s"$query,(,${columns.mkString(",")},),:table"

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TraceQuery.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TraceQuery.scala
@@ -24,23 +24,41 @@ object TraceQuery {
     * Wraps a Query type to be a TraceQuery. This will typically happen via an implicit
     * conversion when using as a parameter to a another operator that expects a TraceQuery.
     */
-  case class Simple(query: Query) extends TraceQuery
+  case class Simple(query: Query) extends TraceQuery {
+
+    override def toString: String = query.toString
+  }
 
   /** Matches if the trace has a span that matches `q1` and a span that matches `q2`. */
-  case class SpanAnd(q1: TraceQuery, q2: TraceQuery) extends TraceQuery
+  case class SpanAnd(q1: TraceQuery, q2: TraceQuery) extends TraceQuery {
+
+    override def toString: String = s"$q1,$q2,:span-and"
+  }
 
   /** Matches if the trace has a span that matches `q1` or a span that matches `q2`. */
-  case class SpanOr(q1: TraceQuery, q2: TraceQuery) extends TraceQuery
+  case class SpanOr(q1: TraceQuery, q2: TraceQuery) extends TraceQuery {
+
+    override def toString: String = s"$q1,$q2,:span-or"
+  }
 
   /**
     * Matches if the trace has a span that matches `q1` with a direct child span that
     * matches `q2`.
     */
-  case class Child(q1: Query, q2: Query) extends TraceQuery
+  case class Child(q1: Query, q2: Query) extends TraceQuery {
+
+    override def toString: String = s"$q1,$q2,:child"
+  }
 
   /** Filter to select the set of spans from a trace to forward as events. */
-  case class SpanFilter(q: TraceQuery, f: Query) extends Expr
+  case class SpanFilter(q: TraceQuery, f: Query) extends Expr {
+
+    override def toString: String = s"$q,$f,:span-filter"
+  }
 
   /** Time series based on data from a set of matching traces. */
-  case class SpanTimeSeries(q: TraceQuery, expr: StyleExpr) extends Expr
+  case class SpanTimeSeries(q: TraceQuery, expr: StyleExpr) extends Expr {
+
+    override def toString: String = s"$q,$expr,:span-time-series"
+  }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/EventVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/EventVocabularySuite.scala
@@ -23,10 +23,12 @@ class EventVocabularySuite extends FunSuite {
   private val interpreter = new Interpreter(EventVocabulary.allWords)
 
   private def parse(str: String): EventExpr.Table = {
-    interpreter.execute(str).stack match {
+    val expr = interpreter.execute(str).stack match {
       case (t: EventExpr.Table) :: Nil => t
       case _                           => throw new IllegalArgumentException(str)
     }
+    assertEquals(expr.toString, str)
+    expr
   }
 
   test("table, empty set of columns") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TraceVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TraceVocabularySuite.scala
@@ -24,24 +24,30 @@ class TraceVocabularySuite extends FunSuite {
 
   private def parseTraceQuery(str: String): TraceQuery = {
     import ModelExtractors.*
-    interpreter.execute(str).stack match {
+    val expr = interpreter.execute(str).stack match {
       case TraceQueryType(t) :: Nil => t
       case _                        => throw new IllegalArgumentException(str)
     }
+    assertEquals(expr.toString, str)
+    expr
   }
 
   private def parseFilter(str: String): TraceQuery.SpanFilter = {
-    interpreter.execute(str).stack match {
+    val expr = interpreter.execute(str).stack match {
       case (t: TraceQuery.SpanFilter) :: Nil => t
       case _                                 => throw new IllegalArgumentException(str)
     }
+    assertEquals(expr.toString, str)
+    expr
   }
 
   private def parseTimeSeries(str: String): TraceQuery.SpanTimeSeries = {
-    interpreter.execute(str).stack match {
+    val expr = interpreter.execute(str).stack match {
       case (t: TraceQuery.SpanTimeSeries) :: Nil => t
       case _                                     => throw new IllegalArgumentException(str)
     }
+    assertEquals(expr.toString, str)
+    expr
   }
 
   test("simple Query coerced to TraceQuery") {
@@ -89,7 +95,7 @@ class TraceVocabularySuite extends FunSuite {
   }
 
   test("span-time-series") {
-    val q = parseTimeSeries("app,foo,:eq,app,bar,:eq,:child,app,foo,:eq,:span-time-series")
+    val q = parseTimeSeries("app,foo,:eq,app,bar,:eq,:child,app,foo,:eq,:sum,:span-time-series")
     val expected = TraceQuery.SpanTimeSeries(
       TraceQuery.Child(
         Query.Equal("app", "foo"),


### PR DESCRIPTION
Update toString to output an expression that conforms to the model. This makes them consistent with other expr types.