### PR TITLE
core: bound rolling-window buffer size

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/RollingBuffer.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/RollingBuffer.scala
@@ -117,8 +117,22 @@ class RollingBuffer(val values: Array[Double], start: Int = 0) {
 
 object RollingBuffer {
 
+  /**
+    * Maximum allowed window size. Window operators (`:rolling-*`, `:delay`, `:trend`)
+    * eagerly allocate an array of this size for each matching time series, so a window
+    * taken from a user-supplied expression must be bounded to avoid exhausting the heap.
+    * The cap of 86400 is one day of data at a 1s step (or several weeks at 1m), which is
+    * well beyond any legitimate window, while preventing a crafted query such as
+    * `300000000,:rolling-mean` from triggering an out-of-memory error.
+    */
+  val MaxWindowSize: Int = 86400
+
   /** Create a new buffer of size `n` initialized with NaN values. */
   def apply(n: Int): RollingBuffer = {
+    require(
+      n > 0 && n <= MaxWindowSize,
+      s"window size must be between 1 and $MaxWindowSize: $n"
+    )
     new RollingBuffer(ArrayHelper.fill(n, Double.NaN))
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMeanSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineRollingMeanSuite.scala
@@ -25,6 +25,12 @@ class OnlineRollingMeanSuite extends BaseOnlineAlgorithmSuite {
     assertEquals(algo.next(1.0), 1.0)
   }
 
+  test("window size beyond max is rejected") {
+    intercept[IllegalArgumentException] {
+      OnlineRollingMean(RollingBuffer.MaxWindowSize + 1, 1)
+    }
+  }
+
   test("n = 2, min = 1") {
     val algo = OnlineRollingMean(2, 1)
     assertEquals(algo.next(0.0), 0.0)

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/RollingBufferSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/RollingBufferSuite.scala
@@ -25,6 +25,23 @@ class RollingBufferSuite extends FunSuite {
     }
   }
 
+  test("n < 0") {
+    intercept[IllegalArgumentException] {
+      RollingBuffer(-1)
+    }
+  }
+
+  test("n = max window size") {
+    val buf = RollingBuffer(RollingBuffer.MaxWindowSize)
+    assertEquals(buf.values.length, RollingBuffer.MaxWindowSize)
+  }
+
+  test("n > max window size") {
+    intercept[IllegalArgumentException] {
+      RollingBuffer(RollingBuffer.MaxWindowSize + 1)
+    }
+  }
+
   test("n = 1, add") {
     val buf = RollingBuffer(1)
     assert(buf.add(0.0).isNaN)


### PR DESCRIPTION
The window size for :rolling-*, :delay, and :trend was taken from the user expression with no upper bound and used to eagerly allocate a double[] per matching series, so a crafted query such as 300000000,:rolling-mean could allocate ~2.4GB per series and exhaust the heap. Bound the size at the RollingBuffer allocation chokepoint (covering every window operator) to 86400 (one day at a 1s step), and reject out-of-range sizes with IllegalArgumentException (mapped to 400) instead of allowing the allocation or a NegativeArraySizeException.