### PR TITLE
core: improve handling of large spikes for rolling-sum

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingSum.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineRollingSum.scala
@@ -15,8 +15,6 @@
  */
 package com.netflix.atlas.core.algorithm
 
-import com.netflix.atlas.core.util.Math
-
 /**
   * Sum of the values within a moving window of the input.
   *
@@ -25,31 +23,15 @@ import com.netflix.atlas.core.util.Math
   */
 case class OnlineRollingSum(buf: RollingBuffer) extends OnlineAlgorithm {
 
-  import java.lang.Double as JDouble
-
-  private[this] var sum = Math.addNaN(0.0, buf.sum)
-  private[this] var count = buf.values.count(v => !JDouble.isNaN(v))
+  private val buffer = new RollingSumBuffer(buf)
 
   override def next(v: Double): Double = {
-    val removed = buf.add(v)
-
-    if (!JDouble.isNaN(removed)) {
-      sum -= removed
-      count -= 1
-    }
-
-    if (!JDouble.isNaN(v)) {
-      sum += v
-      count += 1
-    }
-
-    if (count > 0) sum else Double.NaN
+    buffer.update(v)
+    if (buffer.count > 0) buffer.sum else Double.NaN
   }
 
   override def reset(): Unit = {
-    buf.clear()
-    sum = 0.0
-    count = 0
+    buffer.reset()
   }
 
   override def isEmpty: Boolean = buf.isEmpty

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/RollingSumBuffer.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/RollingSumBuffer.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+import com.netflix.atlas.core.util.Math
+
+/**
+  * Buffer for OnlineRollingSum and OnlineRollingMean.
+  */
+private[algorithm] class RollingSumBuffer(val buf: RollingBuffer) {
+
+  import java.lang.Double as JDouble
+
+  var sum: Double = Math.addNaN(0.0, buf.sum)
+  var count: Double = buf.values.count(v => !JDouble.isNaN(v))
+
+  def update(v: Double): Unit = {
+    val removed = buf.add(v)
+
+    val isRemovedNaN = JDouble.isNaN(removed)
+    val isValueNaN = JDouble.isNaN(v)
+    if (!isRemovedNaN && !isValueNaN) {
+      adjustSum(-removed + v)
+    } else if (!isRemovedNaN) {
+      adjustSum(-removed)
+      count -= 1
+    } else if (!isValueNaN) {
+      adjustSum(v)
+      count += 1
+    }
+  }
+
+  /**
+    * Check if there is a large discrepancy between value sizes and either adjust the sum
+    * using the delta or recompute from the buffer.
+    */
+  private def adjustSum(delta: Double): Unit = {
+    val newSum = sum + delta
+    val expSum = getExponent(sum)
+    val expNewSum = getExponent(newSum)
+    if (java.lang.Math.abs(expSum - expNewSum) < 15)
+      sum = newSum
+    else
+      sum = buf.sum
+  }
+
+  /**
+    * Get the exponent for a double value, special case 0 to return 0 instead of -1023.
+    */
+  private def getExponent(v: Double): Int = {
+    val exp = java.lang.Math.getExponent(v)
+    if (exp == -1023) 0 else exp
+  }
+
+  def reset(): Unit = {
+    buf.clear()
+    sum = 0.0
+    count = 0
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMeanSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMeanSuite.scala
@@ -57,6 +57,22 @@ class OnlineRollingMeanSuite extends BaseOnlineAlgorithmSuite {
     assert(algo.isEmpty)
   }
 
+  test("n = 2, recover from large value") {
+    val algo = OnlineRollingMean(2, 1)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(1.0e300), 5.0e299)
+    assertEquals(algo.next(2.0), 5.0e299)
+    assertEquals(algo.next(3.0), 2.5)
+  }
+
+  test("n = 2, recover from small value") {
+    val algo = OnlineRollingMean(2, 1)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(-1.0e300), -5.0e299)
+    assertEquals(algo.next(2.0), -5.0e299)
+    assertEquals(algo.next(3.0), 2.5)
+  }
+
   test("n = 2, min = 1, reset") {
     val algo = OnlineRollingMean(2, 1)
     assertEquals(algo.next(1.0), 1.0)

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingSumSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingSumSuite.scala
@@ -68,4 +68,20 @@ class OnlineRollingSumSuite extends BaseOnlineAlgorithmSuite {
     algo.reset()
     assertEquals(algo.next(5.0), 5.0)
   }
+
+  test("n = 2, recover from large value") {
+    val algo = OnlineRollingSum(2)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(1.0e300), 1.0e300)
+    assertEquals(algo.next(2.0), 1.0e300)
+    assertEquals(algo.next(3.0), 5.0)
+  }
+
+  test("n = 2, recover from small value") {
+    val algo = OnlineRollingSum(2)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(-1.0e300), -1.0e300)
+    assertEquals(algo.next(2.0), -1e300)
+    assertEquals(algo.next(3.0), 5.0)
+  }
 }


### PR DESCRIPTION
Update rolling-sum and rolling-mean to better handle cases where there is a large value. Before a really large value compared to others would skew the sum and it would never fully recover since the sum is maintained incrementally. Now it will check if there is a big difference in the exponent and recompute from the buffer to recover.