### PR TITLE
lwc-events: support value extraction for traces

### DIFF
--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/ExprUtils.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/ExprUtils.scala
@@ -21,7 +21,6 @@ import com.netflix.atlas.core.model.EventExpr
 import com.netflix.atlas.core.model.EventVocabulary
 import com.netflix.atlas.core.model.ModelExtractors
 import com.netflix.atlas.core.model.Query
-import com.netflix.atlas.core.model.StyleExpr
 import com.netflix.atlas.core.model.TraceQuery
 import com.netflix.atlas.core.model.TraceVocabulary
 import com.netflix.atlas.core.stacklang.Interpreter

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/LwcEventClientSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/LwcEventClientSuite.scala
@@ -176,6 +176,28 @@ class LwcEventClientSuite extends FunSuite {
     val vs = output.result()
     assertEquals(vs.size, 1)
   }
+
+  test("trace analytics, basic aggregate extract value") {
+    val subs = Subscriptions.fromTypedList(
+      List(
+        Subscription(
+          "1",
+          step,
+          "app,www,:eq,value,duration,:eq,:span-time-series",
+          Subscriptions.TraceTimeSeries
+        )
+      )
+    )
+    val output = List.newBuilder[String]
+    val client = LwcEventClient(subs, output.addOne, clock)
+    client.processTrace(Seq(new TestSpan(sampleSpan)))
+    clock.setWallTime(step)
+    client.process(LwcEvent.HeartbeatLwcEvent(step))
+    val vs = output.result()
+    assertEquals(vs.size, 1)
+    assert(vs.forall(_.contains(""""tags":{"value":"duration"}""")))
+    assert(vs.forall(_.contains(""""value":8.4""")))
+  }
 }
 
 object LwcEventClientSuite {


### PR DESCRIPTION
Update trace time series to support extracting a particular value from the event the same as event time series.