### PR TITLE
core: fix percentile approximation

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -980,8 +980,7 @@ object MathExpr {
           var j = 0
           while (j < usedCounts.length) {
             val v = bounded(j).data(i)
-            if (v.isFinite)
-              counts(usedCounts(j)) = v
+            counts(usedCounts(j)) = if (v.isFinite) v else 0.0
             j += 1
           }
           PercentileBuckets.percentiles(counts, pcts, results)


### PR DESCRIPTION
In #1704 the approximation was updated to use doubles instead of longs. As part of that non-finite values were ignored. Before they would be treated as 0. By ignoring them a bad value could potentially be carried forward if it only occurred for a single interval.