### PR TITLE
pekko: just use client flow if no retries

### DIFF
--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/PekkoHttpClient.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/PekkoHttpClient.scala
@@ -209,7 +209,7 @@ object PekkoHttpClient {
               .withMaxAttempts(settings.maxRetries + 1)
             request -> Context(accessLogger, callerContext)
         }
-        .via(retryFlow)
+        .via(if (settings.maxRetries > 0) retryFlow else clientFlow)
         .map {
           case (response, context) => response -> context.callerContext
         }


### PR DESCRIPTION
Simplify to just the client flow if no retries are specified. The retry flow may not allow concurrent requests on the flow.