### PR TITLE
core: add global common query operator

### DIFF
--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
@@ -34,8 +34,8 @@ class ModelExtractorsSuite extends FunSuite {
 
   completionTest("name", 8)
   completionTest("name,sps", 22)
-  completionTest("name,sps,:eq", 22)
-  completionTest("name,sps,:eq,app,foo,:eq", 43)
+  completionTest("name,sps,:eq", 23)
+  completionTest("name,sps,:eq,app,foo,:eq", 44)
   completionTest("name,sps,:eq,app,foo,:eq,:and,(,asg,)", 12)
 
   test("TraceQueryType: implicit from Query") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/QueryVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/QueryVocabularySuite.scala
@@ -125,4 +125,37 @@ class QueryVocabularySuite extends FunSuite {
     val exp = execEquals(s"a,$txt,:eq")
     assertEquals(exp.v, ")")
   }
+
+  test("gcq, empty stack") {
+    intercept[IllegalStateException] {
+      interpreter.execute(":gcq")
+    }
+  }
+
+  test("gcq, just query") {
+    val context = interpreter.execute("app,www,:eq,:gcq")
+    assertEquals(context.stack, Nil)
+    assertEquals(context.frozenStack, Nil)
+  }
+
+  test("gcq, apply to expr") {
+    val context = interpreter.execute("name,cpu,:eq,app,www,:eq,:gcq")
+    val expected = interpreter.execute("name,cpu,:eq,app,www,:eq,:and")
+    assertEquals(context.stack, expected.stack)
+    assertEquals(context.frozenStack, expected.frozenStack)
+  }
+
+  test("gcq, apply to multiple exprs") {
+    val context = interpreter.execute("name,cpu,:eq,42,name,disk,:eq,app,www,:eq,:gcq")
+    val expected = interpreter.execute("name,cpu,:eq,app,www,:eq,:and,42,name,disk,:eq,app,www,:eq,:and")
+    assertEquals(context.stack, expected.stack)
+    assertEquals(context.frozenStack, expected.frozenStack)
+  }
+
+  test("gcq, apply to frozen stack") {
+    val context = interpreter.execute("name,cpu,:eq,42,:freeze,name,disk,:eq,app,www,:eq,:gcq")
+    val expected = interpreter.execute("name,cpu,:eq,app,www,:eq,:and,42,:freeze,name,disk,:eq,app,www,:eq,:and")
+    assertEquals(context.stack, expected.stack)
+    assertEquals(context.frozenStack, expected.frozenStack)
+  }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/QueryVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/QueryVocabularySuite.scala
@@ -147,14 +147,16 @@ class QueryVocabularySuite extends FunSuite {
 
   test("gcq, apply to multiple exprs") {
     val context = interpreter.execute("name,cpu,:eq,42,name,disk,:eq,app,www,:eq,:gcq")
-    val expected = interpreter.execute("name,cpu,:eq,app,www,:eq,:and,42,name,disk,:eq,app,www,:eq,:and")
+    val expected =
+      interpreter.execute("name,cpu,:eq,app,www,:eq,:and,42,name,disk,:eq,app,www,:eq,:and")
     assertEquals(context.stack, expected.stack)
     assertEquals(context.frozenStack, expected.frozenStack)
   }
 
   test("gcq, apply to frozen stack") {
     val context = interpreter.execute("name,cpu,:eq,42,:freeze,name,disk,:eq,app,www,:eq,:gcq")
-    val expected = interpreter.execute("name,cpu,:eq,app,www,:eq,:and,42,:freeze,name,disk,:eq,app,www,:eq,:and")
+    val expected =
+      interpreter.execute("name,cpu,:eq,app,www,:eq,:and,42,:freeze,name,disk,:eq,app,www,:eq,:and")
     assertEquals(context.stack, expected.stack)
     assertEquals(context.frozenStack, expected.frozenStack)
   }


### PR DESCRIPTION
Allows a scoping query to be applied to all expressions for both the current and frozen stack.