### PR TITLE
core: fix rolling-sum with NaN data

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/RollingSumBuffer.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/RollingSumBuffer.scala
@@ -25,7 +25,7 @@ private[algorithm] class RollingSumBuffer(val buf: RollingBuffer) {
   import java.lang.Double as JDouble
 
   var sum: Double = Math.addNaN(0.0, buf.sum)
-  var count: Double = buf.values.count(v => !JDouble.isNaN(v))
+  var count: Int = buf.values.count(v => !JDouble.isNaN(v))
 
   def update(v: Double): Unit = {
     val removed = buf.add(v)
@@ -48,7 +48,7 @@ private[algorithm] class RollingSumBuffer(val buf: RollingBuffer) {
     * using the delta or recompute from the buffer.
     */
   private def adjustSum(delta: Double): Unit = {
-    val newSum = sum + delta
+    val newSum = Math.addNaN(sum, delta)
     val expSum = getExponent(sum)
     val expNewSum = getExponent(newSum)
     if (java.lang.Math.abs(expSum - expNewSum) < 15)

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingSumSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingSumSuite.scala
@@ -26,6 +26,26 @@ class OnlineRollingSumSuite extends BaseOnlineAlgorithmSuite {
     assertEquals(algo.next(2.0), 2.0)
   }
 
+  test("n = 1, NaN") {
+    val algo = OnlineRollingSum(1)
+    assertEquals(algo.next(0.0), 0.0)
+    assertEquals(algo.next(1.0), 1.0)
+    assert(algo.next(Double.NaN).isNaN)
+    assert(algo.next(Double.NaN).isNaN)
+    assertEquals(algo.next(2.0), 2.0)
+  }
+
+  test("n = 1, NaN, with fractional data") {
+    val algo = OnlineRollingSum(1)
+    assertEqualsDouble(algo.next(0.007222), 0.007222, 1e-9)
+    assertEqualsDouble(algo.next(0.001667), 0.001667, 1e-9)
+    assertEqualsDouble(algo.next(0.011667), 0.011667, 1e-9)
+    assertEqualsDouble(algo.next(0.001111), 0.001111, 1e-9)
+    assert(algo.next(Double.NaN).isNaN)
+    algo.next(0.000556)
+    assertEqualsDouble(algo.next(0.000556), 0.000556, 1e-9)
+  }
+
   test("n = 2") {
     val algo = OnlineRollingSum(2)
     assertEquals(algo.next(0.0), 0.0)

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingSumSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingSumSuite.scala
@@ -42,7 +42,6 @@ class OnlineRollingSumSuite extends BaseOnlineAlgorithmSuite {
     assertEqualsDouble(algo.next(0.011667), 0.011667, 1e-9)
     assertEqualsDouble(algo.next(0.001111), 0.001111, 1e-9)
     assert(algo.next(Double.NaN).isNaN)
-    algo.next(0.000556)
     assertEqualsDouble(algo.next(0.000556), 0.000556, 1e-9)
   }
 


### PR DESCRIPTION
In some cases when it falls back to summing the buffer, the sum will be set to NaN. In this case it will not recover until there is another fall back. Update it to use addNaN so that it will recover correctly when values start coming in again.