### PR TITLE
core: fix corner cases with less than comparison

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/RoaringTagIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/RoaringTagIndexSuite.scala
@@ -15,7 +15,9 @@
  */
 package com.netflix.atlas.core.index
 
+import com.netflix.atlas.core.model.BasicTaggedItem
 import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.TimeSeries
 import org.roaringbitmap.RoaringBitmap
 
@@ -59,5 +61,169 @@ class RoaringTagIndexSuite extends TagIndexSuite {
     (1 until 21 by 2).foreach(b2.add)
     b2.add(20)
     assert(RoaringTagIndex.hasNonEmptyIntersection(b1, b2))
+  }
+
+  private def createLessThanIndex: TagIndex[BasicTaggedItem] = {
+    val items = (0 until 10).map { i =>
+      val tags = Map(
+        "name" -> "test",
+        "a" -> i.toString,
+        "b" -> "foo"
+      )
+      BasicTaggedItem(tags)
+    }
+    RoaringTagIndex(items.toArray, new IndexStats())
+  }
+
+  test("lt, first element for tag") {
+    val idx = createLessThanIndex
+    val q = Query.LessThan("a", "0")
+    val rs = idx.findItems(TagQuery(Some(q)))
+    assertEquals(rs.map(_.tags("a")).toSet, Set.empty[String])
+  }
+
+  test("lt, second element for tag") {
+    val idx = createLessThanIndex
+    val q = Query.LessThan("a", "1")
+    val rs = idx.findItems(TagQuery(Some(q)))
+    assertEquals(rs.map(_.tags("a")).toSet, Set("0"))
+  }
+
+  test("lt, missing element after first for tag") {
+    val idx = createLessThanIndex
+    val q = Query.LessThan("a", "00")
+    val rs = idx.findItems(TagQuery(Some(q)))
+    assertEquals(rs.map(_.tags("a")).toSet, Set("0"))
+  }
+
+  test("lt, last element for tag") {
+    val idx = createLessThanIndex
+    val q = Query.LessThan("a", "9")
+    val rs = idx.findItems(TagQuery(Some(q)))
+    assertEquals(rs.map(_.tags("a")).toSet, (0 until 9).map(_.toString).toSet)
+  }
+
+  test("lt, after last element for tag") {
+    val idx = createLessThanIndex
+    val q = Query.LessThan("a", "a")
+    val rs = idx.findItems(TagQuery(Some(q)))
+    assertEquals(rs.map(_.tags("a")).toSet, (0 until 10).map(_.toString).toSet)
+  }
+
+  test("le, first element for tag") {
+    val idx = createLessThanIndex
+    val q = Query.LessThanEqual("a", "0")
+    val rs = idx.findItems(TagQuery(Some(q)))
+    assertEquals(rs.map(_.tags("a")).toSet, Set("0"))
+  }
+
+  test("le, second element for tag") {
+    val idx = createLessThanIndex
+    val q = Query.LessThanEqual("a", "1")
+    val rs = idx.findItems(TagQuery(Some(q)))
+    assertEquals(rs.map(_.tags("a")).toSet, Set("0", "1"))
+  }
+
+  test("le, missing element after first for tag") {
+    val idx = createLessThanIndex
+    val q = Query.LessThanEqual("a", "00")
+    val rs = idx.findItems(TagQuery(Some(q)))
+    assertEquals(rs.map(_.tags("a")).toSet, Set("0"))
+  }
+
+  test("le, last element for tag") {
+    val idx = createLessThanIndex
+    val q = Query.LessThanEqual("a", "9")
+    val rs = idx.findItems(TagQuery(Some(q)))
+    assertEquals(rs.map(_.tags("a")).toSet, (0 until 10).map(_.toString).toSet)
+  }
+
+  test("le, after last element for tag") {
+    val idx = createLessThanIndex
+    val q = Query.LessThanEqual("a", "a")
+    val rs = idx.findItems(TagQuery(Some(q)))
+    assertEquals(rs.map(_.tags("a")).toSet, (0 until 10).map(_.toString).toSet)
+  }
+
+  private def createGreaterThanIndex: TagIndex[BasicTaggedItem] = {
+    val items = (0 until 10).map { i =>
+      val tags = Map(
+        "name" -> "test",
+        "z" -> i.toString,
+        "b" -> "foo"
+      )
+      BasicTaggedItem(tags)
+    }
+    RoaringTagIndex(items.toArray, new IndexStats())
+  }
+
+  test("gt, first element for tag") {
+    val idx = createGreaterThanIndex
+    val q = Query.GreaterThan("z", "0")
+    val rs = idx.findItems(TagQuery(Some(q)))
+    assertEquals(rs.map(_.tags("z")).toSet, (1 until 10).map(_.toString).toSet)
+  }
+
+  test("gt, second element for tag") {
+    val idx = createGreaterThanIndex
+    val q = Query.GreaterThan("z", "1")
+    val rs = idx.findItems(TagQuery(Some(q)))
+    assertEquals(rs.map(_.tags("z")).toSet, (2 until 10).map(_.toString).toSet)
+  }
+
+  test("gt, missing element after first for tag") {
+    val idx = createGreaterThanIndex
+    val q = Query.GreaterThan("z", "00")
+    val rs = idx.findItems(TagQuery(Some(q)))
+    assertEquals(rs.map(_.tags("z")).toSet, (1 until 10).map(_.toString).toSet)
+  }
+
+  test("gt, last element for tag") {
+    val idx = createGreaterThanIndex
+    val q = Query.GreaterThan("z", "9")
+    val rs = idx.findItems(TagQuery(Some(q)))
+    assertEquals(rs.map(_.tags("z")).toSet, Set.empty[String])
+  }
+
+  test("gt, after last element for tag") {
+    val idx = createGreaterThanIndex
+    val q = Query.GreaterThan("z", "a")
+    val rs = idx.findItems(TagQuery(Some(q)))
+    assertEquals(rs.map(_.tags("z")).toSet, Set.empty[String])
+  }
+
+  test("ge, first element for tag") {
+    val idx = createGreaterThanIndex
+    val q = Query.GreaterThanEqual("z", "0")
+    val rs = idx.findItems(TagQuery(Some(q)))
+    assertEquals(rs.map(_.tags("z")).toSet, (0 until 10).map(_.toString).toSet)
+  }
+
+  test("ge, second element for tag") {
+    val idx = createGreaterThanIndex
+    val q = Query.GreaterThanEqual("z", "1")
+    val rs = idx.findItems(TagQuery(Some(q)))
+    assertEquals(rs.map(_.tags("z")).toSet, (1 until 10).map(_.toString).toSet)
+  }
+
+  test("ge, missing element after first for tag") {
+    val idx = createGreaterThanIndex
+    val q = Query.GreaterThanEqual("z", "00")
+    val rs = idx.findItems(TagQuery(Some(q)))
+    assertEquals(rs.map(_.tags("z")).toSet, (1 until 10).map(_.toString).toSet)
+  }
+
+  test("ge, last element for tag") {
+    val idx = createGreaterThanIndex
+    val q = Query.GreaterThanEqual("z", "9")
+    val rs = idx.findItems(TagQuery(Some(q)))
+    assertEquals(rs.map(_.tags("z")).toSet, Set("9"))
+  }
+
+  test("ge, after last element for tag") {
+    val idx = createGreaterThanIndex
+    val q = Query.GreaterThanEqual("z", "a")
+    val rs = idx.findItems(TagQuery(Some(q)))
+    assertEquals(rs.map(_.tags("z")).toSet, Set.empty[String])
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/RoaringTagIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/RoaringTagIndexSuite.scala
@@ -67,8 +67,8 @@ class RoaringTagIndexSuite extends TagIndexSuite {
     val items = (0 until 10).map { i =>
       val tags = Map(
         "name" -> "test",
-        "a" -> i.toString,
-        "b" -> "foo"
+        "a"    -> i.toString,
+        "b"    -> "foo"
       )
       BasicTaggedItem(tags)
     }
@@ -149,8 +149,8 @@ class RoaringTagIndexSuite extends TagIndexSuite {
     val items = (0 until 10).map { i =>
       val tags = Map(
         "name" -> "test",
-        "z" -> i.toString,
-        "b" -> "foo"
+        "z"    -> i.toString,
+        "b"    -> "foo"
       )
       BasicTaggedItem(tags)
     }


### PR DESCRIPTION
For the roaring tag index there were some bugs resulting in incorrect matching if the value being compared was larger than the last element for a given tag. The offset position was for the last tag and so it would return an empty match set since the tag key didn't match.