### PR TITLE
lwc-events: test case for event based on OTEL trace

### DIFF
--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/LwcEventClientSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/LwcEventClientSuite.scala
@@ -186,16 +186,18 @@ class LwcEventClientSuite extends FunSuite {
   test("trace analytics, basic aggregate") {
     val subs = Subscriptions.fromTypedList(
       List(
-        Subscription("1", step, "app,www,:eq", Subscriptions.TraceTimeSeries)
+        Subscription("1", step, "app,e,:eq,parent.app,b,:eq,:and", Subscriptions.TimeSeries)
       )
     )
     val output = List.newBuilder[String]
     val client = LwcEventClient(subs, output.addOne, clock)
-    client.processTrace(Seq(new TestSpan(sampleSpan)))
+    TraceLwcEvent.sampleTrace.foreach(client.process)
     clock.setWallTime(step)
     client.process(LwcEvent.HeartbeatLwcEvent(step))
     val vs = output.result()
     assertEquals(vs.size, 1)
+    assert(vs.forall(_.contains(""""tags":{"app":"e","parent.app":"b"}""")))
+    assert(vs.forall(_.contains(""""value":0.6""")))
   }
 
   test("trace analytics, basic aggregate extract value") {
@@ -204,20 +206,43 @@ class LwcEventClientSuite extends FunSuite {
         Subscription(
           "1",
           step,
-          "app,www,:eq,value,duration,:eq,:span-time-series",
-          Subscriptions.TraceTimeSeries
+          "app,e,:eq,value,duration,:eq,:and,:sum",
+          Subscriptions.TimeSeries
         )
       )
     )
     val output = List.newBuilder[String]
     val client = LwcEventClient(subs, output.addOne, clock)
-    client.processTrace(Seq(new TestSpan(sampleSpan)))
+    TraceLwcEvent.sampleTrace.foreach(client.process)
     clock.setWallTime(step)
     client.process(LwcEvent.HeartbeatLwcEvent(step))
     val vs = output.result()
     assertEquals(vs.size, 1)
-    assert(vs.forall(_.contains(""""tags":{"value":"duration"}""")))
-    assert(vs.forall(_.contains(""""value":8.4""")))
+    assert(vs.forall(_.contains(""""tags":{"app":"e","value":"duration"}""")))
+    assert(vs.forall(_.contains(""""value":2.1E-8""")))
+  }
+
+  test("trace analytics, group by with parent attributes") {
+    val subs = Subscriptions.fromTypedList(
+      List(
+        Subscription("1", step, "app,e,:eq,(,app,parent.app,parent.parent.app,),:by", Subscriptions.TimeSeries)
+      )
+    )
+    val output = List.newBuilder[String]
+    val client = LwcEventClient(subs, output.addOne, clock)
+    TraceLwcEvent.sampleTrace.foreach(client.process)
+    clock.setWallTime(step)
+    client.process(LwcEvent.HeartbeatLwcEvent(step))
+    val vs = output.result()
+    assertEquals(vs.size, 2)
+    vs.foreach { v =>
+      if (v.contains(""""tags":{"app":"e","parent.app":"b","parent.parent.app":"a"}"""))
+        assert(v.contains(""""value":0.6"""), v)
+      else if (v.contains(""""tags":{"app":"e","parent.app":"c","parent.parent.app":"a"}"""))
+        assert(v.contains(""""value":0.4"""), v)
+      else
+        fail(s"invalid result: $v")
+    }
   }
 
   test("check if event matches query") {

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/TraceLwcEvent.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/TraceLwcEvent.scala
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwc.events
+
+import com.netflix.atlas.core.model.Query
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.SpanContext
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.TraceFlags
+import io.opentelemetry.api.trace.TraceState
+import io.opentelemetry.sdk.testing.trace.TestSpanData
+import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.sdk.trace.data.StatusData
+
+import java.time.Duration
+import scala.util.Random
+
+/**
+  * Helper to convert OTEL spans to LwcEvent for tests.
+  */
+class TraceLwcEvent(spans: Seq[SpanData]) extends LwcEvent {
+
+  require(spans.size > 1, "must have at least one span")
+
+  // Map to lookup parent by id
+  private val spanIdMap: Map[String, SpanData] = {
+    spans.map(s => s.getSpanId -> s).toMap
+  }
+
+  // Root span is the first where the parentId is not present in the set of
+  // spans. For full traces it should be "0000000000000000", but for partial traces
+  // may be a valid span id for a span that wasn't sampled.
+  private val root: SpanData = {
+    spans.find(s => !spanIdMap.contains(s.getParentSpanId)).getOrElse {
+      spans.head
+    }
+  }
+
+  // Current span to be considered, defaults to the root span
+  private var current: SpanData = root
+
+  /** Invoke the function for each span in the trace as an LwcEvent. */
+  def foreach(f: LwcEvent => Unit): Unit = {
+    spans.foreach { span =>
+      current = span
+      f(this)
+    }
+  }
+
+  override def rawEvent: Any = current
+
+  override def timestamp: Long = current.getEndEpochNanos / 1_000_000L
+
+  override def extractValue(key: String): Any = {
+    if (key.startsWith("root."))
+      extractValue(root, key.substring("root.".length))
+    else if (key.startsWith("parent."))
+      extractFromParent(current, key.substring("parent.".length))
+    else
+      extractValue(current, key)
+  }
+
+  @scala.annotation.tailrec
+  private def extractFromParent(span: SpanData, key: String): Any = {
+    spanIdMap.get(span.getParentSpanId) match {
+      case Some(s) if key.startsWith("parent.") =>
+        extractFromParent(s, key.substring("parent.".length))
+      case Some(s) =>
+        extractValue(s, key)
+      case None =>
+        null
+    }
+  }
+
+  private def extractValue(span: SpanData, key: String): Any = {
+    key match {
+      case "name"     => span.getName
+      case "spanId"   => span.getSpanId
+      case "traceId"  => span.getTraceId
+      case "kind"     => span.getKind
+      case "status"   => span.getStatus.getStatusCode
+      case "duration" => Duration.ofNanos(span.getEndEpochNanos - span.getStartEpochNanos)
+      case k          => span.getAttributes.get(AttributeKey.stringKey(k))
+    }
+  }
+}
+
+object TraceLwcEvent {
+
+  /**
+    * Rewrite keys for the query to use parent instead of child. Child is just a convenience
+    * but can be rewritten to use parent that can be quickly looked up from the span.
+    */
+  def rewriteToParentQuery(query: Query): Query = {
+    val keys = Query.allKeys(query)
+    val depths = keys.map(k => k -> computeDepth(k)).toMap
+    val min = depths.values.min
+    val newKeys = depths.map(t => t._1 -> computeNewKey(t._1, t._2 - min))
+    query
+      .rewrite {
+        case q: Query.Equal            => q.copy(k = newKeys(q.k))
+        case q: Query.In               => q.copy(k = newKeys(q.k))
+        case q: Query.Regex            => q.copy(k = newKeys(q.k))
+        case q: Query.RegexIgnoreCase  => q.copy(k = newKeys(q.k))
+        case q: Query.LessThan         => q.copy(k = newKeys(q.k))
+        case q: Query.LessThanEqual    => q.copy(k = newKeys(q.k))
+        case q: Query.GreaterThan      => q.copy(k = newKeys(q.k))
+        case q: Query.GreaterThanEqual => q.copy(k = newKeys(q.k))
+        case q: Query.HasKey           => q.copy(k = newKeys(q.k))
+      }
+      .asInstanceOf[Query]
+  }
+
+  private def computeDepth(key: String): Int = {
+    if (key.startsWith("child."))
+      computeDepth(key.substring("child.".length)) - 1
+    else if (key.startsWith("parent."))
+      computeDepth(key.substring("parent.".length)) + 1
+    else
+      0
+  }
+
+  @scala.annotation.tailrec
+  private def stripPrefix(key: String): String = {
+    if (key.startsWith("child."))
+      stripPrefix(key.substring("child.".length))
+    else if (key.startsWith("parent."))
+      stripPrefix(key.substring("parent.".length))
+    else
+      key
+  }
+
+  private def computeNewKey(key: String, depth: Int): String = {
+    val prefix = "parent." * depth
+    s"$prefix${stripPrefix(key)}"
+  }
+
+  private def attrs(tags: (String, String)*): Attributes = {
+    val builder = Attributes.builder()
+    tags.foreach {
+      case (k, v) => builder.put(k, v)
+    }
+    builder.build()
+  }
+
+  private def spanContext(id: String): SpanContext = {
+    SpanContext.create("12345678" * 4, id, TraceFlags.getDefault, TraceState.getDefault)
+  }
+
+  // A
+  // ├── B
+  // │   ├── E
+  // │   ├── E
+  // │   ├── E (error)
+  // │   └── F
+  // ├── C
+  // │   ├── E
+  // │   └── E
+  // └── D
+  def sampleTrace: TraceLwcEvent = {
+    val spans = List(
+      TestSpanData
+        .builder()
+        .setName("A")
+        .setKind(SpanKind.SERVER)
+        .setSpanContext(spanContext("a" * 16))
+        .setStartEpochNanos(0L)
+        .setEndEpochNanos(100L)
+        .setHasEnded(true)
+        .setStatus(StatusData.ok())
+        .setAttributes(attrs("app" -> "a"))
+        .build(),
+      TestSpanData
+        .builder()
+        .setName("B")
+        .setKind(SpanKind.SERVER)
+        .setSpanContext(spanContext("b" * 16))
+        .setParentSpanContext(spanContext("a" * 16))
+        .setStartEpochNanos(5L)
+        .setEndEpochNanos(80L)
+        .setHasEnded(true)
+        .setStatus(StatusData.ok())
+        .setAttributes(attrs("app" -> "b"))
+        .build(),
+      TestSpanData
+        .builder()
+        .setName("C")
+        .setKind(SpanKind.SERVER)
+        .setSpanContext(spanContext("c" * 16))
+        .setParentSpanContext(spanContext("a" * 16))
+        .setStartEpochNanos(5L)
+        .setEndEpochNanos(10L)
+        .setHasEnded(true)
+        .setStatus(StatusData.ok())
+        .setAttributes(attrs("app" -> "c"))
+        .build(),
+      TestSpanData
+        .builder()
+        .setName("D")
+        .setKind(SpanKind.SERVER)
+        .setSpanContext(spanContext("d" * 16))
+        .setParentSpanContext(spanContext("a" * 16))
+        .setStartEpochNanos(10L)
+        .setEndEpochNanos(20L)
+        .setHasEnded(true)
+        .setStatus(StatusData.ok())
+        .setAttributes(attrs("app" -> "d"))
+        .build(),
+      TestSpanData
+        .builder()
+        .setName("E")
+        .setKind(SpanKind.SERVER)
+        .setSpanContext(spanContext("e" * 16))
+        .setParentSpanContext(spanContext("b" * 16))
+        .setStartEpochNanos(6L)
+        .setEndEpochNanos(15L)
+        .setHasEnded(true)
+        .setStatus(StatusData.ok())
+        .setAttributes(attrs("app" -> "e", "part" -> "1"))
+        .build(),
+      TestSpanData
+        .builder()
+        .setName("E")
+        .setKind(SpanKind.SERVER)
+        .setSpanContext(spanContext("e" * 16))
+        .setParentSpanContext(spanContext("b" * 16))
+        .setStartEpochNanos(6L)
+        .setEndEpochNanos(15L)
+        .setHasEnded(true)
+        .setStatus(StatusData.ok())
+        .setAttributes(attrs("app" -> "e", "part" -> "2"))
+        .build(),
+      TestSpanData
+        .builder()
+        .setName("E")
+        .setKind(SpanKind.SERVER)
+        .setSpanContext(spanContext("e" * 16))
+        .setParentSpanContext(spanContext("b" * 16))
+        .setStartEpochNanos(6L)
+        .setEndEpochNanos(75L)
+        .setHasEnded(true)
+        .setStatus(StatusData.error())
+        .setAttributes(attrs("app" -> "e", "part" -> "3"))
+        .build(),
+      TestSpanData
+        .builder()
+        .setName("E")
+        .setKind(SpanKind.SERVER)
+        .setSpanContext(spanContext("e" * 16))
+        .setParentSpanContext(spanContext("c" * 16))
+        .setStartEpochNanos(6L)
+        .setEndEpochNanos(15L)
+        .setHasEnded(true)
+        .setStatus(StatusData.ok())
+        .setAttributes(attrs("app" -> "e", "part" -> "4"))
+        .build(),
+      TestSpanData
+        .builder()
+        .setName("E")
+        .setKind(SpanKind.SERVER)
+        .setSpanContext(spanContext("e" * 16))
+        .setParentSpanContext(spanContext("c" * 16))
+        .setStartEpochNanos(6L)
+        .setEndEpochNanos(15L)
+        .setHasEnded(true)
+        .setStatus(StatusData.ok())
+        .setAttributes(attrs("app" -> "e", "part" -> "5"))
+        .build(),
+      TestSpanData
+        .builder()
+        .setName("F")
+        .setKind(SpanKind.SERVER)
+        .setSpanContext(spanContext("f" * 16))
+        .setParentSpanContext(spanContext("b" * 16))
+        .setStartEpochNanos(6L)
+        .setEndEpochNanos(15L)
+        .setHasEnded(true)
+        .setStatus(StatusData.ok())
+        .setAttributes(attrs("app" -> "f"))
+        .build()
+    )
+    // Randomly order the list to check it constructs the trace graph correctly
+    // regardless of order
+    new TraceLwcEvent(Random.shuffle(spans))
+  }
+}

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/TraceLwcEventSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/TraceLwcEventSuite.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwc.events
+
+import munit.FunSuite
+
+class TraceLwcEventSuite extends FunSuite {
+
+  test("tagValue: exists") {
+    assertEquals(TraceLwcEvent.sampleTrace.tagValue("kind"), "SERVER")
+    assertEquals(TraceLwcEvent.sampleTrace.tagValue("status"), "OK")
+    assertEquals(TraceLwcEvent.sampleTrace.tagValue("app"), "a")
+    assertEquals(TraceLwcEvent.sampleTrace.tagValue("root.app"), "a")
+  }
+
+  test("tagValue: missing") {
+    assertEquals(TraceLwcEvent.sampleTrace.tagValue("parent.app"), null)
+    assertEquals(TraceLwcEvent.sampleTrace.tagValue("foo"), null)
+  }
+
+  test("tagValue: foreach") {
+    TraceLwcEvent.sampleTrace.foreach { event =>
+      event.tagValue("app") match {
+        case "a" => assertEquals(event.tagValue("parent.app"), null)
+        case "b" => assertEquals(event.tagValue("parent.app"), "a")
+        case "c" => assertEquals(event.tagValue("parent.app"), "a")
+        case "d" => assertEquals(event.tagValue("parent.app"), "a")
+        case "e" => assert(Set("b", "c").contains(event.tagValue("parent.app")))
+        case "f" => assertEquals(event.tagValue("parent.app"), "b")
+      }
+    }
+  }
+
+  test("tagValue: multi-level parent") {
+    TraceLwcEvent.sampleTrace.foreach { event =>
+      event.tagValue("app") match {
+        case "e" | "f" =>
+          assertEquals(event.tagValue("parent.parent.app"), "a", event.toJson)
+        case _ =>
+          assertEquals(event.tagValue("parent.parent.app"), null, event.toJson)
+      }
+    }
+  }
+
+  private def rewrite(str: String): String = {
+    val query = ExprUtils.parseDataExpr(str).query
+    TraceLwcEvent.rewriteToParentQuery(query).toString
+  }
+
+  test("rewriteToParentQuery: no prefix") {
+    List(":eq", ":re", ":reic", ":lt", ":le", ":gt", ":ge").foreach { op =>
+      assertEquals(rewrite(s"app,foo,$op"), s"app,foo,$op")
+    }
+  }
+
+  test("rewriteToParentQuery: parent depth 1") {
+    List(":eq", ":re", ":reic", ":lt", ":le", ":gt", ":ge").foreach { op =>
+      assertEquals(rewrite(s"parent.app,foo,$op"), s"app,foo,$op")
+    }
+  }
+
+  test("rewriteToParentQuery: child depth 1") {
+    List(":eq", ":re", ":reic", ":lt", ":le", ":gt", ":ge").foreach { op =>
+      assertEquals(rewrite(s"child.app,foo,$op"), s"app,foo,$op")
+    }
+  }
+
+  test("rewriteToParentQuery: local and child key") {
+    assertEquals(
+      rewrite("app,foo,:eq,child.app,bar,:eq,:and"),
+      "parent.app,foo,:eq,app,bar,:eq,:and"
+    )
+  }
+
+  test("rewriteToParentQuery: multi-level cancel out") {
+    assertEquals(
+      rewrite("app,foo,:eq,child.app,bar,:eq,:and,parent.child.child.parent.status,200,:eq,:and"),
+      "parent.app,foo,:eq,app,bar,:eq,:and,parent.status,200,:eq,:and"
+    )
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -108,7 +108,9 @@ lazy val `atlas-lwc-events` = project
   .dependsOn(`atlas-pekko`, `atlas-core`, `atlas-json`)
   .settings(libraryDependencies ++= Seq(
     Dependencies.iepDynConfig,
-    Dependencies.spectatorAtlas
+    Dependencies.spectatorAtlas,
+    Dependencies.otelSdk % "test",
+    Dependencies.otelSdkTest % "test"
   ))
 
 lazy val `atlas-postgres` = project

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,6 +9,7 @@ object Dependencies {
     val iep         = "5.1.8"
     val jackson     = "2.20.0"
     val log4j       = "2.25.1"
+    val otel        = "1.54.1"
     val scala       = "2.13.16"
     val slf4j       = "2.0.17"
     val spectator   = "1.9.0"
@@ -51,6 +52,8 @@ object Dependencies {
   val log4jJul          = "org.apache.logging.log4j" % "log4j-jul" % log4j
   val log4jSlf4j        = "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4j
   val munit             = "org.scalameta" %% "munit" % "1.1.1"
+  val otelSdk           = "io.opentelemetry" % "opentelemetry-sdk" % otel
+  val otelSdkTest       = "io.opentelemetry" % "opentelemetry-sdk-testing" % otel
   val postgres          = "org.postgresql" % "postgresql" % "42.7.7"
   val postgresEmbedded  = "io.zonky.test" % "embedded-postgres" % "2.1.1"
   val roaringBitmap     = "org.roaringbitmap" % "RoaringBitmap" % "1.3.0"


### PR DESCRIPTION
Adding a test case to show how an event could be modelled over a trace using the OTEL model. The event has some basic structure for the trace to allow efficient access to the root and parent spans to support querying trace shape from an event. Child is not supported directly, but can be rewritten to query based on the parent if needed.

To avoid recomputing some of the trace structure for each span while processing, it provides a `foreach` to iterate over the spans for the trace when processing.