### PR TITLE
core: move `:cq` to query vocabulary

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -46,7 +46,6 @@ object MathVocabulary extends Vocabulary {
     Time,
     TimeSpan,
     CommonGroupBy,
-    CommonQuery,
     NamedRewrite,
     ClampMin,
     ClampMax,
@@ -550,41 +549,6 @@ object MathVocabulary extends Vocabulary {
       List(
         "name,sps,:eq,(,nf.region,)",
         "name,bar,:eq,(,nf.node,),:by,(,nf.region,)"
-      )
-  }
-
-  case object CommonQuery extends SimpleWord {
-
-    override def name: String = "cq"
-
-    protected def matcher: PartialFunction[List[Any], Boolean] = {
-      case (_: Query) :: _ :: _ => true
-    }
-
-    protected def executor: PartialFunction[List[Any], List[Any]] = {
-      case (q2: Query) :: (expr: Expr) :: stack =>
-        val newExpr = expr.rewrite {
-          case q1: Query => q1.and(q2)
-        }
-        newExpr :: stack
-      case (_: Query) :: stack =>
-        // Ignore items on the stack that are not expressions. So we pop the query and leave
-        // the rest of the stack unchanged.
-        stack
-    }
-
-    override def summary: String =
-      """
-        |Recursively AND a common query to all queries in an expression. If the first parameter
-        |is not an expression, then it will be not be modified.
-      """.stripMargin.trim
-
-    override def signature: String = "Expr Query -- Expr"
-
-    override def examples: List[String] =
-      List(
-        "name,ssCpuUser,:eq,name,DiscoveryStatus_UP,:eq,:mul,nf.app,alerttest,:eq",
-        "42,nf.app,alerttest,:eq"
       )
   }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/QueryVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/QueryVocabulary.scala
@@ -46,7 +46,8 @@ object QueryVocabulary extends Vocabulary {
     In,
     And,
     Or,
-    Not
+    Not,
+    CommonQuery
   )
 
   case object True extends SimpleWord {
@@ -556,4 +557,38 @@ object QueryVocabulary extends Vocabulary {
     override def examples: List[String] = List(":false", ":true")
   }
 
+  case object CommonQuery extends SimpleWord {
+
+    override def name: String = "cq"
+
+    protected def matcher: PartialFunction[List[Any], Boolean] = {
+      case (_: Query) :: _ :: _ => true
+    }
+
+    protected def executor: PartialFunction[List[Any], List[Any]] = {
+      case (q2: Query) :: (expr: Expr) :: stack =>
+        val newExpr = expr.rewrite {
+          case q1: Query => q1.and(q2)
+        }
+        newExpr :: stack
+      case (_: Query) :: stack =>
+        // Ignore items on the stack that are not expressions. So we pop the query and leave
+        // the rest of the stack unchanged.
+        stack
+    }
+
+    override def summary: String =
+      """
+        |Recursively AND a common query to all queries in an expression. If the first parameter
+        |is not an expression, then it will be not be modified.
+      """.stripMargin.trim
+
+    override def signature: String = "Expr Query -- Expr"
+
+    override def examples: List[String] =
+      List(
+        "name,ssCpuUser,:eq,name,DiscoveryStatus_UP,:eq,:or,nf.app,alerttest,:eq",
+        "42,nf.app,alerttest,:eq"
+      )
+  }
 }

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/TagsApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/TagsApiSuite.scala
@@ -119,6 +119,10 @@ class TagsApiSuite extends MUnitRouteSuite {
     assertEquals(responseAs[String], """["01"]""")
   }
 
+  testGet("/api/v1/tags/name?q=name,01,:eq,:list,(,class,odd,:eq,:cq,),:each") {
+    assertEquals(responseAs[String], """["01"]""")
+  }
+
   testGet("/api/v1/tags/name?verbose=1") {
     val expected = (0 to 11).map(toTagJson).mkString("[", ",", "]")
     assertEquals(responseAs[String], expected)


### PR DESCRIPTION
This allows it to be used for APIs that only accept a query. The main benefit is to support `:list,(,contextQuery,:cq,),:each` pattern. It could be done with as `baseQuery,contextQuery,:and`, but in some cases it is convenient for tools to use the same pattern for tags and graph API.