### PR TITLE
pekko: helper to decompress while streaming ByteString

### DIFF
--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/ByteStringInputStreamSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/ByteStringInputStreamSuite.scala
@@ -18,16 +18,28 @@ package com.netflix.atlas.pekko
 import java.io.ByteArrayInputStream
 import java.security.MessageDigest
 import java.util.Random
-
 import org.apache.pekko.util.ByteString
 import munit.FunSuite
 
+import java.io.ByteArrayOutputStream
+import java.util.zip.GZIPOutputStream
+import scala.util.Using
+
 class ByteStringInputStreamSuite extends FunSuite {
+
+  private def compress(data: ByteString): ByteString = {
+    val baos = new ByteArrayOutputStream()
+    Using.resource(new GZIPOutputStream(baos)) { out =>
+      out.write(data.toArray)
+    }
+    ByteString(baos.toByteArray)
+  }
 
   private def singleRead(name: String, data: ByteString): Unit = {
     test(s"$name: read() and available()") {
       val bais = new ByteArrayInputStream(data.toArray)
-      val bsis = new ByteStringInputStream(data)
+      val bsis = ByteStringInputStream.create(data)
+      val gzis = ByteStringInputStream.create(compress(data))
 
       data.indices.foreach { i =>
         if (data.isCompact) {
@@ -36,38 +48,56 @@ class ByteStringInputStreamSuite extends FunSuite {
         } else {
           assert(bsis.available() > 0)
         }
-        assertEquals(bais.read(), bsis.read())
+        assert(gzis.available() > 0)
+
+        val expected = bais.read()
+        assertEquals(expected, bsis.read())
+        assertEquals(expected, gzis.read())
       }
 
-      assertEquals(bais.read(), bsis.read())
+      val expected = bais.read()
+      assertEquals(expected, bsis.read())
+      assertEquals(expected, gzis.read())
+
+      bsis.close()
+      gzis.close()
     }
   }
 
   private def bulkRead(name: String, data: ByteString): Unit = {
     test(s"$name: read(buffer, offset, length)") {
       val bais = new ByteArrayInputStream(data.toArray)
-      val bsis = new ByteStringInputStream(data)
+      val bsis = ByteStringInputStream.create(data)
+      val gzis = ByteStringInputStream.create(compress(data))
 
       val h1 = MessageDigest.getInstance("SHA-256")
       val h2 = MessageDigest.getInstance("SHA-256")
+      val h3 = MessageDigest.getInstance("SHA-256")
 
       val b1 = new Array[Byte](13)
       val b2 = new Array[Byte](13)
-      var i = 0
-      while (i < data.length) {
+      val b3 = new Array[Byte](13)
+      var continue = true
+      while (continue) {
         val len1 = bais.read(b1)
         val len2 = bsis.read(b2)
+        val len3 = gzis.read(b3)
         if (data.isCompact) {
           assertEquals(len1, len2)
           assertEquals(b1.toSeq, b2.toSeq)
         }
         if (len1 > 0) h1.update(b1, 0, len1)
         if (len2 > 0) h2.update(b2, 0, len2)
-        i += len2
+        if (len3 > 0) h3.update(b3, 0, len3)
+        continue = len1 > 0 || len2 > 0 || len3 > 0
       }
 
-      assertEquals(bais.read(b1), bsis.read(b2))
-      assertEquals(h1.digest().toSeq, h2.digest().toSeq)
+      val digest = h1.digest().toSeq
+      assertEquals(digest, h2.digest().toSeq)
+      assertEquals(digest, h3.digest().toSeq)
+
+      bsis.close()
+      gzis.close()
     }
   }
 


### PR DESCRIPTION
Update the ByteStringInputStream to add a helper method for creating the stream that automatically wraps with a GZIP input stream if the data is compressed.