### PR TITLE
core: improve expr.toString performance

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
@@ -60,8 +60,10 @@ sealed trait DataExpr extends TimeSeriesExpr with Product {
     ResultSet(this, data.getOrElse(this, Nil), context.state)
   }
 
-  override def toString: String = {
-    if (offset.isZero) exprString else s"$exprString,$offset,:offset"
+  override def append(builder: java.lang.StringBuilder): Unit = {
+    builder.append(exprString)
+    if (!offset.isZero)
+      builder.append(',').append(offset).append(",:offset")
   }
 
   /**

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/EventExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/EventExpr.scala
@@ -34,7 +34,9 @@ object EventExpr {
     */
   case class Raw(query: Query) extends EventExpr {
 
-    override def toString: String = query.toString
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, query)
+    }
   }
 
   /**
@@ -49,6 +51,8 @@ object EventExpr {
 
     require(columns.nonEmpty, "set of columns cannot be empty")
 
-    override def toString: String = Interpreter.toString(query, columns, ":table")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, query, columns, ":table")
+    }
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Expr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Expr.scala
@@ -15,7 +15,18 @@
  */
 package com.netflix.atlas.core.model
 
-trait Expr extends Product {
+import com.netflix.atlas.core.stacklang.StackItem
+
+trait Expr extends Product with StackItem {
+
+  /** Use builder for encoding as a string. Sub-classes should override the append method. */
+  override def toString: String = {
+    // 256 is a rough size that isn't too large to waste a lot, but also limit the
+    // need for growing the buffer with typical expressions
+    val builder = new java.lang.StringBuilder(256)
+    append(builder)
+    builder.toString
+  }
 
   /**
     * Returns a string that can be executed with the stack interpreter to create this expression.

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterExpr.scala
@@ -39,7 +39,12 @@ object FilterExpr {
   case class Stat(expr: TimeSeriesExpr, stat: String, str: Option[String] = None)
       extends FilterExpr {
 
-    override def toString: String = str.getOrElse(s"$expr,$stat,:stat")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      str match {
+        case Some(s) => builder.append(s)
+        case None    => Interpreter.append(builder, expr, stat, ":stat")
+      }
+    }
 
     def dataExprs: List[DataExpr] = expr.dataExprs
 
@@ -64,7 +69,9 @@ object FilterExpr {
 
     def name: String
 
-    override def toString: String = s":stat-$name"
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, s":stat-$name")
+    }
 
     def dataExprs: List[DataExpr] = Nil
 
@@ -113,7 +120,9 @@ object FilterExpr {
 
     if (!expr1.isGrouped) require(!expr2.isGrouped, "filter grouping must match expr grouping")
 
-    override def toString: String = Interpreter.toString(expr1, expr2, ":filter")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, expr1, expr2, ":filter")
+    }
 
     def dataExprs: List[DataExpr] = expr1.dataExprs ::: expr2.dataExprs
 
@@ -183,7 +192,9 @@ object FilterExpr {
 
     require(k > 0, s"k must be positive ($k <= 0)")
 
-    override def toString: String = Interpreter.toString(expr, stat, k, s":$opName")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, expr, stat, k, s":$opName")
+    }
 
     def dataExprs: List[DataExpr] = expr.dataExprs
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
@@ -246,7 +246,9 @@ object Query {
 
     def labelString: String = "true"
 
-    override def toString: String = ":true"
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      builder.append(":true")
+    }
 
     override def and(query: Query): Query = query
 
@@ -265,7 +267,9 @@ object Query {
 
     def labelString: String = "false"
 
-    override def toString: String = ":false"
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      builder.append(":false")
+    }
 
     override def and(query: Query): Query = Query.False
 
@@ -318,7 +322,9 @@ object Query {
 
     def labelString: String = s"has($k)"
 
-    override def toString: String = Interpreter.toString(k, ":has")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, k, ":has")
+    }
   }
 
   case class Equal(k: String, v: String) extends KeyValueQuery {
@@ -327,7 +333,9 @@ object Query {
 
     def labelString: String = s"$k=$v"
 
-    override def toString: String = Interpreter.toString(k, v, ":eq")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, k, v, ":eq")
+    }
   }
 
   case class LessThan(k: String, v: String) extends KeyValueQuery {
@@ -336,7 +344,9 @@ object Query {
 
     def labelString: String = s"$k<$v"
 
-    override def toString: String = Interpreter.toString(k, v, ":lt")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, k, v, ":lt")
+    }
   }
 
   case class LessThanEqual(k: String, v: String) extends KeyValueQuery {
@@ -345,7 +355,9 @@ object Query {
 
     def labelString: String = s"$k<=$v"
 
-    override def toString: String = Interpreter.toString(k, v, ":le")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, k, v, ":le")
+    }
   }
 
   case class GreaterThan(k: String, v: String) extends KeyValueQuery {
@@ -354,7 +366,9 @@ object Query {
 
     def labelString: String = s"$k>$v"
 
-    override def toString: String = Interpreter.toString(k, v, ":gt")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, k, v, ":gt")
+    }
   }
 
   case class GreaterThanEqual(k: String, v: String) extends KeyValueQuery {
@@ -363,7 +377,9 @@ object Query {
 
     def labelString: String = s"$k>=$v"
 
-    override def toString: String = Interpreter.toString(k, v, ":ge")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, k, v, ":ge")
+    }
   }
 
   sealed trait PatternQuery extends KeyValueQuery {
@@ -379,7 +395,9 @@ object Query {
 
     def labelString: String = s"$k~/^$v/"
 
-    override def toString: String = Interpreter.toString(k, v, ":re")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, k, v, ":re")
+    }
   }
 
   case class RegexIgnoreCase(k: String, v: String) extends PatternQuery {
@@ -390,7 +408,9 @@ object Query {
 
     def labelString: String = s"$k~/^$v/i"
 
-    override def toString: String = Interpreter.toString(k, v, ":reic")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, k, v, ":reic")
+    }
   }
 
   case class In(k: String, vs: List[String]) extends KeyValueQuery {
@@ -401,7 +421,9 @@ object Query {
 
     def labelString: String = s"$k in (${vs.mkString(",")})"
 
-    override def toString: String = Interpreter.toString(k, vs, ":in")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, k, vs, ":in")
+    }
 
     /** Convert this to a sequence of OR'd together equal queries. */
     def toOrQuery: Query = {
@@ -423,7 +445,9 @@ object Query {
 
     def labelString: String = s"(${q1.labelString}) and (${q2.labelString})"
 
-    override def toString: String = Interpreter.toString(q1, q2, ":and")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, q1, q2, ":and")
+    }
   }
 
   case class Or(q1: Query, q2: Query) extends Query {
@@ -437,7 +461,9 @@ object Query {
 
     def labelString: String = s"(${q1.labelString}) or (${q2.labelString})"
 
-    override def toString: String = Interpreter.toString(q1, q2, ":or")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, q1, q2, ":or")
+    }
   }
 
   case class Not(q: Query) extends Query {
@@ -450,6 +476,8 @@ object Query {
 
     def labelString: String = s"not(${q.labelString})"
 
-    override def toString: String = Interpreter.toString(q, ":not")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, q, ":not")
+    }
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
@@ -52,7 +52,9 @@ object StatefulExpr {
       if (period <= 1) OnlineIgnoreN(0) else OnlineTrend(period)
     }
 
-    override def toString: String = Interpreter.toString(expr, window, ":trend")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, expr, window, ":trend")
+    }
   }
 
   /**
@@ -69,7 +71,9 @@ object StatefulExpr {
       OnlineIntegral(Double.NaN)
     }
 
-    override def toString: String = Interpreter.toString(expr, s":$name")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, expr, s":$name")
+    }
   }
 
   /**
@@ -83,7 +87,9 @@ object StatefulExpr {
       OnlineDerivative(Double.NaN)
     }
 
-    override def toString: String = Interpreter.toString(expr, s":$name")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, expr, s":$name")
+    }
   }
 
   /**
@@ -98,7 +104,9 @@ object StatefulExpr {
       OnlineDelay(n)
     }
 
-    override def toString: String = Interpreter.toString(expr, n, s":$name")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, expr, n, s":$name")
+    }
   }
 
   /**
@@ -112,7 +120,9 @@ object StatefulExpr {
       OnlineRollingCount(n)
     }
 
-    override def toString: String = Interpreter.toString(expr, n, s":$name")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, expr, n, s":$name")
+    }
   }
 
   /**
@@ -126,7 +136,9 @@ object StatefulExpr {
       OnlineRollingMin(n)
     }
 
-    override def toString: String = Interpreter.toString(expr, n, s":$name")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, expr, n, s":$name")
+    }
   }
 
   /**
@@ -140,7 +152,9 @@ object StatefulExpr {
       OnlineRollingMax(n)
     }
 
-    override def toString: String = Interpreter.toString(expr, n, s":$name")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, expr, n, s":$name")
+    }
   }
 
   /**
@@ -154,7 +168,9 @@ object StatefulExpr {
       OnlineRollingMean(n, minNumValues)
     }
 
-    override def toString: String = Interpreter.toString(expr, n, minNumValues, s":$name")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, expr, n, minNumValues, s":$name")
+    }
   }
 
   /**
@@ -168,7 +184,9 @@ object StatefulExpr {
       OnlineRollingSum(n)
     }
 
-    override def toString: String = Interpreter.toString(expr, n, s":$name")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, expr, n, s":$name")
+    }
   }
 
   /**
@@ -184,8 +202,8 @@ object StatefulExpr {
       OnlineDes(trainingSize, alpha, beta)
     }
 
-    override def toString: String = {
-      Interpreter.toString(expr, trainingSize, alpha, beta, s":$name")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, expr, trainingSize, alpha, beta, s":$name")
     }
   }
 
@@ -218,8 +236,8 @@ object StatefulExpr {
         context.start / trainingStep * trainingStep + trainingStep
     }
 
-    override def toString: String = {
-      Interpreter.toString(expr, trainingSize, alpha, beta, s":$name")
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, expr, trainingSize, alpha, beta, s":$name")
     }
   }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
@@ -25,7 +25,8 @@ import com.netflix.atlas.core.util.Strings
 
 case class StyleExpr(expr: TimeSeriesExpr, settings: Map[String, String]) extends Expr {
 
-  override def toString: String = {
+  override def append(builder: java.lang.StringBuilder): Unit = {
+    Interpreter.append(builder, expr)
     // Use descending order to ensure that an explicit alpha used with
     // a palette is not overwritten when reprocessing the expression string.
     // This works because palette will be sorted before alpha, though a better
@@ -36,7 +37,9 @@ case class StyleExpr(expr: TimeSeriesExpr, settings: Map[String, String]) extend
       case ("ls", v)  => s":$v"
       case (k, v)     => s"$v,:$k"
     }
-    if (vs.isEmpty) expr.toString else s"$expr,${vs.mkString(",")}"
+    vs.foreach { v =>
+      builder.append(',').append(v)
+    }
   }
 
   def legend(t: TimeSeries): String = {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TraceQuery.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TraceQuery.scala
@@ -15,6 +15,8 @@
  */
 package com.netflix.atlas.core.model
 
+import com.netflix.atlas.core.stacklang.Interpreter
+
 /** Base type for a query to match a trace. */
 sealed trait TraceQuery extends Expr
 
@@ -26,19 +28,25 @@ object TraceQuery {
     */
   case class Simple(query: Query) extends TraceQuery {
 
-    override def toString: String = query.toString
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, query)
+    }
   }
 
   /** Matches if the trace has a span that matches `q1` and a span that matches `q2`. */
   case class SpanAnd(q1: TraceQuery, q2: TraceQuery) extends TraceQuery {
 
-    override def toString: String = s"$q1,$q2,:span-and"
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, q1, q2, ":span-and")
+    }
   }
 
   /** Matches if the trace has a span that matches `q1` or a span that matches `q2`. */
   case class SpanOr(q1: TraceQuery, q2: TraceQuery) extends TraceQuery {
 
-    override def toString: String = s"$q1,$q2,:span-or"
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, q1, q2, ":span-or")
+    }
   }
 
   /**
@@ -47,18 +55,26 @@ object TraceQuery {
     */
   case class Child(q1: Query, q2: Query) extends TraceQuery {
 
-    override def toString: String = s"$q1,$q2,:child"
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, q1, q2, ":child")
+    }
   }
 
   /** Filter to select the set of spans from a trace to forward as events. */
   case class SpanFilter(q: TraceQuery, f: Query) extends Expr {
 
     override def toString: String = s"$q,$f,:span-filter"
+
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, q, f, ":span-filter")
+    }
   }
 
   /** Time series based on data from a set of matching traces. */
   case class SpanTimeSeries(q: TraceQuery, expr: StyleExpr) extends Expr {
 
-    override def toString: String = s"$q,$expr,:span-time-series"
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, q, expr, ":span-time-series")
+    }
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/StackItem.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/StackItem.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.stacklang
+
+trait StackItem {
+
+  /**
+    * Append the string representation of this object.
+    *
+    * @param builder
+    *     Builder to append the string representation into.
+    */
+  def append(builder: java.lang.StringBuilder): Unit
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
@@ -147,8 +147,16 @@ object Strings {
     * Escape special characters in the input string to unicode escape sequences (\uXXXX).
     */
   def escape(input: String, isSpecial: Int => Boolean): String = {
+    val builder = new java.lang.StringBuilder(input.length)
+    escape(builder, input, isSpecial)
+    builder.toString
+  }
+
+  /**
+    * Escape special characters in the input string to unicode escape sequences (\uXXXX).
+    */
+  def escape(builder: java.lang.StringBuilder, input: String, isSpecial: Int => Boolean): Unit = {
     val length = input.length
-    val builder = new java.lang.StringBuilder(length)
     var i = 0
     while (i < length) {
       val cp = input.codePointAt(i)
@@ -159,7 +167,6 @@ object Strings {
         builder.appendCodePoint(cp)
       i += len
     }
-    builder.toString
   }
 
   private def escapeCodePoint(cp: Int, builder: java.lang.StringBuilder): Unit = {

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/stacklang/InterpreterEscape.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/stacklang/InterpreterEscape.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.stacklang
+
+import com.netflix.atlas.core.model.StyleExpr
+import com.netflix.atlas.core.model.StyleVocabulary
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.infra.Blackhole
+
+/**
+  * Simple test for escaping a stacklang expression.
+  *
+  * ```
+  * > jmh:run -wi 10 -i 10 -f1 -t1 .*InterpreterEscape.*
+  * ...
+  * Benchmark           Mode  Cnt       Score       Error  Units
+  * withEscapes        thrpt   10   956439.595 ±  5243.582  ops/s
+  * withNoEscapes      thrpt   10  1031542.340 ± 25261.261  ops/s
+  * ```
+  */
+@State(Scope.Thread)
+class InterpreterEscape {
+
+  import InterpreterEscape.*
+
+  private val exprWithNoEscapes = parseExpr(
+    """
+      |name,sys.cpu.coreUtilization,:eq,
+      |statistic,totalAmount,:eq,:and,
+      |nf.app,foo,:eq,:and,
+      |nf.asg,foo-v[0-9]+,:eq,:and,
+      |:sum,
+      |
+      |name,sys.cpu.coreUtilization,:eq,
+      |statistic,count,:eq,:and,
+      |nf.app,foo,:eq,:and,
+      |nf.asg,foo-v[0-9]+,:eq,:and,
+      |:sum,
+      |
+      |:div,
+      |average-latency,:legend
+      |""".stripMargin
+  )
+
+  private val exprWithEscapes = parseExpr(
+    """
+      |name,sys.cpu.coreUtilization,:eq,
+      |statistic,totalAmount,:eq,:and,
+      |nf.app,foo,:eq,:and,
+      |nf.asg,foo-v[0-9]{1\\u002c3},:eq,:and,
+      |:sum,
+      |
+      |name,sys.cpu.coreUtilization,:eq,
+      |statistic,count,:eq,:and,
+      |nf.app,foo,:eq,:and,
+      |nf.asg,foo-v[0-9]{1\\u002c3},:eq,:and,
+      |:sum,
+      |
+      |:div,
+      |average latency,:legend
+      |""".stripMargin
+  )
+
+  @Benchmark
+  def withNoEscapes(bh: Blackhole): Unit = {
+    bh.consume(exprWithNoEscapes.toString)
+  }
+
+  @Benchmark
+  def withEscapes(bh: Blackhole): Unit = {
+    bh.consume(exprWithEscapes.toString)
+  }
+
+}
+
+object InterpreterEscape {
+
+  import com.netflix.atlas.core.model.ModelExtractors.*
+
+  private val interpreter = Interpreter(StyleVocabulary.allWords)
+
+  private def parseExpr(str: String): StyleExpr = {
+    interpreter.execute(str).stack match {
+      case PresentationType(expr) :: Nil => expr
+      case _                             => throw new MatchError(str)
+    }
+  }
+}


### PR DESCRIPTION
Creating a string from the expression can be a common operation when creating messages. This change reduces the overhead by allowing it to be written to an existing builder instance and reduce the amount of internal resizing and copies.

**Before**

```
Benchmark           Mode  Cnt         Score       Error  Units
withEscapes        thrpt   10    581,213.514 ± 4708.897  ops/s
withNoEscapes      thrpt   10    643,706.596 ± 9144.301  ops/s
```

**After**

```
Benchmark           Mode  Cnt         Score       Error  Units
withEscapes        thrpt   10    956,439.595 ±  5243.582  ops/s
withNoEscapes      thrpt   10  1,031,542.340 ± 25261.261  ops/s
```