### PR TITLE
jackson 2.16.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val pekko       = "1.0.2"
     val pekkoHttpV  = "1.0.1"
     val iep        = "5.0.19"
-    val jackson    = "2.17.0"
+    val jackson    = "2.16.2"
     val log4j      = "2.23.1"
     val scala      = "2.13.13"
     val slf4j      = "1.7.36"


### PR DESCRIPTION
Switch back to older version as there is a known performance regression in 2.17.0 ([#672]).

[#672]: https://github.com/FasterXML/jackson-module-scala/issues/672