### PR TITLE
core: unescape list values consumed as data

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/DataExpr.scala
@@ -17,6 +17,7 @@ package com.netflix.atlas.core.model
 
 import java.time.Duration
 import com.netflix.atlas.core.model.ConsolidationFunction.SumOrAvgCf
+import com.netflix.atlas.core.stacklang.Interpreter
 import com.netflix.atlas.core.util.Math
 import com.netflix.atlas.core.util.SortedTagMap
 import com.netflix.atlas.core.util.Strings
@@ -289,7 +290,8 @@ object DataExpr {
 
     override def finalGrouping: List[String] = keys
 
-    override def exprString: String = s"$af,(,${keys.mkString(",")},),:by"
+    override def exprString: String =
+      s"$af,(,${keys.map(Interpreter.escape).mkString(",")},),:by"
 
     override def eval(context: EvalContext, data: List[TimeSeries]): ResultSet = {
       val ks = Query.exactKeys(query) ++ keys

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -1087,7 +1087,9 @@ object MathExpr {
 
           val grouping = evalExpr.finalGrouping
           if (grouping.nonEmpty) {
-            builder.append(grouping.mkString(",(,", ",", ",),:by"))
+            builder.append(",(,")
+            Interpreter.append(builder, grouping*)
+            builder.append(",),:by")
           }
         case t: TimeSeriesExpr if groupingMatches =>
           // The passed in expression maybe the result of a rewrite to the display expression

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/QueryVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/QueryVocabulary.scala
@@ -24,7 +24,6 @@ import com.netflix.atlas.core.stacklang.TypedWord
 import com.netflix.atlas.core.stacklang.Vocabulary
 import com.netflix.atlas.core.stacklang.Word
 import com.netflix.atlas.core.stacklang.ast.DataType
-import com.netflix.atlas.core.stacklang.ast.DataType.StringListType
 import com.netflix.atlas.core.stacklang.ast.Parameter
 import com.netflix.spectator.impl.matcher.PatternUtils
 
@@ -457,12 +456,16 @@ object QueryVocabulary extends Vocabulary {
 
     override def execute(context: Context, params: IndexedSeq[Any]): Context = {
       val k = params(0).asInstanceOf[String]
-      val vs = params(1).asInstanceOf[List[?]]
+      // `params(1)` has already been coerced and unescaped by the StringListType
+      // extractor. Re-matching `StringListType` here would unescape a second time, and
+      // since `Strings.unescape` is not idempotent that would corrupt multi-value `:in`
+      // and make it inconsistent with `:eq` and the single-value case. Use the extracted
+      // list directly.
+      val vs = params(1).asInstanceOf[List[String]]
       val query = vs match {
-        case Nil                => Query.False
-        case (v: String) :: Nil => Query.Equal(k, v)
-        case StringListType(sv) => Query.In(k, sv)
-        case _ => throw new IllegalArgumentException("list must contain only strings")
+        case Nil      => Query.False
+        case v :: Nil => Query.Equal(k, v)
+        case _        => Query.In(k, vs)
       }
       context.copy(stack = query :: context.stack)
     }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/ast/DataType.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/ast/DataType.scala
@@ -162,8 +162,13 @@ object DataType {
     def extract(value: Any): Option[Any] = unapply(value)
 
     def unapply(value: Any): Option[List[String]] = value match {
-      case vs: List[?] if vs.forall(_.isInstanceOf[String]) => Some(vs.asInstanceOf[List[String]])
-      case _                                                => None
+      // Unlike scalar string tokens, list elements are not unescaped when pushed
+      // onto the stack (the raw form must be preserved for lists used as programs,
+      // e.g. `:each`/`:map`/`:call`). Unescape here so list values consumed as data
+      // match the behavior of scalar string values (e.g. `:in` matches `:eq`).
+      case vs: List[?] if vs.forall(_.isInstanceOf[String]) =>
+        Some(vs.asInstanceOf[List[String]].map(Strings.unescape))
+      case _ => None
     }
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataExprSuite.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.core.model
 
+import com.netflix.atlas.core.stacklang.Interpreter
 import munit.FunSuite
 
 class DataExprSuite extends FunSuite {
@@ -23,6 +24,21 @@ class DataExprSuite extends FunSuite {
     val expr = DataExpr.Sum(Query.True)
     val tags = Map("name" -> "foo")
     assertEquals(expr.groupByKey(tags), None)
+  }
+
+  test("GroupBy exprString round-trips keys that need escaping") {
+    val interpreter = Interpreter(StyleVocabulary.allWords)
+    def dataExpr(s: String): DataExpr = interpreter.execute(s).stack match {
+      case ModelDataTypes.PresentationType(t) :: Nil => t.expr.asInstanceOf[DataExpr]
+      case _                                         => throw new IllegalArgumentException(s)
+    }
+
+    // The single tag key contains a comma (escaped on input). Parsing unescapes it,
+    // so the rendered expression must re-escape it; otherwise re-parsing splits it
+    // into two keys.
+    val expr = dataExpr("name,sps,:eq,:sum,(,a\\u002cb,),:by")
+    assertEquals(expr.asInstanceOf[DataExpr.GroupBy].keys, List("a,b"))
+    assertEquals(dataExpr(expr.exprString), expr)
   }
 
   test("allKeys") {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/QueryVocabularySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/QueryVocabularySuite.scala
@@ -46,6 +46,51 @@ class QueryVocabularySuite extends FunSuite {
     assert(!q.matches(Map("foo" -> "my $var. [work-in progress]")))
   }
 
+  test("eq and in handle escapes consistently") {
+    // `:` is the escape sequence for ':'. With :eq the value is unescaped
+    // to ":foo". The same value passed through a list to :in should behave the
+    // same way.
+    val eq = interpreter.execute("name,\\u003afoo,:eq").stack.head.asInstanceOf[Query.Equal]
+    assertEquals(eq.v, ":foo")
+
+    // :in with a single value optimizes to Query.Equal and should match :eq.
+    val in = interpreter.execute("name,(,\\u003afoo,),:in").stack.head.asInstanceOf[Query.Equal]
+    assertEquals(in.v, ":foo")
+  }
+
+  test("in unescapes all values, not just the single-value opt case") {
+    // With multiple values :in produces a Query.In and each value in the set
+    // should be unescaped the same way a scalar token would be.
+    val in = interpreter
+      .execute("name,(,\\u003afoo,\\u003abar,),:in")
+      .stack
+      .head
+      .asInstanceOf[Query.In]
+    assertEquals(in.vs, List(":foo", ":bar"))
+  }
+
+  test("in unescapes each value exactly once, matching eq") {
+    // Strings.unescape is not idempotent: the token used below decodes in one pass
+    // to a 6-character string that still contains a valid escape sequence, which a
+    // second pass would decode further. Asserting the once-decoded form pins the
+    // value to exactly one unescape, matching the scalar :eq path. The earlier tests
+    // use a colon escape whose decoded form is a fixed point, so they cannot detect a
+    // double unescape.
+    val eq = interpreter.execute("name,\\u005cu0041,:eq").stack.head.asInstanceOf[Query.Equal]
+    assertEquals(eq.v, "\\u0041")
+
+    val in = interpreter
+      .execute("name,(,\\u005cu0041,\\u005cu0042,),:in")
+      .stack
+      .head
+      .asInstanceOf[Query.In]
+    assertEquals(in.vs, List("\\u0041", "\\u0042"))
+  }
+
+  test("in with empty list is Query.False") {
+    assertEquals(interpreter.execute("name,(,),:in").stack.head, Query.False)
+  }
+
   test("starts, prefix and escape") {
     val exp = interpreter.execute("a,[foo],:starts").stack.head
     assertEquals(exp.asInstanceOf[Query.Regex].pattern.prefix(), "[foo]")


### PR DESCRIPTION
List elements were stored raw by the interpreter (the raw form is needed for lists used as programs via :each/:map/:call), while scalar tokens are unescaped when pushed. As a result list values consumed as data were not unescaped: name,\u003afoo,:eq matched ":foo" but name,(,\u003afoo,),:in matched "\u003afoo".

Unescape elements in the StringListType coercion so list values consumed as data (:in, :by keys, event columns) match scalar handling. Avoid a double unescape in :in by using the already-extracted list instead of re-matching StringListType (Strings.unescape is not idempotent). Re-escape group-by keys in DataExpr.GroupBy.exprString and the NamedRewrite aggregate render so they round-trip, matching MathExpr.GroupBy and Query.In.