### PR TITLE
core: support sub-second durations

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
@@ -38,7 +38,7 @@ object Strings {
   /**
     * Period following conventions of unix `at` command.
     */
-  private val AtPeriod = """^(\d+)([a-z]+)$""".r
+  private val AtPeriod = """^(\d+)([a-zμ]+)$""".r
 
   /**
     * Period following the ISO8601 conventions.
@@ -420,10 +420,13 @@ object Strings {
     * Convert an `at` command time range into a joda period object.
     */
   private def parseAtDuration(amount: String, unit: String): Duration = {
-    val v = amount.toInt
+    val v = amount.toLong
 
     // format: off
     unit match {
+      case "ns"                               => Duration.ofNanos(v)
+      case "us" | "μs"                        => Duration.ofNanos(v * 1000L)
+      case "ms"                               => Duration.ofMillis(v)
       case "seconds" | "second" | "s"         => Duration.ofSeconds(v)
       case "minutes" | "minute" | "min" | "m" => Duration.ofMinutes(v)
       case "hours"   | "hour"   | "h"         => Duration.ofHours(v)

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
@@ -208,6 +208,19 @@ class StringsSuite extends FunSuite {
     assertEquals(parseQueryString(query), expected)
   }
 
+  test("parseDuration, at nanoseconds") {
+    assertEquals(parseDuration("42ns"), Duration.ofNanos(42L))
+  }
+
+  test("parseDuration, at microseconds") {
+    assertEquals(parseDuration("42us"), Duration.ofNanos(42_000L))
+    assertEquals(parseDuration("42μs"), Duration.ofNanos(42_000L))
+  }
+
+  test("parseDuration, at milliseconds") {
+    assertEquals(parseDuration("42ms"), Duration.ofMillis(42))
+  }
+
   test("parseDuration, at seconds") {
     assertEquals(parseDuration("42seconds"), Duration.ofSeconds(42))
     assertEquals(parseDuration("42second"), Duration.ofSeconds(42))


### PR DESCRIPTION
Update `Strings.parseDuration` to support sub-second durations.