### PR TITLE
webapi: config option to adjust chunk size

### DIFF
--- a/atlas-webapi/src/main/resources/reference.conf
+++ b/atlas-webapi/src/main/resources/reference.conf
@@ -71,6 +71,10 @@ atlas {
       png-metadata-enabled = false
     }
 
+    fetch {
+      chunk-size = 60
+    }
+
     publish {
       // Should we try to intern strings and tag values while parsing the request?
       intern-while-parsing = true

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ApiSettings.scala
@@ -75,6 +75,8 @@ class ApiSettings(root: => Config) {
     }
   }
 
+  def fetchChunkSize: Int = config.getInt("fetch.chunk-size")
+
   def maxPermittedTags: Int = config.getInt("publish.max-permitted-tags")
 
   def maxDatapointAge: Long = config.getDuration("publish.max-age", TimeUnit.MILLISECONDS)

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/FetchRequestSource.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/FetchRequestSource.scala
@@ -63,6 +63,8 @@ import scala.util.Using
   */
 object FetchRequestSource {
 
+  private val chunkSize = ApiSettings.fetchChunkSize
+
   /**
     * Create an SSE source that can be used as the entity for the HttpResponse.
     */
@@ -75,7 +77,7 @@ object FetchRequestSource {
       val step = graphCfg.roundedStepSize
       val (fstart, fend) = roundToStep(step, graphCfg.resStart, graphCfg.resEnd)
       EvalContext(fstart.toEpochMilli, fend.toEpochMilli, step)
-        .partition(60 * step, ChronoUnit.MILLIS)
+        .partition(chunkSize * step, ChronoUnit.MILLIS)
     }
 
     val heartbeatSrc = Source


### PR DESCRIPTION
Add option to configure the number of datapoints per chunk for the fetch API. In some cases it is more
efficient to use a larger window.