### PR TITLE
lwcapi: drop old data if queue is full

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/QueueHandler.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/QueueHandler.scala
@@ -28,8 +28,10 @@ import com.typesafe.scalalogging.StrictLogging
   * @param queue
   *     Underlying queue that will receive the messsages.
   */
-class QueueHandler(streamMeta: StreamMetadata, queue: StreamOps.SourceQueue[Seq[JsonSupport]])
-    extends StrictLogging {
+class QueueHandler(
+  streamMeta: StreamMetadata,
+  queue: StreamOps.BlockingSourceQueue[Seq[JsonSupport]]
+) extends StrictLogging {
 
   private val id = streamMeta.streamId
 

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/StreamSubscriptionManagerSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/StreamSubscriptionManagerSuite.scala
@@ -23,6 +23,7 @@ import com.netflix.atlas.pekko.StreamOps
 import com.netflix.spectator.api.NoopRegistry
 import munit.FunSuite
 
+import java.util.concurrent.ArrayBlockingQueue
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
@@ -35,8 +36,9 @@ class StreamSubscriptionManagerSuite extends FunSuite {
     val sm = new StreamSubscriptionManager(registry)
     val meta = StreamMetadata("id")
 
+    val blockingQueue = new ArrayBlockingQueue[Seq[JsonSupport]](100)
     val (queue, queueSrc) = StreamOps
-      .blockingQueue[Seq[JsonSupport]](registry, "SubscribeApi", 100)
+      .wrapBlockingQueue[Seq[JsonSupport]](registry, "SubscribeApi", blockingQueue, dropNew = false)
       .toMat(Sink.ignore)(Keep.both)
       .run()
     val handler = new QueueHandler(meta, queue)


### PR DESCRIPTION
Update queue for incoming data to drop old data rather than new data. For use-cases like logs pass-through it is preferable to bias for new data.