### PR TITLE
avoid per-block counter increments in executeImpl

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
@@ -186,17 +186,27 @@ class MemoryDatabase(registry: Registry, config: Config) extends Database {
       TimeSeriesBuffer(tags, cfStep, bufStart, bufEnd)
     }
 
+    // Accumulate the block counts locally and increment the counters once after
+    // the loop. These counts scale with (matched series * blocks per series), so
+    // for broad queries on a busy node this inner loop runs billions of times.
+    // Calling Counter.increment() per block makes the counter bookkeeping
+    // (expiry checks, last-mod updates, step rolls) a top CPU consumer. Avoid
+    // per-iteration meter updates in hot paths like this.
+    var numQueryBlocks = 0L
+    var numAggrBlocks = 0L
     index.findItems(query).foreach { item =>
       item.blocks.blockList.foreach { b =>
-        queryBlocks.increment()
+        numQueryBlocks += 1
         // Check if the block has data for the desired time range
         val blockEnd = b.start + (b.size + 1) * step
         if (b.start <= bufEnd && blockEnd > bufStart - cfStep) {
-          aggrBlocks.increment()
+          numAggrBlocks += 1
           collector.add(item.tags, List(b), aggr, expr.cf, multiple, newBuffer)
         }
       }
     }
+    queryBlocks.increment(numQueryBlocks)
+    aggrBlocks.increment(numAggrBlocks)
 
     val stats = collector.stats
     queryMetrics.increment(stats.inputLines)


### PR DESCRIPTION
The queryBlocks and aggrBlocks counters were incremented once per block inside the innermost query loop. That loop runs roughly (matched series * blocks per series) times, so on a busy node with high limits a single broad query drives billions of increment calls.

Profiling showed the counter bookkeeping (expiry checks, last-mod updates, step rolls) as the top CPU consumer, around half of total on-CPU time, dwarfing the actual block scan work.

Accumulate the counts in locals and call increment(n) once per counter after the loop. The recorded totals are unchanged.