### PR TITLE
lwcapi: add option to ignore publish step

### DIFF
--- a/atlas-lwcapi/src/main/resources/reference.conf
+++ b/atlas-lwcapi/src/main/resources/reference.conf
@@ -23,6 +23,11 @@ atlas {
 
     # How long to keep cached copies of encoded expressions
     exprs-ttl = 5m
+
+    # When retrieving cluster data indicate if expressions using the publish step should be
+    # ignored. These are filtered out on the client side when using a bridge, enabling this
+    # can significantly reduce the response sizes if there are many poorly scoped expressions.
+    exprs-cluster-ignore-publish-step = false
   }
 
   pekko {

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionApi.scala
@@ -194,7 +194,6 @@ object ExpressionApi {
           "cluster" -> sm.subscriptionsForCluster(cluster).filter(clusterSubFilter).map(_.metadata)
         case None => "overall" -> sm.subscriptions.map(_.metadata)
       }
-      println(s"loading $key ${expressions.size}")
       val start = registry.clock().monotonicTime()
       val encoded = encode(expressions)
       val encodingTimeNanos = registry.clock().monotonicTime() - start

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionApi.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/ExpressionApi.scala
@@ -41,6 +41,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 import java.util.zip.CRC32
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -58,7 +59,9 @@ case class ExpressionApi(
   private implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
 
   private val exprsTTL = config.getDuration("atlas.lwcapi.exprs-ttl").toMillis
-  private val responseCache = new ExpressionsCache(sm, registry, exprsTTL)
+
+  private val responseCache =
+    new ExpressionsCache(sm, registry, exprsTTL, createClusterSubFilter(config))
 
   /** Helper for testing to force the recomputation of encoded expressions. */
   private[lwcapi] def clearCache(): Unit = {
@@ -106,13 +109,35 @@ case class ExpressionApi(
 
 object ExpressionApi {
 
+  private def createClusterSubFilter(config: Config): Subscription => Boolean = {
+    val ignorePublishStep = config.getBoolean("atlas.lwcapi.exprs-cluster-ignore-publish-step")
+    if (ignorePublishStep) {
+      val publishStep = config.getDuration("atlas.lwcapi.register.default-step").toMillis
+      sub => sub.metadata.frequency != publishStep
+    } else { _ =>
+      true
+    }
+  }
+
   case class Return(expressions: List[ExpressionMetadata]) extends JsonSupport
 
   case class EncodedExpressions(etag: String, data: ByteString, size: Int)
 
-  private class CacheEntry(val exprs: EncodedExpressions, val lastAccessed: AtomicLong) {
+  private class CacheEntry(
+    val exprs: AtomicReference[EncodedExpressions],
+    val lastUpdated: AtomicLong,
+    val lastAccessed: AtomicLong
+  ) {
 
     def isExpired(clock: Clock, ttl: Long): Boolean = (clock.wallTime() - lastAccessed.get()) > ttl
+  }
+
+  private def newEntry(exprs: EncodedExpressions, now: Long): CacheEntry = {
+    new CacheEntry(
+      new AtomicReference[EncodedExpressions](exprs),
+      new AtomicLong(now),
+      new AtomicLong(now)
+    )
   }
 
   /**
@@ -120,20 +145,23 @@ object ExpressionApi {
     * encoded immediately. Otherwise, it will return the previously encoded data. The encoded
     * data will be refreshed in the background, not inline with the requests.
     */
-  class ExpressionsCache(sm: StreamSubscriptionManager, registry: Registry, ttl: Long)
-      extends StrictLogging {
+  class ExpressionsCache(
+    sm: StreamSubscriptionManager,
+    registry: Registry,
+    ttl: Long,
+    clusterSubFilter: Subscription => Boolean
+  ) extends StrictLogging {
 
     private val executor =
       new ScheduledThreadPoolExecutor(1, ThreadPools.threadFactory("ExpressionsCache"))
     executor.scheduleWithFixedDelay(() => refresh(), 10, 10, TimeUnit.SECONDS)
 
-    @volatile private var lastUpdateTime: Long = 0L
     private val data = new ConcurrentHashMap[Option[String], CacheEntry]()
 
     def get(key: Option[String]): EncodedExpressions = {
-      val entry = data.computeIfAbsent(key, k => load(k))
+      val entry = data.computeIfAbsent(key, k => newEntry(load(k), registry.clock().wallTime()))
       entry.lastAccessed.set(registry.clock().wallTime())
-      entry.exprs
+      entry.exprs.get()
     }
 
     /**
@@ -141,7 +169,6 @@ object ExpressionApi {
       * any entries that haven't been accessed recently.
       */
     def refresh(): Unit = {
-      val exprsUpdated = lastUpdateTime < sm.lastUpdateTime
       try {
         val iter = data.entrySet().iterator()
         while (iter.hasNext) {
@@ -150,27 +177,29 @@ object ExpressionApi {
           val value = entry.getValue
           if (value.isExpired(registry.clock(), ttl)) {
             iter.remove()
-          } else if (exprsUpdated) {
-            data.put(key, load(key))
+          } else if (value.lastUpdated.get() < sm.lastUpdateTime) {
+            value.lastUpdated.set(sm.lastUpdateTime)
+            value.exprs.set(load(key))
           }
         }
-        lastUpdateTime = registry.clock().wallTime()
         logger.debug(s"successfully refreshed cache")
       } catch {
         case e: Exception => logger.warn("failed to refresh expression cache", e)
       }
     }
 
-    private def load(key: Option[String]): CacheEntry = {
+    private def load(key: Option[String]): EncodedExpressions = {
       val (id, expressions) = key match {
-        case Some(cluster) => "cluster" -> sm.subscriptionsForCluster(cluster).map(_.metadata)
-        case None          => "overall" -> sm.subscriptions.map(_.metadata)
+        case Some(cluster) =>
+          "cluster" -> sm.subscriptionsForCluster(cluster).filter(clusterSubFilter).map(_.metadata)
+        case None => "overall" -> sm.subscriptions.map(_.metadata)
       }
+      println(s"loading $key ${expressions.size}")
       val start = registry.clock().monotonicTime()
       val encoded = encode(expressions)
       val encodingTimeNanos = registry.clock().monotonicTime() - start
       updateStats(id, encoded.size, encodingTimeNanos)
-      new CacheEntry(encoded, new AtomicLong(registry.clock().wallTime()))
+      encoded
     }
 
     private def updateStats(id: String, size: Int, encodingTimeNanos: Long): Unit = {

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
@@ -286,6 +286,8 @@ class SubscriptionManager[T](registry: Registry) extends StrictLogging {
   def clear(): Unit = {
     logger.debug("clearing all subscriptions")
     registrations.clear()
+    subHandlers.clear()
+    subscriptionsList = Nil
     queryListChanged = true
     updateQueryIndex()
   }


### PR DESCRIPTION
When listing expressions for a cluster, the client will often ignore the publish step because it is covered by a bridge cluster. Add an option so we can disable listing those for a cluster to reduce the payload sizes.

Also fixes updates so that refreshing will not update the access time for the cache entry.