### PR TITLE
lwcapi: fix npe when samples missing

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/EvaluateApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/EvaluateApi.scala
@@ -88,7 +88,7 @@ object EvaluateApi {
     id: String,
     @JsonDeserialize(`using` = classOf[SortedTagMapDeserializer]) tags: SortedTagMap,
     value: Double,
-    samples: List[List[Any]]
+    samples: List[List[Any]] = Nil
   )
 
   case class EvaluateRequest(

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/EvaluateApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/EvaluateApiSuite.scala
@@ -88,4 +88,10 @@ class EvaluateApiSuite extends MUnitRouteSuite {
       assertEquals(response.status, StatusCodes.OK)
     }
   }
+
+  test("item samples decode") {
+    val json = """{"id":"1","tags":{"name":"test"},"value":1.0}"""
+    val expected = EvaluateApi.Item("1", SortedTagMap("name" -> "test"), 1.0, Nil)
+    assertEquals(Json.decode[EvaluateApi.Item](json), expected)
+  }
 }


### PR DESCRIPTION
If the payload didn't include a samples key, then it would get set to `null` and result in errors. Default to an empty list.