### PR TITLE
lwc-events: support enums as tag values

### DIFF
--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEvent.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEvent.scala
@@ -43,8 +43,9 @@ trait LwcEvent {
     */
   def tagValue(key: String): String = {
     extractValue(key) match {
-      case v: String => v
-      case _         => null
+      case v: String  => v
+      case e: Enum[_] => e.name()
+      case _          => null
     }
   }
 

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/LwcEventSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/LwcEventSuite.scala
@@ -18,6 +18,8 @@ package com.netflix.atlas.lwc.events
 import com.netflix.atlas.core.util.SortedTagMap
 import munit.FunSuite
 
+import java.lang.System.Logger
+
 class LwcEventSuite extends FunSuite {
 
   import LwcEventSuite.*
@@ -31,6 +33,10 @@ class LwcEventSuite extends FunSuite {
   test("tagValue: exists") {
     assertEquals(sampleLwcEvent.tagValue("app"), "www")
     assertEquals(sampleLwcEvent.tagValue("node"), "i-123")
+  }
+
+  test("tagValue: enum") {
+    assertEquals(sampleLwcEvent.tagValue("level"), "TRACE")
   }
 
   test("tagValue: missing") {
@@ -80,6 +86,7 @@ object LwcEventSuite {
     key match {
       case "tags"     => span.tags
       case "duration" => span.duration
+      case "level"    => Logger.Level.TRACE
       case k          => span.tags.getOrElse(k, null)
     }
   }


### PR DESCRIPTION
Add support for mapping Java Enum types to tag string values.