### PR TITLE
Avoid boxing the primitive when iterating ref-keyed/valued maps

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntRefHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntRefHashMap.scala
@@ -15,6 +15,19 @@
  */
 package com.netflix.atlas.core.util
 
+object IntRefHashMap {
+
+  /**
+    * Consumer for [[IntRefHashMap.foreach]]. A single-abstract-method trait with a
+    * primitive `int` key parameter, so iteration does not box the key the way a
+    * `Function2[Int, T, Unit]` would. Call sites can still pass a lambda; it is
+    * converted to this SAM type.
+    */
+  trait Consumer[T] {
+    def accept(key: Int, value: T): Unit
+  }
+}
+
 /**
   * Mutable integer map based on open-addressing. Primary use-case is computing
   * a count for the number of times a particular value was encountered.
@@ -102,12 +115,17 @@ class IntRefHashMap[T <: AnyRef](noData: Int, capacity: Int = 10) {
     null.asInstanceOf[T]
   }
 
-  /** Execute `f` for each item in the set. */
-  def foreach(f: (Int, T) => Unit): Unit = {
+  /**
+    * Execute `f` for each item in the set. Uses a specialized consumer rather than
+    * a `Function2[Int, T, Unit]` so the int key is not boxed on each call: a
+    * `Function2` with a reference-typed parameter has no specialized `apply`, so the
+    * generic `apply(Object, Object)` would box the key (see IntRefHashMap.Consumer).
+    */
+  def foreach(f: IntRefHashMap.Consumer[T]): Unit = {
     var i = 0
     while (i < keys.length) {
       val k = keys(i)
-      if (k != noData) f(k, values(i))
+      if (k != noData) f.accept(k, values(i))
       i += 1
     }
   }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/RefDoubleHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/RefDoubleHashMap.scala
@@ -15,6 +15,19 @@
  */
 package com.netflix.atlas.core.util
 
+object RefDoubleHashMap {
+
+  /**
+    * Consumer for [[RefDoubleHashMap.foreach]]. A single-abstract-method trait with
+    * a primitive `double` value parameter, so iteration does not box the value the
+    * way a `Function2[T, Double, Unit]` would. Call sites can still pass a lambda; it
+    * is converted to this SAM type.
+    */
+  trait Consumer[T] {
+    def accept(key: T, value: Double): Unit
+  }
+}
+
 /**
   * Mutable reference to double map based on open-addressing. Primary use-case is
   * computing an aggregate double value based on a key.
@@ -183,12 +196,17 @@ class RefDoubleHashMap[T <: AnyRef](capacity: Int = 10) {
     }
   }
 
-  /** Execute `f` for each item in the set. */
-  def foreach(f: (T, Double) => Unit): Unit = {
+  /**
+    * Execute `f` for each item in the set. Uses a specialized consumer rather than
+    * a `Function2[T, Double, Unit]` so the double value is not boxed on each call (a
+    * `Function2` with a reference-typed parameter falls back to the generic
+    * `apply(Object, Object)`, which boxes the double).
+    */
+  def foreach(f: RefDoubleHashMap.Consumer[T]): Unit = {
     var i = 0
     while (i < keys.length) {
       val k = keys(i)
-      if (k != null) f(k, values(i))
+      if (k != null) f.accept(k, values(i))
       i += 1
     }
   }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/RefIntHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/RefIntHashMap.scala
@@ -15,6 +15,19 @@
  */
 package com.netflix.atlas.core.util
 
+object RefIntHashMap {
+
+  /**
+    * Consumer for [[RefIntHashMap.foreach]]. A single-abstract-method trait with a
+    * primitive `int` value parameter, so iteration does not box the value the way a
+    * `Function2[T, Int, Unit]` would. Call sites can still pass a lambda; it is
+    * converted to this SAM type.
+    */
+  trait Consumer[T] {
+    def accept(key: T, value: Int): Unit
+  }
+}
+
 /**
   * Mutable reference to integer map based on open-addressing. Primary use-case is
   * computing a count for the number of times a particular value was encountered.
@@ -143,12 +156,17 @@ class RefIntHashMap[T <: AnyRef](capacity: Int = 10) {
     }
   }
 
-  /** Execute `f` for each item in the set. */
-  def foreach(f: (T, Int) => Unit): Unit = {
+  /**
+    * Execute `f` for each item in the set. Uses a specialized consumer rather than
+    * a `Function2[T, Int, Unit]` so the int value is not boxed on each call (a
+    * `Function2` with a reference-typed parameter falls back to the generic
+    * `apply(Object, Object)`, which boxes the int).
+    */
+  def foreach(f: RefIntHashMap.Consumer[T]): Unit = {
     var i = 0
     while (i < keys.length) {
       val k = keys(i)
-      if (k != null) f(k, values(i))
+      if (k != null) f.accept(k, values(i))
       i += 1
     }
   }

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/IntRefForeach.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/IntRefForeach.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.infra.Blackhole
+
+/**
+  * Iterating an `IntRefHashMap` via the specialized `Consumer` SAM avoids boxing the
+  * int key, which a `Function2[Int, T, Unit]` callback would do (no specialized
+  * `apply` exists when one parameter is a reference type, so the generic
+  * `apply(Object, Object)` boxes the key). This is the hot path behind
+  * `RoaringTagIndex` pattern queries (`strPattern`).
+  *
+  * `consumer` and `boxedFunction2` run the identical loop over the same data and
+  * differ only in the callback type, isolating the boxing cost. `mapForeach` uses the
+  * real `map.foreach` (now SAM).
+  *
+  * ```
+  * > jmh:run -wi 5 -i 5 -f1 -t1 -prof gc .*IntRefForeach.*
+  * ```
+  *
+  * Observed (size=1000, -wi 5 -i 8 -f1; absolute numbers vary by machine/JDK):
+  * ```
+  * boxedFunction2   2.49M ops/s
+  * consumer         4.14M ops/s   (~1.66x: no box/unbox, no generic apply)
+  * mapForeach       0.88M ops/s   (real sparse-table traversal; box-free)
+  * ```
+  * Note: in this tight monomorphic loop the JIT scalarizes the boxing, so
+  * gc.alloc.rate.norm is ~0 for all three; the throughput gap is the on-CPU box/unbox
+  * cost (the 5% self-time `boxToInteger` seen in CPU profiles). At polymorphic
+  * production call sites escape analysis often fails and the box also allocates, so
+  * removing it at the bytecode level (the SAM) is the robust fix.
+  */
+@State(Scope.Thread)
+class IntRefForeach {
+
+  private val size = 1000
+
+  private var map: IntRefHashMap[String] = _
+
+  // Parallel arrays holding the same entries, so the boxing/non-boxing callbacks
+  // traverse identical data and differ only in the callback type.
+  private var keys: Array[Int] = _
+  private var values: Array[String] = _
+
+  @Setup
+  def setup(): Unit = {
+    map = new IntRefHashMap[String](noData = Int.MinValue, capacity = 2 * size)
+    keys = new Array[Int](size)
+    values = new Array[String](size)
+    var i = 0
+    while (i < size) {
+      // Keys above the Integer cache (>127) so boxing actually allocates.
+      val k = 1000 + i
+      val v = k.toString
+      map.put(k, v)
+      keys(i) = k
+      values(i) = v
+      i += 1
+    }
+  }
+
+  // Mirrors the pre-change signature: a Function2 with a reference-typed parameter,
+  // which forces the generic apply(Object, Object) and boxes the int key.
+  private def boxedLoop(f: (Int, String) => Unit): Unit = {
+    var i = 0
+    while (i < keys.length) {
+      f(keys(i), values(i))
+      i += 1
+    }
+  }
+
+  private def consumerLoop(f: IntRefHashMap.Consumer[String]): Unit = {
+    var i = 0
+    while (i < keys.length) {
+      f.accept(keys(i), values(i))
+      i += 1
+    }
+  }
+
+  @Benchmark
+  def boxedFunction2(bh: Blackhole): Unit = {
+    boxedLoop((k, v) => { bh.consume(k); bh.consume(v) })
+  }
+
+  @Benchmark
+  def consumer(bh: Blackhole): Unit = {
+    consumerLoop((k, v) => { bh.consume(k); bh.consume(v) })
+  }
+
+  @Benchmark
+  def mapForeach(bh: Blackhole): Unit = {
+    map.foreach((k, v) => { bh.consume(k); bh.consume(v) })
+  }
+}


### PR DESCRIPTION
IntRefHashMap, RefIntHashMap, and RefDoubleHashMap exposed foreach as a Function2 callback. Because one parameter is a reference type, no specialized apply variant exists, so the generic apply(Object, Object) is used and the primitive (int key / int value / double value) is boxed on every element. This showed up as boxToInteger at IntRefHashMap.foreach being the #2 self-time leaf in a CPU profile, driven by RoaringTagIndex pattern queries (strPattern) scanning a key's value map.

Replace the Function2 callback with a small single-abstract-method Consumer per map whose method carries the primitive directly (e.g. accept(int, T)); it erases to a primitive descriptor, so iteration no longer boxes. Call sites pass lambdas and are unchanged via SAM conversion. After the change RoaringTagIndex compiles with zero boxToInteger.

Only these three maps box: the all-primitive maps (IntIntHashMap, DoubleIntHashMap, LongIntHashMap) and single-arg Function1 callbacks (foreachKey, the int/long sets, InternMap.retain) are already specialized by the compiler and were left unchanged.

Adds a JMH benchmark contrasting the boxing Function2 path with the SAM.