### PR TITLE
eval: make backend ws pattern configurable

### DIFF
--- a/atlas-eval/src/main/resources/reference.conf
+++ b/atlas-eval/src/main/resources/reference.conf
@@ -9,6 +9,10 @@ atlas.eval {
         edda-uri = "http://localhost:7102/api/v1/autoScalingGroups/local-dev:7001"
       }
     ]
+
+    // Pattern to use for backend URIs
+    backend-uri-pattern = "ws://{ip}:{port}"
+
     // Number of buffers to use for the time grouping. More buffers means that data has
     // more time to accumulate and there is less chance of data being dropped because it
     // is too old

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -92,6 +92,9 @@ private[stream] abstract class EvaluatorImpl(
   // Cached context instance used for things like expression validation.
   private val validationStreamContext = newStreamContext(new ThrowingDSLogger)
 
+  // URI pattern for web-socket request to backend
+  private val backendUriPattern = config.getString("atlas.eval.stream.backend-uri-pattern")
+
   // Timeout for DataSources unique operator: emit repeating DataSources after timeout exceeds
   private val uniqueTimeout: Long = config.getDuration("atlas.eval.stream.unique-timeout").toMillis
 
@@ -533,7 +536,7 @@ private[stream] abstract class EvaluatorImpl(
   private def createWebSocketFlow(
     instance: EddaSource.Instance
   ): Flow[ByteString, ByteString, NotUsed] = {
-    val base = instance.substitute("ws://{ip}:{port}")
+    val base = instance.substitute(backendUriPattern)
     val id = UUID.randomUUID().toString
     val uri = s"$base/api/v$lwcapiVersion/subscribe/$id"
     val webSocketFlowOrigin = Http(system).webSocketClientFlow(WebSocketRequest(uri))


### PR DESCRIPTION
Allow the pattern to be customized so secure option can be used for use-cases other than local testing.