### PR TITLE
eval: reject non-positive graph width/height

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
@@ -127,10 +127,15 @@ case class Grapher(settings: DefaultSettings) {
     val theme = params.get("theme").getOrElse(settings.theme)
     val palette = params.get("palette").getOrElse(settings.primaryPalette(theme))
 
+    val width = params.get("w").fold(settings.width)(_.toInt)
+    val height = params.get("h").fold(settings.height)(_.toInt)
+    require(width > 0, s"width must be positive (got $width)")
+    require(height > 0, s"height must be positive (got $height)")
+
     val flags = ImageFlags(
       title = params.get("title").filter(_ != ""),
-      width = params.get("w").fold(settings.width)(_.toInt),
-      height = params.get("h").fold(settings.height)(_.toInt),
+      width = width,
+      height = height,
       zoom = params.get("zoom").fold(1.0)(_.toDouble),
       axes = axes,
       axisPerLine = params.get("axis_per_line").contains("1"),

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GrapherSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/graph/GrapherSuite.scala
@@ -304,6 +304,34 @@ class GrapherSuite extends FunSuite {
     }
   }
 
+  test("reject zero width") {
+    val uri = "/api/v1/graph?e=2012-01-01T00:00&q=1&w=0"
+    intercept[IllegalArgumentException] {
+      grapher.toGraphConfig(Uri(uri))
+    }
+  }
+
+  test("reject negative width") {
+    val uri = "/api/v1/graph?e=2012-01-01T00:00&q=1&w=-5"
+    intercept[IllegalArgumentException] {
+      grapher.toGraphConfig(Uri(uri))
+    }
+  }
+
+  test("reject zero height") {
+    val uri = "/api/v1/graph?e=2012-01-01T00:00&q=1&h=0"
+    intercept[IllegalArgumentException] {
+      grapher.toGraphConfig(Uri(uri))
+    }
+  }
+
+  test("reject negative height") {
+    val uri = "/api/v1/graph?e=2012-01-01T00:00&q=1&h=-5"
+    intercept[IllegalArgumentException] {
+      grapher.toGraphConfig(Uri(uri))
+    }
+  }
+
   imageTest("multi-Y, 5 axis per line") {
     "/api/v1/graph?e=2012-01-01T00:00&q=0,1,2,3,4&axis_per_line=1"
   }


### PR DESCRIPTION
The w and h query parameters were parsed with no lower bound. A width of 0 reached Step.compute via GraphConfig.stepSize and threw ArithmeticException (/ by zero), which the request handler maps to a 500 rather than a client error; negative or zero dimensions otherwise passed through to produce a degenerate config/image. Validate that width and height are positive when parsing the graph config (shared by the graph, fetch, and streaming paths) so invalid dimensions fail with an IllegalArgumentException (400) instead.