### PR TITLE
eval: simplify data point source

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapoint.scala
@@ -49,9 +49,6 @@ private[stream] class LwcToAggrDatapoint(context: StreamContext)
 
       private[this] val state = scala.collection.mutable.AnyRefMap.empty[String, LwcDataExpr]
 
-      // HACK: needed until we can plumb the actual source through the system
-      private var nextSource: Int = 0
-
       override def onPush(): Unit = {
         val builder = List.newBuilder[AggrDatapoint]
         grab(in).foreach {
@@ -79,11 +76,9 @@ private[stream] class LwcToAggrDatapoint(context: StreamContext)
       private def pushDatapoint(dp: LwcDatapoint): Option[AggrDatapoint] = {
         state.get(dp.id) match {
           case Some(sub) =>
-            // TODO, put in source, for now make it random to avoid dedup
-            nextSource += 1
             val expr = sub.expr
             val step = sub.step
-            Some(AggrDatapoint(dp.timestamp, step, expr, nextSource.toString, dp.tags, dp.value))
+            Some(AggrDatapoint(dp.timestamp, step, expr, "datapoint", dp.tags, dp.value))
           case None =>
             unknown.increment()
             None

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/AggrDatapointSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/AggrDatapointSuite.scala
@@ -81,19 +81,6 @@ class AggrDatapointSuite extends FunSuite {
     assert(aggregator.get.limitExceeded)
   }
 
-  test("aggregate dedups using source") {
-    val expr = DataExpr.Sum(Query.True)
-    val dataset = createDatapoints(expr, 0, 10)
-    val aggregator =
-      AggrDatapoint.aggregate(dataset ::: dataset, settings(Integer.MAX_VALUE, Integer.MAX_VALUE))
-    val result = aggregator.get.datapoints
-
-    assertEquals(result.size, 1)
-    assertEquals(result.head.timestamp, 0L)
-    assertEquals(result.head.tags, Map("name" -> "cpu"))
-    assertEquals(result.head.value, 45.0)
-  }
-
   test("aggregate gauges sum") {
     val expr = DataExpr.Sum(Query.True)
     val dataset = createGaugeDatapoints(expr, 0, 10)
@@ -174,20 +161,6 @@ class AggrDatapointSuite extends FunSuite {
       AggrDatapoint.aggregate(dataset, settings(Integer.MAX_VALUE, 5))
 
     assert(aggregator.get.limitExceeded)
-  }
-
-  test("aggregate, dedup and group by") {
-    val expr = DataExpr.GroupBy(DataExpr.Sum(Query.True), List("node"))
-    val dataset = createDatapoints(expr, 0, 10)
-    val aggregator =
-      AggrDatapoint.aggregate(dataset ::: dataset, settings(Integer.MAX_VALUE, Integer.MAX_VALUE))
-    val result = aggregator.get.datapoints
-
-    assertEquals(result.size, 10)
-    result.foreach { d =>
-      val v = d.tags("node").substring(2).toDouble
-      assertEquals(d.value, v)
-    }
   }
 
   test("aggregate all") {


### PR DESCRIPTION
This was originally intended for some deduping, but was never utilized. The only function right now is to indicate a synthetic data point generated from a heartbeat. This change removes some of the deduping overhead based on the source that won't actually dedup anything.