### PR TITLE
core: fix expr string for :percentiles

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -872,9 +872,10 @@ object MathExpr {
 
     override def append(builder: java.lang.StringBuilder): Unit = {
       // Base expr
-      Interpreter.append(builder, expr.af.query)
       if (evalGroupKeys.nonEmpty)
         Interpreter.append(builder, expr.af.query, evalGroupKeys, ":by")
+      else
+        Interpreter.append(builder, expr.af.query)
 
       // Percentiles
       builder.append(",(,")


### PR DESCRIPTION
The changes in #1706 have a bug for percentiles used after a group by where the query clause would get duplicated.