### PR TITLE
core: support binary ops with presentations settings

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -803,6 +803,7 @@ object MathVocabulary extends Vocabulary {
       case TimeSeriesType(_) :: TimeSeriesType(_) :: _ => true
       case (_: StyleExpr) :: TimeSeriesType(_) :: _    => true
       case TimeSeriesType(_) :: (_: StyleExpr) :: _    => true
+      case (_: StyleExpr) :: (_: StyleExpr) :: _       => true
     }
 
     def newInstance(t1: TimeSeriesExpr, t2: TimeSeriesExpr): TimeSeriesExpr
@@ -814,6 +815,10 @@ object MathVocabulary extends Vocabulary {
         t2.copy(expr = newInstance(t1, t2.expr)) :: stack
       case TimeSeriesType(t2) :: (t1: StyleExpr) :: stack =>
         t1.copy(expr = newInstance(t1.expr, t2)) :: stack
+      case (t2: StyleExpr) :: (t1: StyleExpr) :: stack =>
+        // If both sides have presentation, strip the presentation settings to avoid
+        // confusion as to which settings will get used.
+        newInstance(t1.expr, t2.expr) :: stack
     }
 
     override def signature: String = "TimeSeriesExpr TimeSeriesExpr -- TimeSeriesExpr"

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathAcrossStyleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathAcrossStyleSuite.scala
@@ -65,6 +65,12 @@ class MathAcrossStyleSuite extends FunSuite {
         val actual = eval(s"$a,abc,:legend,$b,:${w.name}")
         assertEquals(actual, expected)
       }
+
+      test(s"${w.name}, StyleExpr op StyleExpr") {
+        val expected = eval(s"$a,$b,:${w.name}")
+        val actual = eval(s"$a,a,:legend,$b,b,:legend,f00,:color,:${w.name}")
+        assertEquals(actual, expected)
+      }
     }
 
   test("clamp-min") {


### PR DESCRIPTION
With this change binary math operations can be used even if both sides have presentation settings. To avoid ambiguity the presentation settings will be stripped from both sides for the resulting expression.