### PR TITLE
lwc-events: explicitly flush on heartbeat

### DIFF
--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/AbstractLwcEventClient.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/AbstractLwcEventClient.scala
@@ -41,6 +41,12 @@ abstract class AbstractLwcEventClient(clock: Clock) extends LwcEventClient {
 
   @volatile private var traceHandlersTS: Map[Subscription, TraceTimeSeries] = Map.empty
 
+  /**
+    * Called to force flushing the data. Implementations should override if they have
+    * some buffering.
+    */
+  protected def flush(): Unit = {}
+
   protected def sync(subscriptions: Subscriptions): Unit = {
     val diff = Subscriptions.diff(currentSubs, subscriptions)
     currentSubs = subscriptions
@@ -142,6 +148,7 @@ abstract class AbstractLwcEventClient(clock: Clock) extends LwcEventClient {
     event match {
       case LwcEvent.HeartbeatLwcEvent(timestamp) =>
         handlers.foreach(_.flush(timestamp))
+        flush()
       case _ =>
         index.forEachMatch(k => event.tagValue(k), h => handleMatch(event, h))
     }

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/RemoveLwcEventClientSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/RemoveLwcEventClientSuite.scala
@@ -35,12 +35,16 @@ class RemoveLwcEventClientSuite extends FunSuite {
     registry = new DefaultRegistry()
     client = new RemoteLwcEventClient(registry, config) {
       override def start(): Unit = {
-        val subs = Subscriptions(events = List(Subscription(
-          "test",
-          0L,
-          ":true",
-          "EVENTS"
-        )))
+        val subs = Subscriptions(events =
+          List(
+            Subscription(
+              "test",
+              0L,
+              ":true",
+              "EVENTS"
+            )
+          )
+        )
         sync(subs)
       }
 


### PR DESCRIPTION
Explicitly flush data for the heartbeat to ensure data doesn't get buffered for an excessive length of time.