### PR TITLE
ignore Metals/Bloop IDE directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ target
 .idea
 .idea_modules
 out
+
+# Metals (Scala LSP)
+.metals
+.bloop


### PR DESCRIPTION
Add `.metals` and `.bloop` (Scala LSP / Bloop) to .gitignore so IDE-generated directories aren't accidentally committed.