### PR TITLE
core: support sub-second step sizes

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Step.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Step.scala
@@ -20,17 +20,19 @@ package com.netflix.atlas.core.util
   */
 object Step {
 
+  private final val oneMilli = 1L
   private final val oneSecond = 1000L
   private final val oneMinute = 60000L
   private final val oneHour = 60 * oneMinute
   private final val oneDay = 24 * oneHour
 
   private final val allowedStepSizes = {
+    val subSecond = List(1L, 5L, 10L, 50L, 100L, 500L)
     val div60 = List(1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30)
     val subMinute = div60.map(_ * oneSecond)
     val subHour = div60.map(_ * oneMinute)
     val subDay = List(1, 2, 3, 4, 6, 8, 12).map(_ * oneHour)
-    subMinute ::: subHour ::: subDay
+    subSecond ::: subMinute ::: subHour ::: subDay
   }
 
   private def datapointsPerPixel(datapoints: Long, width: Int): Long = {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StepSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StepSuite.scala
@@ -24,6 +24,17 @@ class StepSuite extends FunSuite {
 
   private def days(n: Long): Long = n * 24 * 60 * 60 * 1000
 
+  test("round: sub-second step sizes") {
+    val primaryStep = 1L
+    assertEquals(1L, Step.round(primaryStep, 1))
+    assertEquals(5L, Step.round(primaryStep, 2))
+    assertEquals(10L, Step.round(primaryStep, 6))
+    assertEquals(50L, Step.round(primaryStep, 20))
+    assertEquals(100L, Step.round(primaryStep, 60))
+    assertEquals(500L, Step.round(primaryStep, 200))
+    assertEquals(1000L, Step.round(primaryStep, 600))
+  }
+
   test("round: allow arbitrary number of days") {
     (1 until 500).foreach { i =>
       assertEquals(days(i), Step.round(60000, days(i)))


### PR DESCRIPTION
Update step rounding logic to allow for sub-second step sizes.