### PR TITLE
avoid double publishing of artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,5 +32,4 @@ jobs:
         run: |
           git fetch --unshallow --tags
           cat /dev/null | project/sbt ++2.13.13 clean test +publishSigned
-          cat /dev/null | project/sbt ++3.4.0 clean test +publishSigned
           cat /dev/null | project/sbt sonatypeBundleRelease

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -32,4 +32,3 @@ jobs:
         run: |
           git fetch --unshallow --tags
           cat /dev/null | project/sbt ++2.13.13 clean test +publishSigned
-          cat /dev/null | project/sbt ++3.4.0 clean test +publishSigned


### PR DESCRIPTION
The `+` on publishSigned will handle the publishing of all scala versions.