### PR TITLE
lwcapi: track encoding time for expressions

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionApi.scala
@@ -110,8 +110,7 @@ case class ExpressionApi(
 
   private def handle(
     receivedETags: Option[String],
-    expressions: EncodedExpressions,
-    id: String
+    expressions: EncodedExpressions
   ): HttpResponse = {
     val tag = expressions.etag
     val headers: List[HttpHeader] = List(RawHeader("ETag", tag))


### PR DESCRIPTION
Add timer to track the time taken to encode the expressions for the overall set and for clusters.