### PR TITLE
make MemoryDatabase.rebuildIndex public

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/db/MemoryDatabase.scala
@@ -113,8 +113,12 @@ class MemoryDatabase(registry: Registry, config: Config) extends Database {
     * entries guarantees that a store removed here cannot linger in the index
     * (the orphaned-series symptom), since the index can only ever contain ids that
     * are currently present in `data`.
+    *
+    * This forces a rebuild unconditionally. Use it to make data written via
+    * `update` queryable synchronously (e.g. in tests, or after a bulk load);
+    * `rebuild()` is the throttled variant the background thread uses.
     */
-  private[db] def rebuildIndex(): Unit = {
+  def rebuildIndex(): Unit = {
     val now = registry.clock().wallTime()
     val query = filter
     logger.info("rebuilding metadata index (filter={})", query)


### PR DESCRIPTION
Deriving index membership from the data map (#1906) stopped update() from feeding the index pending queue, so the synchronous data->index sync now happens only in rebuildIndex(). Callers that write via update() and previously forced a sync with index.rebuildIndex() no longer see their data: the no-arg BatchUpdateTagIndex.rebuildIndex() just drains an empty pending queue.

Expose the unthrottled MemoryDatabase.rebuildIndex() so callers can force a synchronous rebuild after a bulk load or in tests. rebuild() remains the throttled variant used by the background thread.