### PR TITLE
lwc-events: default value for event

### DIFF
--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/DatapointConverter.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/DatapointConverter.scala
@@ -68,20 +68,20 @@ private[events] object DatapointConverter {
       case Some(k) =>
         tags.get("statistic") match {
           case Some("count")          => _ => 1.0
-          case Some("totalOfSquares") => event => squared(event.extractValue(k))
-          case _                      => event => toDouble(event.extractValue(k))
+          case Some("totalOfSquares") => event => squared(event.extractValue(k), event.value)
+          case _                      => event => toDouble(event.extractValue(k), event.value)
         }
       case None =>
-        _ => 1.0
+        event => event.value
     }
   }
 
-  private def squared(value: Any): Double = {
-    val v = toDouble(value)
+  private def squared(value: Any, dflt: Double): Double = {
+    val v = toDouble(value, dflt)
     v * v
   }
 
-  def toDouble(value: Any): Double = {
+  private[events] def toDouble(value: Any, dflt: Double): Double = {
     value match {
       case v: Boolean => if (v) 1.0 else 0.0
       case v: Byte    => v.toDouble
@@ -92,7 +92,7 @@ private[events] object DatapointConverter {
       case v: Double  => v
       case v: Number  => v.doubleValue()
       case v: String  => parseDouble(v)
-      case _          => 1.0
+      case _          => dflt
     }
   }
 
@@ -111,23 +111,22 @@ private[events] object DatapointConverter {
     step: Long,
     valueMapper: LwcEvent => Double,
     consumer: (String, LwcEvent) => Unit
-  ) {
-
-    val buffer = new StepDouble(0.0, clock, step)
-  }
+  )
 
   /** Compute sum for a counter as a rate per second. */
   case class Sum(params: Params) extends DatapointConverter {
 
+    val buffer = new StepDouble(0.0, params.clock, params.step)
+
     override def update(event: LwcEvent): Unit = {
       val value = params.valueMapper(event)
       if (value.isFinite && value >= 0.0) {
-        params.buffer.getCurrent.addAndGet(value)
+        buffer.getCurrent.addAndGet(value)
       }
     }
 
     override def flush(timestamp: Long): Unit = {
-      val value = params.buffer.pollAsRate(timestamp)
+      val value = buffer.pollAsRate(timestamp)
       if (value.isFinite) {
         val ts = timestamp / params.step * params.step
         val event = DatapointEvent(params.id, params.tags, ts, value)
@@ -139,12 +138,14 @@ private[events] object DatapointConverter {
   /** Compute count of contributing events. */
   case class Count(params: Params) extends DatapointConverter {
 
+    val buffer = new StepDouble(0.0, params.clock, params.step)
+
     override def update(event: LwcEvent): Unit = {
-      params.buffer.getCurrent.addAndGet(1.0)
+      buffer.getCurrent.addAndGet(1.0)
     }
 
     override def flush(timestamp: Long): Unit = {
-      val value = params.buffer.poll(timestamp)
+      val value = buffer.poll(timestamp)
       if (value.isFinite) {
         val ts = timestamp / params.step * params.step
         val event = DatapointEvent(params.id, params.tags, ts, value)
@@ -156,15 +157,17 @@ private[events] object DatapointConverter {
   /** Compute max value from contributing events. */
   case class Max(params: Params) extends DatapointConverter {
 
+    val buffer = new StepDouble(Double.NaN, params.clock, params.step)
+
     override def update(event: LwcEvent): Unit = {
       val value = params.valueMapper(event)
-      if (value.isFinite && value >= 0.0) {
-        params.buffer.getCurrent.max(value)
+      if (value.isFinite) {
+        buffer.getCurrent.max(value)
       }
     }
 
     override def flush(timestamp: Long): Unit = {
-      val value = params.buffer.poll(timestamp)
+      val value = buffer.poll(timestamp)
       if (value.isFinite) {
         val ts = timestamp / params.step * params.step
         val event = DatapointEvent(params.id, params.tags, ts, value)
@@ -176,10 +179,12 @@ private[events] object DatapointConverter {
   /** Compute min value from contributing events. */
   case class Min(params: Params) extends DatapointConverter {
 
+    val buffer = new StepDouble(Double.NaN, params.clock, params.step)
+
     override def update(event: LwcEvent): Unit = {
       val value = params.valueMapper(event)
-      if (value.isFinite && value >= 0.0) {
-        min(params.buffer.getCurrent, value)
+      if (value.isFinite) {
+        min(buffer.getCurrent, value)
       }
     }
 
@@ -197,7 +202,7 @@ private[events] object DatapointConverter {
     }
 
     override def flush(timestamp: Long): Unit = {
-      val value = params.buffer.poll(timestamp)
+      val value = buffer.poll(timestamp)
       if (value.isFinite) {
         val ts = timestamp / params.step * params.step
         val event = DatapointEvent(params.id, params.tags, ts, value)

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/DatapointConverter.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/DatapointConverter.scala
@@ -116,7 +116,7 @@ private[events] object DatapointConverter {
   /** Compute sum for a counter as a rate per second. */
   case class Sum(params: Params) extends DatapointConverter {
 
-    val buffer = new StepDouble(0.0, params.clock, params.step)
+    private val buffer = new StepDouble(0.0, params.clock, params.step)
 
     override def update(event: LwcEvent): Unit = {
       val value = params.valueMapper(event)
@@ -138,7 +138,7 @@ private[events] object DatapointConverter {
   /** Compute count of contributing events. */
   case class Count(params: Params) extends DatapointConverter {
 
-    val buffer = new StepDouble(0.0, params.clock, params.step)
+    private val buffer = new StepDouble(0.0, params.clock, params.step)
 
     override def update(event: LwcEvent): Unit = {
       buffer.getCurrent.addAndGet(1.0)
@@ -157,7 +157,7 @@ private[events] object DatapointConverter {
   /** Compute max value from contributing events. */
   case class Max(params: Params) extends DatapointConverter {
 
-    val buffer = new StepDouble(Double.NaN, params.clock, params.step)
+    private val buffer = new StepDouble(Double.NaN, params.clock, params.step)
 
     override def update(event: LwcEvent): Unit = {
       val value = params.valueMapper(event)
@@ -179,7 +179,7 @@ private[events] object DatapointConverter {
   /** Compute min value from contributing events. */
   case class Min(params: Params) extends DatapointConverter {
 
-    val buffer = new StepDouble(Double.NaN, params.clock, params.step)
+    private val buffer = new StepDouble(Double.NaN, params.clock, params.step)
 
     override def update(event: LwcEvent): Unit = {
       val value = params.valueMapper(event)

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/DatapointEvent.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/DatapointEvent.scala
@@ -30,8 +30,12 @@ import com.netflix.atlas.json.Json
   * @param value
   *     Value for the data point.
   */
-case class DatapointEvent(id: String, tags: Map[String, String], timestamp: Long, value: Double)
-    extends LwcEvent {
+case class DatapointEvent(
+  id: String,
+  tags: Map[String, String],
+  timestamp: Long,
+  override val value: Double
+) extends LwcEvent {
 
   override def rawEvent: Any = this
 

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEvent.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEvent.scala
@@ -37,6 +37,12 @@ trait LwcEvent {
   def timestamp: Long
 
   /**
+    * Value to use for the event when mapping to a time series. By default it will be
+    * 1.0 same as incrementing a counter by 1.
+    */
+  def value: Double = 1.0
+
+  /**
     * Extract a tag value for a given key. Returns `null` if there is no value for
     * the key or the value is not a string. By default it will delegate to `extractValue`
     * to ensure the two are consistent.

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/DatapointConverterSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/DatapointConverterSuite.scala
@@ -121,6 +121,21 @@ class DatapointConverterSuite extends FunSuite {
     assertEquals(results.head, DatapointEvent("id", Map("value" -> "responseSize"), step, -10.0))
   }
 
+  test("counter - min negative value") {
+    val expr = DataExpr.Min(Query.Equal("value", "responseSize"))
+    val events = List.newBuilder[LwcEvent]
+    val converter = DatapointConverter("id", expr, clock, step, (_, e) => events.addOne(e))
+    (0 until 5).foreach { i =>
+      val event = LwcEvent(Map("responseSize" -> -i))
+      converter.update(event)
+    }
+    clock.setWallTime(step + 1)
+    converter.flush(clock.wallTime())
+    val results = events.result()
+    assertEquals(results.size, 1)
+    assertEquals(results.head, DatapointEvent("id", Map("value" -> "responseSize"), step, -4.0))
+  }
+
   private def stat(name: String): Query = {
     Query.Equal("statistic", name)
   }


### PR DESCRIPTION
Allow the default value to be specified for an event if an explicit value key is not part of the query. It will default to 1.0. Also support negative values with min/max aggregates.