### PR TITLE
core: fix pagination and lazily compute OR

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/LazyOrBitmap.java
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/LazyOrBitmap.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.index;
+
+
+import org.roaringbitmap.RoaringBitmap;
+
+/**
+ * Subclass to support access to protected methods for lazily computing OR across many
+ * bitmaps. Similar to `FastAggregation.or`, but can be done manually to avoid having
+ * to create an iterator.
+ */
+class LazyOrBitmap extends RoaringBitmap {
+
+  public LazyOrBitmap() {
+  }
+
+  @Override
+  public void naivelazyor(RoaringBitmap b) {
+    super.naivelazyor(b);
+  }
+
+  @Override
+  public void repairAfterLazy() {
+    super.repairAfterLazy();
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/TagIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/TagIndexSuite.scala
@@ -238,6 +238,22 @@ abstract class TagIndexSuite extends FunSuite {
     assertEquals(result.size, 4584)
   }
 
+  test("gt query with paging") {
+    val q = Query.GreaterThan("name", "sps_4")
+    val result = index.findItems(TagQuery(Some(q)))
+    val pageSize = 10
+    val builder = List.newBuilder[TimeSeries]
+    var tmp = index.findItems(TagQuery(Some(q), limit = pageSize))
+    while (tmp.size == pageSize) {
+      builder ++= tmp
+      val last = tmp.last.idString
+      tmp = index.findItems(TagQuery(Some(q), offset = last, limit = pageSize))
+    }
+    builder ++= tmp
+    assertEquals(result.size, builder.result().size)
+    assertEquals(result, builder.result())
+  }
+
   test("lt query") {
     val q = Query.LessThan("name", "sps_5")
     val result = index.findItems(TagQuery(Some(q)))
@@ -256,6 +272,22 @@ abstract class TagIndexSuite extends FunSuite {
     assertEquals(result.size, 4584)
   }
 
+  test("lt query with paging") {
+    val q = Query.LessThan("name", "sps_5")
+    val result = index.findItems(TagQuery(Some(q)))
+    val pageSize = 10
+    val builder = List.newBuilder[TimeSeries]
+    var tmp = index.findItems(TagQuery(Some(q), limit = pageSize))
+    while (tmp.size == pageSize) {
+      builder ++= tmp
+      val last = tmp.last.idString
+      tmp = index.findItems(TagQuery(Some(q), offset = last, limit = pageSize))
+    }
+    builder ++= tmp
+    assertEquals(result.size, builder.result().size)
+    assertEquals(result, builder.result())
+  }
+
   test("in query") {
     val q = Query.In("name", List("sps_5", "sps_7"))
     val result = index.findItems(TagQuery(Some(q)))
@@ -263,6 +295,22 @@ abstract class TagIndexSuite extends FunSuite {
       assert(m.tags("name") == "sps_5" || m.tags("name") == "sps_7")
     }
     assertEquals(result.size, 1528)
+  }
+
+  test("in query with paging") {
+    val q = Query.In("name", List("sps_5", "sps_7"))
+    val result = index.findItems(TagQuery(Some(q)))
+    val pageSize = 10
+    val builder = List.newBuilder[TimeSeries]
+    var tmp = index.findItems(TagQuery(Some(q), limit = pageSize))
+    while (tmp.size == pageSize) {
+      builder ++= tmp
+      val last = tmp.last.idString
+      tmp = index.findItems(TagQuery(Some(q), offset = last, limit = pageSize))
+    }
+    builder ++= tmp
+    assertEquals(result.size, builder.result().size)
+    assertEquals(result, builder.result())
   }
 
   test("regex query, prefix") {
@@ -290,6 +338,22 @@ abstract class TagIndexSuite extends FunSuite {
       assertEquals(m.tags("type2"), "IDEAL")
     }
     assertEquals(result.size, 7640)
+  }
+
+  test("regex query with paging") {
+    val q = Query.Regex("nf.cluster", "^nccp-silver.*")
+    val result = index.findItems(TagQuery(Some(q)))
+    val pageSize = 10
+    val builder = List.newBuilder[TimeSeries]
+    var tmp = index.findItems(TagQuery(Some(q), limit = pageSize))
+    while (tmp.size == pageSize) {
+      builder ++= tmp
+      val last = tmp.last.idString
+      tmp = index.findItems(TagQuery(Some(q), offset = last, limit = pageSize))
+    }
+    builder ++= tmp
+    assertEquals(result.size, builder.result().size)
+    assertEquals(result, builder.result())
   }
 
   test("haskey query") {


### PR DESCRIPTION
Update RoaringTagIndex implementation to fix pagination of findItems for range and pattern clauses. Before the offset was being ignored for these query clauses. In common usage it often wouldn't be noticed because AND with an equal clause would result in the offset gettng applied via the conjunction.

Also updates range queries and patterns to use a lazy OR operation on the bitmap. In some of our benchmarks this improves the throughput by about 30%.