### PR TITLE
lwcapi: update expression cache behavior

### DIFF
--- a/atlas-lwcapi/src/main/resources/reference.conf
+++ b/atlas-lwcapi/src/main/resources/reference.conf
@@ -20,6 +20,9 @@ atlas {
 
     # Should new or old messages get dropped if the queue is full?
     drop-new = true
+
+    # How long to keep cached copies of encoded expressions
+    exprs-ttl = 5m
   }
 
   pekko {

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
@@ -49,6 +49,8 @@ class SubscriptionManager[T](registry: Registry) extends StrictLogging {
   @volatile private var queryListChanged = false
   private val queryIndex = QueryIndex.newInstance[Subscription](registry)
 
+  @volatile var lastUpdateTime: Long = 0L
+
   // Background process for updating the query index. It is not done inline because rebuilding
   // the index can be computationally expensive.
   private val ex =
@@ -73,6 +75,8 @@ class SubscriptionManager[T](registry: Registry) extends StrictLogging {
       val removed = previous.diff(current)
       added.foreach(s => queryIndex.add(s.query, s))
       removed.foreach(s => queryIndex.remove(s.query, s))
+
+      lastUpdateTime = registry.clock().wallTime()
     }
   }
 


### PR DESCRIPTION
Before it would cache for 10s and then re-encode the next time a key was fetched. This could result in many requests waiting for the encode to complete on the next access after expiration. Now it will always return the cached copy if available and refresh them in the background.