### PR TITLE
eval: remove legacy eureka-uri property

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -65,7 +65,7 @@ private[stream] class StreamContext(
     config.getConfigList("backends").asScala.toList.map { cfg =>
       // URI for Edda service. For backwards compatibility Eureka name is also
       // checked.
-      val eddaUri = cfg.getString(if (cfg.hasPath("edda-uri")) "edda-uri" else "eureka-uri")
+      val eddaUri = cfg.getString("edda-uri")
       val checkForExpensiveQueries = isNotFalse(cfg, "check-for-expensive-queries")
       EddaBackend(
         cfg.getString("host"),

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
@@ -39,7 +39,7 @@ object TestContext {
       |  backends = [
       |    {
       |      host = "localhost"
-      |      eureka-uri = "http://localhost:7102/v2/vips/local-dev:7001"
+      |      edda-uri = "http://localhost:7102/v2/vips/local-dev:7001"
       |      instance-uri = "http://{host}:{port}"
       |    },
       |    {


### PR DESCRIPTION
Uses have migrated to edda-uri.