### PR TITLE
core: allow math aggr across style

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleVocabularySuite.scala
@@ -59,4 +59,24 @@ class StyleVocabularySuite extends FunSuite {
     val expected = StyleExpr(DataExpr.Sum(Query.True), Map("color" -> "60ff0000"))
     assertEquals(expr, expected)
   }
+
+  test("math aggr after presentation") {
+    val expr = eval("name,test,:eq,:sum,(,app,),:by,$app,:legend,:count")
+    assertEquals(expr.toString, "name,test,:eq,:sum,(,app,),:by,:count,$app,:legend")
+  }
+
+  test("math aggr via macro after presentation - pct") {
+    val expr = eval("name,test,:eq,:sum,(,app,),:by,$app,:legend,:pct")
+    assertEquals(expr.toString, "name,test,:eq,:sum,(,app,),:by,:pct,$app,:legend")
+  }
+
+  test("math aggr via macro after presentation - avg") {
+    val expr = eval("name,test,:eq,:sum,(,app,),:by,$app,:legend,:avg")
+    assertEquals(expr.toString, "name,test,:eq,:sum,(,app,),:by,:avg,$app,:legend")
+  }
+
+  test("math aggr via macro after presentation - stddev") {
+    val expr = eval("name,test,:eq,:sum,(,app,),:by,$app,:legend,:stddev")
+    assertEquals(expr.toString, "name,test,:eq,:sum,(,app,),:by,:stddev,$app,:legend")
+  }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/StyleVocabularySuite.scala
@@ -82,6 +82,6 @@ class StyleVocabularySuite extends FunSuite {
 
   test(":offset after presentation") {
     val expr = eval("name,test,:eq,:sum,foo,:legend,f00,:color,1h,:offset")
-    assertEquals(expr.toString, "name,test,:eq,:sum,PT1H,:offset,foo,:legend,f00,:color"
+    assertEquals(expr.toString, "name,test,:eq,:sum,PT1H,:offset,foo,:legend,f00,:color")
   }
 }


### PR DESCRIPTION
Update the math aggr functions to behave consistently with unary math operators.