### PR TITLE
pekko: source based on BlockingQueue

### DIFF
--- a/atlas-pekko/src/main/resources/reference.conf
+++ b/atlas-pekko/src/main/resources/reference.conf
@@ -97,6 +97,15 @@ atlas.pekko {
 
   # How long to wait before giving up on bind
   bind-timeout = 5 seconds
+
+  blocking-queue {
+    # If the queue is empty when pulled, then it will keep checking until some new
+    # data is available. This mechanism is simpler than juggling async callbacks and
+    # ensures the overhead is limited to the queue. There is some risk if there is
+    # bursty data that it could increase the rate of drops due to the queue being full
+    # while waiting for the delay.
+    frequency = 100ms
+  }
 }
 
 pekko {


### PR DESCRIPTION
Add helper to create a source that is based on a Java BlockingQueue implementation. This can be used as an alternative to Pekko's BoundedSourceQueue when more control of the queue is desirable. If the queue is full it can be set to either drop newly arriving values or older values that are already in the queue.