### PR TITLE
json: allow mapper to be customized

### DIFF
--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
@@ -107,6 +107,16 @@ object Json {
     smileMapper.registerModule(module)
   }
 
+  /**
+    * Can be called to alter the configuration of the default mapper. Note, this will
+    * cause changes to apply everything using this object which could break things that
+    * expect the default behavior.
+    */
+  def configure(f: ObjectMapper => Unit): Unit = {
+    f(jsonMapper)
+    f(smileMapper)
+  }
+
   def newMapper: ObjectMapper = newMapper(jsonFactory)
 
   def newJsonGenerator(writer: Writer): JsonGenerator = {

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
@@ -19,12 +19,14 @@ import java.math.BigInteger
 import java.util
 import java.util.Optional
 import java.util.regex.Pattern
-
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.core.JsonToken
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.SerializationFeature
 import munit.FunSuite
+
+import java.time.Instant
 
 /**
   * Test case for the capabilities we need from a json parser. Mostly to document what we are using
@@ -472,6 +474,22 @@ class JsonSuite extends FunSuite {
   test("JsonSupport custom encoding") {
     val obj = JsonObjectWithSupport(42.0)
     assertEquals(Json.encode(List(obj)), """[{"custom":42.0}]""")
+  }
+
+  test("customize mapper") {
+    val now = Instant.now()
+    assertEquals(Json.encode(now), now.toEpochMilli.toString)
+
+    try {
+      Json.configure { mapper =>
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+      }
+      assertEquals(Json.encode(now), s"\"${now.toString}\"")
+    } finally {
+      Json.configure { mapper =>
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Provide method that can be used to customize the mapper. This should be used carefully as it will impact all uses of `Json` and could break other aspects that rely on the default behavior.