### PR TITLE
core: avoid integer modulo in open-addressed map slot computation

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Hash.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Hash.scala
@@ -86,9 +86,20 @@ object Hash {
     computeHashBytes("SHA1", input.getBytes("UTF-8"))
   }
 
-  // If the hash value is `Integer.MIN_VALUE`, then the absolute value will be
-  // negative. For our purposes that will get mapped to a starting position of 0.
-  private[util] def absOrZero(v: Int): Int = math.max(math.abs(v), 0)
+  /**
+    * Map a hash into the range `[0, n)` without a division. Based on Lemire's
+    * [[https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/ fast
+    * alternative to the modulo reduction]]: treats `hash` as a 32-bit fraction of the unit
+    * interval and multiplies by `n`, keeping the high 32 bits of the 64-bit product.
+    *
+    * Unlike a bitmask this works for an arbitrary (e.g. prime) `n`, so the backing tables can
+    * keep their existing prime sizing while avoiding the per-slot `idiv`. The reduction keys
+    * off the high bits of `hash`, so callers must feed it a well-mixed value (e.g. the result
+    * of [[lowbias32]]); a raw `hashCode` with weak high bits would cluster.
+    */
+  def reduce(hash: Int, n: Int): Int = {
+    ((hash & 0xFFFFFFFFL) * (n & 0xFFFFFFFFL) >>> 32).toInt
+  }
 
   private def computeHash(algorithm: String, bytes: Array[Byte]): BigInteger = {
     new BigInteger(1, computeHashBytes(algorithm, bytes))

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntHashSet.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntHashSet.scala
@@ -37,7 +37,7 @@ class IntHashSet(noData: Int, capacity: Int = 10) {
   private def computeCutoff(n: Int): Int = math.max(3, n / 2)
 
   private def hash(k: Int, length: Int): Int = {
-    Hash.absOrZero(Hash.lowbias32(k)) % length
+    Hash.reduce(Hash.lowbias32(k), length)
   }
 
   private def newArray(n: Int): Array[Int] = {
@@ -66,7 +66,7 @@ class IntHashSet(noData: Int, capacity: Int = 10) {
     var pos = hash(v, buffer.length)
     var posV = buffer(pos)
     while (posV != noData && posV != v) {
-      pos = (pos + 1) % buffer.length
+      pos = if (pos + 1 < buffer.length) pos + 1 else 0
       posV = buffer(pos)
     }
     buffer(pos) = v

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntIntHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntIntHashMap.scala
@@ -38,7 +38,7 @@ class IntIntHashMap(noData: Int, capacity: Int = 10) {
   private def computeCutoff(n: Int): Int = math.max(3, n / 2)
 
   private def hash(k: Int, length: Int): Int = {
-    Hash.absOrZero(Hash.lowbias32(k)) % length
+    Hash.reduce(Hash.lowbias32(k), length)
   }
 
   private def newArray(n: Int): Array[Int] = {
@@ -69,7 +69,7 @@ class IntIntHashMap(noData: Int, capacity: Int = 10) {
     var pos = hash(k, ks.length)
     var posV = ks(pos)
     while (posV != noData && posV != k) {
-      pos = (pos + 1) % ks.length
+      pos = if (pos + 1 < ks.length) pos + 1 else 0
       posV = ks(pos)
     }
     ks(pos) = k
@@ -100,7 +100,7 @@ class IntIntHashMap(noData: Int, capacity: Int = 10) {
       else if (prev == k)
         return values(pos)
       else
-        pos = (pos + 1) % keys.length
+        pos = if (pos + 1 < keys.length) pos + 1 else 0
     }
     dflt
   }
@@ -120,7 +120,7 @@ class IntIntHashMap(noData: Int, capacity: Int = 10) {
     var pos = hash(k, keys.length)
     var prev = keys(pos)
     while (prev != noData && prev != k) {
-      pos = (pos + 1) % keys.length
+      pos = if (pos + 1 < keys.length) pos + 1 else 0
       prev = keys(pos)
     }
     keys(pos) = k

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntRefHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/IntRefHashMap.scala
@@ -72,14 +72,14 @@ class IntRefHashMap[T <: AnyRef](noData: Int, capacity: Int = 10) {
   }
 
   private def hash(k: Int, length: Int): Int = {
-    Hash.absOrZero(Hash.lowbias32(k)) % length
+    Hash.reduce(Hash.lowbias32(k), length)
   }
 
   private def put(ks: Array[Int], vs: Array[T], k: Int, v: T): Boolean = {
     var pos = hash(k, ks.length)
     var posV = ks(pos)
     while (posV != noData && posV != k) {
-      pos = (pos + 1) % ks.length
+      pos = if (pos + 1 < ks.length) pos + 1 else 0
       posV = ks(pos)
     }
     ks(pos) = k
@@ -110,7 +110,7 @@ class IntRefHashMap[T <: AnyRef](noData: Int, capacity: Int = 10) {
       else if (prev == k)
         return values(pos)
       else
-        pos = (pos + 1) % keys.length
+        pos = if (pos + 1 < keys.length) pos + 1 else 0
     }
     null.asInstanceOf[T]
   }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/InternMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/InternMap.scala
@@ -48,9 +48,10 @@ class OpenHashInternMap[K <: AnyRef](initialCapacity: Int, clock: Clock = Clock.
   private var timestamps = new Array[Long](primeCapacity)
   private var currentSize = 0
 
+  // The raw `hashCode` has weak high-bit dispersion, so mix it with `lowbias32`
+  // before reducing into the slot range (the reduction keys off the high bits).
   private def hash(k: K): Int = {
-    val h = k.hashCode % data.length
-    if (h < 0) -h else h
+    Hash.reduce(Hash.lowbias32(k.hashCode), data.length)
   }
 
   private def resize(newCapacity: Int, keep: Long => Boolean): Unit = {
@@ -70,10 +71,9 @@ class OpenHashInternMap[K <: AnyRef](initialCapacity: Int, clock: Clock = Clock.
   }
 
   private def intern(k: K, t: Long): K = {
-    val h = hash(k)
-    var i = h
-    while (i < h + data.length) {
-      val j = i % data.length
+    var j = hash(k)
+    var n = 0
+    while (n < data.length) {
       if (data(j) == null) {
         currentSize += 1
         data(j) = k
@@ -83,7 +83,8 @@ class OpenHashInternMap[K <: AnyRef](initialCapacity: Int, clock: Clock = Clock.
         timestamps(j) = t
         return data(j)
       }
-      i += 1
+      j = if (j + 1 < data.length) j + 1 else 0
+      n += 1
     }
     throw new IllegalStateException("failed to add entry to map")
   }
@@ -119,9 +120,10 @@ class ConcurrentInternMap[K <: AnyRef](newMap: => InternMap[K], concurrencyLevel
   }
 
   private def index(key: K): Int = {
-    val k = key.hashCode
-    val i = k % concurrencyLevel
-    if (i < 0) -1 * i else i
+    // Mix and reduce rather than `hashCode % concurrencyLevel`: the latter returns a
+    // negative index for hashCode == Integer.MIN_VALUE (negation overflows), and keys off
+    // the weak low bits. `reduce` is always in `[0, concurrencyLevel)`.
+    Hash.reduce(Hash.lowbias32(key.hashCode), concurrencyLevel)
   }
 
   def intern(k: K): K = {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongHashSet.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongHashSet.scala
@@ -59,10 +59,10 @@ class LongHashSet(noData: Long, capacity: Int = 10) {
   }
 
   private def add(buffer: Array[Long], v: Long): Boolean = {
-    var pos = Hash.absOrZero(Hash.lowbias64(v)) % buffer.length
+    var pos = Hash.reduce(Hash.lowbias64(v), buffer.length)
     var posV = buffer(pos)
     while (posV != noData && posV != v) {
-      pos = (pos + 1) % buffer.length
+      pos = if (pos + 1 < buffer.length) pos + 1 else 0
       posV = buffer(pos)
     }
     buffer(pos) = v

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongIntHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/LongIntHashMap.scala
@@ -62,14 +62,14 @@ class LongIntHashMap(noData: Long, capacity: Int = 10) {
   }
 
   private def hash(ks: Array[Long], k: Long): Int = {
-    Hash.absOrZero(Hash.lowbias64(k)) % ks.length
+    Hash.reduce(Hash.lowbias64(k), ks.length)
   }
 
   private def put(ks: Array[Long], vs: Array[Int], k: Long, v: Int): Boolean = {
     var pos = hash(ks, k)
     var posV = ks(pos)
     while (posV != noData && posV != k) {
-      pos = (pos + 1) % ks.length
+      pos = if (pos + 1 < ks.length) pos + 1 else 0
       posV = ks(pos)
     }
     ks(pos) = k
@@ -100,7 +100,7 @@ class LongIntHashMap(noData: Long, capacity: Int = 10) {
       else if (prev == k)
         return values(pos)
       else
-        pos = (pos + 1) % keys.length
+        pos = if (pos + 1 < keys.length) pos + 1 else 0
     }
     dflt
   }
@@ -126,7 +126,7 @@ class LongIntHashMap(noData: Long, capacity: Int = 10) {
         if (prev == noData) used += 1
         return
       }
-      pos = (pos + 1) % keys.length
+      pos = if (pos + 1 < keys.length) pos + 1 else 0
     }
   }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/RefDoubleHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/RefDoubleHashMap.scala
@@ -51,6 +51,12 @@ class RefDoubleHashMap[T <: AnyRef](capacity: Int = 10) {
     ArrayHelper.newInstance[T](PrimeFinder.nextPrime(n))
   }
 
+  // The raw `hashCode` has weak high-bit dispersion, so mix it with `lowbias32`
+  // before reducing into the slot range (the reduction keys off the high bits).
+  private def hash(k: T, length: Int): Int = {
+    Hash.reduce(Hash.lowbias32(k.hashCode()), length)
+  }
+
   private def resize(): Unit = {
     val tmpKS = newArray(keys.length * 2)
     val tmpVS = new Array[Double](tmpKS.length)
@@ -66,10 +72,10 @@ class RefDoubleHashMap[T <: AnyRef](capacity: Int = 10) {
   }
 
   private def put(ks: Array[T], vs: Array[Double], k: T, v: Double): Boolean = {
-    var pos = Hash.absOrZero(k.hashCode()) % ks.length
+    var pos = hash(k, ks.length)
     var posV = ks(pos)
     while (posV != null && posV != k) {
-      pos = (pos + 1) % ks.length
+      pos = if (pos + 1 < ks.length) pos + 1 else 0
       posV = ks(pos)
     }
     ks(pos) = k
@@ -93,10 +99,10 @@ class RefDoubleHashMap[T <: AnyRef](capacity: Int = 10) {
     */
   def putIfAbsent(k: T, v: Double): Boolean = {
     if (used >= cutoff) resize()
-    var pos = Hash.absOrZero(k.hashCode()) % keys.length
+    var pos = hash(k, keys.length)
     var posV = keys(pos)
     while (posV != null && posV != k) {
-      pos = (pos + 1) % keys.length
+      pos = if (pos + 1 < keys.length) pos + 1 else 0
       posV = keys(pos)
     }
     if (posV != null) false
@@ -113,7 +119,7 @@ class RefDoubleHashMap[T <: AnyRef](capacity: Int = 10) {
     * `dflt` value will be returned.
     */
   def get(k: T, dflt: Double): Double = {
-    val start = Hash.absOrZero(k.hashCode()) % keys.length
+    val start = hash(k, keys.length)
     var pos = start
     while (true) {
       val prev = keys(pos)
@@ -122,7 +128,7 @@ class RefDoubleHashMap[T <: AnyRef](capacity: Int = 10) {
       else if (prev.equals(k))
         return values(pos)
       else {
-        pos = (pos + 1) % keys.length
+        pos = if (pos + 1 < keys.length) pos + 1 else 0
         // If we've wrapped around to the start, the key is not present
         if (pos == start)
           return dflt
@@ -137,7 +143,7 @@ class RefDoubleHashMap[T <: AnyRef](capacity: Int = 10) {
     */
   def add(k: T, amount: Double): Unit = {
     if (used >= cutoff) resize()
-    var pos = Hash.absOrZero(k.hashCode()) % keys.length
+    var pos = hash(k, keys.length)
     while (true) {
       val prev = keys(pos)
       if (prev == null || prev == k) {
@@ -146,7 +152,7 @@ class RefDoubleHashMap[T <: AnyRef](capacity: Int = 10) {
         if (prev == null) used += 1
         return
       }
-      pos = (pos + 1) % keys.length
+      pos = if (pos + 1 < keys.length) pos + 1 else 0
     }
   }
 
@@ -156,7 +162,7 @@ class RefDoubleHashMap[T <: AnyRef](capacity: Int = 10) {
     */
   def max(k: T, amount: Double): Unit = {
     if (used >= cutoff) resize()
-    var pos = Hash.absOrZero(k.hashCode()) % keys.length
+    var pos = hash(k, keys.length)
     while (true) {
       val prev = keys(pos)
       if (prev == null || prev == k) {
@@ -169,7 +175,7 @@ class RefDoubleHashMap[T <: AnyRef](capacity: Int = 10) {
         }
         return
       }
-      pos = (pos + 1) % keys.length
+      pos = if (pos + 1 < keys.length) pos + 1 else 0
     }
   }
 
@@ -179,7 +185,7 @@ class RefDoubleHashMap[T <: AnyRef](capacity: Int = 10) {
     */
   def min(k: T, amount: Double): Unit = {
     if (used >= cutoff) resize()
-    var pos = Hash.absOrZero(k.hashCode()) % keys.length
+    var pos = hash(k, keys.length)
     while (true) {
       val prev = keys(pos)
       if (prev == null || prev == k) {
@@ -192,7 +198,7 @@ class RefDoubleHashMap[T <: AnyRef](capacity: Int = 10) {
         }
         return
       }
-      pos = (pos + 1) % keys.length
+      pos = if (pos + 1 < keys.length) pos + 1 else 0
     }
   }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/RefIntHashMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/RefIntHashMap.scala
@@ -51,6 +51,12 @@ class RefIntHashMap[T <: AnyRef](capacity: Int = 10) {
     ArrayHelper.newInstance[T](PrimeFinder.nextPrime(n))
   }
 
+  // The raw `hashCode` has weak high-bit dispersion, so mix it with `lowbias32`
+  // before reducing into the slot range (the reduction keys off the high bits).
+  private def hash(k: T, length: Int): Int = {
+    Hash.reduce(Hash.lowbias32(k.hashCode()), length)
+  }
+
   private def resize(): Unit = {
     val tmpKS = newArray(keys.length * 2)
     val tmpVS = new Array[Int](tmpKS.length)
@@ -66,10 +72,10 @@ class RefIntHashMap[T <: AnyRef](capacity: Int = 10) {
   }
 
   private def put(ks: Array[T], vs: Array[Int], k: T, v: Int): Boolean = {
-    var pos = Hash.absOrZero(k.hashCode()) % ks.length
+    var pos = hash(k, ks.length)
     var posV = ks(pos)
     while (posV != null && posV != k) {
-      pos = (pos + 1) % ks.length
+      pos = if (pos + 1 < ks.length) pos + 1 else 0
       posV = ks(pos)
     }
     ks(pos) = k
@@ -93,10 +99,10 @@ class RefIntHashMap[T <: AnyRef](capacity: Int = 10) {
     */
   def putIfAbsent(k: T, v: Int): Boolean = {
     if (used >= cutoff) resize()
-    var pos = Hash.absOrZero(k.hashCode()) % keys.length
+    var pos = hash(k, keys.length)
     var posV = keys(pos)
     while (posV != null && posV != k) {
-      pos = (pos + 1) % keys.length
+      pos = if (pos + 1 < keys.length) pos + 1 else 0
       posV = keys(pos)
     }
     if (posV != null) false
@@ -113,7 +119,7 @@ class RefIntHashMap[T <: AnyRef](capacity: Int = 10) {
     * `dflt` value will be returned.
     */
   def get(k: T, dflt: Int): Int = {
-    val start = Hash.absOrZero(k.hashCode()) % keys.length
+    val start = hash(k, keys.length)
     var pos = start
     while (true) {
       val prev = keys(pos)
@@ -122,7 +128,7 @@ class RefIntHashMap[T <: AnyRef](capacity: Int = 10) {
       else if (prev.equals(k))
         return values(pos)
       else {
-        pos = (pos + 1) % keys.length
+        pos = if (pos + 1 < keys.length) pos + 1 else 0
         // If we've wrapped around to the start, the key is not present
         if (pos == start)
           return dflt
@@ -143,7 +149,7 @@ class RefIntHashMap[T <: AnyRef](capacity: Int = 10) {
     */
   def increment(k: T, amount: Int): Unit = {
     if (used >= cutoff) resize()
-    var pos = Hash.absOrZero(k.hashCode()) % keys.length
+    var pos = hash(k, keys.length)
     while (true) {
       val prev = keys(pos)
       if (prev == null || prev == k) {
@@ -152,7 +158,7 @@ class RefIntHashMap[T <: AnyRef](capacity: Int = 10) {
         if (prev == null) used += 1
         return
       }
-      pos = (pos + 1) % keys.length
+      pos = if (pos + 1 < keys.length) pos + 1 else 0
     }
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/HashSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/HashSuite.scala
@@ -32,4 +32,35 @@ class HashSuite extends FunSuite {
     val actual = Strings.zeroPad(Hash.sha1bytes("42"), 40)
     assertEquals(actual, expected)
   }
+
+  test("reduce range") {
+    // Result must always be in [0, n) for any hash, including negative values
+    // and extremes such as Integer.MIN_VALUE.
+    val ns = List(1, 5, 7, 8, 97, 1597, 100000)
+    val hashes = List(0, 1, -1, Int.MaxValue, Int.MinValue, 0x7FFFFFFF, 0x80000000)
+    ns.foreach { n =>
+      hashes.foreach { h =>
+        val r = Hash.reduce(h, n)
+        assert(r >= 0 && r < n, s"reduce($h, $n) = $r out of range")
+      }
+    }
+  }
+
+  test("reduce distribution for mixed hashes") {
+    // With a good avalanche mix in front, reduce should spread keys roughly
+    // evenly across the slots and never wildly overload one bucket.
+    val n = 1597
+    val counts = new Array[Int](n)
+    val total = 100000
+    var i = 0
+    while (i < total) {
+      counts(Hash.reduce(Hash.lowbias32(i), n)) += 1
+      i += 1
+    }
+    val expected = total.toDouble / n
+    val max = counts.max
+    // No bucket should hold more than ~3x the expected load.
+    assert(max < expected * 3, s"max bucket $max vs expected $expected")
+    assertEquals(counts.sum, total)
+  }
 }

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/OpenHashMapReduction.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/OpenHashMapReduction.scala
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Threads
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.util.Random
+
+/**
+  * Measures the open-addressed maps in atlas-core on both the build (insert) and query
+  * (get) paths. It exercises whatever slot-index reduction scheme is live in the current
+  * checkout; to compare schemes (e.g. prime+modulo vs Lemire multiply-shift), run the same
+  * benchmark on each branch and diff the results rather than switching schemes within this
+  * file. Both paths matter because the rebuild profile is dominated by `get`/`intern`
+  * lookups where the per-probe reduction is paid on every collision hop.
+  *
+  * The maps themselves are the unit under test; this benchmark is meant to be
+  * run on `main` (baseline) and on each prototype branch with identical
+  * arguments, then diffed:
+  *
+  * ```
+  * > jmh:run -wi 5 -i 10 -f1 -t1 .*OpenHashMapReduction.*
+  * ```
+  *
+  * Key sets are chosen to mirror the rebuild path:
+  *   - `String` tag-like values for RefIntHashMap / OpenHashInternMap
+  *   - dense-ish ints for IntRefHashMap / IntIntHashMap / IntHashSet
+  *   - longs (item-id style) for LongHashSet / LongIntHashMap
+  *
+  * `N` is sized so the maps resize several times (exercising the re-insertion
+  * probe loops) and settle well above the trivial-capacity range.
+  */
+@State(Scope.Thread)
+class OpenHashMapReduction {
+
+  import OpenHashMapReduction.*
+
+  // Distinct keys to insert. Kept fixed across the build/query split so the
+  // query phase looks up keys that are present (hit) interleaved with absent
+  // keys (miss), which is where probe-walk length matters most.
+  private var intKeys: Array[Int] = _
+  private var longKeys: Array[Long] = _
+  private var strKeys: Array[String] = _
+  private var strMiss: Array[String] = _
+  private var intMiss: Array[Int] = _
+
+  // Pre-built maps for the query benchmarks.
+  private var refIntMap: RefIntHashMap[String] = _
+  private var intRefMap: IntRefHashMap[String] = _
+  private var intIntMap: IntIntHashMap = _
+  private var longIntMap: LongIntHashMap = _
+  private var interner: InternMap[String] = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    val rnd = new Random(42)
+
+    intKeys = Array.fill(N)(rnd.nextInt())
+    longKeys = Array.fill(N)(rnd.nextLong())
+    strKeys = Array.tabulate(N)(i => s"i-$i.us-east-1.${rnd.nextInt(1 << 20)}")
+    // Absent keys for miss-path lookups.
+    intMiss = Array.fill(N)(rnd.nextInt())
+    strMiss = Array.tabulate(N)(i => s"absent-$i-${rnd.nextInt(1 << 20)}")
+
+    refIntMap = new RefIntHashMap[String]
+    intRefMap = new IntRefHashMap[String](Int.MinValue)
+    intIntMap = new IntIntHashMap(-1)
+    longIntMap = new LongIntHashMap(-1L)
+    val sentinel = "v"
+    var i = 0
+    while (i < N) {
+      refIntMap.increment(strKeys(i))
+      intRefMap.put(intKeys(i), sentinel)
+      intIntMap.increment(intKeys(i))
+      longIntMap.increment(longKeys(i))
+      i += 1
+    }
+    interner = InternMap.concurrent[String](N)
+    i = 0
+    while (i < N) {
+      interner.intern(strKeys(i))
+      i += 1
+    }
+  }
+
+  // ---- build (insert) path ----
+
+  @Threads(1)
+  @Benchmark
+  def buildRefIntHashMap(bh: Blackhole): Unit = {
+    val m = new RefIntHashMap[String]
+    var i = 0
+    while (i < N) { m.increment(strKeys(i)); i += 1 }
+    bh.consume(m)
+  }
+
+  @Threads(1)
+  @Benchmark
+  def buildIntRefHashMap(bh: Blackhole): Unit = {
+    val m = new IntRefHashMap[String](Int.MinValue)
+    var i = 0
+    while (i < N) { m.put(intKeys(i), "v"); i += 1 }
+    bh.consume(m)
+  }
+
+  @Threads(1)
+  @Benchmark
+  def buildIntIntHashMap(bh: Blackhole): Unit = {
+    val m = new IntIntHashMap(-1)
+    var i = 0
+    while (i < N) { m.increment(intKeys(i)); i += 1 }
+    bh.consume(m)
+  }
+
+  @Threads(1)
+  @Benchmark
+  def buildLongHashSet(bh: Blackhole): Unit = {
+    val s = new LongHashSet(Long.MinValue)
+    var i = 0
+    while (i < N) { s.add(longKeys(i)); i += 1 }
+    bh.consume(s)
+  }
+
+  @Threads(1)
+  @Benchmark
+  def buildLongIntHashMap(bh: Blackhole): Unit = {
+    val m = new LongIntHashMap(-1L)
+    var i = 0
+    while (i < N) { m.increment(longKeys(i)); i += 1 }
+    bh.consume(m)
+  }
+
+  @Threads(1)
+  @Benchmark
+  def buildIntHashSet(bh: Blackhole): Unit = {
+    val s = new IntHashSet(Int.MinValue)
+    var i = 0
+    while (i < N) { s.add(intKeys(i)); i += 1 }
+    bh.consume(s)
+  }
+
+  @Threads(1)
+  @Benchmark
+  def buildInterner(bh: Blackhole): Unit = {
+    val in = InternMap.concurrent[String](N)
+    var i = 0
+    while (i < N) { bh.consume(in.intern(strKeys(i))); i += 1 }
+  }
+
+  // ---- query (get) path: half hits, half misses ----
+
+  @Threads(1)
+  @Benchmark
+  def queryRefIntHashMap(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < N) {
+      bh.consume(refIntMap.get(strKeys(i), -1))
+      bh.consume(refIntMap.get(strMiss(i), -1))
+      i += 1
+    }
+  }
+
+  @Threads(1)
+  @Benchmark
+  def queryIntRefHashMap(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < N) {
+      bh.consume(intRefMap.get(intKeys(i)))
+      bh.consume(intRefMap.get(intMiss(i)))
+      i += 1
+    }
+  }
+
+  @Threads(1)
+  @Benchmark
+  def queryIntIntHashMap(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < N) {
+      bh.consume(intIntMap.get(intKeys(i), -1))
+      bh.consume(intIntMap.get(intMiss(i), -1))
+      i += 1
+    }
+  }
+
+  @Threads(1)
+  @Benchmark
+  def queryLongIntHashMap(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < N) {
+      bh.consume(longIntMap.get(longKeys(i), -1))
+      i += 1
+    }
+  }
+
+  @Threads(1)
+  @Benchmark
+  def queryInterner(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < N) {
+      bh.consume(interner.intern(strKeys(i)))
+      i += 1
+    }
+  }
+}
+
+object OpenHashMapReduction {
+  private val N = 50000
+}


### PR DESCRIPTION
The open-addressed maps in atlas-core computed each slot index with an integer modulo (`% length`) on the initial hash and on every linear-probe step. Integer remainder is an `idiv` (~20-40 cycles), and the index rebuild path spends a substantial fraction of its time there.

Replace the modulo with Lemire's multiply-shift reduction (`Hash.reduce`), which maps a hash into `[0, n)` without a division and works for an arbitrary `n`, so the tables keep their existing prime sizing and there is no change to capacity or memory footprint. Probe steps become a compare- and-reset wrap. The reduction keys off the high bits, so the maps that index off a raw `hashCode` (RefIntHashMap, RefDoubleHashMap, OpenHashInternMap) now mix with `lowbias32` first; the int/long-keyed maps already mixed. `Hash.absOrZero` is no longer needed and is removed.

`ConcurrentInternMap.index` is also switched to `Hash.reduce`: the old `hashCode % concurrencyLevel` returned a negative segment index for hashCode == Integer.MIN_VALUE (negation overflows) and keyed off weak low bits; `reduce` is always in range and better distributed.

Maps converted: RefIntHashMap, IntRefHashMap, IntIntHashMap, LongIntHashMap, IntHashSet, LongHashSet, RefDoubleHashMap, OpenHashInternMap (DoubleIntHashMap delegates to LongIntHashMap).

JMH (atlas-jmh OpenHashMapReduction): query +10-40%, build +12-22% across the family. All existing map suites pass unchanged.