### PR TITLE
eval: fix message drops for higher throughput

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/DatapointsTuple.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/DatapointsTuple.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+import com.netflix.atlas.eval.stream.Evaluator
+
+/**
+  * Pairs set of data points with other arbitrary messages to pass through to the
+  * consumer.
+  */
+case class DatapointsTuple(
+  data: List[AggrDatapoint],
+  messages: List[Evaluator.MessageEnvelope] = Nil
+) {
+
+  def step: Long = {
+    if (data.nonEmpty) data.head.step else 0L
+  }
+
+  def groupByStep: List[DatapointsTuple] = {
+    val dps = data.groupBy(_.step).map(t => DatapointsTuple(t._2)).toList
+    if (messages.nonEmpty)
+      DatapointsTuple(Nil, messages) :: dps
+    else
+      dps
+  }
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/ExprType.java
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/ExprType.java
@@ -19,17 +19,31 @@ package com.netflix.atlas.eval.model;
 public enum ExprType {
 
   /** Expression to select a set of events to be passed through. */
-  EVENTS,
+  EVENTS(false),
 
   /**
    * Time series expression such as used with Atlas Graph API. Can also be used for analytics
    * queries on top of event data.
    */
-  TIME_SERIES,
+  TIME_SERIES(true),
 
   /** Expression to select a set of traces to be passed through. */
-  TRACE_EVENTS,
+  TRACE_EVENTS(false),
 
   /** Time series expression based on data extraced from traces. */
-  TRACE_TIME_SERIES
+  TRACE_TIME_SERIES(true);
+
+  private final boolean timeSeries;
+
+  ExprType(boolean timeSeries) {
+    this.timeSeries = timeSeries;
+  }
+
+  public boolean isEventType() {
+    return !timeSeries;
+  }
+
+  public boolean isTimeSeriesType() {
+    return timeSeries;
+  }
 }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeGroupsTuple.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeGroupsTuple.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.model
+
+import com.netflix.atlas.eval.stream.Evaluator
+
+/**
+  * Pairs set of time groups with other arbitrary messages to pass through to the
+  * consumer.
+  */
+case class TimeGroupsTuple(
+  groups: List[TimeGroup],
+  messages: List[Evaluator.MessageEnvelope] = Nil
+) {
+
+  def step: Long = {
+    if (groups.nonEmpty) groups.head.step else 0L
+  }
+
+  def groupByStep: List[TimeGroupsTuple] = {
+    val gps = groups.groupBy(_.step).map(t => TimeGroupsTuple(t._2)).toList
+    if (messages.nonEmpty)
+      TimeGroupsTuple(Nil, messages) :: gps
+    else
+      gps
+  }
+}

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -770,6 +770,6 @@ class EvaluatorSuite extends FunSuite {
       "synthetic://test/traces/graph?q=name,cpu,:eq,nf.app,foo,:eq,:and&step=1ms&numStepIntervals=5"
     val future = Source.fromPublisher(evaluator.createPublisher(uri)).runWith(Sink.seq)
     val result = Await.result(future, scala.concurrent.duration.Duration.Inf)
-    assertEquals(result.size, 10)
+    assertEquals(result.size, 5)
   }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/ExprInterpreterSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/ExprInterpreterSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import com.netflix.atlas.eval.model.ExprType
+import com.typesafe.config.ConfigFactory
+import munit.FunSuite
+import org.apache.pekko.http.scaladsl.model.Uri
+
+class ExprInterpreterSuite extends FunSuite {
+
+  private val interpreter = new ExprInterpreter(ConfigFactory.load())
+
+  test("determineExprType time series") {
+    assertEquals(interpreter.determineExprType(Uri("/api/v1/graph")), ExprType.TIME_SERIES)
+    assertEquals(interpreter.determineExprType(Uri("/api/v2/fetch")), ExprType.TIME_SERIES)
+    assertEquals(interpreter.determineExprType(Uri("/api/v1/graph/")), ExprType.TIME_SERIES)
+    assertEquals(interpreter.determineExprType(Uri("/graph")), ExprType.TIME_SERIES)
+  }
+
+  test("determineExprType events") {
+    assertEquals(interpreter.determineExprType(Uri("/api/v1/events")), ExprType.EVENTS)
+    assertEquals(interpreter.determineExprType(Uri("/api/v1/events/")), ExprType.EVENTS)
+    assertEquals(interpreter.determineExprType(Uri("/events")), ExprType.EVENTS)
+  }
+
+  test("determineExprType trace events") {
+    assertEquals(interpreter.determineExprType(Uri("/api/v1/traces")), ExprType.TRACE_EVENTS)
+    assertEquals(interpreter.determineExprType(Uri("/api/v1/traces/")), ExprType.TRACE_EVENTS)
+    assertEquals(interpreter.determineExprType(Uri("/traces")), ExprType.TRACE_EVENTS)
+  }
+
+  test("determineExprType trace time series") {
+    assertEquals(
+      interpreter.determineExprType(Uri("/api/v1/traces/graph")),
+      ExprType.TRACE_TIME_SERIES
+    )
+    assertEquals(
+      interpreter.determineExprType(Uri("/api/v1/traces/graph/")),
+      ExprType.TRACE_TIME_SERIES
+    )
+    assertEquals(interpreter.determineExprType(Uri("/traces/graph")), ExprType.TRACE_TIME_SERIES)
+  }
+}

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
@@ -115,6 +115,8 @@ class LwcToAggrDatapointSuite extends FunSuite {
     eval(input)
     assertEquals(logMessages.size(), 2)
     List("1", "2").foreach { i =>
+      // https://github.com/lampepfl/dotty/issues/15661 ?
+      // On 3.4.0 there is an error if using `v` instead of `null`
       logMessages.poll() match {
         case env: Evaluator.MessageEnvelope =>
           env.message match {
@@ -124,8 +126,8 @@ class LwcToAggrDatapointSuite extends FunSuite {
             case v =>
               fail(s"unexpected message: $v")
           }
-        case v =>
-          fail(s"unexpected type: $v")
+        case null =>
+          fail(s"unexpected type: null")
       }
     }
   }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
@@ -22,6 +22,7 @@ import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.eval.model.AggrDatapoint
 import com.netflix.atlas.eval.model.AggrValuesInfo
+import com.netflix.atlas.eval.model.DatapointsTuple
 import com.netflix.atlas.eval.model.TimeGroup
 import com.netflix.spectator.api.DefaultRegistry
 import munit.FunSuite
@@ -55,9 +56,9 @@ class TimeGroupedSuite extends FunSuite {
 
   private def run(data: List[AggrDatapoint]): List[TimeGroup] = {
     val future = Source
-      .single(data)
+      .single(DatapointsTuple(data))
       .via(new TimeGrouped(context))
-      .flatMapConcat(Source.apply)
+      .flatMapConcat(t => Source(t.groups))
       .runFold(List.empty[TimeGroup])((acc, g) => g :: acc)
     result(future)
   }


### PR DESCRIPTION
Diagnostic messages and events were using the ds logger that has a separate queue. This made them prone to getting dropped if the throughput was high. Refactor to pass these messages over the same path as the data points.