### PR TITLE
tag atlas.eval.datapoints counters with streamName

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/AggrDatapoint.scala
@@ -97,11 +97,15 @@ object AggrDatapoint {
     *     Limit for the number of intermediate datapoints.
     * @param registry
     *     Registry used for reporting metrics related to the aggregation behavior.
+    * @param streamName
+    *     Identifier for the LWC stream, used as a tag on emitted metrics so that
+    *     counters from distinct evaluator instances can be distinguished.
     */
   case class AggregatorSettings(
     maxInputDatapoints: Int,
     maxIntermediateDatapoints: Int,
-    registry: Registry
+    registry: Registry,
+    streamName: String = "default"
   ) {
 
     /**
@@ -109,7 +113,13 @@ object AggrDatapoint {
       * configured limits.
       */
     val droppedCounter: Counter =
-      registry.counter("atlas.eval.datapoints", "id", "dropped-datapoints-limit-exceeded")
+      registry.counter(
+        "atlas.eval.datapoints",
+        "id",
+        "dropped-datapoints-limit-exceeded",
+        "streamName",
+        streamName
+      )
   }
 
   /**

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/Evaluator.java
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/Evaluator.java
@@ -58,7 +58,18 @@ public final class Evaluator extends EvaluatorImpl {
    * signature may change over time.
    */
   public Evaluator(Config config, Registry registry, ActorSystem system) {
-    super(config, registry, system, Materializer.createMaterializer(system));
+    this(config, registry, system, "default");
+  }
+
+  /**
+   * Create a new instance with an explicit stream name. The stream name is applied as
+   * a {@code streamName} tag on metrics emitted from this evaluator, allowing an app
+   * that instantiates multiple {@code Evaluator} instances (for example, against
+   * different LWC APIs such as logs and metrics) to distinguish which stream a given
+   * counter value is coming from.
+   */
+  public Evaluator(Config config, Registry registry, ActorSystem system, String streamName) {
+    super(config, registry, system, Materializer.createMaterializer(system), streamName);
   }
 
   /**

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -81,7 +81,8 @@ private[stream] abstract class EvaluatorImpl(
   config: Config,
   registry: Registry,
   implicit val system: ActorSystem,
-  implicit val materializer: Materializer
+  implicit val materializer: Materializer,
+  streamName: String = "default"
 ) {
 
   private val logger = LoggerFactory.getLogger(getClass)
@@ -129,7 +130,8 @@ private[stream] abstract class EvaluatorImpl(
       config,
       materializer,
       registry,
-      dsLogger
+      dsLogger,
+      streamName
     )
   }
 
@@ -362,7 +364,8 @@ private[stream] abstract class EvaluatorImpl(
     val aggrSettings = AggrDatapoint.AggregatorSettings(
       context.maxInputDatapointsPerExpression,
       context.maxIntermediateDatapointsPerExpression,
-      context.registry
+      context.registry,
+      context.streamName
     )
     val valuesInfo = group.datapoints.asScala.zipWithIndex
       .flatMap {

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -51,7 +51,8 @@ private[stream] class StreamContext(
   rootConfig: Config,
   val materializer: Materializer,
   val registry: Registry = new NoopRegistry,
-  val dsLogger: DataSourceLogger = DataSourceLogger.Noop
+  val dsLogger: DataSourceLogger = DataSourceLogger.Noop,
+  val streamName: String = "default"
 ) {
 
   import StreamContext.*

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
@@ -59,7 +59,8 @@ private[stream] class TimeGrouped(
   private val aggrSettings = AggrDatapoint.AggregatorSettings(
     maxInputDatapointsPerExpression,
     maxIntermediateDatapointsPerExpression,
-    context.registry
+    context.registry,
+    context.streamName
   )
 
   private val in = Inlet[DatapointsTuple]("TimeGrouped.in")
@@ -69,9 +70,16 @@ private[stream] class TimeGrouped(
 
   private val metricName = "atlas.eval.datapoints"
   private val registry = context.registry
-  private val droppedOld = registry.counter(metricName, "id", "dropped-old")
-  private val droppedFuture = registry.counter(metricName, "id", "dropped-future")
-  private val buffered = registry.counter(metricName, "id", "buffered")
+  private val streamName = context.streamName
+
+  private val droppedOld =
+    registry.counter(metricName, "id", "dropped-old", "streamName", streamName)
+
+  private val droppedFuture =
+    registry.counter(metricName, "id", "dropped-future", "streamName", streamName)
+
+  private val buffered =
+    registry.counter(metricName, "id", "buffered", "streamName", streamName)
   private val clock = registry.clock()
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/TimeGroupedSuite.scala
@@ -121,7 +121,7 @@ class TimeGroupedSuite extends FunSuite {
   }
 
   private def count(id: String): Long = {
-    registry.counter("atlas.eval.datapoints", "id", id).count()
+    registry.counter("atlas.eval.datapoints", "id", id, "streamName", "default").count()
   }
 
   private def counts: (Long, Long) = {


### PR DESCRIPTION
Adds an optional streamName to Evaluator so apps that run multiple LWC evaluators (e.g. against different LWC APIs) can distinguish which stream produced buffered, dropped-old, dropped-future, or dropped-datapoints-limit-exceeded counts. Defaults to "default" so existing callers are unaffected.