### PR TITLE
eval: use consistent setting for simple legends

### DIFF
--- a/atlas-eval/src/main/resources/reference.conf
+++ b/atlas-eval/src/main/resources/reference.conf
@@ -32,11 +32,6 @@ atlas.eval {
 
     // Which version of the LWC server API to use
     lwcapi-version = 2
-
-    // If set to true, then it will try to generate a simple legend for the set of expressions
-    // on the graph. By default the legend will just summarize the expression which is often
-    // long and hard to read for users.
-    simple-legends-enabled = true
   }
 
   graph {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
@@ -44,7 +44,7 @@ private[stream] class ExprInterpreter(config: Config) {
 
   // Use simple legends for expressions
   private val simpleLegendsEnabled: Boolean =
-    config.getBoolean("atlas.eval.stream.simple-legends-enabled")
+    config.getBoolean("atlas.eval.graph.simple-legends-enabled")
 
   def eval(expr: String): List[StyleExpr] = {
     val exprs = interpreter.execute(expr).stack.map {

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
@@ -61,8 +61,6 @@ object TestContext {
       |  expression-limit = 50000
       |
       |  ignored-tag-keys = []
-      |
-      |  simple-legends-enabled = false
       |}
       |
       |atlas.eval.graph {


### PR DESCRIPTION
Since eval output will now use graph settings to enable presentation metadata, use the same setting for simple legends to avoid confusion.