### PR TITLE
Derive in-memory index membership from the data map

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/BlockStore.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/BlockStore.scala
@@ -114,7 +114,11 @@ class MemoryBlockStore(step: Long, blockSize: Int, numBlocks: Int) extends Block
     hasData = true
   }
 
-  var hasData: Boolean = false
+  // Volatile so the background rebuild thread observes revivals/cleanups made by
+  // ingest threads: index membership is derived from this flag, and it is written
+  // only when a block is created or during cleanup, so the barrier is not on the
+  // per-datapoint path.
+  @volatile var hasData: Boolean = false
 
   def cleanup(cutoff: Long): Unit = {
     var pos = 0

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
@@ -78,7 +78,7 @@ class MemoryDatabase(registry: Registry, config: Config) extends Database {
   // If the last update time for the index is older than the rebuild age force an update
   private val rebuildAge = config.getDuration("rebuild-frequency", TimeUnit.MILLISECONDS)
 
-  private val data = new ConcurrentHashMap[ItemId, BlockStore]
+  private[db] val data = new ConcurrentHashMap[ItemId, BlockStoreItem]
 
   private val rebuildThread = new Thread(new RebuildTask, "MemoryDatabaseRebuildIndex")
   if (!testMode) rebuildThread.start()
@@ -98,39 +98,80 @@ class MemoryDatabase(registry: Registry, config: Config) extends Database {
     }
   }
 
+  /** Force an index rebuild if the last one is older than the configured age. */
   def rebuild(): Unit = {
     val now = registry.clock().wallTime()
-    if (now - index.buildTime > rebuildAge) {
-      val query = filter
-      logger.info("rebuilding metadata index (filter={})", query)
-      val droppedItems = index.rebuildIndex(query)
-      droppedItems.foreach(item => data.remove(item.id))
-
-      // Remove entries if all data has rolled out
-      val windowSize = numBlocks * blockSize * step
-      val cutoff = now - windowSize
-      val iter = data.entrySet.iterator
-      while (iter.hasNext) {
-        val entry = iter.next()
-        entry.getValue.cleanup(cutoff)
-        if (!entry.getValue.hasData) {
-          iter.remove()
-        }
-      }
-      logger.info("done rebuilding metadata index, {} metrics", index.size)
-
-      TaggedItem.retain(_ > cutoff)
-    }
+    if (now - index.buildTime > rebuildAge) rebuildIndex()
   }
 
-  private def getOrCreateBlockStore(id: ItemId, tags: Map[String, String]): BlockStore = {
-    var blkStore = data.get(id)
-    if (blkStore == null) {
-      // Create a new block store and update the index
-      blkStore = data.computeIfAbsent(id, _ => new MemoryBlockStore(step, blockSize, numBlocks))
-      index.update(BlockStoreItem.create(id, tags, blkStore))
+  /**
+    * Clean up rolled-out stores and rebuild the metadata index from `data`.
+    *
+    * Index membership is derived directly from `data` -- the authoritative,
+    * concurrently-maintained set of stores -- rather than carried independently in
+    * the index. Cleaning up first and then building the index from the surviving
+    * entries guarantees that a store removed here cannot linger in the index
+    * (the orphaned-series symptom), since the index can only ever contain ids that
+    * are currently present in `data`.
+    */
+  private[db] def rebuildIndex(): Unit = {
+    val now = registry.clock().wallTime()
+    val query = filter
+    logger.info("rebuilding metadata index (filter={})", query)
+
+    // Single pass: drop entries whose data has rolled out or that no longer match
+    // the filter, and collect the survivors into the array used to rebuild the
+    // index. Building the index from the surviving `data` entries is what keeps a
+    // removed store from lingering in the index. RoaringTagIndex requires the
+    // array sorted by id.
+    val windowSize = numBlocks * blockSize * step
+    val cutoff = now - windowSize
+    val items = new java.util.ArrayList[BlockStoreItem](data.size)
+    val iter = data.entrySet.iterator
+    while (iter.hasNext) {
+      val entry = iter.next()
+      val item = entry.getValue
+      item.blocks.cleanup(cutoff)
+      val kept =
+        if (item.blocks.hasData && query.matches(item.tags)) item
+        else
+          // Re-check under the bin lock so a concurrent update that revived the
+          // store (and still matches the filter) is kept rather than removed.
+          data.computeIfPresent(
+            entry.getKey,
+            (_, it) => if (it.blocks.hasData && query.matches(it.tags)) it else null
+          )
+      if (kept != null) items.add(kept)
     }
-    blkStore
+    val arr = items.toArray(new Array[BlockStoreItem](0))
+    java.util.Arrays.sort(arr, RoaringTagIndex.IdComparator)
+    index.rebuildIndex(arr)
+
+    logger.info("done rebuilding metadata index, {} metrics", arr.length)
+    TaggedItem.retain(_ > cutoff)
+  }
+
+  private def getOrCreateItem(id: ItemId, tags: Map[String, String]): BlockStoreItem = {
+    var item = data.get(id)
+    if (item == null) {
+      item = data.computeIfAbsent(
+        id,
+        _ => BlockStoreItem.create(id, tags, new MemoryBlockStore(step, blockSize, numBlocks))
+      )
+    }
+    item
+  }
+
+  /**
+    * Guard against a concurrent `rebuildIndex` cleanup removing this entry between
+    * the lookup and the write. The common path is a single lock-free `get` that
+    * returns the same item (no-op); the locked `putIfAbsent` runs only in the rare
+    * race where the entry was removed, re-inserting the just-written store so the
+    * datapoint is not lost. (If a different store was already recreated for the id,
+    * that newer store wins and this is a no-op.)
+    */
+  private def ensurePresent(id: ItemId, item: BlockStoreItem): Unit = {
+    if (data.get(id) ne item) data.putIfAbsent(id, item)
   }
 
   def setFilter(query: Query): Unit = {
@@ -139,8 +180,9 @@ class MemoryDatabase(registry: Registry, config: Config) extends Database {
 
   def update(id: ItemId, tags: Map[String, String], timestamp: Long, value: Double): Unit = {
     if (filter.matches(tags)) {
-      val blkStore = getOrCreateBlockStore(id, tags)
-      blkStore.update(timestamp, value)
+      val item = getOrCreateItem(id, tags)
+      item.blocks.update(timestamp, value)
+      ensurePresent(id, item)
     }
   }
 
@@ -153,8 +195,9 @@ class MemoryDatabase(registry: Registry, config: Config) extends Database {
   }
 
   def rollup(dp: DatapointTuple): Unit = {
-    val blkStore = getOrCreateBlockStore(dp.id, dp.tags)
-    blkStore.update(dp.timestamp, dp.value, rollup = true)
+    val item = getOrCreateItem(dp.id, dp.tags)
+    item.blocks.update(dp.timestamp, dp.value, rollup = true)
+    ensurePresent(dp.id, item)
   }
 
   @scala.annotation.tailrec

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/db/MemoryDatabaseSuite.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.core.db
 
+import com.netflix.atlas.core.index.TagQuery
 import com.netflix.atlas.core.model.*
 import com.netflix.atlas.core.stacklang.Interpreter
 import com.netflix.spectator.api.DefaultRegistry
@@ -87,7 +88,7 @@ class MemoryDatabaseSuite extends FunSuite {
         DatapointTuple(id, tags, t, v)
     }
     db.update(data)
-    db.index.rebuildIndex()
+    db.rebuildIndex()
   }
 
   private def addRollupData(name: String, values: Double*): Unit = {
@@ -100,7 +101,7 @@ class MemoryDatabaseSuite extends FunSuite {
         DatapointTuple(id, tags, t, v)
     }
     data.foreach(db.rollup)
-    db.index.rebuildIndex()
+    db.rebuildIndex()
   }
 
   private def addGaugeData(name: String, values: Double*): Unit = {
@@ -113,7 +114,7 @@ class MemoryDatabaseSuite extends FunSuite {
         DatapointTuple(id, tags, t, v)
     }
     gaugeDb.update(data)
-    gaugeDb.index.rebuildIndex()
+    gaugeDb.rebuildIndex()
   }
 
   private def expr(str: String): DataExpr = {
@@ -315,7 +316,119 @@ class MemoryDatabaseSuite extends FunSuite {
     assertEquals(exec("name,(,a,b,),:in"), List(ts("sum(name in (a,b))", 1, 4.0, 4.0, 4.0)))
     clock.setWallTime(4 * step)
     db.setFilter(Query.Equal("name", "a"))
-    db.rebuild()
+    db.rebuildIndex()
     assertEquals(exec("name,(,a,b,),:in"), List(ts("sum(name in (a,b))", 1, 1.0, 2.0, 3.0)))
   }
+
+  private def findItems(name: String): List[BlockStoreItem] =
+    db.index.findItems(TagQuery(Some(Query.Equal("name", name))))
+
+  test("series revived during rebuild cleanup is not orphaned") {
+    val tags = Map("name" -> "racy")
+    val id = TaggedItem.computeId(tags)
+
+    // A block store with a single old datapoint that will age out of the window.
+    val delegate = new MemoryBlockStore(step, 60, 2)
+    delegate.update(start, 1.0)
+
+    // Wrap it to simulate a concurrent update landing in the tiny window between
+    // rebuild()'s emptiness check and the entry's removal from data: once armed,
+    // the first check that observes an empty store reports "no data" (so removal
+    // proceeds) but revives the underlying store as a side effect first, exactly
+    // as a racing ingest thread would.
+    var revived = false
+    val racy = new RacyBlockStore(
+      delegate,
+      () => {
+        // getOrCreateItem still finds this store in `data` and writes to it
+        db.update(id, tags, clock.wallTime(), 2.0)
+        revived = true
+      }
+    )
+
+    db.data.put(id, BlockStoreItem.create(id, tags, racy))
+    db.rebuildIndex()
+
+    // Present in both the data map and the index to start with.
+    assert(db.data.containsKey(id))
+    assert(findItems("racy").nonEmpty)
+
+    // Advance well past the retention window, arm the simulated race, and rebuild.
+    clock.setWallTime(start + 1000 * step)
+    racy.arm()
+    db.rebuildIndex()
+
+    assert(revived, "revive callback should fire during the cleanup emptiness check")
+    assert(racy.hasData, "store was revived, so it has data again")
+
+    // Index membership is derived from `data`, so a revived store must remain in
+    // `data` (kept by the computeIfPresent re-check) and therefore stay queryable;
+    // a removed store would simply be absent from both, never an index-only orphan.
+    assert(db.data.containsKey(id), "revived store must not be removed from data")
+    assert(findItems("racy").nonEmpty, "series should remain queryable and consistent")
+  }
+
+  test("rebuild is throttled until rebuild-frequency elapses") {
+    val tags = Map("name" -> "throttled")
+    val id = TaggedItem.computeId(tags)
+
+    // Establish a known last-build time, then write a new series that is in `data`
+    // but not yet in the index.
+    clock.setWallTime(start + 3 * step)
+    db.rebuildIndex()
+    db.update(id, tags, start + 3 * step, 1.0)
+
+    // Within rebuild-frequency (10s) of the last build, rebuild() is a no-op.
+    clock.setWallTime(start + 3 * step + 5000)
+    db.rebuild()
+    assert(findItems("throttled").isEmpty, "rebuild within the throttle window must not rebuild")
+
+    // Past rebuild-frequency, rebuild() runs and indexes the new series.
+    clock.setWallTime(start + 3 * step + 11000)
+    db.rebuild()
+    assert(
+      findItems("throttled").nonEmpty,
+      "rebuild after the throttle window must index the series"
+    )
+  }
+}
+
+/**
+  * Block store wrapper used to deterministically reproduce the race between
+  * `rebuild()` cleanup and a concurrent `update()`. Once armed, the first call to
+  * `hasData` that observes an empty delegate fires the supplied callback (the
+  * simulated concurrent update), then still reports empty -- its value before the
+  * revive -- so the cleanup loop proceeds to attempt removal of the now-revived
+  * store.
+  */
+private class RacyBlockStore(delegate: MemoryBlockStore, onEmptyCheck: () => Unit)
+    extends BlockStore {
+
+  @volatile private var armed = false
+
+  def arm(): Unit = armed = true
+
+  def hasData: Boolean = {
+    val current = delegate.hasData
+    if (armed && !current) {
+      armed = false
+      onEmptyCheck()
+      false
+    } else {
+      current
+    }
+  }
+
+  def cleanup(cutoff: Long): Unit = delegate.cleanup(cutoff)
+
+  def update(timestamp: Long, value: Double, rollup: Boolean): Unit =
+    delegate.update(timestamp, value, rollup)
+
+  def update(timestamp: Long): Unit = delegate.update(timestamp)
+
+  def blockList: List[Block] = delegate.blockList
+
+  def fetch(start: Long, end: Long, aggr: Int): Array[Double] = delegate.fetch(start, end, aggr)
+
+  def get(start: Long): Option[Block] = delegate.get(start)
 }


### PR DESCRIPTION
The metadata index could retain a series no longer present in the data map ("orphaned series"): a tag query returned it long after its data had aged past the retention window. It happened when a concurrent update revived a block store in the small window between rebuild()'s emptiness check and removing it from the data map -- the store stayed reachable from the index (via its BlockStoreItem) but was dropped from data, so cleanup could never revisit it.

Fix the root cause -- two independent sources of liveness -- by making the data map authoritative. data now holds BlockStoreItem, and rebuildIndex() cleans up rolled-out/filtered stores and rebuilds the index from the surviving entries in a single pass, so a store removed during cleanup cannot linger in the index. The pending-queue feed (index.update) is no longer used by MemoryDatabase.

To avoid losing the datapoint from the residual sub-instruction race, update()/rollup() call ensurePresent() after writing: a lock-free get that re-inserts the store only if it was concurrently removed, adding no per-datapoint locking. hasData is made volatile so the rebuild thread reliably observes ingest-side revivals now that membership depends on it.

Adds a deterministic regression test for the revive-during-cleanup race and a test for the rebuild() throttle.