### PR TITLE
Update Hash.scala

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Hash.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Hash.scala
@@ -61,10 +61,14 @@ object Hash {
   }
 
   def get(algorithm: String): MessageDigest = {
-    cloneableDigests.get(algorithm).fold(MessageDigest.getInstance(algorithm)) { digest =>
-      digest.clone().asInstanceOf[MessageDigest]
-    }
+  if (weakAlgorithms.contains(algorithm.toUpperCase)) {
+    throw new IllegalArgumentException(s"Algorithm $algorithm is not secure for use.")
   }
+  cloneableDigests.get(algorithm).fold(MessageDigest.getInstance(algorithm)) { digest =>
+    digest.clone().asInstanceOf[MessageDigest]
+  }
+}
+
 
   def md5(input: Array[Byte]): BigInteger = {
     computeHash("MD5", input)


### PR DESCRIPTION
This code is not secure for storing passwords!
It may be secure for verifying file integrity or data verification (Checksum) — but not for storing or verifying passwords.

Examples of attacks:
If passwords are encrypted with SHA-256 only, without salts or iterations, a regular processor or even a GPU can try millions of words per second until you find the original password.


Because MessageDigest.getInstance(algorithm) depends on the algorithm passed as a string, here's the problem:

If algorithm = "MD5", "SHA-1", or even "SHA-256", you're using a very fast hash algorithm.

These algorithms are absolutely not suitable for storing passwords! They are easily cracked by:

Brute Force Attack

Dictionary Attack

Rainbow Tables