### PR TITLE
core: zero pad short numbers for ItemId

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/ItemId.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/ItemId.scala
@@ -84,11 +84,17 @@ object ItemId {
   }
 
   /**
-    * Create a new id from an array of bytes. The pre-computed hash code will be generated
-    * using MurmurHash3.
+    * Create a new id from an array of bytes.
     */
   def apply(data: Array[Byte]): ItemId = {
     new ItemId(data)
+  }
+
+  /**
+    * Create a new id from a BigInteger instance.
+    */
+  def apply(data: BigInteger): ItemId = {
+    apply(data.toString(16))
   }
 
   /**
@@ -96,17 +102,19 @@ object ItemId {
     * an `ItemId`.
     */
   def apply(data: String): ItemId = {
-    require(data.length % 2 == 0, s"invalid item id string: $data")
-    val bytes = new Array[Byte](data.length / 2)
+    // Pad to min size for id. Allows it to work easily with hex strings from number types
+    val str = Strings.zeroPad(data, 32)
+    require(str.length % 2 == 0, s"invalid item id string: $str")
+    val bytes = new Array[Byte](str.length / 2)
     var i = 0
     while (i < bytes.length) {
-      val c1 = hexToInt(data.charAt(2 * i))
-      val c2 = hexToInt(data.charAt(2 * i + 1))
+      val c1 = hexToInt(str.charAt(2 * i))
+      val c2 = hexToInt(str.charAt(2 * i + 1))
       val v = (c1 << 4) | c2
       bytes(i) = v.toByte
       i += 1
     }
-    ItemId(bytes)
+    new ItemId(bytes)
   }
 
   private def hexToInt(c: Char): Int = {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ItemIdSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ItemIdSuite.scala
@@ -19,6 +19,8 @@ import com.netflix.atlas.core.util.Hash
 import com.netflix.atlas.core.util.Strings
 import munit.FunSuite
 
+import java.math.BigInteger
+
 class ItemIdSuite extends FunSuite {
 
   def testByteArray: Array[Byte] = {
@@ -92,6 +94,16 @@ class ItemIdSuite extends FunSuite {
     val bytes = testByteArray
     val id = ItemId(bytes)
     assertEquals(id, ItemId("0102030405060708090A0B0C0D0E0F1011121314"))
+  }
+
+  test("from String short") {
+    val id = ItemId(Strings.zeroPad("abc", 32))
+    assertEquals(id, ItemId("abc"))
+  }
+
+  test("from BigInteger short") {
+    val id = ItemId(new BigInteger("abc", 16))
+    assertEquals(id, ItemId("abc"))
   }
 
   test("from String invalid") {


### PR DESCRIPTION
When computing an ItemId from a string or number zero pad the value. This avoids unnecesarily hitting the minimum length check when performing conversions between number types.