### PR TITLE
eval: choose allowed steps based on block size

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StepSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StepSuite.scala
@@ -22,42 +22,63 @@ import munit.FunSuite
 
 class StepSuite extends FunSuite {
 
+  private def minutes(n: Long): Long = n * 60 * 1000
+
   private def days(n: Long): Long = n * 24 * 60 * 60 * 1000
+
+  private val oneHourStep = Step.forBlockStep(minutes(60))
 
   test("round: sub-second step sizes") {
     val primaryStep = 1L
-    assertEquals(1L, Step.round(primaryStep, 1))
-    assertEquals(5L, Step.round(primaryStep, 2))
-    assertEquals(10L, Step.round(primaryStep, 6))
-    assertEquals(50L, Step.round(primaryStep, 20))
-    assertEquals(100L, Step.round(primaryStep, 60))
-    assertEquals(500L, Step.round(primaryStep, 200))
-    assertEquals(1000L, Step.round(primaryStep, 600))
+    assertEquals(1L, oneHourStep.round(primaryStep, 1))
+    assertEquals(5L, oneHourStep.round(primaryStep, 2))
+    assertEquals(10L, oneHourStep.round(primaryStep, 6))
+    assertEquals(50L, oneHourStep.round(primaryStep, 20))
+    assertEquals(100L, oneHourStep.round(primaryStep, 60))
+    assertEquals(500L, oneHourStep.round(primaryStep, 200))
+    assertEquals(1000L, oneHourStep.round(primaryStep, 600))
   }
 
   test("round: allow arbitrary number of days") {
     (1 until 500).foreach { i =>
-      assertEquals(days(i), Step.round(60000, days(i)))
+      assertEquals(days(i), oneHourStep.round(60000, days(i)))
     }
   }
 
   test("round: up if less than a day") {
-    assertEquals(days(1), Step.round(60000, days(1) / 2 + 1))
+    assertEquals(days(1), oneHourStep.round(60000, days(1) / 2 + 1))
   }
 
   test("round: up if not on day boundary") {
-    assertEquals(days(3), Step.round(60000, days(2) + 1))
+    assertEquals(days(3), oneHourStep.round(60000, days(2) + 1))
+  }
+
+  test("round: only use steps that evenly divide block") {
+    val primaryStep = 5_000L
+    val tenMinuteStep = Step.forBlockStep(minutes(10))
+    assertEquals(minutes(1), tenMinuteStep.round(primaryStep, minutes(1)))
+    assertEquals(minutes(2), tenMinuteStep.round(primaryStep, minutes(2)))
+    assertEquals(minutes(5), tenMinuteStep.round(primaryStep, minutes(3)))
+    assertEquals(minutes(5), tenMinuteStep.round(primaryStep, minutes(4)))
+    assertEquals(minutes(5), tenMinuteStep.round(primaryStep, minutes(5)))
+    assertEquals(minutes(10), tenMinuteStep.round(primaryStep, minutes(6)))
+  }
+
+  test("round: only use steps that are multiples of the block") {
+    val primaryStep = 5_000L
+    val tenMinuteStep = Step.forBlockStep(minutes(10))
+    assertEquals(minutes(20), tenMinuteStep.round(primaryStep, minutes(15)))
   }
 
   test("compute: allow arbitrary number of days") {
     (1 until 500).foreach { i =>
-      assertEquals(days(i), Step.compute(60000, 1, 0L, days(i)))
+      assertEquals(days(i), oneHourStep.compute(60000, 1, 0L, days(i)))
     }
   }
 
   test("compute: round less than a day") {
     val e = Instant.parse("2017-06-27T00:00:00Z")
     val s = e.minus(12 * 30, ChronoUnit.DAYS)
-    assertEquals(days(1), Step.compute(60000, 430, s.toEpochMilli, e.toEpochMilli))
+    assertEquals(days(1), oneHourStep.compute(60000, 430, s.toEpochMilli, e.toEpochMilli))
   }
 }

--- a/atlas-eval/src/main/resources/reference.conf
+++ b/atlas-eval/src/main/resources/reference.conf
@@ -58,7 +58,7 @@ atlas.eval {
 
   graph {
     step = ${atlas.core.model.step}
-    block-size = ${atlas.core.model.block-size}
+    block-size = ${atlas.core.db.block-size}
 
     start-time = e-3h
     end-time = now

--- a/atlas-eval/src/main/resources/reference.conf
+++ b/atlas-eval/src/main/resources/reference.conf
@@ -58,6 +58,7 @@ atlas.eval {
 
   graph {
     step = ${atlas.core.model.step}
+    block-size = ${atlas.core.model.block-size}
 
     start-time = e-3h
     end-time = now

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/DefaultSettings.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/DefaultSettings.scala
@@ -48,6 +48,12 @@ case class DefaultSettings(root: Config, config: Config) {
   val stepSize: Long = config.getDuration("step", TimeUnit.MILLISECONDS)
 
   /**
+    * Duration of a block for the underlying storage. Influences the possible consolidated
+    * step sizes that can be used when graphing the data.
+    */
+  val blockStep: Long = config.getInt("block-size") * stepSize
+
+  /**
     * Default start time for the chart. This value should typically be relative to the
     * end time.
     */

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/GraphConfig.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/GraphConfig.scala
@@ -60,18 +60,21 @@ case class GraphConfig(
   val (resStart, resEnd) =
     Strings.timeRange(start.getOrElse(settings.startTime), end.getOrElse(settings.endTime), tz)
 
+  // Step util for block size
+  private val stepUtil = Step.forBlockStep(settings.blockStep)
+
   /** Input step size rounded if necessary to a supported step. */
   val roundedStepSize: Long = {
     val stepDuration = step.map(Strings.parseDuration)
     val stepMillis = settings.stepSize
-    stepDuration.fold(stepMillis)(s => Step.round(stepMillis, s.toMillis))
+    stepDuration.fold(stepMillis)(s => stepUtil.round(stepMillis, s.toMillis))
   }
 
   /** Effective step size for the graph after adjusting based on the size and time window. */
   val stepSize: Long = {
     val datapointWidth = math.min(settings.maxDatapoints, flags.width)
     val stepParam = roundedStepSize
-    Step.compute(stepParam, datapointWidth, resStart.toEpochMilli, resEnd.toEpochMilli)
+    stepUtil.compute(stepParam, datapointWidth, resStart.toEpochMilli, resEnd.toEpochMilli)
   }
 
   // Final start and end time rounded to step boundaries

--- a/atlas-eval/src/test/resources/graph-config-test.conf
+++ b/atlas-eval/src/test/resources/graph-config-test.conf
@@ -8,6 +8,7 @@ atlas {
   eval {
     graph {
       step = 5 seconds
+      block-size = 60
     }
   }
 }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TestContext.scala
@@ -64,6 +64,7 @@ object TestContext {
       |
       |atlas.eval.graph {
       |  step = 60s
+      |  block-size = 60
       |  start-time = e-3h
       |  end-time = now
       |  timezone = US/Pacific


### PR DESCRIPTION
When consolidating data, limit the set of allowed step sizes to those that evenly divide the underlying blocks or are even multiples of the block. Push down doesn't work correctly for step sizes that do not evenly divide the blocks.