### PR TITLE
eval: support presentation metadata for stream

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -311,7 +311,7 @@ private[stream] abstract class EvaluatorImpl(
 
     // Extract data expressions to reuse for creating time groups
     val exprs = sources.sources.asScala
-      .flatMap(ds => interpreter.eval(Uri(ds.uri)))
+      .flatMap(ds => interpreter.eval(Uri(ds.uri)).exprs)
       .flatMap(_.expr.dataExprs)
       .toList
       .distinct
@@ -506,7 +506,7 @@ private[stream] abstract class EvaluatorImpl(
 
   private def toExprSet(dss: DataSources, interpreter: ExprInterpreter): Set[LwcExpression] = {
     dss.sources.asScala.flatMap { dataSource =>
-      interpreter.eval(Uri(dataSource.uri)).map { expr =>
+      interpreter.eval(Uri(dataSource.uri)).exprs.map { expr =>
         LwcExpression(expr.toString, ExprType.TIME_SERIES, dataSource.step.toMillis)
       }
     }.toSet

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -152,7 +152,7 @@ private[stream] class StreamContext(
 
       // Check that expression is parseable and perform basic static analysis of DataExprs to
       // weed out expensive queries up front
-      val results = interpreter.eval(uri)
+      val results = interpreter.eval(uri).exprs
       results.foreach(_.expr.dataExprs.foreach(validateDataExpr))
 
       // Check that there is a backend available for it

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/SyntheticDataSource.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/SyntheticDataSource.scala
@@ -57,7 +57,7 @@ object SyntheticDataSource {
 
   def apply(interpreter: ExprInterpreter, uri: Uri): Source[ByteString, Future[IOResult]] = {
     val settings = getSettings(uri)
-    val exprs = interpreter.eval(uri)
+    val exprs = interpreter.eval(uri).exprs
     val promise = Promise[IOResult]()
     Source(exprs)
       .flatMapMerge(Int.MaxValue, expr => source(settings, expr))

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -151,7 +151,7 @@ class EvaluatorSuite extends FunSuite {
         assertEquals(t, "error")
         assertEquals(
           msg,
-          "IllegalArgumentException: missing required URI parameter `q`: resource:///gc-pause.dat/api/v1/graph"
+          "IllegalArgumentException: missing required parameter 'q'"
         )
       case v =>
         throw new MatchError(v)
@@ -313,7 +313,7 @@ class EvaluatorSuite extends FunSuite {
     val uri = "http://test/api/v1/graph"
     val ds1 = Evaluator.DataSources.of(ds("one", uri))
     val msg =
-      "IllegalArgumentException: missing required URI parameter `q`: http://test/api/v1/graph"
+      "IllegalArgumentException: missing required parameter 'q'"
     testError(ds1, msg)
   }
 

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
@@ -65,6 +65,32 @@ object TestContext {
       |  simple-legends-enabled = false
       |}
       |
+      |atlas.eval.graph {
+      |  step = 60s
+      |  start-time = e-3h
+      |  end-time = now
+      |  timezone = US/Pacific
+      |  width = 700
+      |  height = 300
+      |  theme = "light"
+      |
+      |  light {
+      |    palette {
+      |      primary = "armytage"
+      |      offset = "bw"
+      |    }
+      |    named-colors = {
+      |    }
+      |  }
+      |
+      |  max-datapoints = 1440
+      |  png-metadata-enabled = false
+      |  browser-agent-pattern = "mozilla|msie|gecko|chrome|opera|webkit"
+      |  simple-legends-enabled = false
+      |  engines = []
+      |  vocabulary = "default"
+      |}
+      |
       |atlas.eval.host-rewrite {
       |  pattern = "$^"
       |  key = ""


### PR DESCRIPTION
Honor `presentation-metadata` hint for time series messages emitted by the stream. This allows it to be blended with the backend with consistent presentation.