### PR TITLE
core: fixes for sub-second step size

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -402,8 +402,9 @@ object MathExpr {
     override def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
       val rs = expr.eval(context, data)
       val newData = rs.data.map { t =>
-        // Assumes rate-per-second counter
-        val multiple = t.data.step / 1000
+        // Assumes rate-per-second counter. If the step size is less than a second, then it
+        // will be a fractional multiple and reduce the amount.
+        val multiple = t.data.step / 1000.0
         t.unaryOp(s"$name(%s)", v => v * multiple)
       }
       ResultSet(this, newData, rs.state)
@@ -920,7 +921,7 @@ object MathExpr {
         val results = new Array[Double](pcts.length)
 
         // Inputs are counters reported as a rate per second. We need to convert to a rate per
-        // step to get the correct counts for the estimation
+        // step to get the correct counts for the estimation.
         val multiple = context.step / 1000.0
 
         // If the input was a timer the unit for the buckets is nanoseconds. The type is reflected

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/PerStepSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/PerStepSuite.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.atlas.core.stacklang.Interpreter
+import munit.FunSuite
+
+import scala.language.postfixOps
+
+class PerStepSuite extends FunSuite {
+
+  private val interpreter = Interpreter(MathVocabulary.allWords)
+
+  def eval(str: String, step: Long, value: Double): List[TimeSeries] = {
+    val expr = interpreter.execute(str).stack match {
+      case (v: TimeSeriesExpr) :: _ => v
+      case _                        => throw new IllegalArgumentException("invalid expr")
+    }
+    val seq = new FunctionTimeSeq(DsType.Rate, step, _ => value)
+    val input = List(LazyTimeSeries(Map("name" -> "test"), "test", seq))
+    val context = EvalContext(0L, step * 2, step)
+    expr.eval(context, input).data
+  }
+
+  test("1ms step") {
+    val step = 1L
+    val data = eval("name,test,:eq,:sum,:per-step", step, 4.0)
+    assertEquals(data.size, 1)
+    assertEquals(data.head.data.apply(step), 0.004)
+  }
+
+  test("500ms step") {
+    val step = 500L
+    val data = eval("name,test,:eq,:sum,:per-step", step, 4.0)
+    assertEquals(data.size, 1)
+    assertEquals(data.head.data.apply(step), 2.0)
+  }
+
+  test("1s step") {
+    val step = 1_000L
+    val data = eval("name,test,:eq,:sum,:per-step", step, 4.0)
+    assertEquals(data.size, 1)
+    assertEquals(data.head.data.apply(step), 4.0)
+  }
+
+  test("5s step") {
+    val step = 5_000L
+    val data = eval("name,test,:eq,:sum,:per-step", step, 4.0)
+    assertEquals(data.size, 1)
+    assertEquals(data.head.data.apply(step), 20.0)
+  }
+
+  test("1m step") {
+    val step = 60_000L
+    val data = eval("name,test,:eq,:sum,:per-step", step, 4.0)
+    assertEquals(data.size, 1)
+    assertEquals(data.head.data.apply(step), 240.0)
+  }
+
+  test("10m step") {
+    val step = 600_000L
+    val data = eval("name,test,:eq,:sum,:per-step", step, 4.0)
+    assertEquals(data.size, 1)
+    assertEquals(data.head.data.apply(step), 2400.0)
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/norm/RateValueFunctionSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/norm/RateValueFunctionSuite.scala
@@ -26,7 +26,14 @@ class RateValueFunctionSuite extends FunSuite {
     listVF
   }
 
-  test("basic") {
+  test("basic, 1ms step") {
+    val vf = newFunction
+    assertEquals(vf.update(1L, 1.0), Nil)
+    assertEquals(vf.update(2L, 2.0), List(2L -> 1000.0))
+    assertEquals(vf.update(3L, 4.0), List(3L -> 2000.0))
+  }
+
+  test("basic, 5ms step") {
     val vf = newFunction
     assertEquals(vf.update(5L, 1.0), Nil)
     assertEquals(vf.update(15L, 2.0), List(15L -> 100.0))


### PR DESCRIPTION
Add some tests and put in some patches to address minor issues with using sub-second step sizes. There is a known issue with percentiles operator that will be addressed in a follow up PR after some updates to spectator utility classes.