### PR TITLE
eval: reuse wall time

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
@@ -155,10 +155,10 @@ private[stream] class TimeGrouped(
 
       override def onPush(): Unit = {
         val builder = List.newBuilder[TimeGroup]
+        val now = clock.wallTime()
         val tuple = grab(in)
         tuple.data.foreach { v =>
           val t = v.timestamp
-          val now = clock.wallTime()
           step = v.step
           if (t > now) {
             droppedFutureUpdater.increment()


### PR DESCRIPTION
Access the wall time once for the batch pushed to the time group rather than accessing for each entry in the batch.