### PR TITLE
build: enable unused warnings

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/graphics/Ticks.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/graphics/Ticks.scala
@@ -255,7 +255,7 @@ object Ticks {
     } else {
       valueTickSizes
         .find(t => r / t._1 <= n)
-        .fold(sciTicks(v1, v2, n))(t => decimalTicks(v1, v2, n, t, scale))
+        .fold(sciTicks(v1, v2))(t => decimalTicks(v1, v2, n, t, scale))
     }
   }
 
@@ -313,7 +313,7 @@ object Ticks {
 
     binaryValueTickSizes
       .find(t => r / t._1 <= n)
-      .fold(sciTicks(v1, v2, n))(t => binaryTicks(v1, v2, t))
+      .fold(sciTicks(v1, v2))(t => binaryTicks(v1, v2, t))
   }
 
   def duration(v1: Double, v2: Double, n: Int): List[ValueTick] = {
@@ -321,7 +321,7 @@ object Ticks {
 
     durationValueTickSizes
       .find(t => r / t._1 <= n)
-      .fold(sciTicks(v1, v2, n))(t => durationTicks(v1, v2, t))
+      .fold(sciTicks(v1, v2))(t => durationTicks(v1, v2, t))
   }
 
   /**
@@ -364,7 +364,7 @@ object Ticks {
     if (range < 1e-12) 1.0 else range
   }
 
-  private def sciTicks(v1: Double, v2: Double, n: Int): List[ValueTick] = {
+  private def sciTicks(v1: Double, v2: Double): List[ValueTick] = {
     List(ValueTick(v1, 0.0), ValueTick(v2, 0.0))
   }
 

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/graphics/TicksSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/graphics/TicksSuite.scala
@@ -232,7 +232,7 @@ class TicksSuite extends FunSuite {
   }
 
   test("sanity check, 0 to y") {
-    for (i <- 0 until 100; j <- 2 until 10) {
+    for (_ <- 0 until 100; j <- 2 until 10) {
       val v = Random.nextDouble() * 1e12
       try {
         val ticks = Ticks.value(0.0, v, j)
@@ -245,7 +245,7 @@ class TicksSuite extends FunSuite {
   }
 
   test("sanity check, y1 to y2") {
-    for (i <- 0 until 100; j <- 2 until 10) {
+    for (_ <- 0 until 100; j <- 2 until 10) {
       val v1 = Random.nextDouble() * 1e4
       val v2 = v1 + Random.nextDouble() * 1e3
       try {
@@ -379,7 +379,7 @@ class TicksSuite extends FunSuite {
   }
 
   test("binary sanity check, 0 to y") {
-    for (i <- 0 until 100; j <- 2 until 10) {
+    for (_ <- 0 until 100; j <- 2 until 10) {
       val v = Random.nextDouble() * 1e12
       try {
         val ticks = Ticks.binary(0.0, v, j)
@@ -392,7 +392,7 @@ class TicksSuite extends FunSuite {
   }
 
   test("binary sanity check, y1 to y2") {
-    for (i <- 0 until 100; j <- 2 until 10) {
+    for (_ <- 0 until 100; j <- 2 until 10) {
       val v1 = Random.nextDouble() * 1e4
       val v2 = v1 + Random.nextDouble() * 1e3
       try {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/BlockStore.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/BlockStore.scala
@@ -166,7 +166,7 @@ class MemoryBlockStore(step: Long, blockSize: Int, numBlocks: Int) extends Block
     }
   }
 
-  private def fill(blk: Block, buf: Array[Double], start: Long, end: Long, aggr: Int): Unit = {
+  private def fill(blk: Block, buf: Array[Double], start: Long, end: Long): Unit = {
     val s = start / step
     val e = end / step
     val bs = blk.start / step
@@ -198,7 +198,7 @@ class MemoryBlockStore(step: Long, blockSize: Int, numBlocks: Int) extends Block
     val buffer = ArrayHelper.fill(size, Double.NaN)
     var pos = 0
     while (pos < numBlocks) {
-      if (blocks(pos) != null) fill(blocks(pos), buffer, start, end, aggr)
+      if (blocks(pos) != null) fill(blocks(pos), buffer, start, end)
       pos += 1
     }
     buffer

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndex.scala
@@ -203,7 +203,7 @@ class RoaringTagIndex[T <: TaggedItem](items: Array[T], stats: IndexStats) exten
       case LessThan(k, v)         => lessThan(k, v, false)
       case LessThanEqual(k, v)    => lessThan(k, v, true)
       case q: In                  => findImpl(q.toOrQuery, offset)
-      case q: PatternQuery        => strPattern(q, offset)
+      case q: PatternQuery        => strPattern(q)
       case HasKey(k)              => hasKey(k, offset)
       case True                   => all.clone()
       case False                  => new RoaringBitmap()
@@ -289,7 +289,7 @@ class RoaringTagIndex[T <: TaggedItem](items: Array[T], stats: IndexStats) exten
     }
   }
 
-  private def strPattern(q: Query.PatternQuery, offset: Int): RoaringBitmap = {
+  private def strPattern(q: Query.PatternQuery): RoaringBitmap = {
     val kp = keyMap.get(q.k, -1)
     val vidx = itemIndex.get(kp)
     if (vidx == null) new RoaringBitmap()

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/TaggedItemIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/TaggedItemIndex.scala
@@ -78,7 +78,7 @@ class TaggedItemIndex private (
       case LessThan(k, v)         => lessThan(k, v, false)
       case LessThanEqual(k, v)    => lessThan(k, v, true)
       case q: In                  => find(q.toOrQuery, offset)
-      case q: PatternQuery        => strPattern(q, offset)
+      case q: PatternQuery        => strPattern(q)
       case HasKey(k)              => hasKey(k, offset)
       case True                   => all.clone()
       case False                  => new RoaringBitmap()
@@ -164,7 +164,7 @@ class TaggedItemIndex private (
     }
   }
 
-  private def strPattern(q: Query.PatternQuery, offset: Int): RoaringBitmap = {
+  private def strPattern(q: Query.PatternQuery): RoaringBitmap = {
     val kp = keyMap.get(q.k, -1)
     val vidx = keyValueIdx.get(kp)
     if (vidx == null) new RoaringBitmap()

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Block.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Block.scala
@@ -861,7 +861,7 @@ case class RollupBlock(sum: Block, count: Block, min: Block, max: Block) extends
   def update(pos: Int, value: Double): Unit = {
     if (!value.isNaN) {
       updateSum(pos, value)
-      updateCount(pos, value)
+      updateCount(pos)
       updateMin(pos, value)
       updateMax(pos, value)
     }
@@ -872,7 +872,7 @@ case class RollupBlock(sum: Block, count: Block, min: Block, max: Block) extends
     block.update(pos, Math.addNaN(block.get(pos), value))
   }
 
-  private def updateCount(pos: Int, value: Double): Unit = {
+  private def updateCount(pos: Int): Unit = {
     val block = count.asInstanceOf[MutableBlock]
     block.update(pos, Math.addNaN(block.get(pos), 1.0))
   }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Step.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Step.scala
@@ -20,7 +20,6 @@ package com.netflix.atlas.core.util
   */
 object Step {
 
-  private final val oneMilli = 1L
   private final val oneSecond = 1000L
   private final val oneMinute = 60000L
   private final val oneHour = 60 * oneMinute

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
@@ -470,10 +470,10 @@ object Strings {
         parseRefVar(refs, r)
       case UnixDate(d) =>
         val t = d.toLong match {
-          case v if v <= Integer.MAX_VALUE => Instant.ofEpochSecond(v)
-          case v if v <= millisCutoff      => Instant.ofEpochMilli(v)
-          case v if v <= microsCutoff      => ofEpoch(v, 1_000_000L, 1_000L)
-          case v                           => ofEpoch(v, 1_000_000_000L, 1L)
+          case v if v <= secondsCutoff => Instant.ofEpochSecond(v)
+          case v if v <= millisCutoff  => Instant.ofEpochMilli(v)
+          case v if v <= microsCutoff  => ofEpoch(v, 1_000_000L, 1_000L)
+          case v                       => ofEpoch(v, 1_000_000_000L, 1L)
         }
         ZonedDateTime.ofInstant(t, tz)
       case str =>

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/TagIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/TagIndexSuite.scala
@@ -17,7 +17,7 @@ package com.netflix.atlas.core.index
 
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.Tag
-import com.netflix.atlas.core.model.*
+import com.netflix.atlas.core.model.TimeSeries
 import munit.FunSuite
 
 object TagIndexSuite {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ClampSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ClampSuite.scala
@@ -32,8 +32,6 @@ class ClampSuite extends FunSuite {
     )
   )
 
-  private val des = StatefulExpr.Des(DataExpr.Sum(Query.Equal("name", "cpu")), 2, 0.1, 0.02)
-
   def eval(expr: TimeSeriesExpr, data: List[List[Datapoint]]): List[List[TimeSeries]] = {
     var state = Map.empty[StatefulExpr, Any]
     data.map { ts =>

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/PerStepSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/PerStepSuite.scala
@@ -18,8 +18,6 @@ package com.netflix.atlas.core.model
 import com.netflix.atlas.core.stacklang.Interpreter
 import munit.FunSuite
 
-import scala.language.postfixOps
-
 class PerStepSuite extends FunSuite {
 
   private val interpreter = Interpreter(MathVocabulary.allWords)

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/PercentilesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/PercentilesSuite.scala
@@ -323,7 +323,6 @@ class PercentilesSuite extends FunSuite {
     assertEquals(data.size, 2)
     List("even", "odd").zip(data).foreach {
       case (m, t) =>
-        val estimate = t.data(0L)
         assertEquals(t.tags, Map("name" -> "test", "mode" -> m, "percentile" -> " 90.0"))
         assertEquals(t.label, f"(percentile((mode=$m),  90.0) * 1000.0)")
     }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
@@ -470,7 +470,6 @@ class StringsSuite extends FunSuite {
   }
 
   test("parseDate, epoch + 4h") {
-    val ref = ZonedDateTime.of(2012, 2, 2, 3, 0, 0, 0, ZoneOffset.UTC)
     val expected = ZonedDateTime.of(1970, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC)
     assertEquals(parseDate("epoch+4h", ZoneOffset.UTC), expected)
   }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ConfigConstructorTestRule.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/validation/ConfigConstructorTestRule.scala
@@ -17,6 +17,6 @@ package com.netflix.atlas.core.validation
 
 import com.typesafe.config.Config
 
-class ConfigConstructorTestRule(config: Config) extends TagRule {
+class ConfigConstructorTestRule(@scala.annotation.nowarn config: Config) extends TagRule {
   override def validate(k: String, v: String): String = TagRule.Pass
 }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EddaSource.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EddaSource.scala
@@ -25,12 +25,10 @@ import org.apache.pekko.http.scaladsl.model.headers.*
 import org.apache.pekko.stream.scaladsl.Compression
 import org.apache.pekko.stream.scaladsl.Source
 import org.apache.pekko.util.ByteString
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.netflix.atlas.json.Json
 import com.netflix.atlas.pekko.ByteStringInputStream
 import com.typesafe.scalalogging.StrictLogging
 
-import java.nio.charset.StandardCharsets
 import scala.util.Failure
 import scala.util.Success
 

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -47,7 +47,6 @@ import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.eval.model.AggrDatapoint
 import com.netflix.atlas.eval.model.AggrValuesInfo
-import com.netflix.atlas.eval.model.ExprType
 import com.netflix.atlas.eval.model.LwcExpression
 import com.netflix.atlas.eval.model.LwcMessages
 import com.netflix.atlas.eval.model.TimeGroup

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
@@ -34,7 +34,6 @@ import com.netflix.atlas.core.model.TimeSeries
 import com.netflix.atlas.core.util.IdentityMap
 import com.netflix.atlas.eval.model.ArrayData
 import com.netflix.atlas.eval.model.ChunkData
-import com.netflix.atlas.eval.model.ExprType
 import com.netflix.atlas.eval.model.TimeGroup
 import com.netflix.atlas.eval.model.TimeGroupsTuple
 import com.netflix.atlas.eval.model.TimeSeriesMessage

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -19,7 +19,6 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.UUID
 import org.apache.pekko.NotUsed
-import org.apache.pekko.http.scaladsl.model.HttpRequest
 import org.apache.pekko.http.scaladsl.model.Uri
 import org.apache.pekko.stream.IOResult
 import org.apache.pekko.stream.Materializer
@@ -36,7 +35,6 @@ import com.netflix.atlas.eval.model.ExprType
 import com.netflix.atlas.eval.stream.Evaluator.DataSource
 import com.netflix.atlas.eval.stream.Evaluator.DataSources
 import com.netflix.atlas.json.JsonSupport
-import com.netflix.atlas.pekko.AccessLogger
 import com.netflix.atlas.pekko.DiagnosticMessage
 import com.netflix.atlas.pekko.PekkoHttpClient
 import com.netflix.atlas.pekko.StreamOps

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/package.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/package.scala
@@ -21,8 +21,6 @@ import org.apache.pekko.http.scaladsl.model.HttpResponse
 import org.apache.pekko.stream.scaladsl.Flow
 import com.netflix.atlas.eval.stream.Evaluator.DataSource
 import com.netflix.atlas.eval.stream.Evaluator.DataSources
-import com.netflix.atlas.json.JsonSupport
-import com.netflix.atlas.pekko.AccessLogger
 
 import scala.util.Try
 

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EddaSourceSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EddaSourceSuite.scala
@@ -221,7 +221,6 @@ class EddaSourceSuite extends FunSuite {
   }
 
   test("substitute, IPv6 preferred if available") {
-    val uri = "http://{ip}:{port}"
     val instance = EddaSource.Instance("i-1", Some("1.2.3.4"), Some("::1"))
     assertEquals(instance.substitute("http://{ip}:{port}"), "http://[::1]:7101")
   }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -21,15 +21,11 @@ import java.time.Duration
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
 import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.BroadcastHub
 import org.apache.pekko.stream.scaladsl.Flow
 import org.apache.pekko.stream.scaladsl.Keep
 import org.apache.pekko.stream.scaladsl.Sink
 import org.apache.pekko.stream.scaladsl.Source
-import org.apache.pekko.stream.scaladsl.StreamConverters
 import com.netflix.atlas.chart.util.SrcPath
-import com.netflix.atlas.core.model.FilterExpr.Filter
-import com.netflix.atlas.core.util.Streams
 import com.netflix.atlas.eval.model.ArrayData
 import com.netflix.atlas.eval.model.LwcDatapoint
 import com.netflix.atlas.eval.model.LwcDiagnosticMessage
@@ -44,9 +40,7 @@ import com.netflix.atlas.eval.stream.Evaluator.MessageEnvelope
 import com.netflix.atlas.json.Json
 import com.netflix.atlas.json.JsonSupport
 import com.netflix.atlas.pekko.DiagnosticMessage
-import com.netflix.atlas.pekko.StreamOps
 import com.netflix.spectator.api.DefaultRegistry
-import com.netflix.spectator.api.NoopRegistry
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigValueFactory
 import nl.jqno.equalsverifier.EqualsVerifier
@@ -57,7 +51,6 @@ import org.apache.pekko.util.ByteString
 
 import java.nio.file.Path
 import scala.concurrent.Await
-import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters.CollectionHasAsScala
@@ -815,7 +808,7 @@ class EvaluatorSuite extends FunSuite {
 
     val evaluator = new Evaluator(config, registry, system)
 
-    val future = Source(sampleData(1, 10))
+    val future = Source(input)
       .via(Flow.fromProcessor(() => evaluator.createDatapointProcessor(sources)))
       .runWith(Sink.seq[MessageEnvelope])
     Await.result(future, scala.concurrent.duration.Duration.Inf).toList

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
@@ -27,7 +27,6 @@ import com.netflix.atlas.eval.model.AggrDatapoint
 import com.netflix.atlas.eval.model.LwcMessages
 import com.netflix.atlas.eval.stream.Evaluator.DataSource
 import com.netflix.atlas.eval.stream.Evaluator.DataSources
-import com.netflix.atlas.json.JsonSupport
 import com.netflix.atlas.pekko.DiagnosticMessage
 import com.typesafe.config.ConfigFactory
 import munit.FunSuite

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
@@ -23,7 +23,6 @@ import com.netflix.spectator.api.Registry
 import com.typesafe.config.ConfigFactory
 import org.apache.pekko.http.scaladsl.model.StatusCodes
 
-import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/IntIntMap.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/IntIntMap.scala
@@ -70,7 +70,7 @@ class IntIntMap {
     val map = new java.util.HashMap[Int, Int](10)
     var i = 0
     while (i < values800.length) {
-      map.compute(values800(i), (k, v) => v + 1)
+      map.compute(values800(i), (_, v) => v + 1)
       i += 1
     }
     bh.consume(map)
@@ -94,7 +94,7 @@ class IntIntMap {
     val map = new java.util.HashMap[Int, Int](10)
     var i = 0
     while (i < values8k.length) {
-      map.compute(values8k(i), (k, v) => v + 1)
+      map.compute(values8k(i), (_, v) => v + 1)
       i += 1
     }
     bh.consume(map)

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.module.scala.JavaTypeable
 
 object Json {
 
-  final class Decoder[T: JavaTypeable](reader: ObjectReader, factory: JsonFactory) {
+  final class Decoder[T](reader: ObjectReader, factory: JsonFactory) {
 
     def decode(json: Array[Byte]): T = decode(factory.createParser(json))
 
@@ -155,19 +155,19 @@ object Json {
     smileFactory.createParser(bytes, 0, bytes.length)
   }
 
-  def encode[T: JavaTypeable](obj: T): String = {
+  def encode(obj: Any): String = {
     jsonMapper.writeValueAsString(obj)
   }
 
-  def encode[T: JavaTypeable](writer: Writer, obj: T): Unit = {
+  def encode(writer: Writer, obj: Any): Unit = {
     jsonMapper.writeValue(writer, obj)
   }
 
-  def encode[T: JavaTypeable](stream: OutputStream, obj: T): Unit = {
+  def encode(stream: OutputStream, obj: Any): Unit = {
     jsonMapper.writeValue(stream, obj)
   }
 
-  def encode[T: JavaTypeable](gen: JsonGenerator, obj: T): Unit = {
+  def encode(gen: JsonGenerator, obj: Any): Unit = {
     jsonMapper.writeValue(gen, obj)
   }
 
@@ -204,11 +204,11 @@ object Json {
     new Decoder[T](reader, jsonFactory)
   }
 
-  def smileEncode[T: JavaTypeable](obj: T): Array[Byte] = {
+  def smileEncode(obj: Any): Array[Byte] = {
     smileMapper.writeValueAsBytes(obj)
   }
 
-  def smileEncode[T: JavaTypeable](stream: OutputStream, obj: T): Unit = {
+  def smileEncode(stream: OutputStream, obj: Any): Unit = {
     smileMapper.writeValue(stream, obj)
   }
 

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
@@ -413,7 +413,7 @@ class JsonSuite extends FunSuite {
 
   test("smile encode/decode") {
     val v = List(1, 2, 3)
-    val b = Json.smileEncode[List[Int]](v)
+    val b = Json.smileEncode(v)
     assertEquals(Json.smileDecode[List[Int]](b), v)
   }
 

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/RemoteLwcEventClient.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/RemoteLwcEventClient.scala
@@ -26,7 +26,6 @@ import com.typesafe.scalalogging.StrictLogging
 
 import java.io.ByteArrayOutputStream
 import java.net.URI
-import java.time.Duration
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/TraceMatcherSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/TraceMatcherSuite.scala
@@ -109,7 +109,7 @@ class TraceMatcherSuite extends FunSuite {
     val q3 = ExprUtils
       .parseTraceEventsQuery("app,a,:eq,app,c,:eq,:child,app,e,:eq,:child,app,g,:eq,:child")
       .q
-    checkMatch(q1, true)
+    checkMatch(q3, true)
   }
 }
 

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/WebSocketSessionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/WebSocketSessionManager.scala
@@ -29,7 +29,6 @@ import org.apache.pekko.util.ByteString
 import com.netflix.atlas.eval.model.LwcExpression
 import com.netflix.atlas.eval.model.LwcMessages
 import com.netflix.atlas.json.JsonSupport
-import com.netflix.atlas.lwcapi.SubscribeApi.ErrorMsg
 import com.netflix.atlas.pekko.DiagnosticMessage
 import com.typesafe.scalalogging.StrictLogging
 

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/WebSocketSessionManagerSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/WebSocketSessionManagerSuite.scala
@@ -23,7 +23,6 @@ import com.netflix.atlas.eval.model.ExprType
 import com.netflix.atlas.eval.model.LwcExpression
 import com.netflix.atlas.eval.model.LwcMessages
 import com.netflix.atlas.json.JsonSupport
-import com.netflix.atlas.lwcapi.SubscribeApi.ErrorMsg
 import munit.FunSuite
 import org.apache.pekko.util.ByteString
 

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/AccessLogger.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/AccessLogger.scala
@@ -35,13 +35,8 @@ import scala.util.Try
   *
   * @param entry
   *     Spectator log entry object that formats the log and updates metrics.
-  * @param client
-  *     True if the logger if for a client rather than a server. Clients are
-  *     typically logged based on a name given to the client by the application.
-  *     Server logs based on the endpoint. They will also be marked
-  *     so that they can be partitioned into separate files if needed.
   */
-class AccessLogger private (entry: IpcLogEntry, client: Boolean) {
+class AccessLogger private (entry: IpcLogEntry) {
 
   private var attempt: Int = 1
   private var maxAttempts: Int = 1
@@ -124,7 +119,7 @@ object AccessLogger {
     val entry = ipcLogger.createClientEntry().withOwner(owner).addTag("id", name)
     addRequestInfo(entry, request)
     entry.markStart()
-    new AccessLogger(entry, true)
+    new AccessLogger(entry)
   }
 
   /**
@@ -143,7 +138,7 @@ object AccessLogger {
     */
   def newServerLogger(entry: IpcLogEntry): AccessLogger = {
     entry.withOwner(owner).markStart()
-    new AccessLogger(entry, false)
+    new AccessLogger(entry)
   }
 
   private def addRequestInfo(entry: IpcLogEntry, request: HttpRequest): Unit = {

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/CustomDirectives.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/CustomDirectives.scala
@@ -15,9 +15,7 @@
  */
 package com.netflix.atlas.pekko
 
-import java.io.InputStream
 import java.io.StringWriter
-import java.util.zip.GZIPInputStream
 import org.apache.pekko.http.scaladsl.model.HttpCharsets
 import org.apache.pekko.http.scaladsl.model.HttpEntity
 import org.apache.pekko.http.scaladsl.model.HttpHeader
@@ -84,17 +82,16 @@ object CustomDirectives {
     * `application/x-jackson-smile`, then a smile parser will be used. Otherwise
     * it will be treated as `application/json` regardless of the content type.
     */
-  def customJson[T: JavaTypeable](decoder: JsonParser => T): MediaType => ByteString => T = {
-    mediaType => bs =>
-      {
-        val p =
-          if (isSmile(mediaType))
-            Json.newSmileParser(ByteStringInputStream.create(bs))
-          else
-            Json.newJsonParser(ByteStringInputStream.create(bs))
-        try decoder(p)
-        finally p.close()
-      }
+  def customJson[T](decoder: JsonParser => T): MediaType => ByteString => T = { mediaType => bs =>
+    {
+      val p =
+        if (isSmile(mediaType))
+          Json.newSmileParser(ByteStringInputStream.create(bs))
+        else
+          Json.newJsonParser(ByteStringInputStream.create(bs))
+      try decoder(p)
+      finally p.close()
+    }
   }
 
   /**

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/UnboundedMeteredMailbox.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/UnboundedMeteredMailbox.scala
@@ -73,8 +73,10 @@ object UnboundedMeteredMailbox {
   }
 }
 
-class UnboundedMeteredMailbox(settings: ActorSystem.Settings, config: Config)
-    extends MailboxType
+class UnboundedMeteredMailbox(
+  @scala.annotation.nowarn settings: ActorSystem.Settings,
+  config: Config
+) extends MailboxType
     with ProducesMessageQueue[UnboundedMeteredMailbox.MeteredMessageQueue] {
 
   import UnboundedMeteredMailbox.*

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/PekkoHttpClientSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/PekkoHttpClientSuite.scala
@@ -39,7 +39,6 @@ import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.stream.Collectors
 import scala.concurrent.Await
-import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
@@ -51,7 +50,6 @@ class PekkoHttpClientSuite extends FunSuite {
 
   import PekkoHttpClientSuite.*
   private implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)
-  private implicit val ec: ExecutionContext = system.dispatcher
 
   override def afterAll(): Unit = {
     system.terminate()

--- a/atlas-postgres/src/test/scala/com/netflix/atlas/postgres/SqlUtilsSuite.scala
+++ b/atlas-postgres/src/test/scala/com/netflix/atlas/postgres/SqlUtilsSuite.scala
@@ -23,7 +23,6 @@ import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.stacklang.Interpreter
 
 import java.time.Instant
-import scala.util.Using
 
 class SqlUtilsSuite extends PostgresSuite {
 
@@ -361,13 +360,6 @@ class SqlUtilsSuite extends PostgresSuite {
       ) as t(vs)
       """
     assertEquals(arrayQuery(sql), list(8.0, 7.0, null))
-  }
-
-  private def arrayValues(rs: java.sql.ResultSet, i: Int): List[Any] = {
-    rs.getArray(i)
-      .getArray
-      .asInstanceOf[Array[java.lang.Double]]
-      .toList
   }
 
   test("aggrSum, state should not be preserved") {

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/FetchRequestSource.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/FetchRequestSource.scala
@@ -17,7 +17,6 @@ package com.netflix.atlas.webapi
 
 import com.fasterxml.jackson.core.JsonGenerator
 import com.netflix.atlas.chart.JsonCodec
-import com.netflix.atlas.chart.model.PlotDef
 
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -48,7 +47,6 @@ import com.netflix.atlas.core.model.TimeSeries
 import com.netflix.atlas.eval.graph.GraphConfig
 import com.netflix.atlas.eval.model.TimeSeriesMessage
 import com.netflix.atlas.json.Json
-import com.netflix.atlas.json.JsonSupport
 import com.netflix.atlas.pekko.DiagnosticMessage
 import com.netflix.atlas.webapi.GraphApi.DataRequest
 import com.netflix.atlas.webapi.GraphApi.DataResponse

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalPublishActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalPublishActor.scala
@@ -87,16 +87,8 @@ object LocalPublishActor {
     *     Registry for keeping track of metrics.
     * @param memDb
     *     Database that will receive the final processed datapoints.
-    * @param maxMessageIds
-    *     Maximum number of message ids to track. If this limit is exceeded, then it
-    *     is possible for duplicate messages to get processed which may lead to over
-    *     counting if rollups are being used.
     */
-  private[webapi] class DatapointProcessor(
-    registry: Registry,
-    memDb: MemoryDatabase,
-    maxMessageIds: Int = 1000000
-  ) {
+  private[webapi] class DatapointProcessor(registry: Registry, memDb: MemoryDatabase) {
 
     // Track the ages of data flowing into the system. Data is expected to arrive quickly and
     // should hit the backend within the step interval used.

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -8,7 +8,6 @@ object BuildSettings {
     "-deprecation",
     "-unchecked",
     "-Werror",
-    "-Wunused",
     "-feature",
     "-release", "17",
   )
@@ -23,8 +22,8 @@ object BuildSettings {
     scalaVersion := Dependencies.Versions.scala,
     scalacOptions := {
       CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) => compilerFlags ++ Seq("-Xsource:3")
-        case _            => compilerFlags ++ Seq("-source", "3.3")
+        case Some((2, _)) => compilerFlags ++ Seq("-Xsource:3", "-Wunused")
+        case _            => compilerFlags ++ Seq("-source", "3.3", "-Wunused:all")
       }
     },
     javacOptions ++= Seq("--release", "17"),

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -7,8 +7,8 @@ object BuildSettings {
   val compilerFlags: Seq[String] = Seq(
     "-deprecation",
     "-unchecked",
-    //"-Xlint:_,-infer-any",
-    "-Xfatal-warnings",
+    "-Werror",
+    "-Wunused",
     "-feature",
     "-release", "17",
   )


### PR DESCRIPTION
These were disabled some time back during some version updates where something wasn't working correctly. Re-enable and cleanup a bunch of unused warnings.