### PR TITLE
core: add strip-style operator

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleVocabulary.scala
@@ -16,7 +16,6 @@
 package com.netflix.atlas.core.model
 
 import java.awt.Color
-
 import com.netflix.atlas.core.stacklang.Context
 import com.netflix.atlas.core.stacklang.Interpreter
 import com.netflix.atlas.core.stacklang.SimpleWord
@@ -66,7 +65,9 @@ object StyleVocabulary extends Vocabulary {
     ),
     Macro("vspan", List("vspan", ":ls"), List("name,sps,:eq,:sum,:dup,200e3,:gt")),
     // Legacy macro for visualizing epic expressions
-    Macro("des-epic-viz", desEpicViz, List("name,sps,:eq,:sum,10,0.1,0.5,0.2,0.2,4"))
+    Macro("des-epic-viz", desEpicViz, List("name,sps,:eq,:sum,10,0.1,0.5,0.2,0.2,4")),
+    // Remove presentation settings
+    StripStyle
   )
 
   sealed trait StyleWord extends SimpleWord {
@@ -495,6 +496,31 @@ object StyleVocabulary extends Vocabulary {
   //
   // Helper macros
   //
+
+  case object StripStyle extends SimpleWord {
+
+    override def name: String = "strip-style"
+
+    override def summary: String =
+      """
+        |Remove all presentation settings from an expression.
+      """.stripMargin.trim
+
+    protected def matcher: PartialFunction[List[Any], Boolean] = {
+      case PresentationType(_) :: _ => true
+    }
+
+    protected def executor: PartialFunction[List[Any], List[Any]] = {
+      case PresentationType(t) :: s => t.expr :: s
+    }
+
+    override def signature: String = "StyleExpr -- TimeSeriesExpr"
+
+    override def examples: List[String] = List(
+      "name,sps,:eq,:sum,ff0000,:color",
+      "name,sps,:eq,:sum,custom,:legend"
+    )
+  }
 
   private def desEpicViz = List(
     // Show signal line as a vertical span

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathAcrossStyleSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/MathAcrossStyleSuite.scala
@@ -73,6 +73,18 @@ class MathAcrossStyleSuite extends FunSuite {
       }
     }
 
+  test("binary op, strip-style for LHS") {
+    val expected = eval("a,:has,a,:legend,:strip-style,b,:has,b,:legend,:add")
+    val actual = eval("a,:has,b,:has,:add,b,:legend")
+    assertEquals(actual, expected)
+  }
+
+  test("binary op, strip-style for RHS") {
+    val expected = eval("a,:has,a,:legend,b,:has,b,:legend,:strip-style,:add")
+    val actual = eval("a,:has,b,:has,:add,a,:legend")
+    assertEquals(actual, expected)
+  }
+
   test("clamp-min") {
     val expected = eval("a,:has,1,:clamp-min,abc,:legend")
     val actual = eval("a,:has,abc,:legend,1,:clamp-min")

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
@@ -34,8 +34,8 @@ class ModelExtractorsSuite extends FunSuite {
 
   completionTest("name", 8)
   completionTest("name,sps", 22)
-  completionTest("name,sps,:eq", 21)
-  completionTest("name,sps,:eq,app,foo,:eq", 42)
+  completionTest("name,sps,:eq", 22)
+  completionTest("name,sps,:eq,app,foo,:eq", 43)
   completionTest("name,sps,:eq,app,foo,:eq,:and,(,asg,)", 12)
 
   test("TraceQueryType: implicit from Query") {


### PR DESCRIPTION
Adds an operator that can be used to explicitly remove any presentation settings for a time series expression. This can be useful for taking an existing expression and resetting the style before reusing in other operations.