### PR TITLE
lwc-events: avoid boxing for default value

### DIFF
--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/DatapointConverter.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/DatapointConverter.scala
@@ -106,7 +106,7 @@ private[events] object DatapointConverter {
           case _                      => event => toDouble(event.extractValueSafe(k), Double.NaN)
         }
       case None =>
-        event => toDouble(event.value, 1.0)
+        _ => 1.0
     }
   }
 
@@ -329,8 +329,7 @@ private[events] object DatapointConverter {
 
     override def update(event: LwcEvent): Unit = {
       if (isPercentile) {
-        val rawValue = getRawValue(event)
-        val pctTag = toPercentileTag(rawValue)
+        val pctTag = getPercentileTag(event)
         val tagValues = by.keys
           .map {
             case TagKey.percentile => pctTag
@@ -363,10 +362,10 @@ private[events] object DatapointConverter {
       }
     }
 
-    private def getRawValue(event: LwcEvent): Any = {
+    private def getPercentileTag(event: LwcEvent): String = {
       params.tags.get(params.valueKey) match {
-        case Some(k) => event.extractValueSafe(k)
-        case None    => event.value
+        case Some(k) => toPercentileTag(event.extractValueSafe(k))
+        case None    => toPercentileHex("D", 1L)
       }
     }
 

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/DatapointEvent.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/DatapointEvent.scala
@@ -36,7 +36,7 @@ case class DatapointEvent(
   id: String,
   tags: Map[String, String],
   timestamp: Long,
-  override val value: Double,
+  value: Double,
   samples: List[List[Any]] = Nil
 ) extends LwcEvent {
 

--- a/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEvent.scala
+++ b/atlas-lwc-events/src/main/scala/com/netflix/atlas/lwc/events/LwcEvent.scala
@@ -39,12 +39,6 @@ trait LwcEvent {
   def timestamp: Long
 
   /**
-    * Value to use for the event when mapping to a time series. By default it will be
-    * 1.0 same as incrementing a counter by 1.
-    */
-  def value: Any = 1.0
-
-  /**
     * Extract a tag value for a given key. Returns `null` if there is no value for
     * the key or the value is not a string. By default it will delegate to `extractValue`
     * to ensure the two are consistent.

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/DatapointConverterSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/DatapointConverterSuite.scala
@@ -310,7 +310,9 @@ class DatapointConverterSuite extends FunSuite {
     }
     clock.setWallTime(step + 1)
     converter.flush(clock.wallTime())
-    val results = events.result()
+    val results = events.result().collect {
+      case d: DatapointEvent => d
+    }
     assertEquals(results.size, 4)
     assertEquals(results.head.value, 0.2, 1e-12)
   }
@@ -404,7 +406,9 @@ class DatapointConverterSuite extends FunSuite {
     }
     clock.setWallTime(step + 1)
     converter.flush(clock.wallTime())
-    val results = events.result()
+    val results = events.result().collect {
+      case d: DatapointEvent => d
+    }
     assertEquals(results.size, 4)
     assertEquals(results.head.value, 0.2, 1e-12)
   }
@@ -431,7 +435,9 @@ class DatapointConverterSuite extends FunSuite {
     }
     clock.setWallTime(step + 1)
     converter.flush(clock.wallTime())
-    val results = events.result()
+    val results = events.result().collect {
+      case d: DatapointEvent => d
+    }
     assertEquals(results.size, 4)
     assertEquals(results.head.value, 0.2, 1e-12)
   }

--- a/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/LwcEventDurationSuite.scala
+++ b/atlas-lwc-events/src/test/scala/com/netflix/atlas/lwc/events/LwcEventDurationSuite.scala
@@ -58,10 +58,6 @@ class LwcEventDurationSuite extends FunSuite {
     assertEquals(sampleLwcEvent.extractValueSafe("foo"), null)
   }
 
-  test("default value") {
-    assertEquals(sampleLwcEvent.value, 1.0)
-  }
-
   test("toJson: raw event") {
     val expected = """{"tags":{"app":"www","node":"i-123"},"duration":42}"""
     assertEquals(sampleLwcEvent.toJson, expected)


### PR DESCRIPTION
Always use a default value of 1 and avoid boxing the value to a `java.lang.Double`.