### PR TITLE
lwcapi: reduce overhead for updating query index

### DIFF
--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/Subscription.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/Subscription.scala
@@ -15,4 +15,13 @@
  */
 package com.netflix.atlas.lwcapi
 
-case class Subscription(query: SpectatorQuery, metadata: ExpressionMetadata)
+case class Subscription(query: SpectatorQuery, metadata: ExpressionMetadata) {
+
+  /**
+    * The hash code is needed for most of the usage, precompute when it is created to
+    * keep that usage as cheap as possible.
+    */
+  private val cachedHashCode = super.hashCode()
+
+  override def hashCode(): Int = cachedHashCode
+}

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/SubscriptionManager.scala
@@ -63,19 +63,17 @@ class SubscriptionManager[T](registry: Registry) extends StrictLogging {
     if (queryListChanged) {
       queryListChanged = false
       val previous = subscriptionsList.toSet
-      subscriptionsList = registrations
+      val current = registrations
         .values()
         .asScala
         .flatMap(_.subscriptions)
-        .toList
-        .distinct
-
-      val current = subscriptionsList.toSet
+        .toSet
       val added = current.diff(previous)
       val removed = previous.diff(current)
       added.foreach(s => queryIndex.add(s.query, s))
       removed.foreach(s => queryIndex.remove(s.query, s))
 
+      subscriptionsList = current.toList
       lastUpdateTime = registry.clock().wallTime()
     }
   }


### PR DESCRIPTION
It was computing a distinct list and then converting to a set. The distinct operation will create a set internally. Now just create the set and then use that to generate the list of current expressions.