### PR TITLE
pekko: config settings for access logger

### DIFF
--- a/atlas-pekko/src/main/resources/reference.conf
+++ b/atlas-pekko/src/main/resources/reference.conf
@@ -106,6 +106,21 @@ atlas.pekko {
     # while waiting for the delay.
     frequency = 100ms
   }
+
+  # Settings for spectator IPC logging
+  ipc-logger {
+    # Should inflight metrics be enabled? They are confusing and generally not useful.
+    inflight-metrics-enabled = false
+
+    # Maximum number of values permitted for tag keys on IPC metrics
+    cardinality-limit {
+      default = 25
+      id = 100
+    }
+
+    # Size of queue for reusing logger entries
+    entry-queue-size = 1000
+  }
 }
 
 pekko {


### PR DESCRIPTION
Update access logger so that settings for IPC logger can be managed via typesafe config.