### PR TITLE
core: avoid lambda allocation in query matching

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
@@ -305,7 +305,12 @@ object Query {
           val v = ts.getOrNull(k)
           v != null && check(v)
         case _ =>
-          tags.get(k).exists(check)
+          // Avoid eta-expanding `check` into a function for `exists`. getOrElse with a null
+          // default also lets map implementations that override it (e.g. immutable HashMap
+          // and the small MapN classes) skip the Option allocation from `get`, though the
+          // default implementation still allocates one.
+          val v = tags.getOrElse(k, null)
+          v != null && check(v)
       }
     }
 
@@ -319,7 +324,8 @@ object Query {
           val v = ts.getOrNull(k)
           v == null || check(v)
         case _ =>
-          tags.get(k).fold(true)(check)
+          val v = tags.getOrElse(k, null)
+          v == null || check(v)
       }
     }
   }


### PR DESCRIPTION
KeyValueQuery.matches and couldMatch used tags.get(k).exists(check) and tags.get(k).fold(true)(check) for the generic Map case. Passing the check method to exists/fold eta-expands it into a Function1 that is allocated on each call, on the per-series query matching hot path.

Use getOrElse(k, null) and call check directly, mirroring the existing SortedTagMap branch. This removes the function allocation; it also avoids the Option allocation from get for map implementations that override getOrElse (immutable HashMap and the small MapN classes), though the default implementation still allocates one. Fully avoiding the Option for the generic case requires SortedTagMap tags from the producing application.