### PR TITLE
eval: update default legend for starts/contains

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/SimpleLegends.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/SimpleLegends.scala
@@ -85,11 +85,20 @@ object SimpleLegends extends StrictLogging {
       case Query.LessThanEqual(k, v)    => Map(k -> v)
       case Query.GreaterThan(k, v)      => Map(k -> v)
       case Query.GreaterThanEqual(k, v) => Map(k -> v)
-      case Query.Regex(k, v)            => Map(k -> v)
+      case re: Query.Regex              => Map(re.k -> regexPresentationValue(re))
       case Query.RegexIgnoreCase(k, v)  => Map(k -> v)
       case Query.Not(q: KeyValueQuery)  => keyValues(q).map(t => t._1 -> s"!${t._2}")
       case _                            => Map.empty
     }
+  }
+
+  private def regexPresentationValue(re: Query.Regex): String = {
+    if (re.pattern.isPrefixMatcher)
+      re.pattern.prefix()
+    else if (re.pattern.isContainsMatcher)
+      re.pattern.containedString()
+    else
+      re.v
   }
 
   private def generateLegend(expr: StyleExpr, kv: Map[String, String]): StyleExpr = {

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/SimpleLegendsSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/SimpleLegendsSuite.scala
@@ -98,6 +98,14 @@ class SimpleLegendsSuite extends FunSuite {
     assertEquals(legends("name,cpu,:eq,:not,:sum"), List("!cpu"))
   }
 
+  test("name starts clause") {
+    assertEquals(legends("name,sys.cpu,:starts,:sum"), List("sys.cpu"))
+  }
+
+  test("name contains clause") {
+    assertEquals(legends("name,sys.cpu,:contains,:sum"), List("sys.cpu"))
+  }
+
   test("name with node avg") {
     assertEquals(legends("name,cpu,:eq,:node-avg"), List("cpu"))
   }


### PR DESCRIPTION
Before it was the regex string which would escape characters that are special in regex like `.`. This was confusing to some users. Now it will handle prefix and contains matchers and just use the literal without escaping when constructing the legend.