### PR TITLE
lwc-events: encode samples associated with datapoint

### DIFF
--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/RemoteLwcEventClient.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/RemoteLwcEventClient.scala
@@ -258,6 +258,8 @@ class RemoteLwcEventClient(registry: Registry, config: Config)
     }
     gen.writeEndObject()
     gen.writeNumberField("value", event.value)
+    gen.writeFieldName("samples")
+    Json.encode(gen, event.samples)
     gen.writeEndObject()
   }
 

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/EvaluateApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/EvaluateApi.scala
@@ -51,7 +51,7 @@ class EvaluateApi(registry: Registry, sm: StreamSubscriptionManager)
             req.metrics.groupBy(_.id).foreach {
               case (id, ms) =>
                 val datapoints = ms.map { m =>
-                  LwcDatapoint(timestamp, m.id, m.tags, m.value)
+                  LwcDatapoint(timestamp, m.id, m.tags, m.value, m.samples)
                 }
                 evaluate(addr, id, datapoints)
             }
@@ -87,7 +87,8 @@ object EvaluateApi {
   case class Item(
     id: String,
     @JsonDeserialize(`using` = classOf[SortedTagMapDeserializer]) tags: SortedTagMap,
-    value: Double
+    value: Double,
+    samples: List[List[Any]]
   )
 
   case class EvaluateRequest(

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/EvaluateApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/EvaluateApiSuite.scala
@@ -45,7 +45,7 @@ class EvaluateApiSuite extends MUnitRouteSuite {
   }
 
   test("post metrics") {
-    val metrics = List(Item("abc", SortedTagMap("a" -> "1"), 42.0))
+    val metrics = List(Item("abc", SortedTagMap("a" -> "1"), 42.0, Nil))
     val json = EvaluateRequest(1234L, metrics, Nil, Nil).toJson
     Post("/lwc/api/v1/evaluate", json) ~> routes ~> check {
       assertEquals(response.status, StatusCodes.OK)


### PR DESCRIPTION
Update remote client to encode the samples and lwcapi to read them.