### PR TITLE
core: allow nf.ns on custom average denominator

### DIFF
--- a/atlas-core/src/main/resources/reference.conf
+++ b/atlas-core/src/main/resources/reference.conf
@@ -52,6 +52,7 @@ atlas {
         "nf.zone",
         "nf.region",
         "nf.node",
+        "nf.ns",
         "nf.vmtype"
       ]
 


### PR DESCRIPTION
Update reference config to permit the `nf.ns` dimension to be used on the denominator for custom averages. This ensures a consistent view when used on namespaced queries internally.