### PR TITLE
lwcapi: add test for splitting trace query

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionSplitter.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionSplitter.scala
@@ -21,6 +21,7 @@ import com.netflix.atlas.core.model.EventExpr
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.Query.KeyQuery
 import com.netflix.atlas.core.model.StyleExpr
+import com.netflix.atlas.core.model.TraceQuery
 import com.netflix.atlas.eval.model.ExprType
 import com.netflix.atlas.eval.stream.ExprInterpreter
 import com.netflix.spectator.ipc.ServerGroup
@@ -134,11 +135,23 @@ class ExpressionSplitter(config: Config) {
             val q = intern(compress(e.query))
             DataExprMeta(e.toString, q)
           }
-      case ExprType.TRACE_EVENTS | ExprType.TRACE_TIME_SERIES =>
+      case ExprType.TRACE_EVENTS =>
         parsedExpressions.map { e =>
           // Tracing cannot be scoped to specific infrastructure, always use True
           DataExprMeta(e.toString, Query.True)
         }
+      case ExprType.TRACE_TIME_SERIES =>
+        parsedExpressions
+          .collect {
+            case tq: TraceQuery.SpanTimeSeries =>
+              tq.expr.expr.dataExprs.map(e => tq.copy(expr = StyleExpr(e, Map.empty)))
+          }
+          .flatten
+          .distinct
+          .map { e =>
+            // Tracing cannot be scoped to specific infrastructure, always use True
+            DataExprMeta(e.toString, Query.True)
+          }
     }
   }
 

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionSplitterSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionSplitterSuite.scala
@@ -50,6 +50,25 @@ class ExpressionSplitterSuite extends FunSuite {
     assertEquals(actual, expected)
   }
 
+  test("splits compound trace time series expression into data expressions") {
+    def childExpr(e: String): String = {
+      s"nf.app,api,:eq,nf.cluster,skan-test,:eq,:child,$e,:span-time-series"
+    }
+    val expr = s"${childExpr(query1)},${childExpr(query1)}"
+    val actual = splitter.split(expr, ExprType.TRACE_TIME_SERIES, frequency1)
+    val expected = List(
+      Subscription(
+        Query.True,
+        ExpressionMetadata(childExpr(ds1a), ExprType.TRACE_TIME_SERIES, frequency1)
+      ),
+      Subscription(
+        Query.True,
+        ExpressionMetadata(childExpr(ds1b), ExprType.TRACE_TIME_SERIES, frequency1)
+      )
+    ).reverse
+    assertEquals(actual, expected)
+  }
+
   test("throws IAE for invalid expressions") {
     val msg = intercept[IllegalArgumentException] {
       splitter.split("foo", ExprType.TIME_SERIES, frequency1)


### PR DESCRIPTION
Ensure trace time series query will get split up into representative data expressions correctly.