### PR TITLE
lwc-events: improve data point conversion

### DIFF
--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/DatapointConverter.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/DatapointConverter.scala
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwc.events
+
+import com.netflix.atlas.core.model.DataExpr
+import com.netflix.atlas.core.model.Query
+import com.netflix.spectator.api.Clock
+import com.netflix.spectator.impl.AtomicDouble
+import com.netflix.spectator.impl.StepDouble
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+  * Helper to convert a sequence of events into a data point.
+  */
+private[events] trait DatapointConverter {
+
+  def update(event: LwcEvent): Unit
+
+  def flush(timestamp: Long): Unit
+}
+
+private[events] object DatapointConverter {
+
+  def apply(
+    id: String,
+    expr: DataExpr,
+    clock: Clock,
+    step: Long,
+    consumer: (String, LwcEvent) => Unit
+  ): DatapointConverter = {
+    val tags = Query.tags(expr.query)
+    val mapper = createValueMapper(tags, expr.finalGrouping)
+    val params = Params(id, Query.tags(expr.query), clock, step, mapper, consumer)
+    toConverter(expr, params)
+  }
+
+  private def toConverter(expr: DataExpr, params: Params): DatapointConverter = {
+    expr match {
+      case _: DataExpr.Sum      => Sum(params)
+      case _: DataExpr.Count    => Count(params)
+      case _: DataExpr.Max      => Max(params)
+      case _: DataExpr.Min      => Min(params)
+      case by: DataExpr.GroupBy => GroupBy(by, params)
+      case _                    => Sum(params)
+    }
+  }
+
+  /**
+    * Extract value and map as needed based on the type. Uses statistic and grouping to
+    * coerce events so they structurally work like spectator composite types.
+    */
+  def createValueMapper(tags: Map[String, String], grouping: List[String]): LwcEvent => Double = {
+    tags.get("value") match {
+      case Some(k) =>
+        tags.get("statistic") match {
+          case Some("count")          => _ => 1.0
+          case Some("totalOfSquares") => event => squared(event.extractValue(k))
+          case _                      => event => toDouble(event.extractValue(k))
+        }
+      case None =>
+        _ => 1.0
+    }
+  }
+
+  private def squared(value: Any): Double = {
+    val v = toDouble(value)
+    v * v
+  }
+
+  def toDouble(value: Any): Double = {
+    value match {
+      case v: Boolean => if (v) 1.0 else 0.0
+      case v: Byte    => v.toDouble
+      case v: Short   => v.toDouble
+      case v: Int     => v.toDouble
+      case v: Long    => v.toDouble
+      case v: Float   => v.toDouble
+      case v: Double  => v
+      case v: Number  => v.doubleValue()
+      case v: String  => parseDouble(v)
+      case _          => 1.0
+    }
+  }
+
+  private def parseDouble(v: String): Double = {
+    try {
+      java.lang.Double.parseDouble(v)
+    } catch {
+      case _: Exception => Double.NaN
+    }
+  }
+
+  case class Params(
+    id: String,
+    tags: Map[String, String],
+    clock: Clock,
+    step: Long,
+    valueMapper: LwcEvent => Double,
+    consumer: (String, LwcEvent) => Unit
+  ) {
+
+    val buffer = new StepDouble(0.0, clock, step)
+  }
+
+  /** Compute sum for a counter as a rate per second. */
+  case class Sum(params: Params) extends DatapointConverter {
+
+    override def update(event: LwcEvent): Unit = {
+      val value = params.valueMapper(event)
+      if (value.isFinite && value >= 0.0) {
+        params.buffer.getCurrent.addAndGet(value)
+      }
+    }
+
+    override def flush(timestamp: Long): Unit = {
+      val value = params.buffer.pollAsRate(timestamp)
+      if (value.isFinite) {
+        val ts = timestamp / params.step * params.step
+        val event = DatapointEvent(params.id, params.tags, ts, value)
+        params.consumer(params.id, event)
+      }
+    }
+  }
+
+  /** Compute count of contributing events. */
+  case class Count(params: Params) extends DatapointConverter {
+
+    override def update(event: LwcEvent): Unit = {
+      params.buffer.getCurrent.addAndGet(1.0)
+    }
+
+    override def flush(timestamp: Long): Unit = {
+      val value = params.buffer.poll(timestamp)
+      if (value.isFinite) {
+        val ts = timestamp / params.step * params.step
+        val event = DatapointEvent(params.id, params.tags, ts, value)
+        params.consumer(params.id, event)
+      }
+    }
+  }
+
+  /** Compute max value from contributing events. */
+  case class Max(params: Params) extends DatapointConverter {
+
+    override def update(event: LwcEvent): Unit = {
+      val value = params.valueMapper(event)
+      if (value.isFinite && value >= 0.0) {
+        params.buffer.getCurrent.max(value)
+      }
+    }
+
+    override def flush(timestamp: Long): Unit = {
+      val value = params.buffer.poll(timestamp)
+      if (value.isFinite) {
+        val ts = timestamp / params.step * params.step
+        val event = DatapointEvent(params.id, params.tags, ts, value)
+        params.consumer(params.id, event)
+      }
+    }
+  }
+
+  /** Compute min value from contributing events. */
+  case class Min(params: Params) extends DatapointConverter {
+
+    override def update(event: LwcEvent): Unit = {
+      val value = params.valueMapper(event)
+      if (value.isFinite && value >= 0.0) {
+        min(params.buffer.getCurrent, value)
+      }
+    }
+
+    private def min(current: AtomicDouble, value: Double): Unit = {
+      if (value.isFinite) {
+        var min = current.get()
+        while (isLessThan(value, min) && !current.compareAndSet(min, value)) {
+          min = current.get()
+        }
+      }
+    }
+
+    private def isLessThan(v1: Double, v2: Double): Boolean = {
+      v1 < v2 || v2.isNaN
+    }
+
+    override def flush(timestamp: Long): Unit = {
+      val value = params.buffer.poll(timestamp)
+      if (value.isFinite) {
+        val ts = timestamp / params.step * params.step
+        val event = DatapointEvent(params.id, params.tags, ts, value)
+        params.consumer(params.id, event)
+      }
+    }
+  }
+
+  /** Compute set of data points, one for each distinct group. */
+  case class GroupBy(by: DataExpr.GroupBy, params: Params) extends DatapointConverter {
+
+    private val groups = new ConcurrentHashMap[Map[String, String], DatapointConverter]()
+
+    override def update(event: LwcEvent): Unit = {
+      // Ignore events that are missing dimensions used in the grouping
+      val values = by.keys.map(event.tagValue).filterNot(_ == null)
+      if (by.keys.size == values.size) {
+        val value = params.valueMapper(event)
+        if (value.isFinite) {
+          val tags = by.keys.zip(values).toMap
+          val converter = groups.computeIfAbsent(tags, groupConverter)
+          converter.update(event)
+        }
+      }
+    }
+
+    private def groupConverter(tags: Map[String, String]): DatapointConverter = {
+      val ps = params.copy(consumer = (id, event) => groupConsumer(tags, id, event))
+      toConverter(by.af, ps)
+    }
+
+    private def groupConsumer(tags: Map[String, String], id: String, event: LwcEvent): Unit = {
+      event match {
+        case dp: DatapointEvent => params.consumer(id, dp.copy(tags = dp.tags ++ tags))
+        case ev                 => params.consumer(id, ev)
+      }
+    }
+
+    override def flush(timestamp: Long): Unit = {
+      groups.values().forEach(_.flush(timestamp))
+    }
+  }
+}

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEvent.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEvent.scala
@@ -100,6 +100,14 @@ trait LwcEvent {
 object LwcEvent {
 
   /**
+    * Wrap a Map as an LWC event. The timestamp will be the time when the event is
+    * wrapped.
+    */
+  def apply(event: Map[String, Any]): LwcEvent = {
+    apply(event, k => event.getOrElse(k, null))
+  }
+
+  /**
     * Wrap an object as an LWC event. The timestamp will be the time when the event is
     * wrapped.
     *
@@ -113,6 +121,23 @@ object LwcEvent {
     */
   def apply(rawEvent: Any, extractor: String => Any): LwcEvent = {
     BasicLwcEvent(rawEvent, extractor)
+  }
+
+  /**
+    * Event used to indicate a heartbeat. It just consists of a timestamp and can be used to
+    * ensure regular traffic. Some activity such as flushing analytic data points or cleanup
+    * may be triggered by the heartbeat.
+    */
+  case class HeartbeatLwcEvent(timestamp: Long) extends LwcEvent {
+
+    /** Raw event object that is being considered. */
+    override def rawEvent: Any = timestamp
+
+    /**
+      * Extract a value from the raw event for a given key. This method should be consistent
+      * with the `tagValue` method for keys that can be considered tags.
+      */
+    override def extractValue(key: String): Any = null
   }
 
   private case class BasicLwcEvent(rawEvent: Any, extractor: String => Any) extends LwcEvent {

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEventClient.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEventClient.scala
@@ -16,6 +16,7 @@
 package com.netflix.atlas.lwc.events
 
 import com.netflix.atlas.json.Json
+import com.netflix.spectator.api.Clock
 
 import java.io.StringWriter
 import scala.util.Using
@@ -58,15 +59,24 @@ object LwcEventClient {
     *     Set of subscriptions to match with the events.
     * @param consumer
     *     Function that will receive the output.
+    * @param clock
+    *     Clock to use for timing events.
     * @return
     *     Client instance.
     */
-  def apply(subscriptions: Subscriptions, consumer: String => Unit): LwcEventClient = {
-    new LocalLwcEventClient(subscriptions, consumer)
+  def apply(
+    subscriptions: Subscriptions,
+    consumer: String => Unit,
+    clock: Clock = Clock.SYSTEM
+  ): LwcEventClient = {
+    new LocalLwcEventClient(subscriptions, consumer, clock)
   }
 
-  private class LocalLwcEventClient(subscriptions: Subscriptions, consumer: String => Unit)
-      extends AbstractLwcEventClient {
+  private class LocalLwcEventClient(
+    subscriptions: Subscriptions,
+    consumer: String => Unit,
+    clock: Clock
+  ) extends AbstractLwcEventClient(clock) {
 
     sync(subscriptions)
 

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/DatapointConverterSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/DatapointConverterSuite.scala
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwc.events
+
+import com.netflix.atlas.core.model.DataExpr
+import com.netflix.atlas.core.model.Query
+import com.netflix.spectator.api.ManualClock
+import munit.FunSuite
+
+import java.util.concurrent.atomic.AtomicLong
+
+class DatapointConverterSuite extends FunSuite {
+
+  private val clock = new ManualClock()
+  private val step = 5_000L
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    clock.setWallTime(0L)
+    clock.setMonotonicTime(0L)
+  }
+
+  test("toDouble") {
+    assertEquals(DatapointConverter.toDouble(false), 0.0)
+    assertEquals(DatapointConverter.toDouble(true), 1.0)
+    assertEquals(DatapointConverter.toDouble(42), 42.0)
+    assertEquals(DatapointConverter.toDouble(42L), 42.0)
+    assertEquals(DatapointConverter.toDouble(42.5f), 42.5)
+    assertEquals(DatapointConverter.toDouble(42.5), 42.5)
+    assertEquals(DatapointConverter.toDouble(new AtomicLong(42)), 42.0)
+    assertEquals(DatapointConverter.toDouble("42"), 42.0)
+    assertEquals(DatapointConverter.toDouble("42e3"), 42e3)
+    assert(DatapointConverter.toDouble("foo").isNaN)
+  }
+
+  test("counter - sum") {
+    val expr = DataExpr.Sum(Query.True)
+    val events = List.newBuilder[LwcEvent]
+    val converter = DatapointConverter("id", expr, clock, step, (_, e) => events.addOne(e))
+    (0 until 5).foreach { i =>
+      val event = LwcEvent(Map("value" -> i))
+      converter.update(event)
+    }
+    clock.setWallTime(step + 1)
+    converter.flush(clock.wallTime())
+    val results = events.result()
+    assertEquals(results.size, 1)
+    assertEquals(results.head, DatapointEvent("id", Map.empty, step, 1.0))
+  }
+
+  test("counter - sum custom value") {
+    val expr = DataExpr.Sum(Query.Equal("value", "responseSize"))
+    val events = List.newBuilder[LwcEvent]
+    val converter = DatapointConverter("id", expr, clock, step, (_, e) => events.addOne(e))
+    (0 until 5).foreach { i =>
+      val event = LwcEvent(Map("responseSize" -> i))
+      converter.update(event)
+    }
+    clock.setWallTime(step + 1)
+    converter.flush(clock.wallTime())
+    val results = events.result()
+    assertEquals(results.size, 1)
+    assertEquals(results.head, DatapointEvent("id", Map("value" -> "responseSize"), step, 2.0))
+  }
+
+  test("counter - count") {
+    val expr = DataExpr.Count(Query.Equal("value", "responseSize"))
+    val events = List.newBuilder[LwcEvent]
+    val converter = DatapointConverter("id", expr, clock, step, (_, e) => events.addOne(e))
+    (0 until 5).foreach { i =>
+      val event = LwcEvent(Map("responseSize" -> i))
+      converter.update(event)
+    }
+    clock.setWallTime(step + 1)
+    converter.flush(clock.wallTime())
+    val results = events.result()
+    assertEquals(results.size, 1)
+    assertEquals(results.head, DatapointEvent("id", Map("value" -> "responseSize"), step, 5.0))
+  }
+
+  private def stat(name: String): Query = {
+    Query.Equal("statistic", name)
+  }
+
+  test("timer - sum of totalTime") {
+    val expr = DataExpr.Sum(Query.Equal("value", "latency").and(stat("totalTime")))
+    val events = List.newBuilder[LwcEvent]
+    val converter = DatapointConverter("id", expr, clock, step, (_, e) => events.addOne(e))
+    (0 until 5).foreach { i =>
+      val event = LwcEvent(Map("latency" -> i))
+      converter.update(event)
+    }
+    clock.setWallTime(step + 1)
+    converter.flush(clock.wallTime())
+    val results = events.result()
+    assertEquals(results.size, 1)
+    assertEquals(results.head, DatapointEvent("id", Query.tags(expr.query), step, 2.0))
+  }
+
+  test("timer - sum of count") {
+    val expr = DataExpr.Sum(Query.Equal("value", "latency").and(stat("count")))
+    val events = List.newBuilder[LwcEvent]
+    val converter = DatapointConverter("id", expr, clock, step, (_, e) => events.addOne(e))
+    (0 until 5).foreach { i =>
+      val event = LwcEvent(Map("latency" -> i))
+      converter.update(event)
+    }
+    clock.setWallTime(step + 1)
+    converter.flush(clock.wallTime())
+    val results = events.result()
+    assertEquals(results.size, 1)
+    assertEquals(results.head, DatapointEvent("id", Query.tags(expr.query), step, 1.0))
+  }
+
+  test("timer - sum of totalOfSquares") {
+    val expr = DataExpr.Sum(Query.Equal("value", "latency").and(stat("totalOfSquares")))
+    val events = List.newBuilder[LwcEvent]
+    val converter = DatapointConverter("id", expr, clock, step, (_, e) => events.addOne(e))
+    (0 until 5).foreach { i =>
+      val event = LwcEvent(Map("latency" -> i))
+      converter.update(event)
+    }
+    clock.setWallTime(step + 1)
+    converter.flush(clock.wallTime())
+    val results = events.result()
+    assertEquals(results.size, 1)
+    assertEquals(results.head, DatapointEvent("id", Query.tags(expr.query), step, 6.0))
+  }
+
+  test("timer - dist-max") {
+    val expr = DataExpr.Max(Query.Equal("value", "latency").and(stat("max")))
+    val events = List.newBuilder[LwcEvent]
+    val converter = DatapointConverter("id", expr, clock, step, (_, e) => events.addOne(e))
+    (0 until 5).foreach { i =>
+      val event = LwcEvent(Map("latency" -> i))
+      converter.update(event)
+    }
+    clock.setWallTime(step + 1)
+    converter.flush(clock.wallTime())
+    val results = events.result()
+    assertEquals(results.size, 1)
+    assertEquals(results.head, DatapointEvent("id", Query.tags(expr.query), step, 4.0))
+  }
+
+  test("timer - dist-min") {
+    val expr = DataExpr.Min(Query.Equal("value", "latency").and(stat("max")))
+    val events = List.newBuilder[LwcEvent]
+    val converter = DatapointConverter("id", expr, clock, step, (_, e) => events.addOne(e))
+    (0 until 5).foreach { i =>
+      val event = LwcEvent(Map("latency" -> i))
+      converter.update(event)
+    }
+    clock.setWallTime(step + 1)
+    converter.flush(clock.wallTime())
+    val results = events.result()
+    assertEquals(results.size, 1)
+    assertEquals(results.head, DatapointEvent("id", Query.tags(expr.query), step, 0.0))
+  }
+
+  test("dist - sum of totalTime") {
+    val expr = DataExpr.Sum(Query.Equal("value", "responseSize").and(stat("totalTime")))
+    val events = List.newBuilder[LwcEvent]
+    val converter = DatapointConverter("id", expr, clock, step, (_, e) => events.addOne(e))
+    (0 until 5).foreach { i =>
+      val event = LwcEvent(Map("responseSize" -> i))
+      converter.update(event)
+    }
+    clock.setWallTime(step + 1)
+    converter.flush(clock.wallTime())
+    val results = events.result()
+    assertEquals(results.size, 1)
+    assertEquals(results.head, DatapointEvent("id", Query.tags(expr.query), step, 2.0))
+  }
+
+  test("dist - sum of count") {
+    val expr = DataExpr.Sum(Query.Equal("value", "responseSize").and(stat("count")))
+    val events = List.newBuilder[LwcEvent]
+    val converter = DatapointConverter("id", expr, clock, step, (_, e) => events.addOne(e))
+    (0 until 5).foreach { i =>
+      val event = LwcEvent(Map("responseSize" -> i))
+      converter.update(event)
+    }
+    clock.setWallTime(step + 1)
+    converter.flush(clock.wallTime())
+    val results = events.result()
+    assertEquals(results.size, 1)
+    assertEquals(results.head, DatapointEvent("id", Query.tags(expr.query), step, 1.0))
+  }
+
+  test("dist - sum of totalOfSquares") {
+    val expr = DataExpr.Sum(Query.Equal("value", "responseSize").and(stat("totalOfSquares")))
+    val events = List.newBuilder[LwcEvent]
+    val converter = DatapointConverter("id", expr, clock, step, (_, e) => events.addOne(e))
+    (0 until 5).foreach { i =>
+      val event = LwcEvent(Map("responseSize" -> i))
+      converter.update(event)
+    }
+    clock.setWallTime(step + 1)
+    converter.flush(clock.wallTime())
+    val results = events.result()
+    assertEquals(results.size, 1)
+    assertEquals(results.head, DatapointEvent("id", Query.tags(expr.query), step, 6.0))
+  }
+
+  test("dist - dist-max") {
+    val expr = DataExpr.Max(Query.Equal("value", "responseSize").and(stat("max")))
+    val events = List.newBuilder[LwcEvent]
+    val converter = DatapointConverter("id", expr, clock, step, (_, e) => events.addOne(e))
+    (0 until 5).foreach { i =>
+      val event = LwcEvent(Map("responseSize" -> i))
+      converter.update(event)
+    }
+    clock.setWallTime(step + 1)
+    converter.flush(clock.wallTime())
+    val results = events.result()
+    assertEquals(results.size, 1)
+    assertEquals(results.head, DatapointEvent("id", Query.tags(expr.query), step, 4.0))
+  }
+
+  test("groupBy - sum") {
+    val expr = DataExpr.GroupBy(DataExpr.Sum(Query.Equal("value", "responseSize")), List("app"))
+    val events = List.newBuilder[LwcEvent]
+    val converter = DatapointConverter("id", expr, clock, step, (_, e) => events.addOne(e))
+    (0 until 5).foreach { i =>
+      converter.update(LwcEvent(Map("responseSize" -> i, "app" -> "a")))
+      converter.update(LwcEvent(Map("responseSize" -> i * 2, "app" -> "b")))
+      converter.update(LwcEvent(Map("responseSize" -> i * 3, "app" -> "c")))
+    }
+    clock.setWallTime(step + 1)
+    converter.flush(clock.wallTime())
+    val results = events.result()
+    assertEquals(results.size, 3)
+    results.foreach { event =>
+      val dp = event.asInstanceOf[DatapointEvent]
+      assert(dp.tags.contains("app"))
+      dp.tags("app") match {
+        case "a" => assertEqualsDouble(dp.value, 2.0, 1e-12)
+        case "b" => assertEqualsDouble(dp.value, 4.0, 1e-12)
+        case "c" => assertEqualsDouble(dp.value, 6.0, 1e-12)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Updates to support common statistics for timer and dist summary. Aggregates the values locally to reduce number of messages.