### PR TITLE
core: sample-count is now stable

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -1249,8 +1249,6 @@ object MathVocabulary extends Vocabulary {
 
     override def name: String = "sample-count"
 
-    override def isStable: Boolean = false
-
     override def matches(stack: List[Any]): Boolean = {
       stack match {
         case DoubleType(_) :: DoubleType(_) :: (_: Query) :: _ => true


### PR DESCRIPTION
Update `:sample-count` operator to be considered stable. It has been around for a few months and usage seems to match user expectations.