### PR TITLE
lwc-events: batch based on estimated payload size

### DIFF
--- a/atlas-lwc-events/src/main/resources/reference.conf
+++ b/atlas-lwc-events/src/main/resources/reference.conf
@@ -13,4 +13,7 @@ atlas.lwc.events {
 
   // Batch size for publishing data
   batch-size = 5000
+
+  // Max payload size for events data. Default max payload size for server is 8MiB.
+  payload-size = 7MiB
 }

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEvent.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEvent.scala
@@ -96,6 +96,15 @@ trait LwcEvent {
       w.toString
     }
   }
+
+  /**
+    * Estimates the size of the events in bytes. This is used for batching to ensure that
+    * the payload is not too big for the backend. The default implementation just encodes
+    * to a JSON string. If possible, override with a more efficient implementation.
+    */
+  def estimatedSizeInBytes: Int = {
+    toJson.length
+  }
 }
 
 object LwcEvent {

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/RemoveLwcEventClientSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/RemoveLwcEventClientSuite.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwc.events
+
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.Utils
+import com.typesafe.config.ConfigFactory
+import munit.FunSuite
+
+class RemoveLwcEventClientSuite extends FunSuite {
+
+  private val config = ConfigFactory.load()
+  private var registry: Registry = _
+  private var client: RemoteLwcEventClient = _
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    registry = new DefaultRegistry()
+    client = new RemoteLwcEventClient(registry, config) {
+      override def start(): Unit = ()
+    }
+  }
+
+  test("batch events by size") {
+    val str = "1234567890" * 100_000
+    val event = LwcEvent(str, _ => str)
+    val events = (0 until 100).map(_ => RemoteLwcEventClient.Event("_", event)).toList
+    val results = List.newBuilder[List[RemoteLwcEventClient.Event]]
+    client.batch(events, results.addOne)
+
+    val batches = results.result()
+    assertEquals(batches.size, 100 / 7 + 1)
+    batches.foreach { batch =>
+      assert(batch.size <= 7)
+    }
+  }
+
+  test("batch events, single event is too big") {
+    val str = "1234567890" * 1_000_000
+    val event = LwcEvent(str, _ => str)
+    val events = List(RemoteLwcEventClient.Event("_", event))
+    val results = List.newBuilder[List[RemoteLwcEventClient.Event]]
+    client.batch(events, results.addOne)
+
+    val batches = results.result()
+    assertEquals(batches.size, 0)
+
+    val errors = registry
+      .counters()
+      .filter(c => c.id.name == "lwc.events" && Utils.getTagValue(c.id, "error") == "too-big")
+      .toList
+    assertEquals(errors.size(), 1)
+    errors.forEach { c =>
+      assertEquals(c.count(), 1L)
+    }
+  }
+}


### PR DESCRIPTION
For pass-through events the sizes can vary wildly from one event to the next. Rather than use a fixed size, use an estimated size for the event.