### PR TITLE
lwc-events: fix sync for time series

### DIFF
--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/AbstractLwcEventClient.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/AbstractLwcEventClient.scala
@@ -77,6 +77,11 @@ abstract class AbstractLwcEventClient(clock: Clock) extends LwcEventClient {
       subHandlers.put(sub, q -> handler)
       flushableHandlers += handler
     }
+    diff.unchanged.timeSeries.foreach { sub =>
+      val handlerMeta = subHandlers.get(sub)
+      if (handlerMeta != null)
+        flushableHandlers += handlerMeta._2
+    }
     diff.removed.timeSeries.foreach(removeSubscription)
 
     // Trace pass-through


### PR DESCRIPTION
Ensure that unchanged handlers are added to the set that will get flushed based on the heartbeat.