### PR TITLE
lwcapi: add config option for drop policy

### DIFF
--- a/atlas-lwcapi/src/main/resources/reference.conf
+++ b/atlas-lwcapi/src/main/resources/reference.conf
@@ -17,6 +17,9 @@ atlas {
 
     # Maximum number of messages to batch before sending back to the client.
     batch-size = 100
+
+    # Should new or old messages get dropped if the queue is full?
+    drop-new = true
   }
 
   pekko {

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscribeApi.scala
@@ -65,6 +65,8 @@ class SubscribeApi(
   private val queueSize = config.getInt("atlas.lwcapi.queue-size")
   private val batchSize = config.getInt("atlas.lwcapi.batch-size")
 
+  private val dropNew = config.getBoolean("atlas.lwcapi.drop-new")
+
   private val evalsCounter = registry.counter("atlas.lwcapi.subscribe.count", "action", "subscribe")
 
   private val itemsCounter =
@@ -152,7 +154,7 @@ class SubscribeApi(
     // close a closed queue.
     val blockingQueue = new ArrayBlockingQueue[Seq[JsonSupport]](queueSize)
     val (queue, pub) = StreamOps
-      .wrapBlockingQueue[Seq[JsonSupport]](registry, "SubscribeApi", blockingQueue, dropNew = false)
+      .wrapBlockingQueue[Seq[JsonSupport]](registry, "SubscribeApi", blockingQueue, dropNew)
       .toMat(Sink.asPublisher(true))(Keep.both)
       .run()
 


### PR DESCRIPTION
Whether the queue drops old or new data can now be configured. Defaults to drop new which wa the previous behavior.