### PR TITLE
core: support escaping colon and parenthesis

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/EventExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/EventExpr.scala
@@ -52,7 +52,7 @@ object EventExpr {
     require(columns.nonEmpty, "set of columns cannot be empty")
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, query, columns, ":table")
+      Interpreter.append(builder, query, columns, Interpreter.WordToken(":table"))
     }
   }
 
@@ -73,7 +73,7 @@ object EventExpr {
     require(sampleBy.nonEmpty, "sampleBy cannot be empty")
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, query, sampleBy, projectionKeys, ":sample")
+      Interpreter.append(builder, query, sampleBy, projectionKeys, Interpreter.WordToken(":sample"))
     }
 
     def dataExpr: DataExpr = {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/FilterExpr.scala
@@ -42,7 +42,7 @@ object FilterExpr {
     override def append(builder: java.lang.StringBuilder): Unit = {
       str match {
         case Some(s) => builder.append(s)
-        case None    => Interpreter.append(builder, expr, stat, ":stat")
+        case None    => Interpreter.append(builder, expr, stat, Interpreter.WordToken(":stat"))
       }
     }
 
@@ -70,7 +70,7 @@ object FilterExpr {
     def name: String
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, s":stat-$name")
+      Interpreter.append(builder, Interpreter.WordToken(s":stat-$name"))
     }
 
     def dataExprs: List[DataExpr] = Nil
@@ -121,7 +121,7 @@ object FilterExpr {
     if (!expr1.isGrouped) require(!expr2.isGrouped, "filter grouping must match expr grouping")
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, expr1, expr2, ":filter")
+      Interpreter.append(builder, expr1, expr2, Interpreter.WordToken(":filter"))
     }
 
     def dataExprs: List[DataExpr] = expr1.dataExprs ::: expr2.dataExprs
@@ -193,7 +193,7 @@ object FilterExpr {
     require(k > 0, s"k must be positive ($k <= 0)")
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, expr, stat, k, s":$opName")
+      Interpreter.append(builder, expr, stat, k, Interpreter.WordToken(s":$opName"))
     }
 
     def dataExprs: List[DataExpr] = expr.dataExprs

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -52,7 +52,7 @@ object MathExpr {
     def dataExprs: List[DataExpr] = expr.dataExprs
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, expr, original, replacement, ":as")
+      Interpreter.append(builder, expr, original, replacement, Interpreter.WordToken(":as"))
     }
 
     def isGrouped: Boolean = expr.isGrouped
@@ -88,7 +88,7 @@ object MathExpr {
     def dataExprs: List[DataExpr] = Nil
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, v, ":const")
+      Interpreter.append(builder, v, Interpreter.WordToken(":const"))
     }
 
     def isGrouped: Boolean = false
@@ -114,7 +114,7 @@ object MathExpr {
     def dataExprs: List[DataExpr] = Nil
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, ":random")
+      Interpreter.append(builder, Interpreter.WordToken(":random"))
     }
 
     def isGrouped: Boolean = false
@@ -144,7 +144,7 @@ object MathExpr {
     def dataExprs: List[DataExpr] = Nil
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, seed, ":srandom")
+      Interpreter.append(builder, seed, Interpreter.WordToken(":srandom"))
     }
 
     def isGrouped: Boolean = false
@@ -207,7 +207,7 @@ object MathExpr {
     def dataExprs: List[DataExpr] = Nil
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, mode, ":time")
+      Interpreter.append(builder, mode, Interpreter.WordToken(":time"))
     }
 
     def isGrouped: Boolean = false
@@ -228,7 +228,7 @@ object MathExpr {
     def dataExprs: List[DataExpr] = Nil
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, s, e, ":time-span")
+      Interpreter.append(builder, s, e, Interpreter.WordToken(":time-span"))
     }
 
     def isGrouped: Boolean = false
@@ -301,7 +301,7 @@ object MathExpr {
     def dataExprs: List[DataExpr] = expr.dataExprs
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, expr, min, s":$name")
+      Interpreter.append(builder, expr, min, Interpreter.WordToken(s":$name"))
     }
 
     def isGrouped: Boolean = expr.isGrouped
@@ -333,7 +333,7 @@ object MathExpr {
     override def toString: String = Interpreter.toString(expr, max, s":$name")
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, expr, max, s":$name")
+      Interpreter.append(builder, expr, max, Interpreter.WordToken(s":$name"))
     }
 
     def isGrouped: Boolean = expr.isGrouped
@@ -372,7 +372,7 @@ object MathExpr {
     }
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, expr, s":$name")
+      Interpreter.append(builder, expr, Interpreter.WordToken(s":$name"))
     }
 
     def isGrouped: Boolean = expr.isGrouped
@@ -493,7 +493,7 @@ object MathExpr {
     }
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, expr1, expr2, s":$name")
+      Interpreter.append(builder, expr1, expr2, Interpreter.WordToken(s":$name"))
     }
 
     def isGrouped: Boolean = expr1.isGrouped || expr2.isGrouped
@@ -719,7 +719,7 @@ object MathExpr {
     def dataExprs: List[DataExpr] = expr.dataExprs
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, expr, s":$name")
+      Interpreter.append(builder, expr, Interpreter.WordToken(s":$name"))
     }
 
     def isGrouped: Boolean = false
@@ -821,7 +821,7 @@ object MathExpr {
     }
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, expr, keys, ":by")
+      Interpreter.append(builder, expr, keys, Interpreter.WordToken(":by"))
     }
 
     def dataExprs: List[DataExpr] = expr.dataExprs
@@ -887,7 +887,7 @@ object MathExpr {
     override def append(builder: java.lang.StringBuilder): Unit = {
       // Base expr
       if (evalGroupKeys.nonEmpty)
-        Interpreter.append(builder, expr.af.query, evalGroupKeys, ":by")
+        Interpreter.append(builder, expr.af.query, evalGroupKeys, Interpreter.WordToken(":by"))
       else
         Interpreter.append(builder, expr.af.query)
 
@@ -1090,7 +1090,7 @@ object MathExpr {
           }
           builder.append(str)
         case _ =>
-          Interpreter.append(builder, expr, op)
+          Interpreter.append(builder, expr, Interpreter.WordToken(op))
           val grouping = evalExpr.finalGrouping
           if (grouping.nonEmpty) {
             builder.append(",(,")

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
@@ -337,7 +337,7 @@ object Query {
     def labelString: String = s"has($k)"
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, k, ":has")
+      Interpreter.append(builder, k, Interpreter.WordToken(":has"))
     }
   }
 
@@ -348,7 +348,7 @@ object Query {
     def labelString: String = s"$k=$v"
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, k, v, ":eq")
+      Interpreter.append(builder, k, v, Interpreter.WordToken(":eq"))
     }
   }
 
@@ -359,7 +359,7 @@ object Query {
     def labelString: String = s"$k<$v"
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, k, v, ":lt")
+      Interpreter.append(builder, k, v, Interpreter.WordToken(":lt"))
     }
   }
 
@@ -370,7 +370,7 @@ object Query {
     def labelString: String = s"$k<=$v"
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, k, v, ":le")
+      Interpreter.append(builder, k, v, Interpreter.WordToken(":le"))
     }
   }
 
@@ -381,7 +381,7 @@ object Query {
     def labelString: String = s"$k>$v"
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, k, v, ":gt")
+      Interpreter.append(builder, k, v, Interpreter.WordToken(":gt"))
     }
   }
 
@@ -392,7 +392,7 @@ object Query {
     def labelString: String = s"$k>=$v"
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, k, v, ":ge")
+      Interpreter.append(builder, k, v, Interpreter.WordToken(":ge"))
     }
   }
 
@@ -410,7 +410,7 @@ object Query {
     def labelString: String = s"$k~/^$v/"
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, k, v, ":re")
+      Interpreter.append(builder, k, v, Interpreter.WordToken(":re"))
     }
   }
 
@@ -423,7 +423,7 @@ object Query {
     def labelString: String = s"$k~/^$v/i"
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, k, v, ":reic")
+      Interpreter.append(builder, k, v, Interpreter.WordToken(":reic"))
     }
   }
 
@@ -436,7 +436,7 @@ object Query {
     def labelString: String = s"$k in (${vs.mkString(",")})"
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, k, vs, ":in")
+      Interpreter.append(builder, k, vs, Interpreter.WordToken(":in"))
     }
 
     /** Convert this to a sequence of OR'd together equal queries. */
@@ -462,7 +462,7 @@ object Query {
     def labelString: String = s"(${q1.labelString}) and (${q2.labelString})"
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, q1, q2, ":and")
+      Interpreter.append(builder, q1, q2, Interpreter.WordToken(":and"))
     }
   }
 
@@ -480,7 +480,7 @@ object Query {
     def labelString: String = s"(${q1.labelString}) or (${q2.labelString})"
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, q1, q2, ":or")
+      Interpreter.append(builder, q1, q2, Interpreter.WordToken(":or"))
     }
   }
 
@@ -497,7 +497,7 @@ object Query {
     def labelString: String = s"not(${q.labelString})"
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, q, ":not")
+      Interpreter.append(builder, q, Interpreter.WordToken(":not"))
     }
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
@@ -53,7 +53,7 @@ object StatefulExpr {
     }
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, expr, window, ":trend")
+      Interpreter.append(builder, expr, window, Interpreter.WordToken(":trend"))
     }
   }
 
@@ -72,7 +72,7 @@ object StatefulExpr {
     }
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, expr, s":$name")
+      Interpreter.append(builder, expr, Interpreter.WordToken(s":$name"))
     }
   }
 
@@ -88,7 +88,7 @@ object StatefulExpr {
     }
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, expr, s":$name")
+      Interpreter.append(builder, expr, Interpreter.WordToken(s":$name"))
     }
   }
 
@@ -105,7 +105,7 @@ object StatefulExpr {
     }
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, expr, n, s":$name")
+      Interpreter.append(builder, expr, n, Interpreter.WordToken(s":$name"))
     }
   }
 
@@ -121,7 +121,7 @@ object StatefulExpr {
     }
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, expr, n, s":$name")
+      Interpreter.append(builder, expr, n, Interpreter.WordToken(s":$name"))
     }
   }
 
@@ -137,7 +137,7 @@ object StatefulExpr {
     }
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, expr, n, s":$name")
+      Interpreter.append(builder, expr, n, Interpreter.WordToken(s":$name"))
     }
   }
 
@@ -153,7 +153,7 @@ object StatefulExpr {
     }
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, expr, n, s":$name")
+      Interpreter.append(builder, expr, n, Interpreter.WordToken(s":$name"))
     }
   }
 
@@ -169,7 +169,7 @@ object StatefulExpr {
     }
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, expr, n, minNumValues, s":$name")
+      Interpreter.append(builder, expr, n, minNumValues, Interpreter.WordToken(s":$name"))
     }
   }
 
@@ -185,7 +185,7 @@ object StatefulExpr {
     }
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, expr, n, s":$name")
+      Interpreter.append(builder, expr, n, Interpreter.WordToken(s":$name"))
     }
   }
 
@@ -203,7 +203,7 @@ object StatefulExpr {
     }
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, expr, trainingSize, alpha, beta, s":$name")
+      Interpreter.append(builder, expr, trainingSize, alpha, beta, Interpreter.WordToken(s":$name"))
     }
   }
 
@@ -237,7 +237,7 @@ object StatefulExpr {
     }
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, expr, trainingSize, alpha, beta, s":$name")
+      Interpreter.append(builder, expr, trainingSize, alpha, beta, Interpreter.WordToken(s":$name"))
     }
   }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TraceQuery.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TraceQuery.scala
@@ -37,7 +37,7 @@ object TraceQuery {
   case class SpanAnd(q1: TraceQuery, q2: TraceQuery) extends TraceQuery {
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, q1, q2, ":span-and")
+      Interpreter.append(builder, q1, q2, Interpreter.WordToken(":span-and"))
     }
   }
 
@@ -45,7 +45,7 @@ object TraceQuery {
   case class SpanOr(q1: TraceQuery, q2: TraceQuery) extends TraceQuery {
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, q1, q2, ":span-or")
+      Interpreter.append(builder, q1, q2, Interpreter.WordToken(":span-or"))
     }
   }
 
@@ -56,17 +56,15 @@ object TraceQuery {
   case class Child(q1: Query, q2: Query) extends TraceQuery {
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, q1, q2, ":child")
+      Interpreter.append(builder, q1, q2, Interpreter.WordToken(":child"))
     }
   }
 
   /** Filter to select the set of spans from a trace to forward as events. */
   case class SpanFilter(q: TraceQuery, f: Query) extends Expr {
 
-    override def toString: String = s"$q,$f,:span-filter"
-
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, q, f, ":span-filter")
+      Interpreter.append(builder, q, f, Interpreter.WordToken(":span-filter"))
     }
   }
 
@@ -74,7 +72,7 @@ object TraceQuery {
   case class SpanTimeSeries(q: TraceQuery, expr: StyleExpr) extends Expr {
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, q, expr, ":span-time-series")
+      Interpreter.append(builder, q, expr, Interpreter.WordToken(":span-time-series"))
     }
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
@@ -96,7 +96,7 @@ case class Interpreter(vocabulary: List[Word]) {
           case "("       => popAndPushList(0, Nil, Step(tokens, context))
           case ")"       => throw new IllegalStateException("unmatched closing parenthesis")
           case IsWord(t) => Step(tokens, executeWord(t, context))
-          case t         => Step(tokens, context.copy(stack = t :: context.stack))
+          case t         => Step(tokens, context.copy(stack = unescape(t) :: context.stack))
         }
       case Nil => s
     }
@@ -180,6 +180,8 @@ object Interpreter {
 
   case class Step(program: List[Any], context: Context)
 
+  case class WordToken(name: String)
+
   case object IsWord {
 
     def unapply(v: String): Option[String] = if (v.startsWith(":")) Some(v.substring(1)) else None
@@ -227,6 +229,7 @@ object Interpreter {
     value match {
       case vs: Seq[?]   => appendSeq(builder, vs)
       case v: String    => escape(builder, v)
+      case v: WordToken => builder.append(v.name)
       case v: StackItem => v.append(builder)
       case v            => builder.append(v)
     }
@@ -254,28 +257,48 @@ object Interpreter {
     while (i < parts.length) {
       val tmp = parts(i).trim
       if (tmp.nonEmpty)
-        builder += unescape(tmp)
+        builder += tmp
       i += 1
     }
     builder.result()
   }
 
   private def isSpecial(c: Int): Boolean = {
-    c == ',' || Character.isWhitespace(c)
+    c == ',' || c == ':' || Character.isWhitespace(c)
   }
 
   /** Escape special characters in the expression. */
   def escape(str: String): String = {
-    Strings.escape(str, isSpecial)
+    // Parenthesis only matter if they are the only part of the token for constructing
+    // lists. Only escape if using as a literal in that context. For things like regex
+    // escaping makes the expression much harder to read.
+    str match {
+      case "(" => "\\u0028"
+      case ")" => "\\u0029"
+      case s   => Strings.escape(s, isSpecial)
+    }
   }
 
   /** Escape special characters in the expression. */
   def escape(builder: java.lang.StringBuilder, str: String): Unit = {
-    Strings.escape(builder, str, isSpecial)
+    // Parenthesis only matter if they are the only part of the token for constructing
+    // lists. Only escape if using as a literal in that context. For things like regex
+    // escaping makes the expression much harder to read.
+    str match {
+      case "(" => builder.append("\\u0028")
+      case ")" => builder.append("\\u0029")
+      case s   => Strings.escape(builder, s, isSpecial)
+    }
   }
 
   /** Unescape unicode characters in the expression. */
   def unescape(str: String): String = {
     Strings.unescape(str)
+  }
+
+  /** Unescape unicode characters in the expression. */
+  def unescape(value: Any): Any = value match {
+    case s: String => Strings.unescape(s)
+    case v         => v
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/QueryVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/QueryVocabularySuite.scala
@@ -80,13 +80,17 @@ class QueryVocabularySuite extends FunSuite {
     assert(!q.matches(Map("foo" -> "my $var. [work-in progress]")))
   }
 
+  private def execEquals(str: String): Query.Equal = {
+    val exp1 = interpreter.execute(str).stack.head
+    val exp2 = interpreter.execute(exp1.toString).stack.head
+    assertEquals(exp1, exp2)
+    exp1.asInstanceOf[Query.Equal]
+  }
+
   test("eq, with escaped comma") {
     val txt = Interpreter.escape("foo, bar, baz")
-    val exp = interpreter.execute(s"a,$txt,:eq").stack.head
-    assertEquals(
-      exp.asInstanceOf[Query.Equal].v,
-      "foo, bar, baz"
-    )
+    val exp = execEquals(s"a,$txt,:eq")
+    assertEquals(exp.v, "foo, bar, baz")
   }
 
   test("contains, with escaped comma") {
@@ -96,5 +100,29 @@ class QueryVocabularySuite extends FunSuite {
       exp.asInstanceOf[Query.Regex].pattern.toString,
       ".*foo,\\u0020bar,\\u0020baz"
     )
+  }
+
+  test("eq, with escaped colon in value") {
+    val txt = Interpreter.escape(":foo")
+    val exp = execEquals(s"a,$txt,:eq")
+    assertEquals(exp.v, ":foo")
+  }
+
+  test("eq, with escaped colon in key") {
+    val txt = Interpreter.escape(":foo")
+    val exp = execEquals(s"$txt,a,:eq")
+    assertEquals(exp.k, ":foo")
+  }
+
+  test("eq, with escaped open paren in value") {
+    val txt = Interpreter.escape("(")
+    val exp = execEquals(s"a,$txt,:eq")
+    assertEquals(exp.v, "(")
+  }
+
+  test("eq, with escaped close paren in value") {
+    val txt = Interpreter.escape(")")
+    val exp = execEquals(s"a,$txt,:eq")
+    assertEquals(exp.v, ")")
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/InterpreterSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/InterpreterSuite.scala
@@ -186,7 +186,7 @@ class InterpreterSuite extends FunSuite {
     val tab = Interpreter.escape("\t")
     val escaped = s"$space${space}a$nl,$nl${tab}b$space,c"
     val actual = Interpreter.splitAndTrim(escaped)
-    assertEquals(actual, List("  a\n", "\n\tb ", "c"))
+    assertEquals(actual, List(s"$space${space}a$nl", s"$nl${tab}b$space", "c"))
     assertEquals(Interpreter.toString(actual.reverse), escaped)
   }
 
@@ -194,7 +194,7 @@ class InterpreterSuite extends FunSuite {
     val comma = Interpreter.escape(",")
     val escaped = s"a${comma}b${comma}c,d"
     val actual = Interpreter.splitAndTrim(escaped)
-    assertEquals(actual, List("a,b,c", "d"))
+    assertEquals(actual, List(s"a${comma}b${comma}c", "d"))
     assertEquals(Interpreter.toString(actual.reverse), escaped)
   }
 }


### PR DESCRIPTION
Updates the escaping to support the beginning colon used for operations and the parenthesis used to indicate lists.