### PR TITLE
json: enabled lenient UTF encoding

### DIFF
--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.core.json.JsonWriteFeature
 import com.fasterxml.jackson.databind.*
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.dataformat.smile.SmileFactory
+import com.fasterxml.jackson.dataformat.smile.SmileGenerator
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
@@ -75,6 +76,7 @@ object Json {
     .builder()
     .enable(StreamReadFeature.AUTO_CLOSE_SOURCE)
     .enable(StreamWriteFeature.AUTO_CLOSE_TARGET)
+    .enable(SmileGenerator.Feature.LENIENT_UTF_ENCODING)
     .build()
 
   private val jsonMapper = newMapper(jsonFactory)

--- a/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
+++ b/atlas-json/src/test/scala/com/netflix/atlas/json/JsonSuite.scala
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.core.JsonToken
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.node.ObjectNode
 import munit.FunSuite
 
 import java.time.Instant
@@ -446,6 +447,15 @@ class JsonSuite extends FunSuite {
     val obj = Json.decode[JsonSuiteArrayString]("""{"name":"name", "values":[]}""")
     val json = Json.encode(obj)
     assertEquals(json, """{"name":"name","values":[]}""")
+  }
+
+  test("unmatched surrogate pairs") {
+    val json = "{\"test\": 1, \"test\uD83D\": 2}"
+    val jsonNode = Json.decode[ObjectNode](json)
+    val smile = Json.smileEncode(jsonNode)
+    val smileNode = Json.smileDecode[ObjectNode](smile)
+    val expected = Json.decode[ObjectNode](json.replace('\uD83D', '\uFFFD'))
+    assertEquals(smileNode, expected)
   }
 
   test("decode from JsonData") {


### PR DESCRIPTION
When using smile enable lenient UTF encoding. In some cases log strings can have invalid UTF characters that work for encoding as JSON, but fail surrogate checks with smile. The lenient encoding allows these to go through, but replaces the invalid characters with `\uFFFD`.