### PR TITLE
eval: add a rewrite module to handle queries with namespaces.

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/DataSourceRewriter.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/DataSourceRewriter.scala
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import com.netflix.atlas.eval.stream.Evaluator.DataSource
+import com.netflix.atlas.eval.stream.Evaluator.DataSources
+import com.netflix.atlas.eval.stream.HostSource.unzipIfNeeded
+import com.netflix.atlas.json.Json
+import com.netflix.atlas.pekko.DiagnosticMessage
+import com.netflix.atlas.pekko.PekkoHttpClient
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+import org.apache.pekko.NotUsed
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model.ContentTypes
+import org.apache.pekko.http.scaladsl.model.HttpEntity
+import org.apache.pekko.http.scaladsl.model.HttpMethods
+import org.apache.pekko.http.scaladsl.model.HttpRequest
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.stream.scaladsl.Flow
+
+import java.io.ByteArrayOutputStream
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Using
+
+class DataSourceRewriter(config: Config, implicit val system: ActorSystem) extends StrictLogging {
+
+  private val (enabled, rewriteUrl) = {
+    val enabled = config.hasPath("atlas.eval.stream.rewrite-url")
+    val url = if (enabled) config.getString("atlas.eval.stream.rewrite-url") else ""
+    if (enabled) {
+      logger.info(s"Rewriting enabled with url: ${url}")
+    } else {
+      logger.info("Rewriting is disabled")
+    }
+    (enabled, url)
+  }
+
+  private val client = PekkoHttpClient
+    .create("datasource-rewrite", system)
+    .superPool[List[DataSource]]()
+
+  def rewrite(context: StreamContext): Flow[DataSources, DataSources, NotUsed] = {
+    rewrite(client, context)
+  }
+
+  def rewrite(
+    client: SuperPoolClient,
+    context: StreamContext
+  ): Flow[DataSources, DataSources, NotUsed] = {
+    if (!enabled) {
+      return Flow[DataSources]
+    }
+
+    Flow[DataSources]
+      .map(_.sources().asScala.toList)
+      .map(dsl => constructRequest(dsl) -> dsl)
+      .via(client)
+      .flatMapConcat {
+        case (Success(resp), dsl) =>
+          unzipIfNeeded(resp)
+            .map(_.utf8String)
+            .map { body =>
+              resp.status match {
+                case StatusCodes.OK =>
+                  val rewrites = List.newBuilder[DataSource]
+                  Json
+                    .decode[List[Rewrite]](body)
+                    .zip(dsl)
+                    .map {
+                      case (r, ds) =>
+                        if (!r.status.equals("OK")) {
+                          val msg =
+                            DiagnosticMessage.error(s"failed rewrite of ${ds.uri()}: ${r.message}")
+                          context.dsLogger(ds, msg)
+                        } else {
+                          rewrites += new DataSource(ds.id, ds.step(), r.rewrite)
+                        }
+                    }
+                    .toArray
+                  // NOTE: We're assuming that the number of items returned will be the same as the
+                  // number of uris sent to the rewrite service. If they differ, data sources may be
+                  // mapped to IDs and steps incorrectly.
+                  DataSources.of(rewrites.result().toArray: _*)
+                case _ =>
+                  logger.error(
+                    "Exception from rewrite service. status={}, resp={}",
+                    resp.status,
+                    body
+                  )
+                  throw new RuntimeException(body)
+              }
+            }
+        case (Failure(ex), _) =>
+          throw ex
+      }
+  }
+
+  private[stream] def constructRequest(dss: List[DataSource]): HttpRequest = {
+    val baos = new ByteArrayOutputStream
+    Using(Json.newJsonGenerator(baos)) { json =>
+      json.writeStartArray()
+      dss.foreach(s => json.writeString(s.uri()))
+      json.writeEndArray()
+    }
+    HttpRequest(
+      uri = rewriteUrl,
+      method = HttpMethods.POST,
+      entity = HttpEntity(ContentTypes.`application/json`, baos.toByteArray)
+    )
+  }
+
+}
+
+case class Rewrite(status: String, rewrite: String, original: String, message: String)

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/DataSourceRewriter.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/DataSourceRewriter.scala
@@ -20,7 +20,10 @@ import com.netflix.atlas.eval.stream.Evaluator.DataSources
 import com.netflix.atlas.eval.stream.HostSource.unzipIfNeeded
 import com.netflix.atlas.json.Json
 import com.netflix.atlas.pekko.DiagnosticMessage
+import com.netflix.atlas.pekko.OpportunisticEC.ec
 import com.netflix.atlas.pekko.PekkoHttpClient
+import com.netflix.atlas.pekko.StreamOps
+import com.netflix.spectator.api.Registry
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.pekko.NotUsed
@@ -30,15 +33,25 @@ import org.apache.pekko.http.scaladsl.model.HttpEntity
 import org.apache.pekko.http.scaladsl.model.HttpMethods
 import org.apache.pekko.http.scaladsl.model.HttpRequest
 import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.stream.scaladsl.BroadcastHub
 import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko.stream.scaladsl.Keep
+import org.apache.pekko.stream.scaladsl.RetryFlow
+import org.apache.pekko.stream.scaladsl.Source
 
 import java.io.ByteArrayOutputStream
+import java.util.concurrent.ConcurrentHashMap
+import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Using
 
-class DataSourceRewriter(config: Config, implicit val system: ActorSystem) extends StrictLogging {
+class DataSourceRewriter(
+  config: Config,
+  registry: Registry,
+  implicit val system: ActorSystem
+) extends StrictLogging {
 
   private val (enabled, rewriteUrl) = {
     val enabled = config.hasPath("atlas.eval.stream.rewrite-url")
@@ -55,21 +68,84 @@ class DataSourceRewriter(config: Config, implicit val system: ActorSystem) exten
     .create("datasource-rewrite", system)
     .superPool[List[DataSource]]()
 
-  def rewrite(context: StreamContext): Flow[DataSources, DataSources, NotUsed] = {
-    rewrite(client, context)
+  private val rewriteCache = new ConcurrentHashMap[String, String]()
+
+  private val rewriteSuccess = registry.counter("atlas.eval.stream.rewrite.success")
+  private val rewriteFailures = registry.createId("atlas.eval.stream.rewrite.failures")
+  private val rewriteCacheHits = registry.counter("atlas.eval.stream.rewrite.cache", "id", "hits")
+
+  private val rewriteCacheMisses =
+    registry.counter("atlas.eval.stream.rewrite.cache", "id", "misses")
+
+  def rewrite(
+    context: StreamContext,
+    keepRetrying: Boolean = true
+  ): Flow[DataSources, DataSources, NotUsed] = {
+    rewrite(client, context, keepRetrying)
   }
 
   def rewrite(
     client: SuperPoolClient,
-    context: StreamContext
+    context: StreamContext,
+    keepRetrying: Boolean
   ): Flow[DataSources, DataSources, NotUsed] = {
     if (!enabled) {
       return Flow[DataSources]
     }
 
+    val (cachedQueue, cachedSource) = StreamOps
+      .blockingQueue[DataSources](registry, "cachedRewrites", 1)
+      .toMat(BroadcastHub.sink(1))(Keep.both)
+      .run()
+    var sentCacheData = false
+
+    val retryFlow = RetryFlow
+      .withBackoff(
+        minBackoff = 100.milliseconds,
+        maxBackoff = 5.second,
+        randomFactor = 0.35,
+        maxRetries = if (keepRetrying) -1 else 0,
+        flow = httpFlow(client, context)
+      ) {
+        case (original, resp) =>
+          resp match {
+            case Success(_) => None
+            case Failure(ex) =>
+              val (request, dsl) = original
+              logger.debug("Retrying the rewrite request due to error", ex)
+              if (!sentCacheData) {
+                if (!cachedQueue.offer(returnFromCache(dsl))) {
+                  // note that this should never happen.
+                  logger.error("Unable to send cached results to queue.")
+                } else {
+                  sentCacheData = true
+                }
+              }
+              Some(request -> dsl)
+          }
+
+      }
+      .watchTermination() { (_, f) =>
+        f.onComplete { _ =>
+          cachedQueue.complete()
+        }
+      }
+
     Flow[DataSources]
       .map(_.sources().asScala.toList)
       .map(dsl => constructRequest(dsl) -> dsl)
+      .via(retryFlow)
+      .filter(_.isSuccess)
+      .map {
+        // reset the cached flag
+        sentCacheData = false
+        _.get
+      }
+      .merge(cachedSource)
+  }
+
+  private[stream] def httpFlow(client: SuperPoolClient, context: StreamContext) = {
+    Flow[(HttpRequest, List[DataSource])]
       .via(client)
       .flatMapConcat {
         case (Success(resp), dsl) =>
@@ -89,6 +165,7 @@ class DataSourceRewriter(config: Config, implicit val system: ActorSystem) exten
                             DiagnosticMessage.error(s"failed rewrite of ${ds.uri()}: ${r.message}")
                           context.dsLogger(ds, msg)
                         } else {
+                          rewriteCache.put(ds.uri(), r.rewrite)
                           rewrites += new DataSource(ds.id, ds.step(), r.rewrite)
                         }
                     }
@@ -96,19 +173,49 @@ class DataSourceRewriter(config: Config, implicit val system: ActorSystem) exten
                   // NOTE: We're assuming that the number of items returned will be the same as the
                   // number of uris sent to the rewrite service. If they differ, data sources may be
                   // mapped to IDs and steps incorrectly.
-                  DataSources.of(rewrites.result().toArray: _*)
+                  rewriteSuccess.increment()
+                  Success(DataSources.of(rewrites.result().toArray: _*))
                 case _ =>
                   logger.error(
-                    "Exception from rewrite service. status={}, resp={}",
+                    "Error from rewrite service. status={}, resp={}",
                     resp.status,
                     body
                   )
-                  throw new RuntimeException(body)
+                  registry
+                    .counter(
+                      rewriteFailures.withTags("status", resp.status.toString(), "exception", "NA")
+                    )
+                    .increment()
+                  Failure(
+                    new RuntimeException(
+                      s"Error from rewrite service. status=${resp.status}, resp=$body"
+                    )
+                  )
               }
             }
         case (Failure(ex), _) =>
-          throw ex
+          logger.error("Failure from rewrite service", ex)
+          registry
+            .counter(
+              rewriteFailures.withTags("status", "0", "exception", ex.getClass.getSimpleName)
+            )
+            .increment()
+          Source.single(Failure(ex))
       }
+  }
+
+  private[stream] def returnFromCache(dsl: List[DataSource]): DataSources = {
+    val rewrites = dsl.flatMap { ds =>
+      val rewrite = rewriteCache.get(ds.uri())
+      if (rewrite == null) {
+        rewriteCacheMisses.increment()
+        None
+      } else {
+        rewriteCacheHits.increment()
+        Some(new DataSource(ds.id, ds.step(), rewrite))
+      }
+    }
+    DataSources.of(rewrites: _*)
   }
 
   private[stream] def constructRequest(dss: List[DataSource]): HttpRequest = {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -88,7 +88,7 @@ private[stream] abstract class EvaluatorImpl(
   private val logger = LoggerFactory.getLogger(getClass)
 
   // Calls out to a rewrite service in case URIs need mutating to pick the proper backend.
-  private[stream] var dataSourceRewriter = new DataSourceRewriter(config, system)
+  private[stream] var dataSourceRewriter = new DataSourceRewriter(config, registry, system)
 
   // Cached context instance used for things like expression validation.
   private val validationStreamContext = newStreamContext(new ThrowingDSLogger)
@@ -135,7 +135,7 @@ private[stream] abstract class EvaluatorImpl(
   protected def validateImpl(ds: DataSource): Unit = {
     val future = Source
       .single(DataSources.of(ds))
-      .via(dataSourceRewriter.rewrite(validationStreamContext))
+      .via(dataSourceRewriter.rewrite(validationStreamContext, false))
       .map(_.sources().asScala.map(validationStreamContext.validateDataSource).map(_.get))
       .toMat(Sink.head)(Keep.right)
       .run()

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/HostSource.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/HostSource.scala
@@ -103,7 +103,7 @@ private[stream] object HostSource extends StrictLogging {
     Source.empty[ByteString]
   }
 
-  private def unzipIfNeeded(res: HttpResponse): Source[ByteString, Any] = {
+  def unzipIfNeeded(res: HttpResponse): Source[ByteString, Any] = {
     val isCompressed = res.headers.contains(`Content-Encoding`(HttpEncodings.gzip))
     val dataBytes = res.entity.withoutSizeLimit().dataBytes
     if (isCompressed) dataBytes.via(Compression.gunzip()) else dataBytes

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/package.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/package.scala
@@ -30,5 +30,8 @@ package object stream {
 
   type SimpleClient = Flow[HttpRequest, Try[HttpResponse], NotUsed]
 
+  type SuperPoolClient =
+    Flow[(HttpRequest, List[DataSource]), (Try[HttpResponse], List[DataSource]), NotUsed]
+
   type SourcesAndGroups = (DataSources, EddaSource.Groups)
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/DataSourceRewriterSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/DataSourceRewriterSuite.scala
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.netflix.atlas.eval.stream.Evaluator.DataSource
+import com.netflix.atlas.eval.stream.Evaluator.DataSources
+import com.netflix.atlas.json.Json
+import com.netflix.atlas.json.JsonSupport
+import com.netflix.atlas.pekko.PekkoHttpClient
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigValueFactory
+import munit.FunSuite
+import org.apache.pekko.NotUsed
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model.ContentTypes
+import org.apache.pekko.http.scaladsl.model.HttpEntity
+import org.apache.pekko.http.scaladsl.model.HttpRequest
+import org.apache.pekko.http.scaladsl.model.HttpResponse
+import org.apache.pekko.http.scaladsl.model.StatusCode
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko.stream.scaladsl.Keep
+import org.apache.pekko.stream.scaladsl.Sink
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.testkit.TestKitBase
+
+import java.time.Duration
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+class DataSourceRewriterSuite extends FunSuite with TestKitBase {
+
+  val dss = DataSources.of(
+    new DataSource("foo", Duration.ofSeconds(60), "http://localhost/api/v1/graph?q=name,foo,:eq"),
+    new DataSource(
+      "bar",
+      Duration.ofSeconds(60),
+      "http://localhost/api/v1/graph?q=nf.ns,seg.prod,:eq,name,bar,:eq,:and"
+    )
+  )
+
+  var config: Config = _
+  var logger: MockLogger = _
+  var ctx: StreamContext = null
+
+  override implicit def system: ActorSystem = ActorSystem("Test")
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    config = ConfigFactory
+      .load()
+      .withValue(
+        "atlas.eval.stream.rewrite-url",
+        ConfigValueFactory.fromAnyRef("http://localhost/api/v1/rewrite")
+      )
+    logger = new MockLogger()
+    ctx = new StreamContext(config, Materializer(system), dsLogger = logger)
+  }
+
+  test("rewrite: Disabled") {
+    config = ConfigFactory.load()
+    val obtained = rewrite(dss, null)
+    assertEquals(obtained, dss)
+  }
+
+  test("rewrite: OK") {
+    val client = mockClient(
+      StatusCode.int2StatusCode(200),
+      Map(
+        "http://localhost/api/v1/graph?q=name,foo,:eq" -> Rewrite(
+          "OK",
+          "http://localhost/api/v1/graph?q=name,foo,:eq",
+          "http://localhost/api/v1/graph?q=name,foo,:eq",
+          ""
+        ),
+        "http://localhost/api/v1/graph?q=nf.ns,seg.prod,:eq,name,bar,:eq,:and" -> Rewrite(
+          "OK",
+          "http://atlas-seg.prod.netflix.net/api/v1/graph?q=name,bar,:eq",
+          "http://localhost/api/v1/graph?q=nf.ns,seg.prod,:eq,name,bar,:eq,:and",
+          ""
+        )
+      )
+    )
+    val expected = DataSources.of(
+      new DataSource("foo", Duration.ofSeconds(60), "http://localhost/api/v1/graph?q=name,foo,:eq"),
+      new DataSource(
+        "bar",
+        Duration.ofSeconds(60),
+        "http://atlas-seg.prod.netflix.net/api/v1/graph?q=name,bar,:eq"
+      )
+    )
+    val obtained = rewrite(dss, client)
+    assertEquals(obtained, expected)
+    ctx.dsLogger.asInstanceOf[MockLogger].assertSize(0)
+  }
+
+  test("parseRewrites: Bad URI in datasources") {
+    val client = mockClient(
+      StatusCode.int2StatusCode(200),
+      Map(
+        "http://localhost/api/v1/graph?q=name,foo,:eq" -> Rewrite(
+          "OK",
+          "http://localhost/api/v1/graph?q=name,foo,:eq",
+          "http://localhost/api/v1/graph?q=name,foo,:eq",
+          ""
+        ),
+        "http://localhost/api/v1/graph?q=nf.ns,seg.prod,:eq,name,bar,:eq,:and" -> Rewrite(
+          "NOT_FOUND",
+          "http://atlas-seg.prod.netflix.net/api/v1/graph?q=name,bar,:eq",
+          "http://atlas-seg.prod.netflix.net/api/v1/graph?q=name,bar,:eq",
+          "No namespace found for seg"
+        )
+      )
+    )
+    val expected = DataSources.of(
+      new DataSource("foo", Duration.ofSeconds(60), "http://localhost/api/v1/graph?q=name,foo,:eq")
+    )
+    val obtained = rewrite(dss, client)
+    assertEquals(obtained, expected)
+    ctx.dsLogger.asInstanceOf[MockLogger].assertSize(1)
+  }
+
+  test("parseRewrites: Malformed response JSON") {
+    val client = mockClient(
+      StatusCode.int2StatusCode(200),
+      Map(
+        "http://localhost/api/v1/graph?q=name,foo,:eq" -> Rewrite(
+          "OK",
+          "http://localhost/api/v1/graph?q=name,foo,:eq",
+          "http://localhost/api/v1/graph?q=name,foo,:eq",
+          ""
+        ),
+        "http://localhost/api/v1/graph?q=nf.ns,seg.prod,:eq,name,bar,:eq,:and" -> Rewrite(
+          "OK",
+          "http://atlas-seg.prod.netflix.net/api/v1/graph?q=name,bar,:eq",
+          "http://localhost/api/v1/graph?q=nf.ns,seg.prod,:eq,name,bar,:eq,:and",
+          ""
+        )
+      ),
+      malformed = true
+    )
+    intercept[JsonMappingException] {
+      rewrite(dss, client)
+    }
+  }
+
+  test("parseRewrites: 500") {
+    val client = mockClient(
+      StatusCode.int2StatusCode(500),
+      Map.empty
+    )
+    intercept[RuntimeException] {
+      rewrite(dss, client)
+    }
+  }
+
+  test("parseRewrites: Missing a rewrite") {
+    val client = mockClient(
+      StatusCode.int2StatusCode(200),
+      Map(
+        "http://localhost/api/v1/graph?q=name,foo,:eq" -> Rewrite(
+          "OK",
+          "http://localhost/api/v1/graph?q=name,foo,:eq",
+          "http://localhost/api/v1/graph?q=name,foo,:eq",
+          ""
+        )
+      )
+    )
+    val expected = DataSources.of(
+      new DataSource("foo", Duration.ofSeconds(60), "http://localhost/api/v1/graph?q=name,foo,:eq")
+    )
+    val obtained = rewrite(dss, client)
+    assertEquals(obtained, expected)
+    ctx.dsLogger.asInstanceOf[MockLogger].assertSize(1)
+  }
+
+  def mockClient(
+    status: StatusCode,
+    response: Map[String, Rewrite],
+    returnEx: Option[Exception] = None,
+    malformed: Boolean = false
+  ): SuperPoolClient = {
+    returnEx
+      .map { ex =>
+        PekkoHttpClient.create(Failure(ex)).superPool[List[DataSource]]()
+      }
+      .getOrElse {
+        new MockClient(status, response, malformed).superPool[List[DataSource]]()
+      }
+  }
+
+  def rewrite(dss: DataSources, client: SuperPoolClient): DataSources = {
+    val rewriter = new DataSourceRewriter(config, system)
+    val future = Source
+      .single(dss)
+      .via(
+        rewriter.rewrite(client, ctx)
+      )
+      .toMat(Sink.head)(Keep.right)
+      .run()
+    Await.result(future, 30.seconds)
+  }
+
+  class MockClient(status: StatusCode, response: Map[String, Rewrite], malformed: Boolean = false)
+      extends PekkoHttpClient {
+
+    override def singleRequest(request: HttpRequest): Future[HttpResponse] = ???
+
+    override def superPool[C](
+      config: PekkoHttpClient.ClientConfig
+    ): Flow[(HttpRequest, C), (Try[HttpResponse], C), NotUsed] = {
+      Flow[(HttpRequest, C)]
+        .flatMapConcat {
+          case (req, context) =>
+            req.entity.withoutSizeLimit().dataBytes.map { body =>
+              val uris = Json.decode[List[String]](body.toArray)
+              val rewrites = uris.map { uri =>
+                response.get(uri) match {
+                  case Some(r) => r
+                  case None    => Rewrite("NOT_FOUND", uri, uri, "Empty")
+                }
+              }
+
+              val json =
+                if (malformed) Json.encode(rewrites).substring(0, 25) else Json.encode(rewrites)
+
+              val httpResp =
+                HttpResponse(
+                  status,
+                  entity = HttpEntity(ContentTypes.`application/json`, json)
+                )
+              Success(httpResp) -> context
+            }
+        }
+    }
+  }
+
+  class MockLogger extends DataSourceLogger {
+
+    var tuples: List[(DataSource, JsonSupport)] = Nil
+
+    override def apply(ds: DataSource, msg: JsonSupport): Unit = {
+      tuples = (ds, msg) :: tuples
+    }
+
+    override def close(): Unit = {
+      tuples = Nil
+    }
+
+    def assertSize(n: Int): Unit = {
+      assertEquals(tuples.size, n)
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -68,10 +68,10 @@ lazy val `atlas-eval` = project
   .configure(BuildSettings.profile)
   .dependsOn(`atlas-pekko`, `atlas-chart`, `atlas-core`)
   .settings(libraryDependencies ++= Seq(
+    Dependencies.equalsVerifier % "test",
     Dependencies.pekkoHttpTestkit % "test",
     Dependencies.pekkoStreamTestkit % "test",
-    Dependencies.pekkoTestkit % "test",
-    Dependencies.equalsVerifier % "test"
+    Dependencies.pekkoTestkit % "test"
   ))
 
 lazy val `atlas-jmh` = project


### PR DESCRIPTION
DataSource URIs are sent via HTTP (with retries) and if they incorporate namespace predicates, the service will rewrite them to route to the proper host, removing the namespace predicate.