### PR TITLE
lwcapi: fix status code for event without id

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcEvent.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcEvent.scala
@@ -27,5 +27,6 @@ import com.netflix.atlas.json.JsonSupport
   *     Raw event payload.
   */
 case class LwcEvent(id: String, payload: JsonNode) extends JsonSupport {
+  require(id != null, "id cannot be null")
   val `type`: String = "event"
 }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcEvent.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcEvent.scala
@@ -27,6 +27,7 @@ import com.netflix.atlas.json.JsonSupport
   *     Raw event payload.
   */
 case class LwcEvent(id: String, payload: JsonNode) extends JsonSupport {
+
   require(id != null, "id cannot be null")
   val `type`: String = "event"
 }


### PR DESCRIPTION
If an event is sent to `/evaluate` without an id, respond with a 400 error instead of 500.