### PR TITLE
eval: add event message type

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/EventMessage.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/EventMessage.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonNode
+import com.netflix.atlas.json.Json
+import com.netflix.atlas.json.JsonSupport
+
+/**
+  * Message type use for events to forward to a consumer.
+  */
+case class EventMessage(payload: JsonNode) extends JsonSupport {
+
+  override def encode(gen: JsonGenerator): Unit = {
+    gen.writeStartObject()
+    gen.writeStringField("type", "event")
+    gen.writeFieldName("payload")
+    Json.encode(gen, payload)
+    gen.writeEndObject()
+  }
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcEvent.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcEvent.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.netflix.atlas.json.JsonSupport
+
+/**
+  * Raw event data to pass through to the consumer.
+  *
+  * @param id
+  *     Identifies the expression that resulted in this datapoint being generated.
+  * @param payload
+  *     Raw event payload.
+  */
+case class LwcEvent(id: String, payload: JsonNode) extends JsonSupport {
+  val `type`: String = "event"
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -33,6 +33,7 @@ import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.util.Streams
 import com.netflix.atlas.eval.stream.Evaluator.DataSource
 import com.netflix.atlas.eval.stream.Evaluator.DataSources
+import com.netflix.atlas.json.JsonSupport
 import com.netflix.atlas.pekko.AccessLogger
 import com.netflix.atlas.pekko.DiagnosticMessage
 import com.netflix.atlas.pekko.StreamOps
@@ -233,7 +234,7 @@ private[stream] class StreamContext(
   /**
     * Send a diagnostic message to all data sources that use a particular data expression.
     */
-  def log(expr: DataExpr, msg: DiagnosticMessage): Unit = {
+  def log(expr: DataExpr, msg: JsonSupport): Unit = {
     dataExprMap.get(expr).foreach { ds =>
       ds.foreach(s => dsLogger(s, msg))
     }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -29,6 +29,7 @@ import com.netflix.atlas.chart.util.SrcPath
 import com.netflix.atlas.eval.model.ArrayData
 import com.netflix.atlas.eval.model.LwcDatapoint
 import com.netflix.atlas.eval.model.LwcDiagnosticMessage
+import com.netflix.atlas.eval.model.LwcEvent
 import com.netflix.atlas.eval.model.LwcExpression
 import com.netflix.atlas.eval.model.LwcHeartbeat
 import com.netflix.atlas.eval.model.LwcMessages
@@ -117,6 +118,7 @@ class EvaluatorSuite extends FunSuite {
           case m: LwcExpression        => Option(m.`type`)
           case m: LwcSubscription      => Option(m.`type`)
           case m: LwcDatapoint         => Option(m.`type`)
+          case m: LwcEvent             => Option(m.`type`)
           case m: LwcDiagnosticMessage => Option(m.`type`)
           case m: LwcHeartbeat         => Option(m.`type`)
           case _                       => None


### PR DESCRIPTION
Update messages parsing to handle simple pass-through events. They get logged out just like diagnostic
messages.