### PR TITLE
add event sample operator

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/EventExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/EventExpr.scala
@@ -55,4 +55,29 @@ object EventExpr {
       Interpreter.append(builder, query, columns, ":table")
     }
   }
+
+  /**
+    * Expression that specifies how to map an event to a simple row with the specified columns.
+    *
+    * @param query
+    *     Query to determine if an event should be matched.
+    * @param sampleBy
+    *     The set of tag values to extract for purposes of the sampling groups. A value will be
+    *     sent for each distinct sample group.
+    * @param projectionKeys
+    *     Set of columns to export into a row.
+    */
+  case class Sample(query: Query, sampleBy: List[String], projectionKeys: List[String])
+      extends EventExpr {
+
+    require(sampleBy.nonEmpty, "sampleBy cannot be empty")
+
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, query, sampleBy, projectionKeys, ":sample")
+    }
+
+    def dataExpr: DataExpr = {
+      DataExpr.GroupBy(DataExpr.Sum(query), sampleBy)
+    }
+  }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/EventVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/EventVocabulary.scala
@@ -25,7 +25,7 @@ object EventVocabulary extends Vocabulary {
 
   val dependsOn: List[Vocabulary] = List(QueryVocabulary)
 
-  override def words: List[Word] = List(TableWord)
+  override def words: List[Word] = List(SampleWord, TableWord)
 
   case object TableWord extends SimpleWord {
 
@@ -49,5 +49,32 @@ object EventVocabulary extends Vocabulary {
         |""".stripMargin
 
     override def examples: List[String] = List("level,ERROR,:eq,(,message,)")
+  }
+
+  case object SampleWord extends SimpleWord {
+
+    import ModelExtractors.*
+
+    override def name: String = "sample"
+
+    override protected def matcher: PartialFunction[List[Any], Boolean] = {
+      case StringListType(_) :: StringListType(_) :: (_: Query) :: _ => true
+    }
+
+    override protected def executor: PartialFunction[List[Any], List[Any]] = {
+      case StringListType(pks) :: StringListType(by) :: (q: Query) :: stack =>
+        EventExpr.Sample(q, by, pks) :: stack
+    }
+
+    override def signature: String = "q:Query sampleBy:List projectionKeys:List -- EventExpr"
+
+    override def summary: String =
+      """
+        |Find matching events and sample based on a set of keys. The output will be a count
+        |for the step interval along with some sample data for that group based on the projection
+        |keys.
+        |""".stripMargin
+
+    override def examples: List[String] = List("level,ERROR,:eq,(,fingerprint,),(,message,)")
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/EventVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/EventVocabularySuite.scala
@@ -43,4 +43,11 @@ class EventVocabularySuite extends FunSuite {
     assertEquals(table.columns, List("a", "b"))
     assertEquals(table.query, Query.Equal("name", "sps"))
   }
+
+  test("sample, empty set of sampleBy") {
+    val e = intercept[IllegalArgumentException] {
+      parse("name,sps,:eq,(,),(,message,),:sample")
+    }
+    assert(e.getMessage.contains("sampleBy cannot be empty"))
+  }
 }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
@@ -49,6 +49,9 @@ import com.netflix.spectator.api.Registry
   *     Tags associated with the datapoint.
   * @param value
   *     Value for the datapoint.
+  * @param samples
+  *     Optional set of event samples associated with the message. Typically used when
+  *     mapping events into a count with a few sample messages.
   */
 case class AggrDatapoint(
   timestamp: Long,
@@ -56,7 +59,8 @@ case class AggrDatapoint(
   expr: DataExpr,
   source: String,
   tags: Map[String, String],
-  value: Double
+  value: Double,
+  samples: List[List[Any]] = Nil
 ) {
 
   /**

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcDatapoint.scala
@@ -16,6 +16,7 @@
 package com.netflix.atlas.eval.model
 
 import com.fasterxml.jackson.core.JsonGenerator
+import com.netflix.atlas.json.Json
 import com.netflix.atlas.json.JsonSupport
 
 /**
@@ -31,9 +32,17 @@ import com.netflix.atlas.json.JsonSupport
   *     Tags associated with the datapoint.
   * @param value
   *     Value for the datapoint.
+  * @param samples
+  *     Optional set of event samples associated with the message. Typically used when
+  *     mapping events into a count with a few sample messages.
   */
-case class LwcDatapoint(timestamp: Long, id: String, tags: Map[String, String], value: Double)
-    extends JsonSupport {
+case class LwcDatapoint(
+  timestamp: Long,
+  id: String,
+  tags: Map[String, String],
+  value: Double,
+  samples: List[List[Any]] = Nil
+) extends JsonSupport {
 
   val `type`: String = "datapoint"
 
@@ -48,6 +57,10 @@ case class LwcDatapoint(timestamp: Long, id: String, tags: Map[String, String], 
     tags.foreachEntry(gen.writeStringField)
     gen.writeEndObject()
     gen.writeNumberField("value", value)
+    if (samples.nonEmpty) {
+      gen.writeFieldName("samples")
+      Json.encode(gen, samples)
+    }
     gen.writeEndObject()
   }
 }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeSeriesMessage.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/TimeSeriesMessage.scala
@@ -20,6 +20,7 @@ import com.netflix.atlas.chart.model.LineStyle
 import com.netflix.atlas.chart.model.Palette
 import com.netflix.atlas.core.model.*
 import com.netflix.atlas.core.util.Strings
+import com.netflix.atlas.json.Json
 import com.netflix.atlas.json.JsonSupport
 
 import java.awt.Color
@@ -57,6 +58,9 @@ import java.time.Duration
   *     Data for the time series.
   * @param styleMetadata
   *     Metadata for presentation details related to how to render the line.
+  * @param samples
+  *     Optional set of event samples associated with the message. Typically used when
+  *     mapping events into a count with a few sample messages.
   */
 case class TimeSeriesMessage(
   id: String,
@@ -68,7 +72,8 @@ case class TimeSeriesMessage(
   label: String,
   tags: Map[String, String],
   data: ChunkData,
-  styleMetadata: Option[LineStyleMetadata]
+  styleMetadata: Option[LineStyleMetadata],
+  samples: List[List[Any]]
 ) extends JsonSupport {
 
   override def hasCustomEncoding: Boolean = true
@@ -96,6 +101,10 @@ case class TimeSeriesMessage(
     gen.writeNumberField("step", step)
     gen.writeFieldName("data")
     data.encode(gen)
+    if (samples.nonEmpty) {
+      gen.writeFieldName("samples")
+      Json.encode(gen, samples)
+    }
     gen.writeEndObject()
   }
 
@@ -150,7 +159,8 @@ object TimeSeriesMessage {
       ts.label,
       outputTags,
       ArrayData(data.data),
-      palette.map(p => createStyleMetadata(expr, ts.label, p))
+      palette.map(p => createStyleMetadata(expr, ts.label, p)),
+      Nil
     )
   }
 

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
@@ -221,6 +221,14 @@ class ExprInterpreter(config: Config) {
     exprType -> exprs.distinct
   }
 
+  /** Parse sampled event expression URI. */
+  def parseSampleExpr(uri: Uri): List[EventExpr.Sample] = {
+    determineExprType(uri) match {
+      case ExprType.EVENTS => evalEvents(uri).collect { case s: EventExpr.Sample => s }
+      case _               => Nil
+    }
+  }
+
   def dataExprs(uri: Uri): List[String] = {
     val exprs = determineExprType(uri) match {
       case ExprType.TIME_SERIES       => eval(uri).exprs.flatMap(_.expr.dataExprs)

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcMessagesSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcMessagesSuite.scala
@@ -104,6 +104,32 @@ class LwcMessagesSuite extends FunSuite {
     assertEquals(actual, expected)
   }
 
+  private def checkSamples(samples: List[List[Any]]): Unit = {
+    val tags = Map("foo" -> "bar")
+    val input = LwcDatapoint(step, "a", tags, 42.0, samples)
+    val actual = LwcMessages.parse(Json.encode(input))
+    val expected = input.copy(samples = Json.decode[List[List[JsonNode]]](Json.encode(samples)))
+    assertEquals(actual, expected)
+  }
+
+  test("datapoint, with samples empty") {
+    checkSamples(Nil)
+  }
+
+  test("datapoint, with samples empty rows") {
+    checkSamples(List(Nil, Nil, Nil))
+  }
+
+  test("datapoint, with samples") {
+    val tags = Map("foo" -> "bar")
+    checkSamples(List(List("a", tags)))
+  }
+
+  test("datapoint, with samples uneven") {
+    val tags = Map("foo" -> "bar")
+    checkSamples(List(List("a", tags), Nil, List("b", tags)))
+  }
+
   test("event") {
     val payload = Json.decode[JsonNode]("""{"foo":"bar"}""")
     val expected = LwcEvent("123", payload)

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/TimeSeriesMessageSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/TimeSeriesMessageSuite.scala
@@ -29,7 +29,8 @@ class TimeSeriesMessageSuite extends FunSuite {
     label = "test",
     tags = Map("name" -> "sps", "cluster" -> "www"),
     data = ArrayData(Array(42.0)),
-    None
+    None,
+    Nil
   )
 
   test("json encoding with empty group by") {

--- a/atlas-lwc-events/src/main/resources/reference.conf
+++ b/atlas-lwc-events/src/main/resources/reference.conf
@@ -22,4 +22,8 @@ atlas.lwc.events {
 
   // Max payload size for events data. Default max payload size for server is 8MiB.
   payload-size = 7MiB
+
+  // Maximum size for a group by. Used to avoid OOM for group by with a high cardinality dimension.
+  // If exceeded new groups will be dropped.
+  max-groups = 10000
 }

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/DatapointEvent.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/DatapointEvent.scala
@@ -29,12 +29,15 @@ import com.netflix.atlas.json.Json
   *     Timestamp for the data point.
   * @param value
   *     Value for the data point.
+  * @param samples
+  *     Optional set of event samples associated with the message.
   */
 case class DatapointEvent(
   id: String,
   tags: Map[String, String],
   timestamp: Long,
-  override val value: Double
+  override val value: Double,
+  samples: List[List[Any]] = Nil
 ) extends LwcEvent {
 
   override def rawEvent: Any = this


### PR DESCRIPTION
This operator allows events to be sampled based on a set of tag keys. It works similar to an analytics group by, but will capture some projection fields for a sample event to provide more context to the consumer.

This change also adds a max groups limit for the LWC events client. The limit is needed to help avoid excessive memory usage if the sampling keys have a high cardinality.