### PR TITLE
webapi: improve normalize behavior for sample-count

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/CustomVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/CustomVocabulary.scala
@@ -157,7 +157,7 @@ object CustomVocabulary {
         val avg = MathExpr.Divide(numerator, denominator)
         val ctxt = Context(context.interpreter, Nil, Map.empty)
         val rewrite = Some(this)
-        MathExpr.NamedRewrite(name, q, avg, ctxt, rewrite) :: s
+        MathExpr.NamedRewrite(name, q, Nil, avg, ctxt, rewrite) :: s
     }
 
     /**

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/CustomVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/CustomVocabularySuite.scala
@@ -63,7 +63,7 @@ class CustomVocabularySuite extends FunSuite {
 
   test("simple average") {
     val expr = eval(s"$cpuUser,:node-avg").rewrite {
-      case MathExpr.NamedRewrite("node-avg", _, e, _, _) => e
+      case MathExpr.NamedRewrite("node-avg", _, _, e, _, _) => e
     }
     val expected = eval(s"$cpuUser,:sum,$numInstances,:sum,:div")
     assertEquals(expr, expected)
@@ -71,7 +71,7 @@ class CustomVocabularySuite extends FunSuite {
 
   test("expr with cluster") {
     val expr = eval(s"$cpuUser,cluster,foo,:eq,:and,:node-avg").rewrite {
-      case MathExpr.NamedRewrite("node-avg", _, e, _, _) => e
+      case MathExpr.NamedRewrite("node-avg", _, _, e, _, _) => e
     }
     val expected = eval(s"$cpuUser,:sum,$numInstances,:sum,:div,cluster,foo,:eq,:cq")
     assertEquals(expr, expected)
@@ -79,7 +79,7 @@ class CustomVocabularySuite extends FunSuite {
 
   test("expr with cq using non-infrastructure tags") {
     val expr = eval(s"$cpuUser,:node-avg,core,1,:eq,:cq").rewrite {
-      case MathExpr.NamedRewrite("node-avg", _, e, _, _) => e
+      case MathExpr.NamedRewrite("node-avg", _, _, e, _, _) => e
     }
     val expected = eval(s"$cpuUser,core,1,:eq,:and,:sum,$numInstances,:sum,:div")
     assertEquals(expr, expected)
@@ -87,7 +87,7 @@ class CustomVocabularySuite extends FunSuite {
 
   test("expr grouped by infrastructure tags") {
     val expr = eval(s"$cpuUser,cluster,foo,:eq,:and,:node-avg,(,zone,),:by").rewrite {
-      case MathExpr.NamedRewrite("node-avg", _, e, _, _) => e
+      case MathExpr.NamedRewrite("node-avg", _, _, e, _, _) => e
     }
     val expected =
       eval(s"$cpuUser,:sum,(,zone,),:by,$numInstances,:sum,(,zone,),:by,:div,cluster,foo,:eq,:cq")
@@ -96,7 +96,7 @@ class CustomVocabularySuite extends FunSuite {
 
   test("expr grouped by non-infrastructure tags") {
     val expr = eval(s"$cpuUser,cluster,foo,:eq,:and,:node-avg,(,name,),:by").rewrite {
-      case MathExpr.NamedRewrite("node-avg", _, e, _, _) => e
+      case MathExpr.NamedRewrite("node-avg", _, _, e, _, _) => e
     }
     val expected = eval(s"$cpuUser,:sum,(,name,),:by,$numInstances,:sum,:div,cluster,foo,:eq,:cq")
     assertEquals(expr, expected)
@@ -105,7 +105,7 @@ class CustomVocabularySuite extends FunSuite {
   test("expr grouped by non-infrastructure tags with offset") {
     val displayExpr = eval(s"$cpuUser,cluster,foo,:eq,:and,:node-avg,(,name,),:by,1h,:offset")
     val evalExpr = displayExpr.rewrite {
-      case MathExpr.NamedRewrite("node-avg", _, e, _, _) => e
+      case MathExpr.NamedRewrite("node-avg", _, _, e, _, _) => e
     }
     val expected = eval(
       s"$cpuUser,:sum,(,name,),:by,PT1H,:offset,$numInstances,:sum,PT1H,:offset,:div,cluster,foo,:eq,:cq"
@@ -131,7 +131,7 @@ class CustomVocabularySuite extends FunSuite {
 
   test("expr with not") {
     val expr = eval(s"$cpuUser,foo,bar,:eq,:not,:and,cluster,foo,:eq,:and,:node-avg").rewrite {
-      case MathExpr.NamedRewrite("node-avg", _, e, _, _) => e
+      case MathExpr.NamedRewrite("node-avg", _, _, e, _, _) => e
     }
     val expected =
       eval(s"$cpuUser,foo,bar,:eq,:not,:and,:sum,$numInstances,:sum,:div,cluster,foo,:eq,:cq")
@@ -140,7 +140,7 @@ class CustomVocabularySuite extends FunSuite {
 
   test("group by mixed keys") {
     val expr = eval("name,(,a,b,c,),:in,app,beacon,:eq,:and,:node-avg,(,name,asg,),:by").rewrite {
-      case MathExpr.NamedRewrite("node-avg", _, e, _, _) => e
+      case MathExpr.NamedRewrite("node-avg", _, _, e, _, _) => e
     }
     val expected = eval(
       s"name,(,a,b,c,),:in,:sum,(,name,asg,),:by,$numInstances,:sum,(,asg,),:by,:div,app,beacon,:eq,:cq"

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/SimpleLegends.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/SimpleLegends.scala
@@ -118,7 +118,7 @@ object SimpleLegends extends StrictLogging {
     // a simple aggregate like sum based on the display expression.
     expr
       .rewrite {
-        case MathExpr.NamedRewrite(n, q: Query, evalExpr, _, _) if n.endsWith("-avg") =>
+        case MathExpr.NamedRewrite(n, q: Query, _, evalExpr, _, _) if n.endsWith("-avg") =>
           val aggr = DataExpr.Sum(q)
           if (evalExpr.isGrouped) DataExpr.GroupBy(aggr, evalExpr.finalGrouping) else aggr
       }

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
@@ -137,6 +137,18 @@ class ExprApiSuite extends MUnitRouteSuite {
     assertEquals(data, List("name,(,sps1,sps2,),:in,:sum"))
   }
 
+  testGet("/api/v1/expr/normalize?q=name,latency,:eq,0,5,:sample-count") {
+    assertEquals(response.status, StatusCodes.OK)
+    val data = Json.decode[List[String]](responseAs[String])
+    assertEquals(data, List("name,latency,:eq,0.0,5.0,:sample-count"))
+  }
+
+  testGet("/api/v1/expr/normalize?q=name,latency,:eq,0,5,:sample-count,(,app,),:by") {
+    assertEquals(response.status, StatusCodes.OK)
+    val data = Json.decode[List[String]](responseAs[String])
+    assertEquals(data, List("name,latency,:eq,0.0,5.0,:sample-count,(,app,),:by"))
+  }
+
   testGet(
     "/api/v1/expr/normalize?q=(,name,:swap,:eq,nf.cluster,foo,:eq,:and,:sum,),foo,:sset,cpu,foo,:fcall,disk,foo,:fcall"
   ) {


### PR DESCRIPTION
Before it was getting expanded exposing the underlying details and showing the user a more complex query that is hard to for them to understand. Use named rewrite to preserve the operator when doing the normalization.