### PR TITLE
core: update sed exprs to support tag vars

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
@@ -44,28 +44,28 @@ case class StyleExpr(expr: TimeSeriesExpr, settings: Map[String, String]) extend
 
   def legend(t: TimeSeries): String = {
     val fmt = settings.getOrElse("legend", t.label)
-    sed(Strings.substitute(fmt, t.tags))
+    sed(Strings.substitute(fmt, t.tags), t.tags)
   }
 
   def legend(label: String, tags: Map[String, String]): String = {
     val fmt = settings.getOrElse("legend", label)
-    sed(Strings.substitute(fmt, tags))
+    sed(Strings.substitute(fmt, tags), tags)
   }
 
-  private def sed(str: String): String = {
+  private def sed(str: String, tags: Map[String, String]): String = {
     settings.get("sed").fold(str) { v =>
-      sed(str, v.split(",").toList)
+      sed(str, v.split(",").toList, tags)
     }
   }
 
   @scala.annotation.tailrec
-  private def sed(str: String, cmds: List[String]): String = {
+  private def sed(str: String, cmds: List[String], tags: Map[String, String]): String = {
     if (cmds.isEmpty) str
     else {
       cmds match {
-        case mode :: ":decode" :: cs => sed(decode(str, mode), cs)
-        case s :: r :: ":s" :: cs    => sed(searchAndReplace(str, s, r), cs)
-        case _                       => sed(str, cmds.tail)
+        case mode :: ":decode" :: cs => sed(decode(str, mode), cs, tags)
+        case s :: r :: ":s" :: cs    => sed(searchAndReplace(str, s, r, tags), cs, tags)
+        case _                       => sed(str, cmds.tail, tags)
       }
     }
   }
@@ -78,27 +78,53 @@ case class StyleExpr(expr: TimeSeriesExpr, settings: Map[String, String]) extend
     }
   }
 
-  private def searchAndReplace(str: String, search: String, replace: String): String = {
+  private def searchAndReplace(str: String, search: String, replace: String, tags: Map[String, String]): String = {
     val m = Pattern.compile(search).matcher(str)
     if (!m.find()) str
     else {
       val sb = new StringBuffer()
-      m.appendReplacement(sb, substitute(replace, m))
+      m.appendReplacement(sb, escape(substitute(replace, m, tags)))
       while (m.find()) {
-        m.appendReplacement(sb, substitute(replace, m))
+        m.appendReplacement(sb, escape(substitute(replace, m, tags)))
       }
       m.appendTail(sb)
       sb.toString
     }
   }
 
+  /** Escape string so it is treated like a literal for append replacement. */
+  private def escape(str: String): String = {
+    str.replace("\\", "\\\\").replace("$", "\\$")
+  }
+
   /**
     * The `appendReplacement` method on the matcher will do substitutions, but this makes
     * it consistent with the variable substitutions for legends to avoid confusion about
     * slightly different syntax for variables in legends verses the replacement field.
+    *
+    * If a given variable name is not present, then it will fall back to try and resolve
+    * the variable based on the tags for the expression.
     */
-  private def substitute(str: String, m: Matcher): String = {
-    Strings.substitute(str, k => if (StyleExpr.isNumber(k)) m.group(k.toInt) else m.group(k))
+  private def substitute(str: String, m: Matcher, tags: Map[String, String]): String = {
+    Strings.substitute(str, k => {
+      // Default to use if the value cannot be found in the pattern
+      val tagValue = tags.getOrElse(k, k)
+
+      // Try to extract from the matcher first, if the variable isn't present, then use
+      // the tags as a fallback.
+      if (StyleExpr.isNumber(k)) {
+        val i = k.toInt
+        if (i <= m.groupCount()) m.group(i) else tagValue
+      } else {
+        // Prior to jdk20 there isn't a good way to detect set of available groups. So
+        // for now rely on the exception to detect if the group name doesn't exist.
+        try {
+          m.group(k)
+        } catch {
+          case _: IllegalArgumentException => tagValue
+        }
+      }
+    })
   }
 
   def sortBy: Option[String] = settings.get("sort")

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StyleExpr.scala
@@ -78,7 +78,12 @@ case class StyleExpr(expr: TimeSeriesExpr, settings: Map[String, String]) extend
     }
   }
 
-  private def searchAndReplace(str: String, search: String, replace: String, tags: Map[String, String]): String = {
+  private def searchAndReplace(
+    str: String,
+    search: String,
+    replace: String,
+    tags: Map[String, String]
+  ): String = {
     val m = Pattern.compile(search).matcher(str)
     if (!m.find()) str
     else {
@@ -106,25 +111,28 @@ case class StyleExpr(expr: TimeSeriesExpr, settings: Map[String, String]) extend
     * the variable based on the tags for the expression.
     */
   private def substitute(str: String, m: Matcher, tags: Map[String, String]): String = {
-    Strings.substitute(str, k => {
-      // Default to use if the value cannot be found in the pattern
-      val tagValue = tags.getOrElse(k, k)
+    Strings.substitute(
+      str,
+      k => {
+        // Default to use if the value cannot be found in the pattern
+        val tagValue = tags.getOrElse(k, k)
 
-      // Try to extract from the matcher first, if the variable isn't present, then use
-      // the tags as a fallback.
-      if (StyleExpr.isNumber(k)) {
-        val i = k.toInt
-        if (i <= m.groupCount()) m.group(i) else tagValue
-      } else {
-        // Prior to jdk20 there isn't a good way to detect set of available groups. So
-        // for now rely on the exception to detect if the group name doesn't exist.
-        try {
-          m.group(k)
-        } catch {
-          case _: IllegalArgumentException => tagValue
+        // Try to extract from the matcher first, if the variable isn't present, then use
+        // the tags as a fallback.
+        if (StyleExpr.isNumber(k)) {
+          val i = k.toInt
+          if (i <= m.groupCount()) m.group(i) else tagValue
+        } else {
+          // Prior to jdk20 there isn't a good way to detect set of available groups. So
+          // for now rely on the exception to detect if the group name doesn't exist.
+          try {
+            m.group(k)
+          } catch {
+            case _: IllegalArgumentException => tagValue
+          }
         }
       }
-    })
+    )
   }
 
   def sortBy: Option[String] = settings.get("sort")

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleExprSuite.scala
@@ -67,15 +67,22 @@ class StyleExprSuite extends FunSuite {
   private def check(sed: String, expected: String): Unit = {
     test(sed) {
       val expr = newExpr(s"$$b", sed)
-      val ts = newTimeSeries("foo", Map("a" -> "1", "b" -> "one_21_25_26_3F"))
+      val ts = newTimeSeries("foo", Map("a" -> "1", "2" -> "two", "b" -> "one_21_25_26_3F"))
       assertEquals(expr.legend(ts), expected)
     }
   }
 
   check("^([a-z]+).*$,prefix [$1],:s", "prefix [one]")
   check("^(?<prefix>[a-z]+).*$,prefix [$prefix],:s", "prefix [one]")
+  check("^(?<prefix>[A-Z]*).*$,prefix [$prefix],:s", "prefix []")
+  check("^(?<prefix>[a-z]+).*$,prefix [$1],:s", "prefix [one]")
+  check("^(?<prefix>[A-Z]*).*$,prefix [$1],:s", "prefix []")
+  check("^(?<prefix>[A-Z]*).*$,prefix [$2],:s", "prefix [two]")
   check("_.*,,:s", "one")
   check("(_[A-F0-9]{2}), $1,:s,hex,:decode", "one ! % & ?")
+  check("^([a-z]+).*$,$()prefix [$1],:s", "$prefix [one]")
+  check("^([a-z]+).*$,\\prefix [$1],:s", "\\prefix [one]")
+  check("^([a-z]+).*$,$a [$1],:s", "1 [one]")
   check("hex,:decode,(_[A-F0-9]{2}), $1,:s", "one!%&?")
   check("hex,:decode,%,_25,:s", "one!_25&?")
   check("hex,:decode,%,_25,:s,hex,:decode", "one!%&?")

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleExprSuite.scala
@@ -78,6 +78,7 @@ class StyleExprSuite extends FunSuite {
   check("^(?<prefix>[a-z]+).*$,prefix [$1],:s", "prefix [one]")
   check("^(?<prefix>[A-Z]*).*$,prefix [$1],:s", "prefix []")
   check("^(?<prefix>[A-Z]*).*$,prefix [$2],:s", "prefix [two]")
+  check("^(?<a>[a-z]+).*$,$a [$1],:s", "one [one]")
   check("_.*,,:s", "one")
   check("(_[A-F0-9]{2}), $1,:s,hex,:decode", "one ! % & ?")
   check("^([a-z]+).*$,$()prefix [$1],:s", "$prefix [one]")


### PR DESCRIPTION
Updates the sed expressions for the legend to fallback to the tags if the variable is not present on the regex matcher. Since the substitution is outside the matcher, escape before appending to avoid spurious exceptions if using a `$` or `\` in the replacement value.