### PR TITLE
core: add support for constant math

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -102,6 +102,14 @@ object MathExpr {
       val ts = TimeSeries(Map("name" -> v.toString), v.toString, seq)
       ResultSet(this, List(ts), context.state)
     }
+
+    /** Overridden to allow for NaN value to be equivalent. */
+    override def equals(that: Any): Boolean = {
+      that match {
+        case other: Constant => java.lang.Double.compare(v, other.v) == 0
+        case _               => false
+      }
+    }
   }
 
   /**

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathExamplesSuite.scala
@@ -49,4 +49,14 @@ class MathExamplesSuite extends BaseExamplesSuite {
       "name,test,:eq,app,foo,:eq,:and,:dist-avg,PT1H,:offset,(,cluster,),:by"
     )
   }
+
+  test("constant math: unary expressions") {
+    val expr = eval("name,test,:eq,:sum,5,:neg,:abs,:mul")
+    assertEquals(expr.toString, "name,test,:eq,:sum,5.0,:const,:mul")
+  }
+
+  test("constant math: binary expressions") {
+    val expr = eval("name,test,:eq,:sum,5,4,:mul,2,:add,:div")
+    assertEquals(expr.toString, "name,test,:eq,:sum,22.0,:const,:div")
+  }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/StatefulExamplesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/StatefulExamplesSuite.scala
@@ -26,4 +26,9 @@ class StatefulExamplesSuite extends BaseExamplesSuite {
     val expr = eval("name,test,:eq,:sum,:des-fast,app,foo,:eq,:cq")
     assertEquals(expr.toString, "name,test,:eq,app,foo,:eq,:and,:sum,:des-fast")
   }
+
+  test("constant math: use as parameter") {
+    val expr = eval("name,test,:eq,:sum,3600,60,:div,:int,:rolling-count")
+    assertEquals(expr.toString, "name,test,:eq,:sum,60,:rolling-count")
+  }
 }


### PR DESCRIPTION
Computes constants as the expression is being parsed and allows them to be used as a parameter.