### PR TITLE
eval: refactor flow to create context earlier

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/DataSourceLogger.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/DataSourceLogger.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import com.netflix.atlas.json.JsonSupport
+import com.netflix.atlas.pekko.StreamOps
+
+private[stream] trait DataSourceLogger {
+
+  def apply(ds: Evaluator.DataSource, msg: JsonSupport): Unit
+
+  def close(): Unit
+}
+
+private[stream] object DataSourceLogger {
+
+  case object Noop extends DataSourceLogger {
+
+    override def apply(ds: Evaluator.DataSource, msg: JsonSupport): Unit = {}
+
+    override def close(): Unit = {}
+  }
+
+  case class Queue(queue: StreamOps.SourceQueue[Evaluator.MessageEnvelope])
+      extends DataSourceLogger {
+
+    override def apply(ds: Evaluator.DataSource, msg: JsonSupport): Unit = {
+      val env = new Evaluator.MessageEnvelope(ds.id, msg)
+      queue.offer(env)
+    }
+
+    override def close(): Unit = {
+      queue.complete()
+    }
+  }
+}

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -53,7 +53,7 @@ private[stream] class StreamContext(
   rootConfig: Config,
   val materializer: Materializer,
   val registry: Registry = new NoopRegistry,
-  val dsLogger: DataSourceLogger = (_, _) => ()
+  val dsLogger: DataSourceLogger = DataSourceLogger.Noop
 ) {
 
   import StreamContext.*

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/package.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/package.scala
@@ -31,6 +31,4 @@ package object stream {
   type SimpleClient = Flow[HttpRequest, Try[HttpResponse], NotUsed]
 
   type SourcesAndGroups = (DataSources, EddaSource.Groups)
-
-  type DataSourceLogger = (DataSource, JsonSupport) => Unit
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
@@ -71,7 +71,7 @@ class LwcToAggrDatapointSuite extends FunSuite {
   private val context = new StreamContext(
     ConfigFactory.load(),
     materializer,
-    dsLogger = (_, _) => ()
+    dsLogger = DataSourceLogger.Noop
   )
 
   context.setDataSources(


### PR DESCRIPTION
Create context earlier to allow for performing validation or logging related to the data sources in the firts parts of the stream.