### PR TITLE
lwcapi: use subv2 type for events

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionMetadata.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionMetadata.scala
@@ -40,15 +40,16 @@ case class ExpressionMetadata(
 object ExpressionMetadata {
 
   def apply(expression: String, exprType: ExprType, step: Long): ExpressionMetadata = {
-    val f = if (step > 0) step else ApiSettings.defaultStep
-    new ExpressionMetadata(expression, exprType, f, computeId(expression, f))
+    val dfltStep = if (exprType.isTimeSeriesType) ApiSettings.defaultStep else 0L
+    val f = if (step > 0) step else dfltStep
+    new ExpressionMetadata(expression, exprType, f, computeId(expression, exprType, f))
   }
 
   def apply(expression: String): ExpressionMetadata = {
     apply(expression, ExprType.TIME_SERIES, ApiSettings.defaultStep)
   }
 
-  def computeId(e: String, f: Long): String = {
-    Strings.zeroPad(Hash.sha1bytes(s"$f~$e"), 40)
+  def computeId(e: String, t: ExprType, f: Long): String = {
+    Strings.zeroPad(Hash.sha1bytes(s"$f~$t~$e"), 40)
   }
 }

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
@@ -172,11 +172,11 @@ class ExpressionApiSuite extends MUnitRouteSuite {
   }
 
   private val skanCount =
-    """{"expression":"nf.cluster,skan,:eq,:count","exprType":"TIME_SERIES","frequency":60000,"id":"6278fa6047c07316d7e265a1004882ab9e1007af"}"""
+    """{"expression":"nf.cluster,skan,:eq,:count","exprType":"TIME_SERIES","frequency":60000,"id":"039722fefa66c2cdd0147595fb9b9a50351f90f0"}"""
 
   private val skanSum =
-    """{"expression":"nf.cluster,skan,:eq,:sum","exprType":"TIME_SERIES","frequency":60000,"id":"36e0a2c61b48e062bba5361d059afd313c82c674"}"""
+    """{"expression":"nf.cluster,skan,:eq,:sum","exprType":"TIME_SERIES","frequency":60000,"id":"17e0dc5b1224c825c81cf033c46d0f0490c1ca7f"}"""
 
   private val brhMax =
-    """{"expression":"nf.app,brh,:eq,:max","exprType":"TIME_SERIES","frequency":60000,"id":"16f1b0930c0eeae0225374ea88c01e161e589aff"}"""
+    """{"expression":"nf.app,brh,:eq,:max","exprType":"TIME_SERIES","frequency":60000,"id":"b19b2aa2c802c29216d4aa36024f71a3c92f84db"}"""
 }

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionMetadataSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionMetadataSuite.scala
@@ -48,7 +48,7 @@ class ExpressionMetadataSuite extends FunSuite {
 
   test("computes id") {
     val expr = ExpressionMetadata("test")
-    assertEquals(expr.id, "2684d3c5cb245bd2fd6ee4ea30a500e97ace8141")
+    assertEquals(expr.id, "59ec3895749cc3fb279d41dabc1d4943361de999")
   }
 
   test("id computation considers frequency") {
@@ -114,14 +114,14 @@ class ExpressionMetadataSuite extends FunSuite {
 
   test("renders as json with default frequency") {
     val expected =
-      "{\"expression\":\"this\",\"exprType\":\"TIME_SERIES\",\"frequency\":60000,\"id\":\"fc3a081088771e05bdc3aa99ffd8770157dfe6ce\"}"
+      "{\"expression\":\"this\",\"exprType\":\"TIME_SERIES\",\"frequency\":60000,\"id\":\"8189ff24a1e801c924689aeb0490d5d840f23582\"}"
     val json = ExpressionMetadata("this").toJson
     assertEquals(expected, json)
   }
 
   test("renders as json with frequency of 0") {
     val expected =
-      "{\"expression\":\"this\",\"exprType\":\"TIME_SERIES\",\"frequency\":60000,\"id\":\"fc3a081088771e05bdc3aa99ffd8770157dfe6ce\"}"
+      "{\"expression\":\"this\",\"exprType\":\"TIME_SERIES\",\"frequency\":60000,\"id\":\"8189ff24a1e801c924689aeb0490d5d840f23582\"}"
     val json = ExpressionMetadata("this", ExprType.TIME_SERIES, 0).toJson
     assertEquals(expected, json)
   }

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionSplitterSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionSplitterSuite.scala
@@ -54,7 +54,7 @@ class ExpressionSplitterSuite extends FunSuite {
     val msg = intercept[IllegalArgumentException] {
       splitter.split("foo", ExprType.TIME_SERIES, frequency1)
     }
-    assertEquals(msg.getMessage, "expression is invalid")
+    assertEquals(msg.getMessage, "invalid value on stack: foo")
   }
 
   test("throws IAE for expressions with offset") {

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
@@ -15,15 +15,19 @@
  */
 package com.netflix.atlas.lwcapi
 
+import com.fasterxml.jackson.databind.JsonNode
 import org.apache.pekko.http.scaladsl.model.ws.Message
 import org.apache.pekko.http.scaladsl.testkit.RouteTestTimeout
 import org.apache.pekko.http.scaladsl.testkit.WSProbe
 import com.netflix.atlas.eval.model.ExprType
 import com.netflix.atlas.eval.model.LwcDatapoint
+import com.netflix.atlas.eval.model.LwcEvent
 import com.netflix.atlas.eval.model.LwcExpression
 import com.netflix.atlas.eval.model.LwcHeartbeat
 import com.netflix.atlas.eval.model.LwcMessages
 import com.netflix.atlas.eval.model.LwcSubscription
+import com.netflix.atlas.eval.model.LwcSubscriptionV2
+import com.netflix.atlas.json.Json
 import com.netflix.atlas.pekko.DiagnosticMessage
 import com.netflix.atlas.pekko.RequestHandler
 import com.netflix.atlas.pekko.testkit.MUnitRouteSuite
@@ -87,6 +91,42 @@ class SubscribeApiSuite extends MUnitRouteSuite {
         handlers.head.offer(Seq(datapoint))
 
         assertEquals(parseBatch(client.expectMessage()), List(datapoint))
+      }
+    }
+  }
+
+  test("subscribe websocket event") {
+    val client = WSProbe()
+    WS("/api/v2/subscribe/222", client.flow) ~> routes ~> check {
+      assert(isWebSocketUpgrade)
+
+      // Send list of expressions to subscribe to
+      val exprs = List(LwcExpression("name,disk,:eq", ExprType.EVENTS, 0L))
+      client.sendMessage(LwcMessages.encodeBatch(exprs))
+
+      // Look for subscription messages, one for sum and one for count
+      var subscriptions = List.empty[LwcSubscriptionV2]
+      while (subscriptions.size < 1) {
+        parseBatch(client.expectMessage()).foreach {
+          case _: DiagnosticMessage   =>
+          case sub: LwcSubscriptionV2 => subscriptions = sub :: subscriptions
+          case h: LwcHeartbeat        => assertEquals(h.step, 5000L)
+          case v                      => throw new MatchError(v)
+        }
+      }
+
+      // Verify subscription is in the manager, push a message to the queue check that it
+      // is received by the client
+      assertEquals(subscriptions.flatMap(_.subExprs).size, 1)
+      subscriptions.flatMap(_.subExprs).foreach { m =>
+        val tags = Map("name" -> "disk")
+        val json = Json.decode[JsonNode](Json.encode(tags))
+        val event = LwcEvent(m.id, json)
+        val handlers = sm.handlersForSubscription(m.id)
+        assertEquals(handlers.size, 1)
+        handlers.head.offer(Seq(event))
+
+        assertEquals(parseBatch(client.expectMessage()), List(event))
       }
     }
   }


### PR DESCRIPTION
Update the subscribe API to send back the subscription V2 message when using event types other than time series. Time series can be converted once all clients are updated.