### PR TITLE
lwc-events: add trace log for bad events payload

### DIFF
--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/RemoteLwcEventClient.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/RemoteLwcEventClient.scala
@@ -225,6 +225,7 @@ class RemoteLwcEventClient(registry: Registry, config: Config)
       } catch {
         case e: Exception =>
           logger.warn("failed to send events", e)
+          logger.trace(s"failed event payload: $payload", e)
           droppedSend.increment(payload.size)
       }
     }


### PR DESCRIPTION
In some cases we see serialization fail. Add a trace level log to help debug those that will output the toString value for the payload.