### PR TITLE
eval: use `ip` variable when creating web-socket

### DIFF
--- a/atlas-eval/src/main/resources/reference.conf
+++ b/atlas-eval/src/main/resources/reference.conf
@@ -6,8 +6,7 @@ atlas.eval {
     backends = [
       {
         host = "localhost"
-        eureka-uri = "http://localhost:7102/v2/vips/local-dev:7001"
-        instance-uri = "http://{local-ipv4}:{port}"
+        edda-uri = "http://localhost:7102/api/v1/autoScalingGroups/local-dev:7001"
       }
     ]
     // Number of buffers to use for the time grouping. More buffers means that data has

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -519,7 +519,7 @@ private[stream] abstract class EvaluatorImpl(
   private def createWebSocketFlow(
     instance: EddaSource.Instance
   ): Flow[Set[LwcExpression], ByteString, NotUsed] = {
-    val base = instance.substitute("ws://{local-ipv4}:{port}")
+    val base = instance.substitute("ws://{ip}:{port}")
     val id = UUID.randomUUID().toString
     val uri = s"$base/api/v$lwcapiVersion/subscribe/$id"
     val webSocketFlowOrigin = Http(system).webSocketClientFlow(WebSocketRequest(uri))

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -72,7 +72,6 @@ private[stream] class StreamContext(
       EddaBackend(
         cfg.getString("host"),
         eddaUri,
-        cfg.getString("instance-uri"),
         checkForExpensiveQueries
       )
     }
@@ -331,7 +330,6 @@ private[stream] object StreamContext {
   case class EddaBackend(
     host: String,
     eddaUri: String,
-    instanceUri: String,
     checkForExpensiveQueries: Boolean = true
   ) extends Backend {
 


### PR DESCRIPTION
Remove references to instance-uri for the backend that are not used. Use the `ip` variable so it will work with IPv4 or IPv6.