### PR TITLE
json: create builder instead of mapper

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcMessages.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcMessages.scala
@@ -36,7 +36,7 @@ import java.util.zip.GZIPOutputStream
 object LwcMessages {
 
   // For reading arbitrary json structures for events
-  private val mapper = Json.newMapper
+  private val mapper = Json.newMapperBuilder.build()
 
   /**
     * Parse the message string into an internal model object based on the type.

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
@@ -85,7 +85,8 @@ object Json {
   private val smileMapper = newMapperBuilder(smileFactory).build()
 
   private def newMapperBuilder(factory: JsonFactory): JsonMapper.Builder = {
-    JsonMapper.builder(factory)
+    JsonMapper
+      .builder(factory)
       .serializationInclusion(JsonInclude.Include.NON_ABSENT)
       .disable(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)
       .disable(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)

--- a/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
+++ b/atlas-json/src/main/scala/com/netflix/atlas/json/Json.scala
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.core.*
 import com.fasterxml.jackson.core.json.JsonReadFeature
 import com.fasterxml.jackson.core.json.JsonWriteFeature
 import com.fasterxml.jackson.databind.*
+import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.dataformat.smile.SmileFactory
 import com.fasterxml.jackson.dataformat.smile.SmileGenerator
@@ -79,23 +80,20 @@ object Json {
     .enable(SmileGenerator.Feature.LENIENT_UTF_ENCODING)
     .build()
 
-  private val jsonMapper = newMapper(jsonFactory)
+  private val jsonMapper = newMapperBuilder(jsonFactory).build()
 
-  private val smileMapper = newMapper(smileFactory)
+  private val smileMapper = newMapperBuilder(smileFactory).build()
 
-  private def newMapper(factory: JsonFactory): ObjectMapper = {
-    val mapper = new ObjectMapper(factory)
-    mapper.setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
-    mapper.configure(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, false)
-    mapper.configure(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS, false)
-    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-    mapper.registerModule(DefaultScalaModule)
-    mapper.registerModule(new JavaTimeModule)
-    mapper.registerModule(new Jdk8Module)
-    mapper.registerModule(
-      new SimpleModule().setSerializerModifier(new JsonSupportSerializerModifier)
-    )
-    mapper
+  private def newMapperBuilder(factory: JsonFactory): JsonMapper.Builder = {
+    JsonMapper.builder(factory)
+      .serializationInclusion(JsonInclude.Include.NON_ABSENT)
+      .disable(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)
+      .disable(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+      .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+      .addModule(DefaultScalaModule)
+      .addModule(new JavaTimeModule)
+      .addModule(new Jdk8Module)
+      .addModule(new SimpleModule().setSerializerModifier(new JsonSupportSerializerModifier))
   }
 
   /**
@@ -119,7 +117,10 @@ object Json {
     f(smileMapper)
   }
 
-  def newMapper: ObjectMapper = newMapper(jsonFactory)
+  def newMapperBuilder: JsonMapper.Builder = newMapperBuilder(jsonFactory)
+
+  @deprecated(message = "Use newMapperBuilder instead.")
+  def newMapper: ObjectMapper = newMapperBuilder.build()
 
   def newJsonGenerator(writer: Writer): JsonGenerator = {
     jsonFactory.createGenerator(writer)


### PR DESCRIPTION
Update to add a `newMapperBuilder` to get a builder for the caller to modify. Helps to phase out deprecation warnings when modifying the ObjectMapper.