### PR TITLE
core: remove interning for BlockStoreItem

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/BlockStoreItem.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/BlockStoreItem.scala
@@ -29,21 +29,11 @@ case class BlockStoreItem(id: ItemId, tags: Map[String, String], blocks: BlockSt
 
 object BlockStoreItem {
 
-  import com.netflix.atlas.core.util.InternMap
-
-  private val metricInterner = InternMap.concurrent[BlockStoreItem](1000000)
-
   def create(tags: Map[String, String], blocks: BlockStore): BlockStoreItem = {
     create(TaggedItem.createId(tags), tags, blocks)
   }
 
   def create(id: ItemId, tags: Map[String, String], blocks: BlockStore): BlockStoreItem = {
-    val m = new BlockStoreItem(id, tags, blocks)
-    metricInterner.intern(m)
-  }
-
-  def retain(keep: Long => Boolean): Unit = {
-    TaggedItem.retain(keep)
-    metricInterner.retain(keep)
+    new BlockStoreItem(id, tags, blocks)
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
@@ -29,6 +29,7 @@ import com.netflix.atlas.core.model.DefaultSettings
 import com.netflix.atlas.core.model.EvalContext
 import com.netflix.atlas.core.model.ItemId
 import com.netflix.atlas.core.model.Query
+import com.netflix.atlas.core.model.TaggedItem
 import com.netflix.atlas.core.model.TimeSeries
 import com.netflix.spectator.api.Registry
 import com.netflix.spectator.api.Spectator
@@ -118,7 +119,7 @@ class MemoryDatabase(registry: Registry, config: Config) extends Database {
       }
       logger.info("done rebuilding metadata index, {} metrics", index.size)
 
-      BlockStoreItem.retain(_ > cutoff)
+      TaggedItem.retain(_ > cutoff)
     }
   }
 


### PR DESCRIPTION
The block store included would not match the equality check so it wouldn't work as intended. The items will get deduped as part of the index update.