### PR TITLE
1.7.x: update to publish to central portal

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,15 +4,15 @@ on: [pull_request]
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-14
     strategy:
       matrix:
-        java: [17, 19]
-        scala: [2.13.10]
+        java: [17, 25]
+        scala: [2.13.16, 3.7.1]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
@@ -22,11 +22,11 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'zulu'
           cache: 'sbt'
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,9 @@ jobs:
     if: ${{ github.repository == 'Netflix/atlas' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: 'zulu'
@@ -31,5 +31,5 @@ jobs:
           PGP_PASSPHRASE: ${{ secrets.ORG_SIGNING_PASSWORD }}
         run: |
           git fetch --unshallow --tags
-          cat /dev/null | project/sbt clean test +publishSigned
-          cat /dev/null | project/sbt sonatypeBundleRelease
+          cat /dev/null | project/sbt ++2.13.16 clean test +publishSigned
+          cat /dev/null | project/sbt sonaRelease

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -11,9 +11,9 @@ jobs:
     if: ${{ github.repository == 'Netflix/atlas' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: 'zulu'
@@ -31,4 +31,4 @@ jobs:
           PGP_PASSPHRASE: ${{ secrets.ORG_SIGNING_PASSWORD }}
         run: |
           git fetch --unshallow --tags
-          cat /dev/null | project/sbt clean test +publishSigned
+          cat /dev/null | project/sbt ++2.13.16 clean test +publishSigned

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/graphics/Ticks.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/graphics/Ticks.scala
@@ -395,7 +395,7 @@ object Ticks {
     if (logDistance <= n) {
       1
     } else {
-      math.ceil(logDistance / n).toInt
+      math.ceil(logDistance.toDouble / n).toInt
     }
   }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/QueryIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/QueryIndex.scala
@@ -164,7 +164,7 @@ case class QueryIndex[T](
   */
 object QueryIndex {
 
-  type IndexMap[T <: Any] = scala.collection.mutable.AnyRefMap[AnyRef, QueryIndex[T]]
+  type IndexMap[T <: Any] = scala.collection.mutable.HashMap[AnyRef, QueryIndex[T]]
 
   case class Entry[T](query: Query, value: T)
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
@@ -225,7 +225,7 @@ object StatefulExpr {
     */
   trait OnlineExpr extends StatefulExpr {
 
-    type StateMap = scala.collection.mutable.AnyRefMap[ItemId, AlgoState]
+    type StateMap = scala.collection.mutable.HashMap[ItemId, AlgoState]
 
     protected def name: String
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Hash.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Hash.scala
@@ -47,8 +47,8 @@ object Hash {
   // https://github.com/jruby/jruby/commit/e840823c435393e8365be1bae93f646c1bb0043f
   private val cloneableDigests = createDigests()
 
-  private def createDigests(): scala.collection.mutable.AnyRefMap[String, MessageDigest] = {
-    val digests = new scala.collection.mutable.AnyRefMap[String, MessageDigest]()
+  private def createDigests(): scala.collection.mutable.HashMap[String, MessageDigest] = {
+    val digests = new scala.collection.mutable.HashMap[String, MessageDigest]()
     List("MD5", "SHA1").foreach { algorithm =>
       Try(MessageDigest.getInstance(algorithm)).foreach { digest =>
         // Try to clone the digest to make sure it is cloneable
@@ -61,7 +61,7 @@ object Hash {
   }
 
   def get(algorithm: String): MessageDigest = {
-    val digest = cloneableDigests.getOrNull(algorithm)
+    val digest = cloneableDigests.getOrElse(algorithm, null)
     if (digest != null)
       digest.clone().asInstanceOf[MessageDigest]
     else

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/SmallHashMap.scala
@@ -391,7 +391,7 @@ final class SmallHashMap[K <: Any, V <: Any] private (val data: Array[Any], data
         // exclude equality.
         if (this eq m) return true
         size == m.size && hashCode == m.hashCode && dataEquals(m.asInstanceOf[SmallHashMap[K, V]])
-      case m: Map[_, _] =>
+      case _: Map[_, _] =>
         super.equals(obj)
       case _ =>
         false

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
@@ -423,7 +423,7 @@ object Strings {
     */
   def parseDuration(str: String): Duration = str match {
     case AtPeriod(a, u) => parseAtDuration(a, u)
-    case IsoPeriod(p)   => Duration.parse(str)
+    case IsoPeriod(_)   => Duration.parse(str)
     case _              => throw new IllegalArgumentException("invalid period " + str)
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/QueryIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/QueryIndexSuite.scala
@@ -254,7 +254,7 @@ class QueryIndexSuite extends FunSuite {
     assertEquals(matchingEntries(index, tags), List(clusterQuery))
   }
 
-  type QueryInterner = scala.collection.mutable.AnyRefMap[Query, Query]
+  type QueryInterner = scala.collection.mutable.HashMap[Query, Query]
 
   private def intern(interner: QueryInterner, query: Query): Query = {
     query match {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
@@ -217,7 +217,7 @@ object AggrDatapoint {
   private class GroupByAggregator(settings: AggregatorSettings) extends Aggregator(settings) {
 
     private val aggregators =
-      scala.collection.mutable.AnyRefMap.empty[Map[String, String], Aggregator]
+      scala.collection.mutable.HashMap.empty[Map[String, String], Aggregator]
 
     private def newAggregator(datapoint: AggrDatapoint): Aggregator = {
       datapoint.expr match {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/FinalExprEval.scala
@@ -62,7 +62,7 @@ private[stream] class FinalExprEval(interpreter: ExprInterpreter)
       // Maintains the state for each expression we need to evaluate. TODO: implement
       // limits to sanity check against running of our memory
       private val states =
-        scala.collection.mutable.AnyRefMap.empty[StyleExpr, Map[StatefulExpr, Any]]
+        scala.collection.mutable.HashMap.empty[StyleExpr, Map[StatefulExpr, Any]]
 
       // Step size for datapoints flowing through, it will be determined by the first data
       // sources message that arrives and should be consistent for the life of this stage

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapoint.scala
@@ -45,7 +45,7 @@ private[stream] class LwcToAggrDatapoint(context: StreamContext)
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
     new GraphStageLogic(shape) with InHandler with OutHandler {
 
-      private[this] val state = scala.collection.mutable.AnyRefMap.empty[String, LwcDataExpr]
+      private[this] val state = scala.collection.mutable.HashMap.empty[String, LwcDataExpr]
 
       // HACK: needed until we can plumb the actual source through the system
       private var nextSource: Int = 0

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookupSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaGroupsLookupSuite.scala
@@ -37,8 +37,8 @@ class EurekaGroupsLookupSuite extends FunSuite {
   import EurekaSource._
   import Evaluator._
 
-  private implicit val system = ActorSystem(getClass.getSimpleName)
-  private implicit val mat = Materializer(system)
+  private implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)
+  private implicit val mat: Materializer = Materializer(system)
 
   private val eurekaGroup = EurekaSource.VipResponse(
     uri = "http://eureka/v2/vips/atlas-lwcapi:7001",

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaSourceSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EurekaSourceSuite.scala
@@ -95,8 +95,8 @@ class EurekaSourceSuite extends FunSuite {
 
   private val vipJson = s"""{"applications": {"application": [$innerAppJson]}}"""
 
-  private implicit val system = ActorSystem(getClass.getSimpleName)
-  private implicit val mat = Materializer(system)
+  private implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)
+  private implicit val mat: Materializer = Materializer(system)
 
   private def run(uri: String, response: Try[HttpResponse]): GroupResponse = {
     val client = Flow[(HttpRequest, AccessLogger)].map {

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -60,7 +60,7 @@ class EvaluatorSuite extends FunSuite {
 
   private val config = ConfigFactory.load()
   private val registry = new DefaultRegistry()
-  private implicit val system = ActorSystem("test", config)
+  private implicit val system: ActorSystem = ActorSystem("test", config)
 
   override def beforeEach(context: BeforeEach): Unit = {
     Files.createDirectories(targetDir)

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FillRemovedKeysWithSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FillRemovedKeysWithSuite.scala
@@ -25,7 +25,7 @@ import scala.concurrent.duration.Duration
 
 class FillRemovedKeysWithSuite extends FunSuite {
 
-  implicit val system = ActorSystem(getClass.getSimpleName)
+  implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)
 
   val map1 = Map[String, String]("a" -> "1")
   val map2 = Map[String, String]("b" -> "2")

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/FinalExprEvalSuite.scala
@@ -43,7 +43,7 @@ class FinalExprEvalSuite extends FunSuite {
 
   private val step = 60000L
 
-  private implicit val system = ActorSystem(getClass.getSimpleName)
+  private implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)
 
   private val interpreter = new ExprInterpreter(ConfigFactory.load())
 

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/HostSourceSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/HostSourceSuite.scala
@@ -47,7 +47,7 @@ class HostSourceSuite extends FunSuite {
 
   import scala.concurrent.duration._
 
-  implicit val system = ActorSystem(getClass.getSimpleName)
+  implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)
 
   def source(response: => Try[HttpResponse]): Source[ByteString, NotUsed] = {
     val client = Flow[HttpRequest].map(_ => response)

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
@@ -37,8 +37,8 @@ import scala.concurrent.duration.Duration
 
 class LwcToAggrDatapointSuite extends FunSuite {
 
-  implicit val system = ActorSystem(getClass.getSimpleName)
-  private implicit val materializer = Materializer(system)
+  implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)
+  private implicit val materializer: Materializer = Materializer(system)
 
   private val step = 10000
 

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
@@ -32,8 +32,8 @@ import scala.concurrent.duration.Duration
 
 class TimeGroupedSuite extends FunSuite {
 
-  private implicit val system = ActorSystem(getClass.getSimpleName)
-  private implicit val materializer = Materializer(system)
+  private implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)
+  private implicit val materializer: Materializer = Materializer(system)
 
   private val registry = new DefaultRegistry()
 
@@ -230,7 +230,7 @@ class TimeGroupedSuite extends FunSuite {
     val data = (0 until n).toList.map { i =>
       AggrDatapoint(10, 10, expr, "test", Map.empty, i)
     }
-    val expected = AggrDatapoint(10, 10, expr, "test", Map.empty, n * (n - 1) / 2)
+    val expected = AggrDatapoint(10, 10, expr, "test", Map.empty, (n * (n - 1) / 2).toDouble)
 
     val groups = run(data)
     assertEquals(groups, List(TimeGroup(10, step, Map(expr -> AggrValuesInfo(List(expected), n)))))
@@ -266,7 +266,7 @@ class TimeGroupedSuite extends FunSuite {
     val data = (0 until n).toList.map { i =>
       AggrDatapoint(10, 10, expr, "test", Map.empty, i)
     }
-    val expected = AggrDatapoint(10, 10, expr, "test", Map.empty, n * (n - 1) / 2)
+    val expected = AggrDatapoint(10, 10, expr, "test", Map.empty, (n * (n - 1) / 2).toDouble)
 
     val groups = run(data)
     assertEquals(groups, List(TimeGroup(10, step, Map(expr -> AggrValuesInfo(List(expected), n)))))

--- a/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamMetadata.scala
+++ b/atlas-lwcapi/src/main/scala/com/netflix/atlas/lwcapi/StreamMetadata.scala
@@ -38,16 +38,17 @@ import com.netflix.spectator.impl.StepLong
 case class StreamMetadata(
   streamId: String,
   remoteAddress: String = "unknown",
+  clock: Clock = Clock.SYSTEM,
   receivedMessages: StepLong = new StepLong(0, Clock.SYSTEM, 60_000),
   droppedMessages: StepLong = new StepLong(0, Clock.SYSTEM, 60_000)
 ) extends JsonSupport {
 
   def updateReceived(n: Int): Unit = {
-    receivedMessages.getCurrent.addAndGet(n)
+    receivedMessages.addAndGet(clock.wallTime(), n)
   }
 
   def updateDropped(n: Int): Unit = {
-    droppedMessages.getCurrent.addAndGet(n)
+    droppedMessages.addAndGet(clock.wallTime(), n)
   }
 
   override def hasCustomEncoding: Boolean = true

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/EvaluateApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/EvaluateApiSuite.scala
@@ -28,7 +28,7 @@ class EvaluateApiSuite extends MUnitRouteSuite {
 
   import scala.concurrent.duration._
 
-  private implicit val routeTestTimeout = RouteTestTimeout(5.second)
+  private implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(5.second)
 
   private val sm = new StreamSubscriptionManager(new NoopRegistry)
   private val endpoint = new EvaluateApi(new NoopRegistry, sm)

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/ExpressionApiSuite.scala
@@ -36,7 +36,7 @@ class ExpressionApiSuite extends MUnitRouteSuite {
 
   import scala.concurrent.duration._
 
-  private implicit val routeTestTimeout = RouteTestTimeout(5.second)
+  private implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(5.second)
 
   private val splitter = new ExpressionSplitter(ConfigFactory.load())
 

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/StreamMetadataSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/StreamMetadataSuite.scala
@@ -25,7 +25,7 @@ class StreamMetadataSuite extends FunSuite {
     val clock = new ManualClock()
     val step = 60_000L
     val meta =
-      StreamMetadata("id", "addr", new StepLong(0, clock, step), new StepLong(0, clock, step))
+      StreamMetadata("id", "addr", clock, new StepLong(0, clock, step), new StepLong(0, clock, step))
     meta.updateReceived(100)
     meta.updateDropped(2)
 

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscribeApiSuite.scala
@@ -33,7 +33,7 @@ class SubscribeApiSuite extends MUnitRouteSuite {
 
   import scala.concurrent.duration._
 
-  private implicit val routeTestTimeout = RouteTestTimeout(5.second)
+  private implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(5.second)
 
   private val config = ConfigFactory.load()
   private val sm = new StreamSubscriptionManager(new NoopRegistry)

--- a/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
+++ b/atlas-lwcapi/src/test/scala/com/netflix/atlas/lwcapi/SubscriptionManagerSuite.scala
@@ -228,7 +228,7 @@ class SubscriptionManagerSuite extends FunSuite {
 
     val sm = new SubscriptionManager[Integer](registry)
     val meta =
-      StreamMetadata("a", "test", new StepLong(0, clock, step), new StepLong(0, clock, step))
+      StreamMetadata("a", "test", clock, new StepLong(0, clock, step), new StepLong(0, clock, step))
     assert(sm.register(meta, 1))
 
     val ok = Id.create("atlas.lwcapi.currentStreams").withTag("state", "ok")

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/ClusterOps.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/ClusterOps.scala
@@ -101,7 +101,7 @@ object ClusterOps extends StrictLogging {
       new GraphStageLogic(shape) with InHandler with OutHandler {
 
         private val registry = context.registry
-        private val membersSources = mutable.AnyRefMap.empty[M, SourceQueue[D]]
+        private val membersSources = mutable.HashMap.empty[M, SourceQueue[D]]
 
         override def onPush(): Unit = {
           val msg = grab(in)

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/ImperativeRequestContext.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/ImperativeRequestContext.scala
@@ -19,6 +19,7 @@ import org.apache.pekko.http.scaladsl.model.HttpResponse
 import org.apache.pekko.http.scaladsl.server.RequestContext
 import org.apache.pekko.http.scaladsl.server.RouteResult
 
+import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.Promise
 
 /**
@@ -31,7 +32,7 @@ case class ImperativeRequestContext(value: AnyRef, ctx: RequestContext) {
 
   val promise: Promise[RouteResult] = Promise()
 
-  private implicit val ec = ctx.executionContext
+  private implicit val ec: ExecutionContextExecutor = ctx.executionContext
 
   def complete(res: HttpResponse): Unit = {
     ctx.complete(res).onComplete(promise.complete)

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/PekkoHttpClient.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/PekkoHttpClient.scala
@@ -19,6 +19,8 @@ import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.Http
 import org.apache.pekko.http.scaladsl.model.HttpRequest
 import org.apache.pekko.http.scaladsl.model.HttpResponse
+
+import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.Future
 
 /**
@@ -44,7 +46,7 @@ trait PekkoHttpClient {
 class DefaultPekkoHttpClient(name: String)(implicit val system: ActorSystem)
     extends PekkoHttpClient {
 
-  private implicit val ec = system.dispatcher
+  private implicit val ec: ExecutionContextExecutor = system.dispatcher
 
   override def singleRequest(request: HttpRequest): Future[HttpResponse] = {
     val accessLogger = AccessLogger.newClientLogger(name, request)

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/ActorServiceSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/ActorServiceSuite.scala
@@ -28,7 +28,7 @@ import scala.concurrent.Await
 class ActorServiceSuite extends FunSuite {
 
   import scala.concurrent.duration._
-  implicit val timeout = Timeout(5.seconds)
+  implicit val timeout: Timeout = Timeout(5.seconds)
 
   test("simple actor") {
     val config = ConfigFactory.parseString(s"""

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/ClusterOpsSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/ClusterOpsSuite.scala
@@ -26,7 +26,7 @@ import scala.concurrent.duration.Duration
 
 class ClusterOpsSuite extends FunSuite {
 
-  private implicit val system = ActorSystem(getClass.getSimpleName)
+  private implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)
 
   test("groupBy: empty cluster") {
     val input = List(

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/ConfigApiSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/ConfigApiSuite.scala
@@ -27,7 +27,7 @@ class ConfigApiSuite extends MUnitRouteSuite {
 
   import scala.concurrent.duration._
 
-  implicit val routeTestTimeout = RouteTestTimeout(5.second)
+  implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(5.second)
 
   val sysConfig = ConfigFactory.load()
   val endpoint = new ConfigApi(sysConfig, system)

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/CustomDirectivesSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/CustomDirectivesSuite.scala
@@ -45,7 +45,7 @@ class CustomDirectivesSuite extends MUnitRouteSuite {
   import CustomDirectivesSuite._
 
   // Some of the tests were a bit flakey with default of 1 second on slower machines
-  implicit val timeout = RouteTestTimeout(5.seconds)
+  implicit val timeout: RouteTestTimeout = RouteTestTimeout(5.seconds)
 
   class TestService(val actorRefFactory: ActorRefFactory) {
 

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/RequestHandlerNoCompressionSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/RequestHandlerNoCompressionSuite.scala
@@ -34,7 +34,8 @@ import java.lang.reflect.Type
 class RequestHandlerNoCompressionSuite extends MUnitRouteSuite {
 
   import scala.concurrent.duration._
-  implicit val routeTestTimeout = RouteTestTimeout(5.second)
+
+  implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(5.second)
 
   private val config = ConfigFactory.parseString(
     """

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/RequestHandlerSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/RequestHandlerSuite.scala
@@ -34,7 +34,8 @@ import java.lang.reflect.Type
 class RequestHandlerSuite extends MUnitRouteSuite {
 
   import scala.concurrent.duration._
-  implicit val routeTestTimeout = RouteTestTimeout(5.second)
+
+  implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(5.second)
 
   private val config = ConfigFactory.parseString(
     """

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/StreamOpsSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/StreamOpsSuite.scala
@@ -40,7 +40,7 @@ class StreamOpsSuite extends FunSuite {
 
   import OpportunisticEC._
 
-  private implicit val system = ActorSystem(getClass.getSimpleName)
+  private implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)
 
   private def checkOfferedCounts(registry: Registry, expected: Map[String, Double]): Unit = {
     import scala.jdk.CollectionConverters._

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/TestApiSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/TestApiSuite.scala
@@ -22,7 +22,7 @@ class TestApiSuite extends MUnitRouteSuite {
 
   import scala.concurrent.duration._
 
-  implicit val routeTestTimeout = RouteTestTimeout(5.second)
+  implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(5.second)
 
   val endpoint = new TestApi(system)
   val routes = RequestHandler.standardOptions(endpoint.routes)

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishApi.scala
@@ -32,6 +32,7 @@ import com.netflix.atlas.json.JsonSupport
 import com.netflix.iep.config.ConfigManager
 import com.typesafe.scalalogging.StrictLogging
 
+import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.Promise
 
 class PublishApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi with StrictLogging {
@@ -109,7 +110,7 @@ object PublishApi {
     ctx: RequestContext
   ) {
 
-    private implicit val ec = ctx.executionContext
+    private implicit val ec: ExecutionContextExecutor = ctx.executionContext
 
     def complete(res: HttpResponse): Unit = {
       ctx.complete(res).onComplete(promise.complete)

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsApi.scala
@@ -36,13 +36,15 @@ import com.netflix.atlas.core.model.Tag
 import com.netflix.atlas.core.stacklang.Interpreter
 import com.netflix.atlas.json.Json
 
+import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration._
 import scala.util.Failure
 
 class TagsApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi {
 
   import com.netflix.atlas.webapi.TagsApi._
-  implicit val ec = actorRefFactory.dispatcher
+
+  implicit val ec: ExecutionContextExecutor = actorRefFactory.dispatcher
 
   private val dbRef = actorRefFactory.actorSelection("/user/db")
 

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiMemDbSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiMemDbSuite.scala
@@ -32,7 +32,7 @@ class GraphApiMemDbSuite extends MUnitRouteSuite {
 
   // Set to high value to avoid spurious failures with code coverage. Typically 5s shows no
   // issues outside of running with code coverage.
-  private implicit val routeTestTimeout = RouteTestTimeout(5.seconds)
+  private implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(5.seconds)
 
   private val dbConfig = ConfigFactory.parseString("""
       |atlas.core.db {

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/GraphApiSuite.scala
@@ -39,7 +39,7 @@ class GraphApiSuite extends MUnitRouteSuite {
 
   // Set to high value to avoid spurious failures with code coverage. Typically 5s shows no
   // issues outside of running with code coverage.
-  implicit val routeTestTimeout = RouteTestTimeout(600.seconds)
+  implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(600.seconds)
 
   private val db = StaticDatabase.demo
   system.actorOf(Props(new LocalDatabaseActor(db)), "db")

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishApiSuite.scala
@@ -32,7 +32,7 @@ class PublishApiSuite extends MUnitRouteSuite {
 
   import scala.concurrent.duration._
 
-  implicit val routeTestTimeout = RouteTestTimeout(5.second)
+  implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(5.second)
 
   system.actorOf(Props(new TestActor), "publish")
 

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/TagsApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/TagsApiSuite.scala
@@ -32,7 +32,7 @@ class TagsApiSuite extends MUnitRouteSuite {
 
   import scala.concurrent.duration._
 
-  implicit val routeTestTimeout = RouteTestTimeout(5.second)
+  implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(5.second)
 
   private val staticDb = StaticDatabase.range(0, 11)
 

--- a/build.sbt
+++ b/build.sbt
@@ -148,6 +148,7 @@ lazy val `atlas-standalone` = project
     Dependencies.log4jApi,
     Dependencies.log4jCore,
     Dependencies.log4jSlf4j,
+    Dependencies.spectatorAtlas,
     Dependencies.spectatorLog4j
   ))
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,12 +7,12 @@ object Dependencies {
     val pekko       = "1.0.1"
     val pekkoHttpV  = "1.0.0"
 
-    val iep        = "4.2.0"
+    val iep        = "4.2.1"
     val jackson    = "2.15.0"
-    val log4j      = "2.20.0"
-    val scala      = "2.13.10"
+    val log4j      = "2.25.2"
+    val scala      = "2.13.16"
     val slf4j      = "1.7.36"
-    val spectator  = "1.5.4"
+    val spectator  = "1.9.0"
     val spring     = "5.3.25"
 
     val crossScala = Seq(scala)
@@ -30,7 +30,7 @@ object Dependencies {
   val pekkoTestkit       = "org.apache.pekko" %% "pekko-testkit" % pekko
   val caffeine          = "com.github.ben-manes.caffeine" % "caffeine" % "2.9.3"
   val datasketches      = "org.apache.datasketches" % "datasketches-java" % "3.3.0"
-  val equalsVerifier    = "nl.jqno.equalsverifier" % "equalsverifier" % "3.14"
+  val equalsVerifier    = "nl.jqno.equalsverifier" % "equalsverifier" % "4.1"
   val iepLeaderApi      = "com.netflix.iep" % "iep-leader-api" % iep
   val iepLeaderDynamoDb = "com.netflix.iep" % "iep-leader-dynamodb" % iep
   val iepDynConfig      = "com.netflix.iep" % "iep-dynconfig" % iep

--- a/project/GitVersion.scala
+++ b/project/GitVersion.scala
@@ -64,6 +64,7 @@ object GitVersion {
         case releaseVersion(v)   => v
         case v                   => v
       }
-    }
+    },
+    ThisBuild / versionScheme := Some("semver-spec")
   )
 }

--- a/project/SonatypeSettings.scala
+++ b/project/SonatypeSettings.scala
@@ -1,7 +1,5 @@
-import sbt._
-import sbt.Keys._
-import xerial.sbt.Sonatype._
-import xerial.sbt.Sonatype.SonatypeKeys._
+import sbt.*
+import sbt.Keys.*
 
 object SonatypeSettings {
 
@@ -12,14 +10,40 @@ object SonatypeSettings {
   private lazy val user = get("USERNAME")
   private lazy val pass = get("PASSWORD")
 
-  lazy val settings: Seq[Def.Setting[_]] = sonatypeSettings ++ Seq(
-    sonatypeProfileName := "com.netflix",
-    sonatypeProjectHosting := Some(GitHubHosting("Netflix", "atlas", "netflixoss@netflix.com")),
+  lazy val settings: Seq[Def.Setting[_]] = Seq(
+    organization := "com.netflix.atlas_v1",
+    organizationName := "netflix",
+    organizationHomepage := Some(url("https://github.com/Netflix")),
+    homepage := Some(url("https://github.com/Netflix/atlas")),
+    description := "In-memory time series database",
+
+    scmInfo := Some(
+      ScmInfo(
+        url("https://github.com/Netflix/atlas"),
+        "scm:git@github.com:Netflix/atlas.git"
+      )
+    ),
+
+    developers := List(
+      Developer(
+        id = "netflixgithub",
+        name = "Netflix Open Source Development",
+        email = "netflixoss@netflix.com",
+        url = url("https://github.com/Netflix")
+      )
+    ),
 
     publishMavenStyle := true,
-    licenses += ("APL2" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt")),
-    credentials += Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", user, pass),
+    pomIncludeRepository := { _ => false },
 
-    publishTo := sonatypePublishToBundle.value
+    licenses += ("Apache 2" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt")),
+    credentials += Credentials("Sonatype Nexus Repository Manager", "central.sonatype.com", user, pass),
+
+    publishTo := {
+      if (isSnapshot.value)
+        Some(Resolver.sonatypeCentralSnapshots)
+      else
+        localStaging.value
+    }
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.11.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,9 @@
-addSbtPlugin("org.xerial.sbt"            % "sbt-sonatype"         % "3.9.13")
-addSbtPlugin("com.github.sbt"            % "sbt-pgp"              % "2.1.2")
-addSbtPlugin("com.github.sbt"            % "sbt-release"          % "1.1.0")
-addSbtPlugin("pl.project13.scala"        % "sbt-jmh"              % "0.4.3")
-addSbtPlugin("com.github.sbt"            % "sbt-git"              % "2.0.0")
+addSbtPlugin("com.github.sbt"            % "sbt-pgp"              % "2.3.1")
+addSbtPlugin("com.github.sbt"            % "sbt-release"          % "1.4.0")
+addSbtPlugin("pl.project13.scala"        % "sbt-jmh"              % "0.4.7")
+addSbtPlugin("com.github.sbt"            % "sbt-git"              % "2.1.0")
 
 addSbtPlugin("org.scalameta"             % "sbt-scalafmt"         % "2.4.6")
 
 // Convenient helpers, not required
 addSbtPlugin("com.timushev.sbt"          % "sbt-updates"          % "0.6.4")
-


### PR DESCRIPTION
Sonatype is phasing out OSSRH so update the publishing to go to the new central portal.

Also updates scala, log4j, and spectator to recent versions and fix various warnings.