### PR TITLE
eval: compress subscription message

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcMessages.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcMessages.scala
@@ -27,6 +27,8 @@ import com.netflix.atlas.pekko.ByteStringInputStream
 import com.netflix.atlas.pekko.DiagnosticMessage
 
 import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+import java.util.zip.GZIPOutputStream
 
 /**
   * Helpers for working with messages coming back from the LWCAPI service.
@@ -40,7 +42,7 @@ object LwcMessages {
     * Parse the message string into an internal model object based on the type.
     */
   def parse(msg: ByteString): AnyRef = {
-    parse(Json.newJsonParser(new ByteStringInputStream(msg)))
+    parse(Json.newJsonParser(ByteStringInputStream.create(msg)))
   }
 
   /**
@@ -191,8 +193,13 @@ object LwcMessages {
   /**
     * Encode messages using Jackson's smile format into a ByteString.
     */
-  def encodeBatch(msgs: Seq[AnyRef]): ByteString = {
-    encodeBatch(msgs, new ByteArrayOutputStream())
+  def encodeBatch(msgs: Seq[AnyRef], compress: Boolean = false): ByteString = {
+    val baos = new ByteArrayOutputStream()
+    if (compress)
+      encodeBatchImpl(msgs, new GZIPOutputStream(baos))
+    else
+      encodeBatchImpl(msgs, baos)
+    ByteString.fromArrayUnsafe(baos.toByteArray)
   }
 
   /**
@@ -202,82 +209,90 @@ object LwcMessages {
     */
   def encodeBatch(msgs: Seq[AnyRef], baos: ByteArrayOutputStream): ByteString = {
     baos.reset()
-    val gen = Json.newSmileGenerator(baos)
-    try {
-      gen.writeStartArray()
-      msgs.foreach {
-        case msg: LwcExpression =>
-          gen.writeNumber(Expression)
-          gen.writeString(msg.expression)
-          if (msg.exprType != ExprType.TIME_SERIES)
-            gen.writeString(msg.exprType.name())
-          gen.writeNumber(msg.step)
-        case msg: LwcSubscription =>
-          gen.writeNumber(Subscription)
-          gen.writeString(msg.expression)
-          gen.writeStartArray()
-          msg.metrics.foreach { m =>
-            gen.writeString(m.id)
-            gen.writeString(m.expression)
-            gen.writeNumber(m.step)
-          }
-          gen.writeEndArray()
-        case msg: LwcSubscriptionV2 =>
-          gen.writeNumber(SubscriptionV2)
-          gen.writeString(msg.expression)
-          gen.writeString(msg.exprType.name())
-          gen.writeStartArray()
-          msg.subExprs.foreach { s =>
-            gen.writeString(s.id)
-            gen.writeString(s.expression)
-            gen.writeNumber(s.step)
-          }
-          gen.writeEndArray()
-        case msg: LwcDatapoint =>
-          gen.writeNumber(Datapoint)
-          gen.writeNumber(msg.timestamp)
-          gen.writeString(msg.id)
-          // Should already be sorted, but convert if needed to ensure we can rely on
-          // the order. It will be a noop if already a SortedTagMap.
-          val tags = SortedTagMap(msg.tags)
-          gen.writeNumber(tags.size)
-          tags.foreachEntry { (k, v) =>
-            gen.writeString(k)
-            gen.writeString(v)
-          }
-          gen.writeNumber(msg.value)
-        case msg: LwcDiagnosticMessage =>
-          gen.writeNumber(LwcDiagnostic)
-          gen.writeString(msg.id)
-          gen.writeString(msg.message.typeName)
-          gen.writeString(msg.message.message)
-        case msg: DiagnosticMessage =>
-          gen.writeNumber(Diagnostic)
-          gen.writeString(msg.typeName)
-          gen.writeString(msg.message)
-        case msg: LwcHeartbeat =>
-          gen.writeNumber(Heartbeat)
-          gen.writeNumber(msg.timestamp)
-          gen.writeNumber(msg.step)
-        case msg: LwcEvent =>
-          gen.writeNumber(Event)
-          gen.writeString(msg.id)
-          mapper.writeTree(gen, msg.payload)
-        case msg =>
-          throw new MatchError(s"$msg")
-      }
-      gen.writeEndArray()
-    } finally {
-      gen.close()
-    }
+    encodeBatchImpl(msgs, baos)
     ByteString.fromArrayUnsafe(baos.toByteArray)
+  }
+
+  private def encodeBatchImpl(msgs: Seq[AnyRef], out: OutputStream): Unit = {
+    try {
+      val gen = Json.newSmileGenerator(out)
+      try {
+        gen.writeStartArray()
+        msgs.foreach {
+          case msg: LwcExpression =>
+            gen.writeNumber(Expression)
+            gen.writeString(msg.expression)
+            if (msg.exprType != ExprType.TIME_SERIES)
+              gen.writeString(msg.exprType.name())
+            gen.writeNumber(msg.step)
+          case msg: LwcSubscription =>
+            gen.writeNumber(Subscription)
+            gen.writeString(msg.expression)
+            gen.writeStartArray()
+            msg.metrics.foreach { m =>
+              gen.writeString(m.id)
+              gen.writeString(m.expression)
+              gen.writeNumber(m.step)
+            }
+            gen.writeEndArray()
+          case msg: LwcSubscriptionV2 =>
+            gen.writeNumber(SubscriptionV2)
+            gen.writeString(msg.expression)
+            gen.writeString(msg.exprType.name())
+            gen.writeStartArray()
+            msg.subExprs.foreach { s =>
+              gen.writeString(s.id)
+              gen.writeString(s.expression)
+              gen.writeNumber(s.step)
+            }
+            gen.writeEndArray()
+          case msg: LwcDatapoint =>
+            gen.writeNumber(Datapoint)
+            gen.writeNumber(msg.timestamp)
+            gen.writeString(msg.id)
+            // Should already be sorted, but convert if needed to ensure we can rely on
+            // the order. It will be a noop if already a SortedTagMap.
+            val tags = SortedTagMap(msg.tags)
+            gen.writeNumber(tags.size)
+            tags.foreachEntry { (k, v) =>
+              gen.writeString(k)
+              gen.writeString(v)
+            }
+            gen.writeNumber(msg.value)
+          case msg: LwcDiagnosticMessage =>
+            gen.writeNumber(LwcDiagnostic)
+            gen.writeString(msg.id)
+            gen.writeString(msg.message.typeName)
+            gen.writeString(msg.message.message)
+          case msg: DiagnosticMessage =>
+            gen.writeNumber(Diagnostic)
+            gen.writeString(msg.typeName)
+            gen.writeString(msg.message)
+          case msg: LwcHeartbeat =>
+            gen.writeNumber(Heartbeat)
+            gen.writeNumber(msg.timestamp)
+            gen.writeNumber(msg.step)
+          case msg: LwcEvent =>
+            gen.writeNumber(Event)
+            gen.writeString(msg.id)
+            mapper.writeTree(gen, msg.payload)
+          case msg =>
+            throw new MatchError(s"$msg")
+        }
+        gen.writeEndArray()
+      } finally {
+        gen.close()
+      }
+    } finally {
+      out.close()
+    }
   }
 
   /**
     * Parse a set of messages that were encoded with `encodeBatch`.
     */
   def parseBatch(msgs: ByteString): List[AnyRef] = {
-    parseBatch(Json.newSmileParser(new ByteStringInputStream(msgs)))
+    parseBatch(Json.newSmileParser(ByteStringInputStream.create(msgs)))
   }
 
   private def parseBatch(parser: JsonParser): List[AnyRef] = {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -485,7 +485,7 @@ private[stream] abstract class EvaluatorImpl(
         // Cluster message first: need to connect before subscribe
         val instances = sourcesAndGroups._2.groups.flatMap(_.instances).toSet
         val exprs = toExprSet(sourcesAndGroups._1, context.interpreter)
-        val bytes = LwcMessages.encodeBatch(exprs.toSeq)
+        val bytes = LwcMessages.encodeBatch(exprs.toSeq, compress = true)
         val dataMap = instances.map(i => i -> bytes).toMap
         Source(
           List(

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
@@ -67,7 +67,7 @@ class SubscribeApiSuite extends MUnitRouteSuite {
 
       // Send list of expressions to subscribe to
       val exprs = List(LwcExpression("name,disk,:eq,:avg", ExprType.TIME_SERIES, 60000))
-      client.sendMessage(LwcMessages.encodeBatch(exprs))
+      client.sendMessage(LwcMessages.encodeBatch(exprs, compress = true))
 
       // Look for subscription messages, one for sum and one for count
       var subscriptions = List.empty[LwcSubscription]


### PR DESCRIPTION
There is a often quite a bit of redundancy. For a sample set of 40k expressions it reduced the message size from ~14MB to ~1MB.