### PR TITLE
eval: fix spurious warnings for event expressions

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
@@ -103,7 +103,7 @@ private[stream] class FinalExprEval(exprInterpreter: ExprInterpreter)
         // Compute the new set of expressions
         recipients = sources
           .filter { s =>
-            exprInterpreter.determineExprType(Uri(s.uri)) == ExprType.TIME_SERIES
+            exprInterpreter.determineExprType(Uri(s.uri)).isTimeSeriesType
           }
           .flatMap { s =>
             try {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
@@ -32,6 +32,7 @@ import com.netflix.atlas.core.model.StatefulExpr
 import com.netflix.atlas.core.model.StyleExpr
 import com.netflix.atlas.core.model.TimeSeries
 import com.netflix.atlas.core.util.IdentityMap
+import com.netflix.atlas.eval.model.ExprType
 import com.netflix.atlas.eval.model.TimeGroup
 import com.netflix.atlas.eval.model.TimeGroupsTuple
 import com.netflix.atlas.eval.model.TimeSeriesMessage
@@ -101,6 +102,9 @@ private[stream] class FinalExprEval(exprInterpreter: ExprInterpreter)
 
         // Compute the new set of expressions
         recipients = sources
+          .filter { s =>
+            exprInterpreter.determineExprType(Uri(s.uri)) == ExprType.TIME_SERIES
+          }
           .flatMap { s =>
             try {
               val graphCfg = exprInterpreter.eval(Uri(s.uri))

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
@@ -99,6 +99,14 @@ class FinalExprEvalSuite extends FunSuite {
     }
   }
 
+  test("ignore event exprs") {
+    val input = List(
+      sources(ds("a", "http://atlas/events?q=app,foo,:eq,(,message,),:table"))
+    )
+    val output = run(input)
+    assert(output.isEmpty)
+  }
+
   test("division with no data should result in no data line") {
     val input = List(
       sources(ds("a", "http://atlas/graph?q=name,latency,:eq,:dist-avg")),


### PR DESCRIPTION
FinalExprEval stage would emit spurious warnings for event expressions. Ignore the non time series expressions for the eval processing as events are just passed through.