### PR TITLE
eval: optimize computing list of datapoints

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
@@ -248,7 +248,14 @@ object AggrDatapoint {
     }
 
     override def datapoints: List[AggrDatapoint] = {
-      aggregators.values.flatMap(_.datapoints).toList
+      val builder = List.newBuilder[AggrDatapoint]
+      aggregators.foreachEntry { (_, aggr) =>
+        aggr.datapoints match {
+          case d :: Nil => builder.addOne(d)
+          case ds       => builder.addAll(ds)
+        }
+      }
+      builder.result()
     }
   }
 


### PR DESCRIPTION
For the GroupByAggregator optimize computing the datapoints. Use a List builder to avoid creation of iterators and the intermediate collections when doing flatMap and then converting back to a List. Since all aggregators that are part of a group should have a single element in the list, special case that path to avoid the need for a separate iterator.