### PR TITLE
core: fix example for :table

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/EventVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/EventVocabulary.scala
@@ -48,6 +48,6 @@ object EventVocabulary extends Vocabulary {
         |Find matching events and create a row by extracting the specified columns.
         |""".stripMargin
 
-    override def examples: List[String] = List("name,sps,:eq")
+    override def examples: List[String] = List("level,ERROR,:eq,(,message,)")
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/EventExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/EventExamplesSuite.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.atlas.core.stacklang.BaseExamplesSuite
+import com.netflix.atlas.core.stacklang.Vocabulary
+
+class EventExamplesSuite extends BaseExamplesSuite {
+
+  override def vocabulary: Vocabulary = EventVocabulary
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TraceExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TraceExamplesSuite.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.atlas.core.stacklang.BaseExamplesSuite
+import com.netflix.atlas.core.stacklang.Vocabulary
+
+class TraceExamplesSuite extends BaseExamplesSuite {
+
+  override def vocabulary: Vocabulary = TraceVocabulary
+}


### PR DESCRIPTION
The example stack was not valid. Fix it and add tests for the examples on event and trace vocabularies.