### PR TITLE
core: allow comma to be escaped for exprs

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/EventExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/EventExpr.scala
@@ -15,6 +15,8 @@
  */
 package com.netflix.atlas.core.model
 
+import com.netflix.atlas.core.stacklang.Interpreter
+
 /** Base type for event expressions. */
 sealed trait EventExpr extends Expr {
 
@@ -47,6 +49,6 @@ object EventExpr {
 
     require(columns.nonEmpty, "set of columns cannot be empty")
 
-    override def toString: String = s"$query,(,${columns.mkString(",")},),:table"
+    override def toString: String = Interpreter.toString(query, columns, ":table")
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterExpr.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.core.model
 
+import com.netflix.atlas.core.stacklang.Interpreter
 import com.netflix.atlas.core.util.BoundedPriorityBuffer
 import com.netflix.atlas.core.util.Math
 
@@ -112,7 +113,7 @@ object FilterExpr {
 
     if (!expr1.isGrouped) require(!expr2.isGrouped, "filter grouping must match expr grouping")
 
-    override def toString: String = s"$expr1,$expr2,:filter"
+    override def toString: String = Interpreter.toString(expr1, expr2, ":filter")
 
     def dataExprs: List[DataExpr] = expr1.dataExprs ::: expr2.dataExprs
 
@@ -182,7 +183,7 @@ object FilterExpr {
 
     require(k > 0, s"k must be positive ($k <= 0)")
 
-    override def toString: String = s"$expr,$stat,$k,:$opName"
+    override def toString: String = Interpreter.toString(expr, stat, k, s":$opName")
 
     def dataExprs: List[DataExpr] = expr.dataExprs
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -21,9 +21,9 @@ import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoField
-
 import com.netflix.atlas.core.model.DataExpr.AggregateFunction
 import com.netflix.atlas.core.stacklang.Context
+import com.netflix.atlas.core.stacklang.Interpreter
 import com.netflix.atlas.core.util.ArrayHelper
 import com.netflix.atlas.core.util.Hash
 import com.netflix.atlas.core.util.Math
@@ -49,7 +49,7 @@ object MathExpr {
 
     def dataExprs: List[DataExpr] = expr.dataExprs
 
-    override def toString: String = s"$expr,$original,$replacement,:as"
+    override def toString: String = Interpreter.toString(expr, original, replacement, ":as")
 
     def isGrouped: Boolean = expr.isGrouped
 
@@ -83,7 +83,7 @@ object MathExpr {
 
     def dataExprs: List[DataExpr] = Nil
 
-    override def toString: String = s"$v,:const"
+    override def toString: String = Interpreter.toString(v, ":const")
 
     def isGrouped: Boolean = false
 
@@ -107,7 +107,7 @@ object MathExpr {
 
     def dataExprs: List[DataExpr] = Nil
 
-    override def toString: String = s":random"
+    override def toString: String = ":random"
 
     def isGrouped: Boolean = false
 
@@ -135,7 +135,7 @@ object MathExpr {
 
     def dataExprs: List[DataExpr] = Nil
 
-    override def toString: String = s"$seed,:srandom"
+    override def toString: String = Interpreter.toString(seed, ":srandom")
 
     def isGrouped: Boolean = false
 
@@ -215,7 +215,7 @@ object MathExpr {
 
     def dataExprs: List[DataExpr] = Nil
 
-    override def toString: String = s"$s,$e,:time-span"
+    override def toString: String = Interpreter.toString(s, e, ":time-span")
 
     def isGrouped: Boolean = false
 
@@ -286,7 +286,7 @@ object MathExpr {
 
     def dataExprs: List[DataExpr] = expr.dataExprs
 
-    override def toString: String = s"$expr,$min,:$name"
+    override def toString: String = Interpreter.toString(expr, min, s":$name")
 
     def isGrouped: Boolean = expr.isGrouped
 
@@ -314,7 +314,7 @@ object MathExpr {
 
     def dataExprs: List[DataExpr] = expr.dataExprs
 
-    override def toString: String = s"$expr,$max,:$name"
+    override def toString: String = Interpreter.toString(expr, max, s":$name")
 
     def isGrouped: Boolean = expr.isGrouped
 
@@ -344,7 +344,7 @@ object MathExpr {
 
     def dataExprs: List[DataExpr] = expr.dataExprs
 
-    override def toString: String = s"$expr,:$name"
+    override def toString: String = Interpreter.toString(expr, s":$name")
 
     def isGrouped: Boolean = expr.isGrouped
 
@@ -455,7 +455,7 @@ object MathExpr {
 
     def dataExprs: List[DataExpr] = expr1.dataExprs ::: expr2.dataExprs
 
-    override def toString: String = s"$expr1,$expr2,:$name"
+    override def toString: String = Interpreter.toString(expr1, expr2, s":$name")
 
     def isGrouped: Boolean = expr1.isGrouped || expr2.isGrouped
 
@@ -679,7 +679,7 @@ object MathExpr {
 
     def dataExprs: List[DataExpr] = expr.dataExprs
 
-    override def toString: String = s"$expr,:$name"
+    override def toString: String = Interpreter.toString(expr, s":$name")
 
     def isGrouped: Boolean = false
 
@@ -765,7 +765,7 @@ object MathExpr {
       }
     }
 
-    override def toString: String = s"$expr,(,${keys.mkString(",")},),:by"
+    override def toString: String = Interpreter.toString(expr, keys, ":by")
 
     def dataExprs: List[DataExpr] = expr.dataExprs
 
@@ -832,7 +832,7 @@ object MathExpr {
         if (evalGroupKeys.isEmpty)
           expr.af.query.toString
         else
-          s"${expr.af.query},(,${evalGroupKeys.mkString(",")},),:by"
+          Interpreter.toString(expr.af.query, evalGroupKeys, ":by")
       if (expr.offset.isZero)
         s"$baseExpr,(,${pcts.mkString(",")},),:percentiles"
       else

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.core.model
 
+import com.netflix.atlas.core.stacklang.Interpreter
 import com.netflix.atlas.core.util.SmallHashMap
 import com.netflix.spectator.impl.PatternMatcher
 
@@ -323,7 +324,7 @@ object Query {
 
     def labelString: String = s"has($k)"
 
-    override def toString: String = s"$k,:has"
+    override def toString: String = Interpreter.toString(k, ":has")
   }
 
   case class Equal(k: String, v: String) extends KeyValueQuery {
@@ -332,7 +333,7 @@ object Query {
 
     def labelString: String = s"$k=$v"
 
-    override def toString: String = s"$k,$v,:eq"
+    override def toString: String = Interpreter.toString(k, v, ":eq")
   }
 
   case class LessThan(k: String, v: String) extends KeyValueQuery {
@@ -341,7 +342,7 @@ object Query {
 
     def labelString: String = s"$k<$v"
 
-    override def toString: String = s"$k,$v,:lt"
+    override def toString: String = Interpreter.toString(k, v, ":lt")
   }
 
   case class LessThanEqual(k: String, v: String) extends KeyValueQuery {
@@ -350,7 +351,7 @@ object Query {
 
     def labelString: String = s"$k<=$v"
 
-    override def toString: String = s"$k,$v,:le"
+    override def toString: String = Interpreter.toString(k, v, ":le")
   }
 
   case class GreaterThan(k: String, v: String) extends KeyValueQuery {
@@ -359,7 +360,7 @@ object Query {
 
     def labelString: String = s"$k>$v"
 
-    override def toString: String = s"$k,$v,:gt"
+    override def toString: String = Interpreter.toString(k, v, ":gt")
   }
 
   case class GreaterThanEqual(k: String, v: String) extends KeyValueQuery {
@@ -368,7 +369,7 @@ object Query {
 
     def labelString: String = s"$k>=$v"
 
-    override def toString: String = s"$k,$v,:ge"
+    override def toString: String = Interpreter.toString(k, v, ":ge")
   }
 
   sealed trait PatternQuery extends KeyValueQuery {
@@ -384,7 +385,7 @@ object Query {
 
     def labelString: String = s"$k~/^$v/"
 
-    override def toString: String = s"$k,$v,:re"
+    override def toString: String = Interpreter.toString(k, v, ":re")
   }
 
   case class RegexIgnoreCase(k: String, v: String) extends PatternQuery {
@@ -395,7 +396,7 @@ object Query {
 
     def labelString: String = s"$k~/^$v/i"
 
-    override def toString: String = s"$k,$v,:reic"
+    override def toString: String = Interpreter.toString(k, v, ":reic")
   }
 
   case class In(k: String, vs: List[String]) extends KeyValueQuery {
@@ -406,7 +407,7 @@ object Query {
 
     def labelString: String = s"$k in (${vs.mkString(",")})"
 
-    override def toString: String = s"$k,(,${vs.mkString(",")},),:in"
+    override def toString: String = Interpreter.toString(k, vs, ":in")
 
     /** Convert this to a sequence of OR'd together equal queries. */
     def toOrQuery: Query = {
@@ -428,7 +429,7 @@ object Query {
 
     def labelString: String = s"(${q1.labelString}) and (${q2.labelString})"
 
-    override def toString: String = s"$q1,$q2,:and"
+    override def toString: String = Interpreter.toString(q1, q2, ":and")
   }
 
   case class Or(q1: Query, q2: Query) extends Query {
@@ -442,7 +443,7 @@ object Query {
 
     def labelString: String = s"(${q1.labelString}) or (${q2.labelString})"
 
-    override def toString: String = s"$q1,$q2,:or"
+    override def toString: String = Interpreter.toString(q1, q2, ":or")
   }
 
   case class Not(q: Query) extends Query {
@@ -455,6 +456,6 @@ object Query {
 
     def labelString: String = s"not(${q.labelString})"
 
-    override def toString: String = s"$q,:not"
+    override def toString: String = Interpreter.toString(q, ":not")
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
@@ -16,7 +16,6 @@
 package com.netflix.atlas.core.model
 
 import java.time.Duration
-
 import com.netflix.atlas.core.algorithm.OnlineAlgorithm
 import com.netflix.atlas.core.algorithm.OnlineDelay
 import com.netflix.atlas.core.algorithm.OnlineDes
@@ -32,6 +31,7 @@ import com.netflix.atlas.core.algorithm.OnlineRollingCount
 import com.netflix.atlas.core.algorithm.OnlineRollingMean
 import com.netflix.atlas.core.algorithm.OnlineRollingSum
 import com.netflix.atlas.core.algorithm.OnlineTrend
+import com.netflix.atlas.core.stacklang.Interpreter
 
 trait StatefulExpr extends TimeSeriesExpr {}
 
@@ -52,7 +52,7 @@ object StatefulExpr {
       if (period <= 1) OnlineIgnoreN(0) else OnlineTrend(period)
     }
 
-    override def toString: String = s"$expr,$window,:trend"
+    override def toString: String = Interpreter.toString(expr, window, ":trend")
   }
 
   /**
@@ -69,7 +69,7 @@ object StatefulExpr {
       OnlineIntegral(Double.NaN)
     }
 
-    override def toString: String = s"$expr,:integral"
+    override def toString: String = Interpreter.toString(expr, s":$name")
   }
 
   /**
@@ -83,7 +83,7 @@ object StatefulExpr {
       OnlineDerivative(Double.NaN)
     }
 
-    override def toString: String = s"$expr,:derivative"
+    override def toString: String = Interpreter.toString(expr, s":$name")
   }
 
   /**
@@ -98,7 +98,7 @@ object StatefulExpr {
       OnlineDelay(n)
     }
 
-    override def toString: String = s"$expr,$n,:delay"
+    override def toString: String = Interpreter.toString(expr, n, s":$name")
   }
 
   /**
@@ -112,7 +112,7 @@ object StatefulExpr {
       OnlineRollingCount(n)
     }
 
-    override def toString: String = s"$expr,$n,:rolling-count"
+    override def toString: String = Interpreter.toString(expr, n, s":$name")
   }
 
   /**
@@ -126,7 +126,7 @@ object StatefulExpr {
       OnlineRollingMin(n)
     }
 
-    override def toString: String = s"$expr,$n,:rolling-min"
+    override def toString: String = Interpreter.toString(expr, n, s":$name")
   }
 
   /**
@@ -140,7 +140,7 @@ object StatefulExpr {
       OnlineRollingMax(n)
     }
 
-    override def toString: String = s"$expr,$n,:rolling-max"
+    override def toString: String = Interpreter.toString(expr, n, s":$name")
   }
 
   /**
@@ -154,7 +154,7 @@ object StatefulExpr {
       OnlineRollingMean(n, minNumValues)
     }
 
-    override def toString: String = s"$expr,$n,$minNumValues,:rolling-mean"
+    override def toString: String = Interpreter.toString(expr, n, minNumValues, s":$name")
   }
 
   /**
@@ -168,7 +168,7 @@ object StatefulExpr {
       OnlineRollingSum(n)
     }
 
-    override def toString: String = s"$expr,$n,:rolling-sum"
+    override def toString: String = Interpreter.toString(expr, n, s":$name")
   }
 
   /**
@@ -184,7 +184,9 @@ object StatefulExpr {
       OnlineDes(trainingSize, alpha, beta)
     }
 
-    override def toString: String = s"$expr,$trainingSize,$alpha,$beta,:des"
+    override def toString: String = {
+      Interpreter.toString(expr, trainingSize, alpha, beta, s":$name")
+    }
   }
 
   /**
@@ -216,7 +218,9 @@ object StatefulExpr {
         context.start / trainingStep * trainingStep + trainingStep
     }
 
-    override def toString: String = s"$expr,$trainingSize,$alpha,$beta,:sdes"
+    override def toString: String = {
+      Interpreter.toString(expr, trainingSize, alpha, beta, s":$name")
+    }
   }
 
   /**

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
@@ -16,6 +16,7 @@
 package com.netflix.atlas.core.stacklang
 
 import com.netflix.atlas.core.util.Features
+import com.netflix.atlas.core.util.Strings
 
 /**
   * Interpreter for stack expressions.
@@ -197,12 +198,15 @@ object Interpreter {
     stack.reverse.map(getTypeName).mkString("[", ",", "]")
   }
 
+  def toString(items: Any*): String = toStringImpl(items)
+
   def toString(stack: List[Any]): String = toStringImpl(stack.reverse)
 
-  private def toStringImpl(items: List[Any]): String = {
+  private def toStringImpl(items: Seq[Any]): String = {
     val parts = items.map {
-      case vs: List[?] => s"(,${toStringImpl(vs)},)"
-      case v           => v.toString
+      case vs: Seq[?] => s"(,${toStringImpl(vs)},)"
+      case v: String  => escape(v)
+      case v          => v.toString
     }
     parts.mkString(",")
   }
@@ -220,9 +224,23 @@ object Interpreter {
     while (i < parts.length) {
       val tmp = parts(i).trim
       if (tmp.nonEmpty)
-        builder += tmp
+        builder += unescape(tmp)
       i += 1
     }
     builder.result()
+  }
+
+  private def isSpecial(c: Int): Boolean = {
+    c == ',' || Character.isWhitespace(c)
+  }
+
+  /** Escape special characters in the expression. */
+  def escape(str: String): String = {
+    Strings.escape(str, isSpecial)
+  }
+
+  /** Unescape unicode characters in the expression. */
+  def unescape(str: String): String = {
+    Strings.unescape(str)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/InterpreterSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/InterpreterSuite.scala
@@ -179,6 +179,24 @@ class InterpreterSuite extends FunSuite {
     val actual = Interpreter.splitAndTrim(", ,\t,\n\n,")
     assertEquals(actual, Nil)
   }
+
+  test("splitAndTrim with escaped whitespace") {
+    val space = Interpreter.escape(" ")
+    val nl = Interpreter.escape("\n")
+    val tab = Interpreter.escape("\t")
+    val escaped = s"$space${space}a$nl,$nl${tab}b$space,c"
+    val actual = Interpreter.splitAndTrim(escaped)
+    assertEquals(actual, List("  a\n", "\n\tb ", "c"))
+    assertEquals(Interpreter.toString(actual.reverse), escaped)
+  }
+
+  test("splitAndTrim with escaped comma") {
+    val comma = Interpreter.escape(",")
+    val escaped = s"a${comma}b${comma}c,d"
+    val actual = Interpreter.splitAndTrim(escaped)
+    assertEquals(actual, List("a,b,c", "d"))
+    assertEquals(Interpreter.toString(actual.reverse), escaped)
+  }
 }
 
 object InterpreterSuite {


### PR DESCRIPTION
Update stacklang parsing to allow comma and whitespace to be preserved by using unicode escape sequences.