### PR TITLE
core: support query matching using tags function

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
@@ -25,6 +25,7 @@ class QuerySuite extends FunSuite {
   def matches(q: Query, tags: Map[String, String]): Boolean = {
     val result = q.matches(tags)
     assertEquals(result, q.matches(SortedTagMap(tags)))
+    assertEquals(result, q.matches(SortedTagMap(tags).getOrNull _))
     result
   }
 

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/LwcEventClientSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/LwcEventClientSuite.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.lwc.events
 
+import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.util.SortedTagMap
 import com.netflix.atlas.json.Json
 import com.netflix.spectator.api.Clock
@@ -217,6 +218,13 @@ class LwcEventClientSuite extends FunSuite {
     assertEquals(vs.size, 1)
     assert(vs.forall(_.contains(""""tags":{"value":"duration"}""")))
     assert(vs.forall(_.contains(""""value":8.4""")))
+  }
+
+  test("check if event matches query") {
+    val matching = Query.And(Query.Equal("app", "www"), Query.Equal("node", "i-123"))
+    val nonMatching = Query.And(Query.Equal("app", "www"), Query.Equal("node", "i-124"))
+    assert(matching.matches(sampleLwcEvent.tagValue _))
+    assert(!nonMatching.matches(sampleLwcEvent.tagValue _))
   }
 }
 


### PR DESCRIPTION
Add `Query.matches` overload that takes a function to supply the tags. This can be used for cases like `LwcEvent` to do matching where the data structure for the tags may not be known.