### PR TITLE
eval: require precise scoping for hi-res streams

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
@@ -27,7 +27,6 @@ import com.netflix.atlas.eval.stream.Evaluator.DataSources
 import com.netflix.atlas.eval.util.HostRewriter
 import com.typesafe.config.Config
 
-import java.time.Duration
 import scala.util.Success
 
 private[stream] class ExprInterpreter(config: Config) {
@@ -36,16 +35,8 @@ private[stream] class ExprInterpreter(config: Config) {
 
   private val hostRewriter = new HostRewriter(config.getConfig("atlas.eval.host-rewrite"))
 
-  private val maxStep = config.getDuration("atlas.eval.stream.limits.max-step")
-
   def eval(uri: Uri): GraphConfig = {
     val graphCfg = grapher.toGraphConfig(uri)
-
-    // Check step size is within bounds
-    if (graphCfg.stepSize > maxStep.toMillis) {
-      val step = Duration.ofMillis(graphCfg.stepSize)
-      throw new IllegalArgumentException(s"max allowed step size exceeded ($step > $maxStep)")
-    }
 
     // Check that data expressions are supported. The streaming path doesn't support
     // time shifts, filters, and integral. The filters and integral are excluded because

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -363,14 +363,6 @@ class EvaluatorSuite extends FunSuite {
     testError(ds1, msg)
   }
 
-  test("create processor, reject large step size") {
-    val expr = "name,foo,:eq,:sum"
-    val uri = s"http://test/api/v1/graph?q=$expr&step=5m"
-    val msg = s"IllegalArgumentException: max allowed step size exceeded (PT5M > PT1M)"
-    val ds1 = Evaluator.DataSources.of(ds("one", uri))
-    testError(ds1, msg)
-  }
-
   test("processor handles multiple steps") {
     val evaluator = new Evaluator(config, registry, system)
 
@@ -469,14 +461,17 @@ class EvaluatorSuite extends FunSuite {
     assertEquals(ds.step, Duration.ofMinutes(1))
   }
 
-  test("validate: ok") {
+  private def validateOk(params: String): Unit = {
     val evaluator = new Evaluator(config, registry, system)
     val ds = new Evaluator.DataSource(
       "test",
-      Duration.ofMinutes(1),
-      "resource:///gc-pause.dat?q=name,jvm.gc.pause,:eq,:dist-max,(,nf.asg,nf.node,),:by"
+      s"resource:///gc-pause.dat?$params"
     )
     evaluator.validate(ds)
+  }
+
+  test("validate: ok") {
+    validateOk("q=name,jvm.gc.pause,:eq,:dist-max,(,nf.asg,nf.node,),:by")
   }
 
   test("validate: bad expression") {
@@ -503,7 +498,6 @@ class EvaluatorSuite extends FunSuite {
       evaluator.validate(ds)
     }
     assert(e.getMessage.startsWith(s":$op not supported for streaming evaluation "))
-
   }
 
   test("validate: unsupported operation `:offset`") {
@@ -530,6 +524,18 @@ class EvaluatorSuite extends FunSuite {
     invalidOperator("topk", "name,jvm.gc.pause,:eq,:sum,max,5,:topk")
   }
 
+  test("validate: reject large step sizes") {
+    val evaluator = new Evaluator(config, registry, system)
+    val ds = new Evaluator.DataSource(
+      "test",
+      "resource:///gc-pause.dat?q=name,jvm.gc.pause,:eq,:sum&step=5m"
+    )
+    val e = intercept[IllegalArgumentException] {
+      evaluator.validate(ds)
+    }
+    assertEquals(e.getMessage, "max allowed step size exceeded (PT5M > PT1M)")
+  }
+
   test("validate: unknown backend") {
     val evaluator = new Evaluator(config, registry, system)
     val ds = new Evaluator.DataSource(
@@ -541,6 +547,67 @@ class EvaluatorSuite extends FunSuite {
       evaluator.validate(ds)
     }
     assertEquals(e.getMessage, "unknownhost.com")
+  }
+
+  test("validate: hi-res with eq for name and app") {
+    validateOk("q=name,foo,:eq,nf.app,www,:eq,:and,:sum&step=5s")
+  }
+
+  test("validate: hi-res with eq for name and cluster") {
+    validateOk("q=name,foo,:eq,nf.cluster,www-dev,:eq,:and,:sum&step=5s")
+  }
+
+  test("validate: hi-res with eq for name and asg") {
+    validateOk("q=name,foo,:eq,nf.asg,www-dev-v000,:eq,:and,:sum&step=5s")
+  }
+
+  test("validate: hi-res with in for name") {
+    validateOk("q=name,(,foo,bar,),:in,nf.app,www,:eq,:and,:sum&step=5s")
+  }
+
+  test("validate: hi-res with in for app") {
+    validateOk("q=name,foo,:eq,nf.app,(,www,www2,),:in,:and,:sum&step=5s")
+  }
+
+  test("validate: hi-res with in for cluster") {
+    validateOk("q=name,foo,:eq,nf.cluster,(,www-dev,www-prod,),:in,:and,:sum&step=5s")
+  }
+
+  test("validate: hi-res with in for asg") {
+    validateOk("q=name,foo,:eq,nf.asg,(,www-dev-v001,www-dev-v002,),:in,:and,:sum&step=5s")
+  }
+
+  test("validate: hi-res with or for cluster") {
+    validateOk(
+      "q=name,foo,:eq,nf.cluster,www-dev,:eq,nf.cluster,www-prod,:eq,:or,:and,:sum&step=5s"
+    )
+  }
+
+  private def invalidHiResQuery(expr: String): Unit = {
+    val evaluator = new Evaluator(config, registry, system)
+    val ds = new Evaluator.DataSource(
+      "test",
+      s"resource:///gc-pause.dat?q=$expr&step=5s"
+    )
+    val e = intercept[IllegalArgumentException] {
+      evaluator.validate(ds)
+    }
+    assertEquals(
+      e.getMessage,
+      s"rejected expensive query [$expr], hi-res streams must restrict name and nf.app with :eq or :in"
+    )
+  }
+
+  test("validate: hi-res with regex for name") {
+    invalidHiResQuery("name,foo,:re,nf.app,www,:eq,:and")
+  }
+
+  test("validate: hi-res with not name") {
+    invalidHiResQuery("name,foo,:eq,:not,nf.app,www,:eq,:and")
+  }
+
+  test("validate: hi-res with regex for app") {
+    invalidHiResQuery("name,foo,:eq,nf.app,www,:re,:and")
   }
 
   private val datapointStep = Duration.ofMillis(1)


### PR DESCRIPTION
For hi-res streams, require more precise scoping that allows us to more efficiently match the data and run it only where needed. This would ideally be applied everywhere, but for backwards compatiblity the 1m step is opted out for now.