### PR TITLE
lwc-events: support duration type

### DIFF
--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/DatapointConverter.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/DatapointConverter.scala
@@ -21,6 +21,7 @@ import com.netflix.spectator.api.Clock
 import com.netflix.spectator.impl.AtomicDouble
 import com.netflix.spectator.impl.StepDouble
 
+import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -83,16 +84,17 @@ private[events] object DatapointConverter {
 
   private[events] def toDouble(value: Any, dflt: Double): Double = {
     value match {
-      case v: Boolean => if (v) 1.0 else 0.0
-      case v: Byte    => v.toDouble
-      case v: Short   => v.toDouble
-      case v: Int     => v.toDouble
-      case v: Long    => v.toDouble
-      case v: Float   => v.toDouble
-      case v: Double  => v
-      case v: Number  => v.doubleValue()
-      case v: String  => parseDouble(v)
-      case _          => dflt
+      case v: Boolean  => if (v) 1.0 else 0.0
+      case v: Byte     => v.toDouble
+      case v: Short    => v.toDouble
+      case v: Int      => v.toDouble
+      case v: Long     => v.toDouble
+      case v: Float    => v.toDouble
+      case v: Double   => v
+      case v: Number   => v.doubleValue()
+      case v: String   => parseDouble(v)
+      case v: Duration => v.toNanos / 1e9
+      case _           => dflt
     }
   }
 

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/DatapointConverterSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/DatapointConverterSuite.scala
@@ -20,6 +20,7 @@ import com.netflix.atlas.core.model.Query
 import com.netflix.spectator.api.ManualClock
 import munit.FunSuite
 
+import java.time.Duration
 import java.util.concurrent.atomic.AtomicLong
 
 class DatapointConverterSuite extends FunSuite {
@@ -43,6 +44,9 @@ class DatapointConverterSuite extends FunSuite {
     assertEquals(DatapointConverter.toDouble(new AtomicLong(42), -1.0), 42.0)
     assertEquals(DatapointConverter.toDouble("42", -1.0), 42.0)
     assertEquals(DatapointConverter.toDouble("42e3", -1.0), 42e3)
+    assertEquals(DatapointConverter.toDouble(Duration.ofMillis(42131), -1.0), 42.131)
+    assertEquals(DatapointConverter.toDouble(Duration.ofSeconds(42131), -1.0), 42131.0)
+    assertEquals(DatapointConverter.toDouble(Duration.ofMinutes(2), -1.0), 120.0)
     assert(DatapointConverter.toDouble("foo", -1.0).isNaN)
   }
 


### PR DESCRIPTION
Map duration type to seconds when converting to a data point.