### PR TITLE
1.7.x chart: validate width and height dimensions

### DIFF
--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/DefaultGraphEngine.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/DefaultGraphEngine.scala
@@ -50,22 +50,22 @@ class DefaultGraphEngine extends PngGraphEngine {
   override def createImage(gdef: GraphDef): RenderedImage = {
     import com.netflix.atlas.chart.graphics._
 
-    val config = gdef.computeStats
+    val originalConfig = gdef.computeStats
+
+    // Validate and clamp dimensions
+    val validation =
+      GraphConstants.validate(originalConfig.width, originalConfig.height, originalConfig.zoom)
+
+    // Apply validated dimensions to the config
+    val config = originalConfig.copy(
+      width = validation.clampedWidth,
+      height = validation.clampedHeight,
+      zoom = validation.clampedZoom
+    )
 
     val notices = List.newBuilder[String]
     notices ++= config.warnings
-
-    if (config.height > GraphConstants.MaxHeight) {
-      notices += s"Restricted graph height to ${GraphConstants.MaxHeight}."
-    }
-
-    if (config.width > GraphConstants.MaxWidth) {
-      notices += s"Restricted graph width to ${GraphConstants.MaxWidth}."
-    }
-
-    if (config.zoom > GraphConstants.MaxZoom) {
-      notices += s"Restricted zoom to ${GraphConstants.MaxZoom}."
-    }
+    notices ++= validation.warnings
 
     val aboveCanvas = List.newBuilder[Element]
 
@@ -186,7 +186,8 @@ class DefaultGraphEngine extends PngGraphEngine {
     val imgWidth = graph.width
     val imgHeight = height(elements, imgWidth)
 
-    val zoom = if (config.zoom > GraphConstants.MaxZoom) GraphConstants.MaxZoom else config.zoom
+    // Use validated zoom value from config
+    val zoom = config.zoom
     val zoomWidth = (imgWidth * zoom).toInt
     val zoomHeight = (imgHeight * zoom).toInt
     val image = new BufferedImage(zoomWidth, zoomHeight, BufferedImage.TYPE_INT_ARGB)

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/GraphConstants.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/GraphConstants.scala
@@ -27,4 +27,44 @@ object GraphConstants {
   final val MaxWidth = config.getInt("max-width")
   final val MaxHeight = config.getInt("max-height")
   final val MaxZoom = config.getDouble("max-zoom")
+
+  case class ValidationResult(
+    originalWidth: Int,
+    originalHeight: Int,
+    originalZoom: Double,
+    clampedWidth: Int,
+    clampedHeight: Int,
+    clampedZoom: Double,
+    warnings: List[String]
+  )
+
+  def validate(width: Int, height: Int, zoom: Double): ValidationResult = {
+    val clampedWidth = math.min(width, MaxWidth)
+    val clampedHeight = math.min(height, MaxHeight)
+    val clampedZoom = math.min(zoom, MaxZoom)
+
+    val warnings = List.newBuilder[String]
+
+    if (height > MaxHeight) {
+      warnings += s"Restricted graph height to $MaxHeight."
+    }
+
+    if (width > MaxWidth) {
+      warnings += s"Restricted graph width to $MaxWidth."
+    }
+
+    if (zoom > MaxZoom) {
+      warnings += s"Restricted zoom to $MaxZoom."
+    }
+
+    ValidationResult(
+      width,
+      height,
+      zoom,
+      clampedWidth,
+      clampedHeight,
+      clampedZoom,
+      warnings.result()
+    )
+  }
 }

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/util/PngImage.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/util/PngImage.scala
@@ -40,6 +40,8 @@ import javax.imageio.metadata.IIOMetadataNode
 import scala.util.Using
 import scala.util.Using.Releasable
 
+import com.netflix.atlas.chart.GraphConstants
+
 object PngImage {
 
   // Disable using on-disk cache for images. Avoids temp files on shared services.
@@ -103,9 +105,11 @@ object PngImage {
     imgTextColor: Color = Color.WHITE,
     imgBackgroundColor: Color = Color.BLACK
   ): PngImage = {
+    val clampedWidth = math.min(width, GraphConstants.MaxWidth)
+    val clampedHeight = math.min(height, GraphConstants.MaxHeight)
     val fullMsg = s"$imgTextPrefix $imgText"
 
-    val image = newBufferedImage(width, height)
+    val image = newBufferedImage(clampedWidth, clampedHeight)
     val g = image.createGraphics
 
     if (useAntiAliasing) {
@@ -121,7 +125,7 @@ object PngImage {
     g.setFont(font)
 
     g.setPaint(imgBackgroundColor)
-    g.fill(new Rectangle(0, 0, width, height))
+    g.fill(new Rectangle(0, 0, clampedWidth, clampedHeight))
 
     g.setPaint(imgTextColor)
     val attrStr = new AttributedString(fullMsg)
@@ -129,7 +133,7 @@ object PngImage {
     val iterator = attrStr.getIterator
     val measurer = new LineBreakMeasurer(iterator, g.getFontRenderContext)
 
-    val wrap = width - 8.0f
+    val wrap = clampedWidth - 8.0f
     var y = 0.0f
     while (measurer.getPosition < fullMsg.length) {
       val layout = measurer.nextLayout(wrap)

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/DefaultGraphEngineSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/DefaultGraphEngineSuite.scala
@@ -15,9 +15,249 @@
  */
 package com.netflix.atlas.chart
 
+import com.netflix.atlas.chart.model.GraphDef
+import com.netflix.atlas.chart.model.LineDef
+import com.netflix.atlas.chart.model.PlotDef
+
+import java.time.Instant
+
 class DefaultGraphEngineSuite extends PngGraphEngineSuite {
 
   override def prefix: String = "default"
 
   override def graphEngine: PngGraphEngine = new DefaultGraphEngine
+
+  // Dimension validation tests - moved from DimensionValidationSuite
+  private val dimensionStep = 60000L
+  private val dimensionNow = Instant.now()
+  private val dimensionStart = dimensionNow.minusSeconds(3600)
+  private val dimensionEnd = dimensionNow
+
+  private def createGraphDef(
+    width: Int,
+    height: Int,
+    zoom: Double = 1.0,
+    numSeries: Int = 1
+  ): GraphDef = {
+    val series = (1 to numSeries).map(i => LineDef(constant(i * 10.0)))
+    val plotDef = PlotDef(series.toList)
+
+    GraphDef(
+      plots = List(plotDef),
+      startTime = dimensionStart,
+      endTime = dimensionEnd,
+      step = dimensionStep,
+      width = width,
+      height = height,
+      zoom = zoom
+    )
+  }
+
+  test("dimension validation: normal dimensions should work") {
+    val graphDef = createGraphDef(width = 800, height = 400)
+    val image = graphEngine.createImage(graphDef)
+
+    // Should create a successful image (not an error image)
+    assert(image.getWidth > 400, "Image width should be reasonable")
+    assert(image.getHeight > 200, "Image height should be reasonable")
+  }
+
+  test("dimension validation: oversized width should be clamped with warning") {
+    val graphDef = createGraphDef(width = 5000, height = 400) // exceeds MaxWidth of 2000
+    val image = graphEngine.createImage(graphDef)
+
+    // Should still produce a valid graph (not error image), but clamped dimensions
+    assert(image.getWidth > 400, "Should produce valid image with clamped width")
+    assert(image.getHeight > 200, "Should produce valid image")
+    // The actual width will be clamped to MaxWidth by GraphConstants validation
+  }
+
+  test("dimension validation: oversized height should be clamped with warning") {
+    val graphDef = createGraphDef(width = 800, height = 50000) // exceeds MaxHeight of 1000
+    val image = graphEngine.createImage(graphDef)
+
+    // Should still produce a valid graph (not error image), but clamped dimensions
+    assert(image.getWidth > 400, "Should produce valid image")
+    assert(
+      image.getHeight <= GraphConstants.MaxHeight + 300,
+      "Height should not exceed MaxHeight + UI"
+    )
+  }
+
+  test("dimension validation: oversized zoom should be clamped") {
+    val graphDef = createGraphDef(width = 800, height = 400, zoom = 10.0) // exceeds MaxZoom of 2.0
+    val image = graphEngine.createImage(graphDef)
+
+    // Should clamp zoom to MaxZoom and produce valid image
+    assert(image.getWidth > 400, "Should produce valid image with clamped zoom")
+    assert(image.getHeight > 200, "Should produce valid image")
+    // Zoom should be clamped to GraphConstants.MaxZoom
+    // The final image.getWidth should be smaller than the
+    // GraphConstants.MaxWidth
+    assert(image.getWidth <= GraphConstants.MaxWidth)
+  }
+
+  test("dimension validation: many series should expand legend height naturally") {
+    // Create 25 series to generate substantial legend
+    val graphDef = createGraphDef(width = 800, height = 400, numSeries = 25)
+    val image = graphEngine.createImage(graphDef)
+
+    // Should create image with expanded height due to legend
+    assert(image.getWidth > 400, "Should produce valid image")
+    assert(image.getWidth < GraphConstants.MaxWidth)
+    assert(image.getHeight > 1000, "Should have expanded height due to long legend")
+  }
+
+  test("dimension validation: small dimensions should work") {
+    val graphDef = createGraphDef(width = 100, height = 100)
+    val image = graphEngine.createImage(graphDef)
+
+    // Should handle small dimensions gracefully
+    assert(image.getWidth >= 100, "Should handle small width")
+    assert(image.getHeight >= 100, "Should handle small height")
+  }
+
+  test("dimension validation: width at limit") {
+    val graphDef = createGraphDef(width = GraphConstants.MaxWidth, height = 400)
+    val image = graphEngine.createImage(graphDef)
+
+    // Should work fine at the limit and should also account
+    // for the UI elements which are estimated to be 200
+    assert(image.getWidth >= GraphConstants.MaxWidth, "Width should be at least MaxWidth")
+    assert(image.getWidth <= GraphConstants.MaxWidth + 200, "Width should not exceed MaxWidth + UI")
+    assert(image.getHeight > 200, "Should produce valid image")
+  }
+
+  test("dimension validation: height at limit") {
+    val graphDef = createGraphDef(width = 800, height = GraphConstants.MaxHeight)
+    val image = graphEngine.createImage(graphDef)
+
+    // Should work fine at the limit
+    assert(image.getWidth <= GraphConstants.MaxWidth, "Should produce valid image")
+    assert(image.getHeight > 500, "Should work at MaxHeight limit")
+  }
+
+  test("dimension validation: zoom at limit") {
+    val graphDef = createGraphDef(width = 800, height = 400, zoom = GraphConstants.MaxZoom)
+    val image = graphEngine.createImage(graphDef)
+
+    // Should work fine at the zoom limit
+    assert(image.getWidth > 800, "Should work at MaxZoom limit")
+    assert(image.getHeight > 400, "Should produce valid image")
+  }
+
+  test("dimension validation: combined stress test with many series") {
+    // Test the scenario that should work: reasonable request with long legend
+    val graphDef = createGraphDef(width = 800, height = 500, numSeries = 30)
+    val image = graphEngine.createImage(graphDef)
+
+    // Should produce a large image due to legend expansion, but successfully
+    assert(image.getWidth > 400, "Should produce valid image")
+    assert(image.getHeight > 1000, "Should have substantial height from legend")
+  }
+
+  test("GraphConstants validation: oversized dimensions should be clamped") {
+    // Test the validation logic directly before any UI rendering
+    val validation = GraphConstants.validate(5000, 50000, 10.0)
+
+    // Original values should be preserved
+    assertEquals(validation.originalWidth, 5000)
+    assertEquals(validation.originalHeight, 50000)
+    assertEquals(validation.originalZoom, 10.0)
+
+    // Clamped values should respect limits
+    assertEquals(validation.clampedWidth, GraphConstants.MaxWidth)
+    assertEquals(validation.clampedHeight, GraphConstants.MaxHeight)
+    assertEquals(validation.clampedZoom, GraphConstants.MaxZoom)
+
+    // Should generate warnings
+    assertEquals(validation.warnings.size, 3)
+    assert(validation.warnings.exists(_.contains("width")))
+    assert(validation.warnings.exists(_.contains("height")))
+    assert(validation.warnings.exists(_.contains("zoom")))
+  }
+
+  test("GraphConstants validation: normal dimensions should pass") {
+    val validation = GraphConstants.validate(800, 400, 1.0)
+
+    assertEquals(validation.clampedWidth, 800)
+    assertEquals(validation.clampedHeight, 400)
+    assertEquals(validation.clampedZoom, 1.0)
+    assertEquals(validation.warnings.size, 0)
+  }
+
+  test("GraphConstants validation: only width oversized") {
+    val validation = GraphConstants.validate(5000, 400, 1.0)
+
+    assertEquals(validation.clampedWidth, GraphConstants.MaxWidth)
+    assertEquals(validation.clampedHeight, 400)
+    assertEquals(validation.clampedZoom, 1.0)
+    assertEquals(validation.warnings.size, 1)
+    assert(validation.warnings.head.contains("width"))
+  }
+
+  test("GraphConstants validation: only height oversized") {
+    val validation = GraphConstants.validate(800, 5000, 1.0)
+
+    assertEquals(validation.clampedWidth, 800)
+    assertEquals(validation.clampedHeight, GraphConstants.MaxHeight)
+    assertEquals(validation.clampedZoom, 1.0)
+    assertEquals(validation.warnings.size, 1)
+    assert(validation.warnings.head.contains("height"))
+  }
+
+  test("GraphConstants validation: only zoom oversized") {
+    val validation = GraphConstants.validate(800, 400, 10.0)
+
+    assertEquals(validation.clampedWidth, 800)
+    assertEquals(validation.clampedHeight, 400)
+    assertEquals(validation.clampedZoom, GraphConstants.MaxZoom)
+    assertEquals(validation.warnings.size, 1)
+    assert(validation.warnings.head.contains("zoom"))
+  }
+
+  test("GraphConstants validation: dimensions at exact limits") {
+    val validation = GraphConstants.validate(
+      GraphConstants.MaxWidth,
+      GraphConstants.MaxHeight,
+      GraphConstants.MaxZoom
+    )
+
+    assertEquals(validation.clampedWidth, GraphConstants.MaxWidth)
+    assertEquals(validation.clampedHeight, GraphConstants.MaxHeight)
+    assertEquals(validation.clampedZoom, GraphConstants.MaxZoom)
+    assertEquals(validation.warnings.size, 0)
+  }
+
+  test("GraphConstants validation: dimensions one over limit") {
+    val validation = GraphConstants.validate(
+      GraphConstants.MaxWidth + 1,
+      GraphConstants.MaxHeight + 1,
+      GraphConstants.MaxZoom + 0.1
+    )
+
+    assertEquals(validation.clampedWidth, GraphConstants.MaxWidth)
+    assertEquals(validation.clampedHeight, GraphConstants.MaxHeight)
+    assertEquals(validation.clampedZoom, GraphConstants.MaxZoom)
+    assertEquals(validation.warnings.size, 3)
+  }
+
+  test("GraphConstants validation: zero and negative dimensions") {
+    val validation = GraphConstants.validate(0, -100, 0.0)
+
+    // math.min preserves smaller values (including negatives)
+    assertEquals(validation.clampedWidth, 0)
+    assertEquals(validation.clampedHeight, -100)
+    assertEquals(validation.clampedZoom, 0.0)
+    assertEquals(validation.warnings.size, 0) // No warnings since under limits
+  }
+
+  test("GraphConstants validation: extreme values") {
+    val validation = GraphConstants.validate(Int.MaxValue, Int.MaxValue, Double.MaxValue)
+
+    assertEquals(validation.clampedWidth, GraphConstants.MaxWidth)
+    assertEquals(validation.clampedHeight, GraphConstants.MaxHeight)
+    assertEquals(validation.clampedZoom, GraphConstants.MaxZoom)
+    assertEquals(validation.warnings.size, 3)
+  }
 }

--- a/atlas-chart/src/test/scala/com/netflix/atlas/chart/GraphConstantsSuite.scala
+++ b/atlas-chart/src/test/scala/com/netflix/atlas/chart/GraphConstantsSuite.scala
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.chart
+
+import munit.FunSuite
+
+class GraphConstantsSuite extends FunSuite {
+
+  test("validate - normal dimensions should pass without warnings") {
+    val result = GraphConstants.validate(800, 400, 1.0)
+
+    assertEquals(result.originalWidth, 800)
+    assertEquals(result.originalHeight, 400)
+    assertEquals(result.originalZoom, 1.0)
+    assertEquals(result.clampedWidth, 800)
+    assertEquals(result.clampedHeight, 400)
+    assertEquals(result.clampedZoom, 1.0)
+    assertEquals(result.warnings, List.empty)
+  }
+
+  test("validate - width exceeding max should be clamped with warning") {
+    val result = GraphConstants.validate(5000, 400, 1.0)
+
+    assertEquals(result.originalWidth, 5000)
+    assertEquals(result.originalHeight, 400)
+    assertEquals(result.originalZoom, 1.0)
+    assertEquals(result.clampedWidth, GraphConstants.MaxWidth)
+    assertEquals(result.clampedHeight, 400)
+    assertEquals(result.clampedZoom, 1.0)
+    assertEquals(result.warnings.size, 1)
+    assert(result.warnings.head.contains("Restricted graph width"))
+    assert(result.warnings.head.contains(s"${GraphConstants.MaxWidth}"))
+  }
+
+  test("validate - height exceeding max should be clamped with warning") {
+    val result = GraphConstants.validate(800, 5000, 1.0)
+
+    assertEquals(result.originalWidth, 800)
+    assertEquals(result.originalHeight, 5000)
+    assertEquals(result.originalZoom, 1.0)
+    assertEquals(result.clampedWidth, 800)
+    assertEquals(result.clampedHeight, GraphConstants.MaxHeight)
+    assertEquals(result.clampedZoom, 1.0)
+    assertEquals(result.warnings.size, 1)
+    assert(result.warnings.head.contains("Restricted graph height"))
+    assert(result.warnings.head.contains(s"${GraphConstants.MaxHeight}"))
+  }
+
+  test("validate - zoom exceeding max should be clamped with warning") {
+    val result = GraphConstants.validate(800, 400, 10.0)
+
+    assertEquals(result.originalWidth, 800)
+    assertEquals(result.originalHeight, 400)
+    assertEquals(result.originalZoom, 10.0)
+    assertEquals(result.clampedWidth, 800)
+    assertEquals(result.clampedHeight, 400)
+    assertEquals(result.clampedZoom, GraphConstants.MaxZoom)
+    assertEquals(result.warnings.size, 1)
+    assert(result.warnings.head.contains("Restricted zoom"))
+    assert(result.warnings.head.contains(s"${GraphConstants.MaxZoom}"))
+  }
+
+  test("validate - all dimensions exceeding max should generate multiple warnings") {
+    val result = GraphConstants.validate(5000, 3000, 8.0)
+
+    assertEquals(result.originalWidth, 5000)
+    assertEquals(result.originalHeight, 3000)
+    assertEquals(result.originalZoom, 8.0)
+    assertEquals(result.clampedWidth, GraphConstants.MaxWidth)
+    assertEquals(result.clampedHeight, GraphConstants.MaxHeight)
+    assertEquals(result.clampedZoom, GraphConstants.MaxZoom)
+    assertEquals(result.warnings.size, 3)
+
+    val warningText = result.warnings.mkString(" ")
+    assert(warningText.contains("Restricted graph height"))
+    assert(warningText.contains("Restricted graph width"))
+    assert(warningText.contains("Restricted zoom"))
+  }
+
+  test("validate - dimensions at exact limits should not generate warnings") {
+    val result = GraphConstants.validate(
+      GraphConstants.MaxWidth,
+      GraphConstants.MaxHeight,
+      GraphConstants.MaxZoom
+    )
+
+    assertEquals(result.originalWidth, GraphConstants.MaxWidth)
+    assertEquals(result.originalHeight, GraphConstants.MaxHeight)
+    assertEquals(result.originalZoom, GraphConstants.MaxZoom)
+    assertEquals(result.clampedWidth, GraphConstants.MaxWidth)
+    assertEquals(result.clampedHeight, GraphConstants.MaxHeight)
+    assertEquals(result.clampedZoom, GraphConstants.MaxZoom)
+    assertEquals(result.warnings, List.empty)
+  }
+
+  test("validate - dimensions one over limit should generate warnings") {
+    val result = GraphConstants.validate(
+      GraphConstants.MaxWidth + 1,
+      GraphConstants.MaxHeight + 1,
+      GraphConstants.MaxZoom + 0.1
+    )
+
+    assertEquals(result.originalWidth, GraphConstants.MaxWidth + 1)
+    assertEquals(result.originalHeight, GraphConstants.MaxHeight + 1)
+    assertEquals(result.originalZoom, GraphConstants.MaxZoom + 0.1)
+    assertEquals(result.clampedWidth, GraphConstants.MaxWidth)
+    assertEquals(result.clampedHeight, GraphConstants.MaxHeight)
+    assertEquals(result.clampedZoom, GraphConstants.MaxZoom)
+    assertEquals(result.warnings.size, 3)
+  }
+
+  test("validate - negative dimensions stay negative (math.min behavior)") {
+    val result = GraphConstants.validate(-100, -50, -1.0)
+
+    assertEquals(result.originalWidth, -100)
+    assertEquals(result.originalHeight, -50)
+    assertEquals(result.originalZoom, -1.0)
+    // math.min keeps negative values since they're smaller than positive max values
+    assertEquals(result.clampedWidth, -100) // math.min(-100, MaxWidth) = -100
+    assertEquals(result.clampedHeight, -50) // math.min(-50, MaxHeight) = -50
+    assertEquals(result.clampedZoom, -1.0) // math.min(-1.0, MaxZoom) = -1.0
+    assertEquals(result.warnings, List.empty) // No warnings since they're under the max
+  }
+
+  test("validate - zero dimensions should work") {
+    val result = GraphConstants.validate(0, 0, 0.0)
+
+    assertEquals(result.originalWidth, 0)
+    assertEquals(result.originalHeight, 0)
+    assertEquals(result.originalZoom, 0.0)
+    assertEquals(result.clampedWidth, 0)
+    assertEquals(result.clampedHeight, 0)
+    assertEquals(result.clampedZoom, 0.0)
+    assertEquals(result.warnings, List.empty)
+  }
+
+  test("validate - very large dimensions should be handled gracefully") {
+    val result = GraphConstants.validate(Int.MaxValue, Int.MaxValue, Double.MaxValue)
+
+    assertEquals(result.originalWidth, Int.MaxValue)
+    assertEquals(result.originalHeight, Int.MaxValue)
+    assertEquals(result.originalZoom, Double.MaxValue)
+    assertEquals(result.clampedWidth, GraphConstants.MaxWidth)
+    assertEquals(result.clampedHeight, GraphConstants.MaxHeight)
+    assertEquals(result.clampedZoom, GraphConstants.MaxZoom)
+    assertEquals(result.warnings.size, 3)
+  }
+
+  test("ValidationResult - should preserve all original values") {
+    val original = (1234, 5678, 3.14)
+    val result = GraphConstants.validate(original._1, original._2, original._3)
+
+    // Original values should always be preserved exactly
+    assertEquals(result.originalWidth, original._1)
+    assertEquals(result.originalHeight, original._2)
+    assertEquals(result.originalZoom, original._3)
+  }
+
+  test("ValidationResult - clamped values should never exceed constants") {
+    val result = GraphConstants.validate(99999, 99999, 99999.0)
+
+    assert(result.clampedWidth <= GraphConstants.MaxWidth)
+    assert(result.clampedHeight <= GraphConstants.MaxHeight)
+    assert(result.clampedZoom <= GraphConstants.MaxZoom)
+  }
+}

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/chart/GraphEngines.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/chart/GraphEngines.scala
@@ -81,4 +81,26 @@ class GraphEngines {
     }
     bh.consume(bytes)
   }
+
+  @Threads(1)
+  @Benchmark
+  def pngImageGeneration(bh: Blackhole): Unit = {
+    // Defining an image with default dimensions
+    val engine = new DefaultGraphEngine()
+    val image = engine.createImage(graphDef)
+    bh.consume(image)
+  }
+
+  @Threads(1)
+  @Benchmark
+  def oversizedImageGeneration(bh: Blackhole): Unit = {
+    // Defining an oversized chart dimensions using GraphConstants limits + buffer
+    val oversizedGraphDef = graphDef.copy(
+      width = GraphConstants.MaxWidth + 100,
+      height = GraphConstants.MaxHeight + 100
+    )
+    val engine = new DefaultGraphEngine()
+    val image = engine.createImage(oversizedGraphDef)
+    bh.consume(image)
+  }
 }


### PR DESCRIPTION
It was found that the PngEngine was not utilizing the `MaxWidth` and `MaxHeight` restrictions for error images. This applies to requests with valid or invalid queries that have dimensions that are out of bounds for the defined bounds.

Backport of #1814