### PR TITLE
lwc-events: add pre-filter method for events

### DIFF
--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/AbstractLwcEventClient.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/AbstractLwcEventClient.scala
@@ -144,6 +144,10 @@ abstract class AbstractLwcEventClient(clock: Clock) extends LwcEventClient {
     Query.simplify(q, ignore = true)
   }
 
+  override def couldMatch(tags: String => String): Boolean = {
+    index.couldMatch(k => tags(k))
+  }
+
   override def process(event: LwcEvent): Unit = {
     event match {
       case LwcEvent.HeartbeatLwcEvent(timestamp) =>

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEventClient.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEventClient.scala
@@ -27,6 +27,21 @@ import scala.util.Using
 trait LwcEventClient {
 
   /**
+    * Check if an event with a partial set of tags could match one of the expressions.
+    * This can be used as a pre-filter for cases where an expensive transform is required
+    * to generate the final event for consideration.
+    *
+    * @param tags
+    *     Function that returns the tag value for a given key, or `null` if there is no
+    *     value for that key. This tag set may be a subset of the final set of tags that
+    *     would be on the actual events.
+    * @return
+    *     True if an event with the partial set of tags might match one of the current
+    *     expressions.
+    */
+  def couldMatch(tags: String => String): Boolean
+
+  /**
     * Submit an event for a given subscription.
     *
     * @param id

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val log4j      = "2.23.1"
     val scala      = "2.13.14"
     val slf4j      = "1.7.36"
-    val spectator  = "1.7.14"
+    val spectator  = "1.7.16"
     val spring     = "6.1.10"
 
     val crossScala = Seq(scala, "3.4.1")


### PR DESCRIPTION
Add `couldMatch` method to the client to allow for filtering our some data early if it requires an expensive transform to generate the final event.