### PR TITLE
lwc-events: reuse handlers when syncing expressions

### DIFF
--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/ExprUtils.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/ExprUtils.scala
@@ -56,29 +56,19 @@ private[events] object ExprUtils {
 
   private val traceInterpreter = Interpreter(TraceVocabulary.allWords)
 
-  private def matchAllSpans(q: TraceQuery): TraceQuery.SpanFilter = {
-    TraceQuery.SpanFilter(q, Query.True)
-  }
-
   /** Parse a single trace events query expression. */
   def parseTraceEventsQuery(str: String): TraceQuery.SpanFilter = {
     traceInterpreter.execute(str).stack match {
-      case TraceQueryType(q) :: Nil          => matchAllSpans(q)
-      case (f: TraceQuery.SpanFilter) :: Nil => f
-      case _                                 => throw new IllegalArgumentException(str)
+      case TraceFilterType(tq) :: Nil => tq
+      case _                          => throw new IllegalArgumentException(str)
     }
-  }
-
-  private def sumAllSpans(q: TraceQuery): TraceQuery.SpanTimeSeries = {
-    TraceQuery.SpanTimeSeries(q, StyleExpr(DataExpr.Sum(Query.True), Map.empty))
   }
 
   /** Parse a single trace time series query expression. */
   def parseTraceTimeSeriesQuery(str: String): TraceQuery.SpanTimeSeries = {
     traceInterpreter.execute(str).stack match {
-      case TraceQueryType(q) :: Nil              => sumAllSpans(q)
-      case (f: TraceQuery.SpanTimeSeries) :: Nil => f
-      case _                                     => throw new IllegalArgumentException(str)
+      case TraceTimeSeriesType(tq) :: Nil => tq
+      case _                              => throw new IllegalArgumentException(str)
     }
   }
 

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/Subscription.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/Subscription.scala
@@ -24,5 +24,7 @@ package com.netflix.atlas.lwc.events
   *     Step size for the subscription when mapped into a time series.
   * @param expression
   *     Expression for matching events and mapping into the expected output.
+  * @param exprType
+  *     Type for the expression.
   */
-case class Subscription(id: String, step: Long, expression: String)
+case class Subscription(id: String, step: Long, expression: String, exprType: String)

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/Subscriptions.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/Subscriptions.scala
@@ -18,18 +18,63 @@ package com.netflix.atlas.lwc.events
 /**
   * Set of subscriptions to receive event data.
   *
-  * @param passThrough
+  * @param events
   *     Subscriptions looking for the raw events to be passed through.
-  * @param analytics
+  * @param timeSeries
   *     Subscriptions that should be mapped into time series.
-  * @param tracePassThrough
+  * @param traceEvents
   *     Trace subscriptions looking for the trace spans to be passed through.
-  * @param traceAnalytics
+  * @param traceTimeSeries
   *     Trace subscriptions that should map the selected spans into time-series.
   */
 case class Subscriptions(
-  passThrough: List[Subscription] = Nil,
-  analytics: List[Subscription] = Nil,
-  tracePassThrough: List[Subscription] = Nil,
-  traceAnalytics: List[Subscription] = Nil
+  events: List[Subscription] = Nil,
+  timeSeries: List[Subscription] = Nil,
+  traceEvents: List[Subscription] = Nil,
+  traceTimeSeries: List[Subscription] = Nil
 )
+
+object Subscriptions {
+
+  val Events = "EVENTS"
+  val TimeSeries = "TIME_SERIES"
+  val TraceEvents = "TRACE_EVENTS"
+  val TraceTimeSeries = "TRACE_TIME_SERIES"
+
+  /**
+    * Create instance from a flattened list with types based on the ExprType enum
+    * from the eval library.
+    */
+  def fromTypedList(subs: List[Subscription]): Subscriptions = {
+    val groups = subs.groupBy(_.exprType)
+    Subscriptions(
+      events = groups.getOrElse(Events, Nil),
+      timeSeries = groups.getOrElse(TimeSeries, Nil),
+      traceEvents = groups.getOrElse(TraceEvents, Nil),
+      traceTimeSeries = groups.getOrElse(TraceTimeSeries, Nil)
+    )
+  }
+
+  /** Compute set of added and removed expressions between the two sets. */
+  def diff(a: Subscriptions, b: Subscriptions): Diff = {
+    val (addedE, removedE, unchangedE) = diff(a.events, b.events)
+    val (addedTS, removedTS, unchangedTS) = diff(a.timeSeries, b.timeSeries)
+    val (addedTE, removedTE, unchangedTE) = diff(a.traceEvents, b.traceEvents)
+    val (addedTTS, removedTTS, unchangedTTS) = diff(a.traceTimeSeries, b.traceTimeSeries)
+    val added = Subscriptions(addedE, addedTS, addedTE, addedTTS)
+    val removed = Subscriptions(removedE, removedTS, removedTE, removedTTS)
+    val unchanged = Subscriptions(unchangedE, unchangedTS, unchangedTE, unchangedTTS)
+    Diff(added, removed, unchanged)
+  }
+
+  private def diff[T](a: List[T], b: List[T]): (List[T], List[T], List[T]) = {
+    val setA = a.toSet
+    val setB = b.toSet
+    val added = setB.diff(setA)
+    val removed = setA.diff(setB)
+    val unchanged = setA.intersect(setB)
+    (added.toList, removed.toList, unchanged.toList)
+  }
+
+  case class Diff(added: Subscriptions, removed: Subscriptions, unchanged: Subscriptions)
+}

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/LwcEventSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/LwcEventSuite.scala
@@ -83,4 +83,19 @@ object LwcEventSuite {
       case k          => span.tags.getOrElse(k, null)
     }
   }
+
+  class TestSpan(event: TestEvent) extends LwcEvent.Span {
+
+    override def spanId: String = "test"
+
+    override def parentId: String = "parent"
+
+    override def rawEvent: Any = event
+
+    override def timestamp: Long = 0L
+
+    override def extractValue(key: String): Any = {
+      extractSpanValue(event)(key)
+    }
+  }
 }

--- a/atlas-spring-lwc-events/src/main/resources/reference.conf
+++ b/atlas-spring-lwc-events/src/main/resources/reference.conf
@@ -8,9 +8,9 @@ atlas.lwc.events {
   //   subscription = "app,foo,:eq,:sum"
   // }
   subscriptions {
-    pass-through = []
-    analytics = []
-    trace-pass-through = []
-    trace-analytics = []
+    events = []
+    time-series = []
+    trace-events = []
+    trace-time-series = []
   }
 }

--- a/atlas-spring-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEventConfiguration.scala
+++ b/atlas-spring-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEventConfiguration.scala
@@ -39,17 +39,21 @@ class LwcEventConfiguration {
   private def toSubscriptions(config: Config): Subscriptions = {
     val cfg = config.getConfig("atlas.lwc.events.subscriptions")
     Subscriptions(
-      passThrough = toSubscriptions(cfg.getConfigList("pass-through")),
-      analytics = toSubscriptions(cfg.getConfigList("analytics")),
-      tracePassThrough = toSubscriptions(cfg.getConfigList("trace-pass-through")),
-      traceAnalytics = toSubscriptions(cfg.getConfigList("trace-analytics"))
+      events = toSubscriptions(cfg.getConfigList("events"), Subscriptions.Events),
+      timeSeries = toSubscriptions(cfg.getConfigList("time-series"), Subscriptions.TimeSeries),
+      traceEvents = toSubscriptions(cfg.getConfigList("trace-events"), Subscriptions.TraceEvents),
+      traceTimeSeries =
+        toSubscriptions(cfg.getConfigList("trace-time-series"), Subscriptions.TraceTimeSeries)
     )
   }
 
-  private def toSubscriptions(configs: java.util.List[? <: Config]): List[Subscription] = {
+  private def toSubscriptions(
+    configs: java.util.List[? <: Config],
+    exprType: String
+  ): List[Subscription] = {
     configs.asScala.toList.map { c =>
       val step = if (c.hasPath("step")) c.getDuration("step").toMillis else 60_000L
-      Subscription(c.getString("id"), step, c.getString("expression"))
+      Subscription(c.getString("id"), step, c.getString("expression"), exprType)
     }
   }
 }


### PR DESCRIPTION
Update the sync logic to reuse the existing handlers rather than completely replace them. For data point converters this helps avoid losing state during the sync.

Also changes some of the naming to be more consistent with the expressions response.