### PR TITLE
core: report duration overflow as a client error

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
@@ -537,21 +537,29 @@ object Strings {
   private def parseAtDuration(amount: String, unit: String): Duration = {
     val v = amount.toLong
 
-    // format: off
-    unit match {
-      case "ns"                               => Duration.ofNanos(v)
-      case "us" | "μs"                        => Duration.ofNanos(v * 1000L)
-      case "ms"                               => Duration.ofMillis(v)
-      case "seconds" | "second" | "s"         => Duration.ofSeconds(v)
-      case "minutes" | "minute" | "min" | "m" => Duration.ofMinutes(v)
-      case "hours"   | "hour"   | "h"         => Duration.ofHours(v)
-      case "days"    | "day"    | "d"         => Duration.ofDays(v)
-      case "weeks"   | "week"   | "wk"  | "w" => Duration.ofDays(v * 7)
-      case "months"  | "month"                => Duration.ofDays(v * 30)
-      case "years"   | "year"   | "y"         => Duration.ofDays(v * 365)
-      case _                                  => throw new IllegalArgumentException("unknown unit " + unit)
+    // Use multiplyExact and convert overflow to an IllegalArgumentException so an
+    // out-of-range amount is reported as a client error (400) rather than allowing
+    // an ArithmeticException (mapped to a 500) or a silently wrapped value.
+    try {
+      // format: off
+      unit match {
+        case "ns"                               => Duration.ofNanos(v)
+        case "us" | "μs"                        => Duration.ofNanos(java.lang.Math.multiplyExact(v, 1000L))
+        case "ms"                               => Duration.ofMillis(v)
+        case "seconds" | "second" | "s"         => Duration.ofSeconds(v)
+        case "minutes" | "minute" | "min" | "m" => Duration.ofMinutes(v)
+        case "hours"   | "hour"   | "h"         => Duration.ofHours(v)
+        case "days"    | "day"    | "d"         => Duration.ofDays(v)
+        case "weeks"   | "week"   | "wk"  | "w" => Duration.ofDays(java.lang.Math.multiplyExact(v, 7L))
+        case "months"  | "month"                => Duration.ofDays(java.lang.Math.multiplyExact(v, 30L))
+        case "years"   | "year"   | "y"         => Duration.ofDays(java.lang.Math.multiplyExact(v, 365L))
+        case _                                  => throw new IllegalArgumentException("unknown unit " + unit)
+      }
+      // format: on
+    } catch {
+      case e: ArithmeticException =>
+        throw new IllegalArgumentException(s"duration out of range: $amount$unit", e)
     }
-    // format: on
   }
 
   /**

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
@@ -307,6 +307,14 @@ class StringsSuite extends FunSuite {
     assertEquals(parseDuration("42y"), Duration.ofDays(42 * 365))
   }
 
+  test("parseDuration, overflow is a client error") {
+    // Amounts that fit in a Long but overflow the duration arithmetic must surface
+    // as an IllegalArgumentException (400) rather than an ArithmeticException (500).
+    intercept[IllegalArgumentException] { parseDuration("9999999999999999y") }
+    intercept[IllegalArgumentException] { parseDuration("99999999999999999d") }
+    intercept[IllegalArgumentException] { parseDuration("999999999999999999m") }
+  }
+
   test("parseDuration, at invalid unit") {
     val e = intercept[IllegalArgumentException] {
       parseDuration("42fubars")


### PR DESCRIPTION
A relative time/duration amount that fits in a Long but overflows the duration arithmetic (e.g. s=e-9999999999999999y) threw an ArithmeticException from Duration.ofX, which the request handler maps to a 500 rather than a client error. The week/month/year multipliers also used plain Long multiplication, which silently wraps to a wrong value for large inputs.

Use Math.multiplyExact for those multipliers and convert any ArithmeticException from the duration math into an IllegalArgumentException (mapped to 400).