### PR TITLE
spring 6.2.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,13 +6,13 @@ object Dependencies {
   object Versions {
     val pekko       = "1.1.3"
     val pekkoHttpV  = "1.1.0"
-    val iep         = "5.0.33"
+    val iep         = "5.1.0"
     val jackson     = "2.18.3"
     val log4j       = "2.24.3"
     val scala       = "2.13.16"
     val slf4j       = "2.0.17"
     val spectator   = "1.8.7"
-    val spring      = "6.2.3"
+    val spring      = "6.2.2"
 
     val crossScala  = Seq(scala, "3.5.1")
   }


### PR DESCRIPTION
Move back to older versions. Some internal apps are seeing deadlocks with 6.2.3. Maybe fixed in 6.2.4, but testing is still being done.