### PR TITLE
eval: avoid computing default label

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
@@ -43,7 +43,8 @@ case class StyleExpr(expr: TimeSeriesExpr, settings: Map[String, String]) extend
   }
 
   def legend(t: TimeSeries): String = {
-    legend(t.label, t.tags)
+    val fmt = settings.getOrElse("legend", t.label)
+    sed(Strings.substitute(fmt, t.tags))
   }
 
   def legend(label: String, tags: Map[String, String]): String = {


### PR DESCRIPTION
When the legend is explicitly set, avoid computing the default label. In most cases we enable the simple legends option so there will be an explicit legend set on the expressions.