### PR TITLE
webapi: allow data actor to modify the step

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/EvalContext.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/EvalContext.scala
@@ -60,4 +60,19 @@ case class EvalContext(
     val dur = offset / step * step
     if (dur < step) this else EvalContext(start - dur, end - dur, step, state)
   }
+
+  def increaseStep(newStep: Long): EvalContext = {
+    if (newStep == step)
+      return this
+
+    // Compute the new start / end time by rounding to step boundaries. The eval context
+    // will end time is exclusive, so update by a step interval if the end time has changes
+    // due to rounding.
+    val s = start / newStep * newStep
+    val e = end / newStep * newStep
+    if (end == e)
+      EvalContext(s, e, newStep)
+    else
+      EvalContext(s, e + newStep, newStep)
+  }
 }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/GraphConfig.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/GraphConfig.scala
@@ -100,6 +100,16 @@ case class GraphConfig(
     EvalContext(fstart.toEpochMilli, fend.toEpochMilli + stepSize, stepSize)
   }
 
+  def withStep(newStep: Long): GraphConfig = {
+    if (newStep == stepSize)
+      return this
+    copy(
+      step = Some(s"${newStep}ms"),
+      start = Some(fstart.toEpochMilli.toString),
+      end = Some(fend.toEpochMilli.toString)
+    )
+  }
+
   def exprs: List[StyleExpr] = parsedQuery.get
 
   private def getGraphTags(plots: List[PlotDef]): Map[String, String] = {

--- a/atlas-eval/src/test/resources/graph-config-test.conf
+++ b/atlas-eval/src/test/resources/graph-config-test.conf
@@ -1,0 +1,13 @@
+atlas {
+  core {
+    model {
+      step = 5 seconds
+    }
+  }
+
+  eval {
+    graph {
+      step = 5 seconds
+    }
+  }
+}

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GraphConfigSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GraphConfigSuite.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.graph
+
+import com.typesafe.config.ConfigFactory
+import munit.FunSuite
+import org.apache.pekko.http.scaladsl.model.Uri
+
+class GraphConfigSuite extends FunSuite {
+
+  private val grapher = new Grapher(DefaultSettings(ConfigFactory.load("graph-config-test.conf")))
+
+  private def newGraphConfig(s: Long, e: Long, step: Long): GraphConfig = {
+    val uri = s"http://localhost/api/v1/graph?q=name,sps,:eq,:sum&s=$s&e=$e&step=${step}ms"
+    grapher.toGraphConfig(Uri(uri))
+  }
+
+  private val oneMinute = 60_000
+  private val end = System.currentTimeMillis() / oneMinute * oneMinute
+  private val start = end - 30 * oneMinute
+
+  test("increase step, minute boundary") {
+    val newStep = oneMinute
+    val c1 = newGraphConfig(start, end, 5_000)
+    val c2 = c1.withStep(newStep)
+    val expected = newGraphConfig(start, end, newStep)
+    assertEquals(c2.evalContext, expected.evalContext)
+    assertEquals(c1.evalContext.increaseStep(newStep), expected.evalContext)
+  }
+
+  test("increase step, boundary change") {
+    val newStep = oneMinute
+    val s = start + 5_000
+    val e = end + 5_000
+    val c1 = newGraphConfig(s, e, 5_000)
+    val c2 = c1.withStep(newStep)
+    val expected = newGraphConfig(s, e, newStep)
+    assertEquals(c2.evalContext, expected.evalContext)
+    assertEquals(c1.evalContext.increaseStep(newStep), expected.evalContext)
+  }
+
+  test("increase step, boundary change 15s") {
+    val newStep = 15_000
+    val s = start + 5_000
+    val e = end + 5_000
+    val c1 = newGraphConfig(s, e, 5_000)
+    val c2 = c1.withStep(newStep)
+    val expected = newGraphConfig(s, e, newStep)
+    assertEquals(c2.evalContext, expected.evalContext)
+    assertEquals(c1.evalContext.increaseStep(newStep), expected.evalContext)
+  }
+
+  test("increase step, boundary change 20s") {
+    val newStep = 20_000
+    val s = start - 5_000
+    val e = end - 5_000
+    val c1 = newGraphConfig(s, e, 5_000)
+    val c2 = c1.withStep(newStep)
+    val expected = newGraphConfig(s, e, newStep)
+    assertEquals(c2.evalContext, expected.evalContext)
+    assertEquals(c1.evalContext.increaseStep(newStep), expected.evalContext)
+  }
+}

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/FetchRequestSource.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/FetchRequestSource.scala
@@ -93,7 +93,7 @@ object FetchRequestSource {
         Source
           .future(future)
           .collect {
-            case DataResponse(data) => DataChunk(chunk, data)
+            case DataResponse(_, data) => DataChunk(chunk, data)
           }
       }
       .via(new EvalFlow(graphCfg))

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
@@ -72,5 +72,5 @@ object GraphApi {
     }
   }
 
-  case class DataResponse(ts: Map[DataExpr, List[TimeSeries]])
+  case class DataResponse(step: Long, ts: Map[DataExpr, List[TimeSeries]])
 }

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphRequestActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphRequestActor.scala
@@ -64,8 +64,8 @@ class GraphRequestActor(grapher: Grapher, registry: Registry) extends Actor with
       graphCtx = ctx
       dbRef.tell(DataRequest(request), self)
 
-    case DataResponse(data) => sendImage(data)
-    case Failure(t)         => throw t
+    case DataResponse(step, data) => sendImage(step, data)
+    case Failure(t)               => throw t
   }
 
   private def sendErrorImage(t: Throwable, w: Int, h: Int): Unit = {
@@ -83,8 +83,8 @@ class GraphRequestActor(grapher: Grapher, registry: Registry) extends Actor with
     graphCtx.complete(HttpResponse(status = StatusCodes.OK, entity = image))
   }
 
-  private def sendImage(data: Map[DataExpr, List[TimeSeries]]): Unit = {
-    val result = grapher.evalAndRender(request, data)
+  private def sendImage(step: Long, data: Map[DataExpr, List[TimeSeries]]): Unit = {
+    val result = grapher.evalAndRender(request.withStep(step), data)
     val entity = HttpEntity.Strict(request.contentType, ByteString(result.data))
     graphCtx.complete(HttpResponse(StatusCodes.OK, entity = entity))
     context.stop(self)

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalDatabaseActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalDatabaseActor.scala
@@ -43,6 +43,6 @@ class LocalDatabaseActor(db: Database) extends Actor with ActorLogging {
 
   private def executeDataRequest(req: DataRequest): DataResponse = {
     val data = req.exprs.map(expr => expr -> db.execute(req.context, expr)).toMap
-    DataResponse(data)
+    DataResponse(req.context.step, data)
   }
 }


### PR DESCRIPTION
Updates the data response to provide a step size. This makes it possible for the data actor to indicate that the step size was changed from what was requested. This is useful in some contexts where the primary step may vary across the data sources.