### PR TITLE
lwcapi: fix push for new subs

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/WebSocketSessionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/WebSocketSessionManager.scala
@@ -89,7 +89,7 @@ private[lwcapi] class WebSocketSessionManager(
           } else {
             // Only pull when no push happened, because push should have triggered a pull
             // from downstream
-            pull(in)
+            onPull()
           }
         }
       }


### PR DESCRIPTION
If subs change after the data source has been pushed, then it wouldn't push the high priority messages until the next pull. Now it will go ahead and push if messages are ready.