### PR TITLE
Optimize MemoryDB getOrCreateBlockStore with atomic operation 'computeIfAbsent'

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
@@ -119,13 +119,11 @@ class MemoryDatabase(registry: Registry, config: Config) extends Database {
   }
 
   private def getOrCreateBlockStore(id: ItemId, tags: Map[String, String]): BlockStore = {
-    var blkStore = data.get(id)
-    if (blkStore == null) {
-      // Create a new block store and update the index
-      blkStore = data.computeIfAbsent(id, _ => new MemoryBlockStore(step, blockSize, numBlocks))
+    data.computeIfAbsent(id, _ => {
+      val blkStore = new MemoryBlockStore(step, blockSize, numBlocks)
       index.update(BlockStoreItem.create(id, tags, blkStore))
-    }
-    blkStore
+      blkStore
+    })
   }
 
   def update(id: ItemId, tags: Map[String, String], timestamp: Long, value: Double): Unit = {


### PR DESCRIPTION
The separate ``get`` and ``computeIfAbsent`` calls can introduce race conditions in a multithreaded environment. If multiple threads check for the presence of the ``blkStore`` at the same time, they might all find it null and proceed to create new instances, leading to inconsistencies.

CHMap ``computeIfAbsent`` is **atomic**, ensuring that only one thread creates the blkStore if it is absent. This makes the operation thread-safe without additional synchronization.