### PR TITLE
lsp: drain and ignore binary WebSocket messages

### DIFF
--- a/atlas-lspapi/src/main/scala/com/netflix/atlas/lspapi/LspWebSocketFlow.scala
+++ b/atlas-lspapi/src/main/scala/com/netflix/atlas/lspapi/LspWebSocketFlow.scala
@@ -16,6 +16,7 @@
 package com.netflix.atlas.lspapi
 
 import org.apache.pekko.NotUsed
+import org.apache.pekko.http.scaladsl.model.ws.BinaryMessage
 import org.apache.pekko.http.scaladsl.model.ws.Message
 import org.apache.pekko.http.scaladsl.model.ws.TextMessage
 import org.apache.pekko.stream.Materializer
@@ -88,6 +89,12 @@ object LspWebSocketFlow {
     val incoming: Sink[Message, NotUsed] = Flow[Message]
       .flatMapConcat {
         case TextMessage.Strict(text) =>
+          // No explicit size check is needed here: Pekko only delivers a
+          // message as Strict when an entire frame arrives within a single
+          // parser pass (bounded by the TCP read buffer, pekko.io.tcp
+          // .direct-buffer-size, 128 KiB by default). Any larger message is
+          // split across parser passes and delivered as Streamed, which is
+          // bounded by MaxMessageSize below.
           Source.single(text)
         case TextMessage.Streamed(textStream) =>
           textStream.fold("") { (acc, chunk) =>
@@ -96,10 +103,14 @@ object LspWebSocketFlow {
               throw new IllegalStateException("LSP message too large")
             combined
           }
-        case _ =>
-          Source.single(null)
+        case bm: BinaryMessage =>
+          // LSP JSON-RPC is exchanged as text only. Emit nothing for binary
+          // messages (a null element would violate the stream contract), but
+          // drain the data source so an unconsumed streamed message cannot
+          // stall the connection.
+          bm.dataStream.runWith(Sink.ignore)
+          Source.empty
       }
-      .filter(_ != null)
       .to(Sink.foreach { text =>
         val msg = jsonHandler.parseMessage(text)
         remoteEndpoint.consume(msg)

--- a/atlas-lspapi/src/test/scala/com/netflix/atlas/lspapi/LspApiSuite.scala
+++ b/atlas-lspapi/src/test/scala/com/netflix/atlas/lspapi/LspApiSuite.scala
@@ -18,7 +18,10 @@ package com.netflix.atlas.lspapi
 import com.netflix.atlas.pekko.RequestHandler
 import com.netflix.atlas.pekko.testkit.MUnitRouteSuite
 import com.typesafe.config.ConfigFactory
+import org.apache.pekko.http.scaladsl.model.ws.BinaryMessage
 import org.apache.pekko.http.scaladsl.testkit.WSProbe
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 
 class LspApiSuite extends MUnitRouteSuite {
 
@@ -47,6 +50,25 @@ class LspApiSuite extends MUnitRouteSuite {
     val client = WSProbe()
     WS("/lsp/metrics/uri", client.flow) ~> routes ~> check {
       assert(isWebSocketUpgrade)
+      client.sendMessage(initializeRequest(1))
+      val response = client.expectMessage()
+      val text = response.asTextMessage.getStrictText
+      assert(text.contains("\"id\":1"))
+      assert(text.contains("\"result\""))
+      client.sendCompletion()
+    }
+  }
+
+  test("binary message is ignored and does not break the connection") {
+    val client = WSProbe()
+    WS("/lsp/metrics/asl", client.flow) ~> routes ~> check {
+      assert(isWebSocketUpgrade)
+      // LSP transport is text-only. A binary message (here streamed across
+      // multiple chunks) must be drained and ignored, leaving the connection
+      // usable for subsequent text messages.
+      val chunks =
+        Source(List(ByteString(Array.fill[Byte](512)(0)), ByteString(Array.fill[Byte](512)(1))))
+      client.sendMessage(BinaryMessage(chunks))
       client.sendMessage(initializeRequest(1))
       val response = client.expectMessage()
       val text = response.asTextMessage.getStrictText


### PR DESCRIPTION
Binary messages fell into a catch-all that emitted a null stream element, which violates the Reactive Streams contract and crashed the WebSocket flow on the first binary frame; a streamed binary message would also leave its data source unconsumed and stall the connection. LSP JSON-RPC is text only, so drain the data source and ignore binary messages. Document why the Strict text branch needs no size check (it is bounded by the TCP read buffer; larger messages arrive as Streamed and hit the existing MaxMessageSize guard).