### PR TITLE
core: allow offset to be applied across style

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataVocabulary.scala
@@ -198,11 +198,15 @@ object DataVocabulary extends Vocabulary {
     override def name: String = "offset"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
-      case DurationType(_) :: TimeSeriesType(_) :: _ => true
+      case DurationType(_) :: TimeSeriesType(_) :: _   => true
+      case DurationType(_) :: PresentationType(_) :: _ => true
     }
 
     protected def executor: PartialFunction[List[Any], List[Any]] = {
-      case DurationType(d) :: TimeSeriesType(t) :: stack => t.withOffset(d) :: stack
+      case DurationType(d) :: TimeSeriesType(t) :: stack =>
+        t.withOffset(d) :: stack
+      case DurationType(d) :: PresentationType(t) :: stack =>
+        t.copy(expr = t.expr.withOffset(d)) :: stack
     }
 
     override def summary: String =

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleVocabularySuite.scala
@@ -59,4 +59,9 @@ class StyleVocabularySuite extends FunSuite {
     val expected = StyleExpr(DataExpr.Sum(Query.True), Map("color" -> "60ff0000"))
     assertEquals(expr, expected)
   }
+
+  test(":offset after presentation") {
+    val expr = eval("name,test,:eq,:sum,foo,:legend,f00,:color,1h,:offset")
+    assertEquals(expr.toString, "name,test,:eq,:sum,PT1H,:offset,foo,:legend,f00,:color")
+  }
 }


### PR DESCRIPTION
This makes it behave more similarly to other unary operators.