### PR TITLE
postgres: fix SQL injection in identifier escaping

### DIFF
--- a/atlas-postgres/src/main/scala/com/netflix/atlas/postgres/SqlUtils.scala
+++ b/atlas-postgres/src/main/scala/com/netflix/atlas/postgres/SqlUtils.scala
@@ -152,7 +152,7 @@ object SqlUtils {
         val limit = tq.limit
         val offset = s"and $column > '${escapeLiteral(tq.offset)}'"
         s"""
-        select distinct $column as "${escapeLiteral(key)}"
+        select distinct $column as ${escapeIdentifier(key)}
           from $schema.${table.tableName}_$suffix
          where ${toWhere(table.columns, query)} $offset
          order by $column
@@ -186,7 +186,7 @@ object SqlUtils {
           val selectColumns = cs
             .zip(expr.finalGrouping)
             .map {
-              case (column, label) => s"$column as \"${escapeLiteral(label)}\""
+              case (column, label) => s"$column as ${escapeIdentifier(label)}"
             }
             .mkString(", ")
           val groupByColumns = cs.mkString(", ")
@@ -260,7 +260,7 @@ object SqlUtils {
 
   private def formatColumn(columns: List[String], k: String): String = {
     if (columns.contains(k))
-      s"\"${escapeLiteral(k)}\""
+      escapeIdentifier(k)
     else
       s"tags -> '${escapeLiteral(k)}'"
   }
@@ -268,6 +268,19 @@ object SqlUtils {
   private[postgres] def escapeLiteral(str: String): String = {
     val buf = new java.lang.StringBuilder(str.length)
     org.postgresql.core.Utils.escapeLiteral(buf, str, false)
+    buf.toString
+  }
+
+  /**
+   * Escape a string for use as a double-quoted SQL identifier (e.g. a column alias).
+   * Unlike [[escapeLiteral]], this doubles embedded double quotes and includes the
+   * surrounding quotes, so the returned value must not be wrapped in additional quotes.
+   * This is required for any identifier built from user input (tag keys, grouping
+   * labels) to prevent breaking out of the quoted identifier.
+   */
+  private[postgres] def escapeIdentifier(str: String): String = {
+    val buf = new java.lang.StringBuilder(str.length + 2)
+    org.postgresql.core.Utils.escapeIdentifier(buf, str)
     buf.toString
   }
 

--- a/atlas-postgres/src/test/scala/com/netflix/atlas/postgres/SqlUtilsSuite.scala
+++ b/atlas-postgres/src/test/scala/com/netflix/atlas/postgres/SqlUtilsSuite.scala
@@ -449,4 +449,38 @@ class SqlUtilsSuite extends PostgresSuite {
       """
     assertEquals(arrayQuery(sql), list(1.0, 2.0, null))
   }
+
+  //
+  // Security: SQL injection via tag keys / grouping labels. These are used as
+  // double-quoted SQL identifiers (column aliases), so a `"` must be doubled to
+  // prevent breaking out of the identifier and injecting arbitrary SQL.
+  //
+
+  test("grouping label with double quote is treated as a literal identifier") {
+    val table = populateSelectTable()
+    // The label is used as a column alias: `<col> as "<label>"`. Were the `"`
+    // not escaped, this payload would inject `31337 as "injected"` as its own
+    // select column. With escaping the whole payload is one quoted identifier.
+    val payload = "x\", 31337 as \"injected"
+    val expr = DataExpr.GroupBy(DataExpr.Sum(parseQuery("name,cpu,:eq")), List(payload))
+    val sql = SqlUtils.dataQueries(time, List(table), expr).head
+    assert(sql.contains("\"x\"\", 31337 as \"\"injected\""), sql)
+    service.runQueries { stmt =>
+      val rs = stmt.executeQuery(sql)
+      assert(rs.next())
+      // The injection did not create a separate "injected" column.
+      intercept[Exception](rs.findColumn("injected"))
+    }
+  }
+
+  test("value query key with double quote is treated as a literal identifier") {
+    val table = populateSelectTable()
+    // The tag key (e.g. from the /api/v1/tags/<key> path) is used as a column
+    // alias. With escaping the `"` is doubled and the key is just a (nonexistent)
+    // tag name, so the query runs and returns no values instead of injecting SQL.
+    val tq = TagQuery(None, Some("a\"b"))
+    val sql = SqlUtils.valueQueries(time, List(table), tq).head
+    assert(sql.contains("\"a\"\"b\""), sql)
+    assertEquals(stringList(sql), Nil)
+  }
 }


### PR DESCRIPTION
Tag keys and group-by labels are used as double-quoted SQL identifiers (column aliases) but were escaped with escapeLiteral, which doubles single quotes and backslashes but not double quotes. A key or label containing a double quote could break out of the identifier and inject arbitrary SQL into the select list (demonstrated by a grouping label that injected and executed an extra select column).

Add an escapeIdentifier helper backed by the JDBC driver's Utils.escapeIdentifier (which doubles embedded double quotes and adds the surrounding quotes) and use it for every identifier built from request input: value-query aliases, group-by aliases, and the formatColumn identifier branch. Includes regression tests showing the crafted key/label is now treated as a literal identifier.