### PR TITLE
lwc-events: support post filter for matching events

### DIFF
--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEventClient.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEventClient.scala
@@ -67,22 +67,26 @@ object LwcEventClient {
     *     Function that will receive the output.
     * @param clock
     *     Clock to use for timing events.
+    * @param filter
+    *     Filter to perform custom filtering after the index match.
     * @return
     *     Client instance.
     */
   def apply(
     subscriptions: Subscriptions,
     consumer: String => Unit,
-    clock: Clock = Clock.SYSTEM
+    clock: Clock = Clock.SYSTEM,
+    filter: LwcEventFilter = LwcEventFilter.default
   ): LwcEventClient = {
-    new LocalLwcEventClient(subscriptions, consumer, clock)
+    new LocalLwcEventClient(subscriptions, consumer, clock, filter)
   }
 
   private class LocalLwcEventClient(
     subscriptions: Subscriptions,
     consumer: String => Unit,
-    clock: Clock
-  ) extends AbstractLwcEventClient(clock) {
+    clock: Clock,
+    filter: LwcEventFilter
+  ) extends AbstractLwcEventClient(clock, filter) {
 
     sync(subscriptions)
 

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEventFilter.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEventFilter.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwc.events
+
+import com.netflix.atlas.core.model.Query
+
+/**
+  * Filter for LWC events that can be used to support a post filter stage for certain
+  * special dimensions.
+  */
+trait LwcEventFilter {
+
+  /**
+    * Returns the dimension used to project a value from the event.
+    */
+  def valueDimension: String
+
+  /**
+    * Split a query into two parts: an indexed query that can be evaluated efficiently,
+    * and a post-filter query that is evaluated after matching events are retrieved.
+    *
+    * @param query
+    *     The original query to split
+    * @return
+    *     A Queries object containing both the index query and post-filter query
+    */
+  def splitQuery(query: Query): LwcEventFilter.Queries
+
+  /**
+    * Check if an event matches the post-filter query.
+    *
+    * @param event
+    *     The event to check
+    * @param postFilterQuery
+    *     The query to evaluate against the event
+    * @return
+    *     True if the event matches the query
+    */
+  def matches(event: LwcEvent, postFilterQuery: Query): Boolean
+}
+
+object LwcEventFilter {
+
+  /**
+    * Container for the split query components.
+    *
+    * @param indexQuery
+    *     Query that can be indexed for efficient matching
+    * @param postFilterQuery
+    *     Query to be evaluated after index matching
+    */
+  case class Queries(indexQuery: Query, postFilterQuery: Query)
+
+  /**
+    * Returns the default implementation of LwcEventFilter.
+    */
+  def default: LwcEventFilter = new DefaultLwcEventFilter
+
+  private class DefaultLwcEventFilter extends LwcEventFilter {
+
+    override def valueDimension: String = "value"
+
+    private def removeValueClause(query: Query): Query = {
+      val q = query
+        .rewrite {
+          case kq: Query.KeyQuery if kq.k == "value" => Query.True
+        }
+        .asInstanceOf[Query]
+      Query.simplify(q, ignore = true)
+    }
+
+    override def splitQuery(query: Query): Queries = {
+      Queries(removeValueClause(query), Query.True)
+    }
+
+    override def matches(event: LwcEvent, postFilterQuery: Query): Boolean = true
+  }
+}

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/RemoteLwcEventClient.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/RemoteLwcEventClient.scala
@@ -32,8 +32,8 @@ import java.util.concurrent.Executors
 import java.util.concurrent.locks.ReentrantLock
 import scala.util.Using
 
-class RemoteLwcEventClient(registry: Registry, config: Config)
-    extends AbstractLwcEventClient(registry.clock())
+class RemoteLwcEventClient(registry: Registry, config: Config, filter: LwcEventFilter)
+    extends AbstractLwcEventClient(registry.clock(), filter)
     with AutoCloseable
     with StrictLogging {
 

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/TypedLwcEventFilter.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/TypedLwcEventFilter.scala
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwc.events
+
+import com.netflix.atlas.core.model.Query
+import com.netflix.atlas.core.util.Strings
+
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+
+/**
+  * Event filter that supports typed dimensions with custom comparison logic.
+  * Splits queries into indexed and post-filter stages, where typed dimensions
+  * are evaluated in the post-filter stage using type-specific matchers.
+  */
+abstract class TypedLwcEventFilter extends LwcEventFilter {
+
+  /**
+    * Map of dimension names to their type matchers. Dimensions in this map
+    * will be filtered in the post-filter stage using the associated type matcher.
+    */
+  def typedDimensions: Map[String, TypedLwcEventFilter.TypeMatcher]
+
+  private def isSpecial(key: String): Boolean = {
+    typedDimensions.contains(key)
+  }
+
+  private def removeValueKey(query: Query): Query = {
+    val q = query
+      .rewrite {
+        case kq: Query.KeyQuery if kq.k == valueDimension => Query.True
+      }
+      .asInstanceOf[Query]
+    Query.simplify(q, ignore = true)
+  }
+
+  private def computeIndexQuery(query: Query): Query = {
+    val q = query
+      .rewrite {
+        case kq: Query.KeyValueQuery if isSpecial(kq.k) => Query.True
+      }
+      .asInstanceOf[Query]
+    Query.simplify(q, ignore = true)
+  }
+
+  private def computePostFilterQuery(query: Query): Query = {
+    val q = query
+      .rewrite {
+        case kq: Query.KeyValueQuery if !isSpecial(kq.k) => Query.True
+        case q: Query.Or                                 => q
+        case q: Query.Not                                => q
+      }
+      .asInstanceOf[Query]
+    Query.simplify(q, ignore = true)
+  }
+
+  override def splitQuery(query: Query): LwcEventFilter.Queries = {
+    val q = removeValueKey(query)
+    LwcEventFilter.Queries(computeIndexQuery(q), computePostFilterQuery(q))
+  }
+
+  private def checkKV(event: LwcEvent, k: String, v: String, cmp: Int => Boolean): Boolean = {
+    typedDimensions.get(k) match {
+      case Some(matcher) =>
+        val v1 = matcher.cast(event.extractValueSafe(k))
+        val v2 = matcher.cast(v)
+        v1 != null && v2 != null && cmp(matcher.compare(v1, v2))
+      case None =>
+        val v1 = event.tagValue(k)
+        val v2 = v
+        v1 != null && v2 != null && cmp(v1.compareTo(v2))
+    }
+  }
+
+  private def checkIn(event: LwcEvent, k: String, vs: List[String]): Boolean = {
+    typedDimensions.get(k) match {
+      case Some(matcher) =>
+        val v1 = matcher.cast(event.extractValueSafe(k))
+        val vs2 = vs.map(matcher.cast).filterNot(_ == null)
+        v1 != null && vs2.exists(v2 => matcher.compare(v1, v2) == 0)
+      case None =>
+        val v1 = event.tagValue(k)
+        v1 != null && vs.contains(v1)
+    }
+  }
+
+  private def checkPattern(event: LwcEvent, q: Query.PatternQuery): Boolean = {
+    typedDimensions.get(q.k) match {
+      case Some(_) => false
+      case None    => q.check(event.tagValue(q.k))
+    }
+  }
+
+  override def matches(event: LwcEvent, postFilterQuery: Query): Boolean = {
+    postFilterQuery match {
+      case Query.False               => false
+      case Query.True                => true
+      case q: Query.HasKey           => event.extractValueSafe(q.k) != null
+      case q: Query.Equal            => checkKV(event, q.k, q.v, c => c == 0)
+      case q: Query.LessThan         => checkKV(event, q.k, q.v, c => c < 0)
+      case q: Query.LessThanEqual    => checkKV(event, q.k, q.v, c => c <= 0)
+      case q: Query.GreaterThan      => checkKV(event, q.k, q.v, c => c > 0)
+      case q: Query.GreaterThanEqual => checkKV(event, q.k, q.v, c => c >= 0)
+      case q: Query.In               => checkIn(event, q.k, q.vs)
+      case q: Query.Regex            => checkPattern(event, q)
+      case q: Query.RegexIgnoreCase  => checkPattern(event, q)
+      case q: Query.And              => matches(event, q.q1) && matches(event, q.q2)
+      case q: Query.Or               => matches(event, q.q1) || matches(event, q.q2)
+      case q: Query.Not              => !matches(event, q.q)
+    }
+  }
+}
+
+object TypedLwcEventFilter {
+
+  /**
+    * Creates a TypedLwcEventFilter with the specified typed dimensions.
+    *
+    * @param dimensions
+    *     Map of dimension names to type matchers
+    * @param valueKey
+    *     The dimension to use for projecting values from the event
+    * @return
+    *     A new TypedLwcEventFilter instance
+    */
+  def apply(
+    dimensions: Map[String, TypeMatcher],
+    valueKey: String = "value"
+  ): TypedLwcEventFilter = {
+    new TypedLwcEventFilter {
+      override def valueDimension: String = valueKey
+
+      override def typedDimensions: Map[String, TypeMatcher] = dimensions
+    }
+  }
+
+  /**
+    * Trait for matching and comparing typed dimension values.
+    */
+  trait TypeMatcher {
+
+    /**
+      * Cast a value to the appropriate type for comparison.
+      *
+      * @param value
+      *     Value to cast
+      * @return
+      *     Casted value, or null if the value cannot be cast
+      */
+    def cast(value: Any): Any
+
+    /**
+      * Compare two values of the same type.
+      *
+      * @param v1
+      *     First value to compare
+      * @param v2
+      *     Second value to compare
+      * @return
+      *     Negative if v1 < v2, zero if v1 == v2, positive if v1 > v2
+      */
+    def compare(v1: Any, v2: Any): Int
+  }
+
+  /**
+    * Type matcher for long integer values.
+    */
+  object LongMatcher extends TypeMatcher {
+
+    override def cast(value: Any): Any = value match {
+      case v: String => v.toLong
+      case v: Byte   => v.toLong
+      case v: Short  => v.toLong
+      case v: Int    => v.toLong
+      case v: Long   => v
+      case v: Number => v.longValue()
+      case _         => null
+    }
+
+    override def compare(v1: Any, v2: Any): Int = {
+      val i1 = v1.asInstanceOf[Long]
+      val i2 = v2.asInstanceOf[Long]
+      java.lang.Long.compare(i1, i2)
+    }
+  }
+
+  /**
+    * Type matcher for double-precision floating point values.
+    */
+  object DoubleMatcher extends TypeMatcher {
+
+    override def cast(value: Any): Any = value match {
+      case v: String => v.toDouble
+      case v: Byte   => v.toDouble
+      case v: Short  => v.toDouble
+      case v: Int    => v.toDouble
+      case v: Long   => v.toDouble
+      case v: Float  => v.toDouble
+      case v: Double => v
+      case v: Number => v.doubleValue()
+      case _         => null
+    }
+
+    override def compare(v1: Any, v2: Any): Int = {
+      val d1 = v1.asInstanceOf[Double]
+      val d2 = v2.asInstanceOf[Double]
+      java.lang.Double.compare(d1, d2)
+    }
+  }
+
+  /**
+    * Type matcher for duration values. Supports parsing duration strings and
+    * converting numeric values as nanoseconds.
+    */
+  object DurationMatcher extends TypeMatcher {
+
+    override def cast(value: Any): Any = value match {
+      case v: String   => Strings.parseDuration(v)
+      case v: Int      => Duration.ofNanos(v)
+      case v: Long     => Duration.ofNanos(v)
+      case v: Number   => Duration.ofNanos(v.longValue())
+      case v: Duration => v
+      case _           => null
+    }
+
+    override def compare(v1: Any, v2: Any): Int = {
+      val d1 = v1.asInstanceOf[Duration]
+      val d2 = v2.asInstanceOf[Duration]
+      d1.compareTo(d2)
+    }
+  }
+
+  /**
+    * Type matcher for instant (timestamp) values. Supports parsing date strings
+    * and converting numeric values as epoch milliseconds.
+    */
+  object InstantMatcher extends TypeMatcher {
+
+    override def cast(value: Any): Any = value match {
+      case v: String        => Strings.parseDate(v).toInstant
+      case v: ZonedDateTime => v.toInstant
+      case v: Instant       => v
+      case v: Int           => Strings.ofEpoch(v, ZoneOffset.UTC).toInstant
+      case v: Long          => Strings.ofEpoch(v, ZoneOffset.UTC).toInstant
+      case v: Number        => Strings.ofEpoch(v.longValue(), ZoneOffset.UTC).toInstant
+      case _                => null
+    }
+
+    override def compare(v1: Any, v2: Any): Int = {
+      val i1 = v1.asInstanceOf[Instant]
+      val i2 = v2.asInstanceOf[Instant]
+      i1.compareTo(i2)
+    }
+  }
+}

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/RemoteLwcEventClientSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/RemoteLwcEventClientSuite.scala
@@ -33,7 +33,7 @@ class RemoteLwcEventClientSuite extends FunSuite {
   override def beforeEach(context: BeforeEach): Unit = {
     payloads = new CopyOnWriteArrayList[RemoteLwcEventClient.EvalPayload]()
     registry = new DefaultRegistry()
-    client = new RemoteLwcEventClient(registry, config) {
+    client = new RemoteLwcEventClient(registry, config, LwcEventFilter.default) {
       override def start(): Unit = {
         val subs = Subscriptions(events =
           List(

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/TypedLwcEventFilterSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/TypedLwcEventFilterSuite.scala
@@ -1,0 +1,378 @@
+/*
+ * Copyright 2014-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.lwc.events
+
+import com.netflix.atlas.core.model.Query
+import munit.FunSuite
+
+class TypedLwcEventFilterSuite extends FunSuite {
+
+  private def parseQuery(str: String): Query = {
+    ExprUtils.parseDataExpr(str).query
+  }
+
+  test("splitQuery: simple string query") {
+    val filter = TypedLwcEventFilter(Map("duration" -> TypedLwcEventFilter.DurationMatcher))
+    val query = parseQuery("name,foo,:eq")
+    val queries = filter.splitQuery(query)
+    assertEquals(queries.indexQuery, query)
+    assertEquals(queries.postFilterQuery, Query.True)
+  }
+
+  test("splitQuery: simple duration query") {
+    val filter = TypedLwcEventFilter(Map("duration" -> TypedLwcEventFilter.DurationMatcher))
+    val query = parseQuery("duration,42ms,:eq")
+    val queries = filter.splitQuery(query)
+    assertEquals(queries.indexQuery, Query.True)
+    assertEquals(queries.postFilterQuery, query)
+  }
+
+  test("splitQuery: AND both") {
+    val filter = TypedLwcEventFilter(Map("duration" -> TypedLwcEventFilter.DurationMatcher))
+    val query = parseQuery("name,foo,:eq,duration,42ms,:gt,:and")
+    val queries = filter.splitQuery(query)
+    assertEquals(queries.indexQuery, parseQuery("name,foo,:eq"))
+    assertEquals(queries.postFilterQuery, parseQuery("duration,42ms,:gt"))
+  }
+
+  test("splitQuery: OR both") {
+    val filter = TypedLwcEventFilter(Map("duration" -> TypedLwcEventFilter.DurationMatcher))
+    val query = parseQuery("name,foo,:eq,duration,42ms,:gt,:or")
+    val queries = filter.splitQuery(query)
+    assertEquals(queries.indexQuery, Query.True)
+    assertEquals(queries.postFilterQuery, query)
+  }
+
+  test("splitQuery: AND/OR both") {
+    val filter = TypedLwcEventFilter(Map("duration" -> TypedLwcEventFilter.DurationMatcher))
+    val query = parseQuery("app,www,:eq,name,foo,:eq,duration,42ms,:gt,:or,:and")
+    val queries = filter.splitQuery(query)
+    assertEquals(queries.indexQuery, parseQuery("app,www,:eq"))
+    assertEquals(queries.postFilterQuery, parseQuery("name,foo,:eq,duration,42ms,:gt,:or"))
+  }
+
+  test("splitQuery: NOT both") {
+    val filter = TypedLwcEventFilter(Map("duration" -> TypedLwcEventFilter.DurationMatcher))
+    val query = parseQuery("name,foo,:eq,duration,42ms,:gt,:and,:not")
+    val queries = filter.splitQuery(query)
+    assertEquals(queries.indexQuery, parseQuery("name,foo,:eq,:not"))
+    assertEquals(queries.postFilterQuery, query)
+  }
+
+  test("duration: equal") {
+    val filter = TypedLwcEventFilter(Map("duration" -> TypedLwcEventFilter.DurationMatcher))
+    val event = LwcEvent(Map("duration" -> 42_000_000L))
+    assert(filter.matches(event, parseQuery("duration,42ms,:eq")))
+    assert(filter.matches(event, parseQuery("duration,PT0.042S,:eq")))
+    assert(!filter.matches(event, parseQuery("duration,41ms,:eq")))
+  }
+
+  test("duration: less than") {
+    val filter = TypedLwcEventFilter(Map("duration" -> TypedLwcEventFilter.DurationMatcher))
+    val event = LwcEvent(Map("duration" -> 42_000_000L))
+    assert(filter.matches(event, parseQuery("duration,50ms,:lt")))
+    assert(!filter.matches(event, parseQuery("duration,42ms,:lt")))
+    assert(!filter.matches(event, parseQuery("duration,30ms,:lt")))
+  }
+
+  test("duration: less than or equal") {
+    val filter = TypedLwcEventFilter(Map("duration" -> TypedLwcEventFilter.DurationMatcher))
+    val event = LwcEvent(Map("duration" -> 42_000_000L))
+    assert(filter.matches(event, parseQuery("duration,50ms,:le")))
+    assert(filter.matches(event, parseQuery("duration,42ms,:le")))
+    assert(!filter.matches(event, parseQuery("duration,30ms,:le")))
+  }
+
+  test("duration: greater than") {
+    val filter = TypedLwcEventFilter(Map("duration" -> TypedLwcEventFilter.DurationMatcher))
+    val event = LwcEvent(Map("duration" -> 42_000_000L))
+    assert(filter.matches(event, parseQuery("duration,30ms,:gt")))
+    assert(!filter.matches(event, parseQuery("duration,42ms,:gt")))
+    assert(!filter.matches(event, parseQuery("duration,50ms,:gt")))
+  }
+
+  test("duration: greater than or equal") {
+    val filter = TypedLwcEventFilter(Map("duration" -> TypedLwcEventFilter.DurationMatcher))
+    val event = LwcEvent(Map("duration" -> 42_000_000L))
+    assert(filter.matches(event, parseQuery("duration,30ms,:ge")))
+    assert(filter.matches(event, parseQuery("duration,42ms,:ge")))
+    assert(!filter.matches(event, parseQuery("duration,50ms,:ge")))
+  }
+
+  test("duration: in") {
+    val filter = TypedLwcEventFilter(Map("duration" -> TypedLwcEventFilter.DurationMatcher))
+    val event = LwcEvent(Map("duration" -> 42_000_000L))
+    assert(filter.matches(event, parseQuery("duration,(,10ms,42ms,100ms,),:in")))
+    assert(filter.matches(event, parseQuery("duration,(,PT0.042S,),:in")))
+    assert(!filter.matches(event, parseQuery("duration,(,10ms,100ms,),:in")))
+  }
+
+  test("duration: in string") {
+    val filter = TypedLwcEventFilter(Map("duration" -> TypedLwcEventFilter.DurationMatcher))
+    val event = LwcEvent(Map("app" -> "www", "duration" -> 42_000_000L))
+    assert(filter.matches(event, parseQuery("app,(,www,foo,),:in")))
+    assert(!filter.matches(event, parseQuery("app,(,www2,foo,),:in")))
+  }
+
+  test("duration: regex") {
+    val filter = TypedLwcEventFilter(Map("duration" -> TypedLwcEventFilter.DurationMatcher))
+    val event = LwcEvent(Map("duration" -> 42_000_000L))
+    assert(!filter.matches(event, parseQuery("duration,42ms,:re")))
+    assert(!filter.matches(event, parseQuery("duration,42ms,:reic")))
+  }
+
+  test("duration: or") {
+    val filter = TypedLwcEventFilter(Map("duration" -> TypedLwcEventFilter.DurationMatcher))
+    val event = LwcEvent(Map("app" -> "www", "duration" -> 42_000_000L))
+    assert(filter.matches(event, parseQuery("app,www,:eq,duration,42ms,:eq,:or")))
+    assert(filter.matches(event, parseQuery("app,www,:eq,duration,43ms,:eq,:or")))
+    assert(filter.matches(event, parseQuery("app,foo,:eq,duration,42ms,:eq,:or")))
+    assert(!filter.matches(event, parseQuery("app,foo,:eq,duration,43ms,:eq,:or")))
+  }
+
+  test("duration: and, or, not") {
+    val filter = TypedLwcEventFilter(Map("duration" -> TypedLwcEventFilter.DurationMatcher))
+    val event = LwcEvent(Map("app" -> "www", "duration" -> 42_000_000L))
+    assert(
+      filter.matches(event, parseQuery("app,www,:eq,app,foo,:eq,:not,:and,duration,42ms,:eq,:or"))
+    )
+    assert(
+      !filter.matches(event, parseQuery("app,www,:re,app,www,:eq,:not,:and,duration,43ms,:eq,:or"))
+    )
+  }
+
+  test("duration: cast from Int") {
+    val filter = TypedLwcEventFilter(Map("duration" -> TypedLwcEventFilter.DurationMatcher))
+    val event = LwcEvent(Map("duration" -> 42_000_000))
+    assert(filter.matches(event, parseQuery("duration,42ms,:eq")))
+  }
+
+  test("duration: cast from String") {
+    val filter = TypedLwcEventFilter(Map("duration" -> TypedLwcEventFilter.DurationMatcher))
+    val event = LwcEvent(Map("duration" -> "42ms"))
+    assert(filter.matches(event, parseQuery("duration,42ms,:eq")))
+  }
+
+  test("long: equal") {
+    val filter = TypedLwcEventFilter(Map("count" -> TypedLwcEventFilter.LongMatcher))
+    val event = LwcEvent(Map("count" -> 42L))
+    assert(filter.matches(event, parseQuery("count,42,:eq")))
+    assert(!filter.matches(event, parseQuery("count,43,:eq")))
+  }
+
+  test("long: less than") {
+    val filter = TypedLwcEventFilter(Map("count" -> TypedLwcEventFilter.LongMatcher))
+    val event = LwcEvent(Map("count" -> 42L))
+    assert(filter.matches(event, parseQuery("count,50,:lt")))
+    assert(!filter.matches(event, parseQuery("count,42,:lt")))
+    assert(!filter.matches(event, parseQuery("count,30,:lt")))
+  }
+
+  test("long: less than or equal") {
+    val filter = TypedLwcEventFilter(Map("count" -> TypedLwcEventFilter.LongMatcher))
+    val event = LwcEvent(Map("count" -> 42L))
+    assert(filter.matches(event, parseQuery("count,50,:le")))
+    assert(filter.matches(event, parseQuery("count,42,:le")))
+    assert(!filter.matches(event, parseQuery("count,30,:le")))
+  }
+
+  test("long: greater than") {
+    val filter = TypedLwcEventFilter(Map("count" -> TypedLwcEventFilter.LongMatcher))
+    val event = LwcEvent(Map("count" -> 42L))
+    assert(filter.matches(event, parseQuery("count,30,:gt")))
+    assert(!filter.matches(event, parseQuery("count,42,:gt")))
+    assert(!filter.matches(event, parseQuery("count,50,:gt")))
+  }
+
+  test("long: greater than or equal") {
+    val filter = TypedLwcEventFilter(Map("count" -> TypedLwcEventFilter.LongMatcher))
+    val event = LwcEvent(Map("count" -> 42L))
+    assert(filter.matches(event, parseQuery("count,30,:ge")))
+    assert(filter.matches(event, parseQuery("count,42,:ge")))
+    assert(!filter.matches(event, parseQuery("count,50,:ge")))
+  }
+
+  test("long: in") {
+    val filter = TypedLwcEventFilter(Map("count" -> TypedLwcEventFilter.LongMatcher))
+    val event = LwcEvent(Map("count" -> 42L))
+    assert(filter.matches(event, parseQuery("count,(,10,42,100,),:in")))
+    assert(!filter.matches(event, parseQuery("count,(,10,100,),:in")))
+  }
+
+  test("long: cast from Int") {
+    val filter = TypedLwcEventFilter(Map("count" -> TypedLwcEventFilter.LongMatcher))
+    val event = LwcEvent(Map("count" -> 42))
+    assert(filter.matches(event, parseQuery("count,42,:eq")))
+  }
+
+  test("long: cast from String") {
+    val filter = TypedLwcEventFilter(Map("count" -> TypedLwcEventFilter.LongMatcher))
+    val event = LwcEvent(Map("count" -> "42"))
+    assert(filter.matches(event, parseQuery("count,42,:eq")))
+  }
+
+  test("long: cast from Short") {
+    val filter = TypedLwcEventFilter(Map("count" -> TypedLwcEventFilter.LongMatcher))
+    val event = LwcEvent(Map("count" -> 42.toShort))
+    assert(filter.matches(event, parseQuery("count,42,:eq")))
+  }
+
+  test("long: cast from Byte") {
+    val filter = TypedLwcEventFilter(Map("count" -> TypedLwcEventFilter.LongMatcher))
+    val event = LwcEvent(Map("count" -> 42.toByte))
+    assert(filter.matches(event, parseQuery("count,42,:eq")))
+  }
+
+  test("double: equal") {
+    val filter = TypedLwcEventFilter(Map("value" -> TypedLwcEventFilter.DoubleMatcher))
+    val event = LwcEvent(Map("value" -> 42.5))
+    assert(filter.matches(event, parseQuery("value,42.5,:eq")))
+    assert(!filter.matches(event, parseQuery("value,42.6,:eq")))
+  }
+
+  test("double: less than") {
+    val filter = TypedLwcEventFilter(Map("value" -> TypedLwcEventFilter.DoubleMatcher))
+    val event = LwcEvent(Map("value" -> 42.5))
+    assert(filter.matches(event, parseQuery("value,50.0,:lt")))
+    assert(!filter.matches(event, parseQuery("value,42.5,:lt")))
+    assert(!filter.matches(event, parseQuery("value,30.0,:lt")))
+  }
+
+  test("double: less than or equal") {
+    val filter = TypedLwcEventFilter(Map("value" -> TypedLwcEventFilter.DoubleMatcher))
+    val event = LwcEvent(Map("value" -> 42.5))
+    assert(filter.matches(event, parseQuery("value,50.0,:le")))
+    assert(filter.matches(event, parseQuery("value,42.5,:le")))
+    assert(!filter.matches(event, parseQuery("value,30.0,:le")))
+  }
+
+  test("double: greater than") {
+    val filter = TypedLwcEventFilter(Map("value" -> TypedLwcEventFilter.DoubleMatcher))
+    val event = LwcEvent(Map("value" -> 42.5))
+    assert(filter.matches(event, parseQuery("value,30.0,:gt")))
+    assert(!filter.matches(event, parseQuery("value,42.5,:gt")))
+    assert(!filter.matches(event, parseQuery("value,50.0,:gt")))
+  }
+
+  test("double: greater than or equal") {
+    val filter = TypedLwcEventFilter(Map("value" -> TypedLwcEventFilter.DoubleMatcher))
+    val event = LwcEvent(Map("value" -> 42.5))
+    assert(filter.matches(event, parseQuery("value,30.0,:ge")))
+    assert(filter.matches(event, parseQuery("value,42.5,:ge")))
+    assert(!filter.matches(event, parseQuery("value,50.0,:ge")))
+  }
+
+  test("double: in") {
+    val filter = TypedLwcEventFilter(Map("value" -> TypedLwcEventFilter.DoubleMatcher))
+    val event = LwcEvent(Map("value" -> 42.5))
+    assert(filter.matches(event, parseQuery("value,(,10.0,42.5,100.0,),:in")))
+    assert(!filter.matches(event, parseQuery("value,(,10.0,100.0,),:in")))
+  }
+
+  test("double: cast from Int") {
+    val filter = TypedLwcEventFilter(Map("value" -> TypedLwcEventFilter.DoubleMatcher))
+    val event = LwcEvent(Map("value" -> 42))
+    assert(filter.matches(event, parseQuery("value,42.0,:eq")))
+  }
+
+  test("double: cast from Long") {
+    val filter = TypedLwcEventFilter(Map("value" -> TypedLwcEventFilter.DoubleMatcher))
+    val event = LwcEvent(Map("value" -> 42L))
+    assert(filter.matches(event, parseQuery("value,42.0,:eq")))
+  }
+
+  test("double: cast from Float") {
+    val filter = TypedLwcEventFilter(Map("value" -> TypedLwcEventFilter.DoubleMatcher))
+    val event = LwcEvent(Map("value" -> 42.5f))
+    assert(filter.matches(event, parseQuery("value,42.5,:eq")))
+  }
+
+  test("double: cast from String") {
+    val filter = TypedLwcEventFilter(Map("value" -> TypedLwcEventFilter.DoubleMatcher))
+    val event = LwcEvent(Map("value" -> "42.5"))
+    assert(filter.matches(event, parseQuery("value,42.5,:eq")))
+  }
+
+  test("instant: equal") {
+    val filter = TypedLwcEventFilter(Map("timestamp" -> TypedLwcEventFilter.InstantMatcher))
+    val event = LwcEvent(Map("timestamp" -> 1609459200000L)) // 2021-01-01T00:00:00Z
+    assert(filter.matches(event, parseQuery("timestamp,2021-01-01T00:00:00Z,:eq")))
+    assert(!filter.matches(event, parseQuery("timestamp,2021-01-02T00:00:00Z,:eq")))
+  }
+
+  test("instant: less than") {
+    val filter = TypedLwcEventFilter(Map("timestamp" -> TypedLwcEventFilter.InstantMatcher))
+    val event = LwcEvent(Map("timestamp" -> 1609459200000L))
+    assert(filter.matches(event, parseQuery("timestamp,2021-01-02T00:00:00Z,:lt")))
+    assert(!filter.matches(event, parseQuery("timestamp,2021-01-01T00:00:00Z,:lt")))
+    assert(!filter.matches(event, parseQuery("timestamp,2020-12-31T00:00:00Z,:lt")))
+  }
+
+  test("instant: less than or equal") {
+    val filter = TypedLwcEventFilter(Map("timestamp" -> TypedLwcEventFilter.InstantMatcher))
+    val event = LwcEvent(Map("timestamp" -> 1609459200000L))
+    assert(filter.matches(event, parseQuery("timestamp,2021-01-02T00:00:00Z,:le")))
+    assert(filter.matches(event, parseQuery("timestamp,2021-01-01T00:00:00Z,:le")))
+    assert(!filter.matches(event, parseQuery("timestamp,2020-12-31T00:00:00Z,:le")))
+  }
+
+  test("instant: greater than") {
+    val filter = TypedLwcEventFilter(Map("timestamp" -> TypedLwcEventFilter.InstantMatcher))
+    val event = LwcEvent(Map("timestamp" -> 1609459200000L))
+    assert(filter.matches(event, parseQuery("timestamp,2020-12-31T00:00:00Z,:gt")))
+    assert(!filter.matches(event, parseQuery("timestamp,2021-01-01T00:00:00Z,:gt")))
+    assert(!filter.matches(event, parseQuery("timestamp,2021-01-02T00:00:00Z,:gt")))
+  }
+
+  test("instant: greater than or equal") {
+    val filter = TypedLwcEventFilter(Map("timestamp" -> TypedLwcEventFilter.InstantMatcher))
+    val event = LwcEvent(Map("timestamp" -> 1609459200000L))
+    assert(filter.matches(event, parseQuery("timestamp,2020-12-31T00:00:00Z,:ge")))
+    assert(filter.matches(event, parseQuery("timestamp,2021-01-01T00:00:00Z,:ge")))
+    assert(!filter.matches(event, parseQuery("timestamp,2021-01-02T00:00:00Z,:ge")))
+  }
+
+  test("instant: in") {
+    val filter = TypedLwcEventFilter(Map("timestamp" -> TypedLwcEventFilter.InstantMatcher))
+    val event = LwcEvent(Map("timestamp" -> 1609459200000L))
+    assert(
+      filter.matches(
+        event,
+        parseQuery(
+          "timestamp,(,2020-12-31T00:00:00Z,2021-01-01T00:00:00Z,2021-01-02T00:00:00Z,),:in"
+        )
+      )
+    )
+    assert(
+      !filter.matches(
+        event,
+        parseQuery("timestamp,(,2020-12-31T00:00:00Z,2021-01-02T00:00:00Z,),:in")
+      )
+    )
+  }
+
+  test("instant: cast from Int") {
+    val filter = TypedLwcEventFilter(Map("timestamp" -> TypedLwcEventFilter.InstantMatcher))
+    val event = LwcEvent(Map("timestamp" -> 1609459200))
+    assert(filter.matches(event, parseQuery("timestamp,2021-01-01T00:00:00Z,:eq")))
+  }
+
+  test("instant: cast from String") {
+    val filter = TypedLwcEventFilter(Map("timestamp" -> TypedLwcEventFilter.InstantMatcher))
+    val event = LwcEvent(Map("timestamp" -> "2021-01-01T00:00:00Z"))
+    assert(filter.matches(event, parseQuery("timestamp,2021-01-01T00:00:00Z,:eq")))
+  }
+}

--- a/atlas-spring-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEventConfiguration.scala
+++ b/atlas-spring-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEventConfiguration.scala
@@ -31,11 +31,16 @@ class LwcEventConfiguration {
   import scala.jdk.CollectionConverters.*
 
   @Bean
-  def lwcEventClient(registry: Optional[Registry], config: Optional[Config]): LwcEventClient = {
+  def lwcEventClient(
+    registry: Optional[Registry],
+    config: Optional[Config],
+    filter: Optional[LwcEventFilter]
+  ): LwcEventClient = {
     val r = registry.orElseGet(() => new NoopRegistry)
     val c = config.orElseGet(() => ConfigFactory.load())
+    val f = filter.orElseGet(() => LwcEventFilter.default)
     if (c.getBoolean("atlas.lwc.events.enabled")) {
-      val client = new RemoteLwcEventClient(r, c)
+      val client = new RemoteLwcEventClient(r, c, f)
       client.start()
       client
     } else {


### PR DESCRIPTION
This can be used for some cases such as typed matching on some fields in the event. Helpers are provided for matching on durations, instants, long, and double.