### PR TITLE
core: probe interner before allocating tag map

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TaggedItem.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TaggedItem.scala
@@ -86,7 +86,7 @@ object TaggedItem {
 
   /**
     * Probe for an already-interned tag map without inserting. `hashCode` must equal the hash of
-    * the sought map (see [[SortedTagMap.computeHashCode]]) and `isEqual` confirms the candidate,
+    * the sought map (see `SortedTagMap.computeHashCode`) and `isEqual` confirms the candidate,
     * so a caller can probe with a reusable buffer and allocate a permanent copy only on a miss.
     * Returns the interned map or `null`; a hit refreshes recency with `timestamp`.
     */

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TaggedItem.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TaggedItem.scala
@@ -18,6 +18,7 @@ package com.netflix.atlas.core.model
 import com.netflix.atlas.core.util.InternMap
 import com.netflix.atlas.core.util.Interner
 import com.netflix.atlas.core.util.SortedTagMap
+import com.netflix.spectator.api.Clock
 
 /**
   * Helper functions for manipulating tagged items.
@@ -27,8 +28,16 @@ object TaggedItem {
   type Pair = (String, String)
 
   private val initCapacity = 1000000
-  private val idInterner = InternMap.concurrent[ItemId](initCapacity)
-  private val tagsInterner = InternMap.concurrent[Map[String, String]](initCapacity)
+  private val clock = Clock.SYSTEM
+  private val idInterner = InternMap.concurrent[ItemId](initCapacity, clock)
+  private val tagsInterner = InternMap.concurrent[Map[String, String]](initCapacity, clock)
+
+  /**
+    * Current wall time from the interner clock. Code processing a batch can read this once and
+    * pass it to the timestamped `internId`/`internTagsShallow`/`lookupTagsShallow` variants to
+    * avoid a clock read per datapoint.
+    */
+  def currentWallTime: Long = clock.wallTime
 
   /**
     * Compute an identifier for a set of tags. The id is a sha1 hash of a normalized string
@@ -52,6 +61,11 @@ object TaggedItem {
     idInterner.intern(id)
   }
 
+  /** Intern an id using an explicit batch timestamp rather than a per-call clock read. */
+  def internId(id: ItemId, timestamp: Long): ItemId = {
+    idInterner.intern(id, timestamp)
+  }
+
   def internTags(tags: Map[String, String]): Map[String, String] = {
     val strInterner = Interner.forStrings
     val iter = tags.iterator.map { t =>
@@ -63,6 +77,25 @@ object TaggedItem {
 
   def internTagsShallow(tags: Map[String, String]): Map[String, String] = {
     tagsInterner.intern(tags)
+  }
+
+  /** Intern tags using an explicit batch timestamp rather than a per-call clock read. */
+  def internTagsShallow(tags: Map[String, String], timestamp: Long): Map[String, String] = {
+    tagsInterner.intern(tags, timestamp)
+  }
+
+  /**
+    * Probe for an already-interned tag map without inserting. `hashCode` must equal the hash of
+    * the sought map (see [[SortedTagMap.computeHashCode]]) and `isEqual` confirms the candidate,
+    * so a caller can probe with a reusable buffer and allocate a permanent copy only on a miss.
+    * Returns the interned map or `null`; a hit refreshes recency with `timestamp`.
+    */
+  def lookupTagsShallow(
+    hashCode: Int,
+    isEqual: Map[String, String] => Boolean,
+    timestamp: Long
+  ): Map[String, String] = {
+    tagsInterner.get(hashCode, isEqual, timestamp)
   }
 
   def retain(keep: Long => Boolean): Unit = {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/InternMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/InternMap.scala
@@ -35,6 +35,21 @@ trait InternMap[K <: AnyRef] extends Interner[K] {
 
   def intern(k: K): K
 
+  /**
+    * Intern using an explicit `timestamp` for recency rather than reading the clock. Lets code
+    * processing a batch compute one timestamp and reuse it across many calls.
+    */
+  def intern(k: K, timestamp: Long): K
+
+  /**
+    * Probe for an already-interned value without inserting. The slot is located from `hashCode`
+    * (which must equal the sought value's `hashCode`) and a candidate is confirmed with `isEqual`,
+    * so a caller can probe with a reusable buffer and only allocate a permanent copy on a miss.
+    * Returns the interned value or `null`. A hit refreshes recency with `timestamp` so the value
+    * is not dropped by a subsequent [[retain]].
+    */
+  def get(hashCode: Int, isEqual: K => Boolean, timestamp: Long): K
+
   def retain(f: Long => Boolean): Unit
 
   def size: Int
@@ -50,8 +65,8 @@ class OpenHashInternMap[K <: AnyRef](initialCapacity: Int, clock: Clock = Clock.
 
   // The raw `hashCode` has weak high-bit dispersion, so mix it with `lowbias32`
   // before reducing into the slot range (the reduction keys off the high bits).
-  private def hash(k: K): Int = {
-    Hash.reduce(Hash.lowbias32(k.hashCode), data.length)
+  private def slot(hashCode: Int): Int = {
+    Hash.reduce(Hash.lowbias32(hashCode), data.length)
   }
 
   private def resize(newCapacity: Int, keep: Long => Boolean): Unit = {
@@ -64,14 +79,14 @@ class OpenHashInternMap[K <: AnyRef](initialCapacity: Int, clock: Clock = Clock.
     var i = 0
     while (i < oldData.length) {
       if (oldData(i) != null && keep(oldTimestamps(i))) {
-        intern(oldData(i), oldTimestamps(i))
+        internEntry(oldData(i), oldTimestamps(i))
       }
       i += 1
     }
   }
 
-  private def intern(k: K, t: Long): K = {
-    var j = hash(k)
+  private def internEntry(k: K, t: Long): K = {
+    var j = slot(k.hashCode)
     var n = 0
     while (n < data.length) {
       if (data(j) == null) {
@@ -95,9 +110,28 @@ class OpenHashInternMap[K <: AnyRef](initialCapacity: Int, clock: Clock = Clock.
 
   private[util] def capacity: Int = data.length
 
-  def intern(k: K): K = {
+  def intern(k: K): K = intern(k, clock.wallTime)
+
+  def intern(k: K, timestamp: Long): K = {
     if (currentSize + 1 > 3 * data.length / 4) resize(nextCapacity(2 * data.length), _ => true)
-    intern(k, clock.wallTime)
+    internEntry(k, timestamp)
+  }
+
+  def get(hashCode: Int, isEqual: K => Boolean, timestamp: Long): K = {
+    var j = slot(hashCode)
+    var n = 0
+    while (n < data.length) {
+      val d = data(j)
+      if (d == null) {
+        return null.asInstanceOf[K]
+      } else if (isEqual(d)) {
+        timestamps(j) = timestamp
+        return d
+      }
+      j = if (j + 1 < data.length) j + 1 else 0
+      n += 1
+    }
+    null.asInstanceOf[K]
   }
 
   def retain(f: Long => Boolean): Unit = {
@@ -119,17 +153,37 @@ class ConcurrentInternMap[K <: AnyRef](newMap: => InternMap[K], concurrencyLevel
     locks(i) = new ReentrantLock
   }
 
-  private def index(key: K): Int = {
+  private def index(key: K): Int = index(key.hashCode)
+
+  private def index(hashCode: Int): Int = {
     // Mix and reduce rather than `hashCode % concurrencyLevel`: the latter returns a
     // negative index for hashCode == Integer.MIN_VALUE (negation overflows), and keys off
     // the weak low bits. `reduce` is always in `[0, concurrencyLevel)`.
-    Hash.reduce(Hash.lowbias32(key.hashCode), concurrencyLevel)
+    Hash.reduce(Hash.lowbias32(hashCode), concurrencyLevel)
   }
 
   def intern(k: K): K = {
     val i = index(k)
     locks(i).lock()
     try segments(i).intern(k)
+    finally {
+      locks(i).unlock()
+    }
+  }
+
+  def intern(k: K, timestamp: Long): K = {
+    val i = index(k)
+    locks(i).lock()
+    try segments(i).intern(k, timestamp)
+    finally {
+      locks(i).unlock()
+    }
+  }
+
+  def get(hashCode: Int, isEqual: K => Boolean, timestamp: Long): K = {
+    val i = index(hashCode)
+    locks(i).lock()
+    try segments(i).get(hashCode, isEqual, timestamp)
     finally {
       locks(i).unlock()
     }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/SortedTagMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/SortedTagMap.scala
@@ -162,21 +162,24 @@ final class SortedTagMap private (private val data: Array[String])
     * objects as well as tuples during iteration.
     */
   private[util] def computeHashCode: Int = {
-    var a, b = 0
-    var c = 1
-    var i = 0
-    while (i < data.length) {
-      val h = data(i).hashCode
-      a += h
-      b ^= h
-      if (h != 0) c *= h
-      i += 1
-    }
-    var h = 0x3C074A61
-    h = scala.util.hashing.MurmurHash3.mix(h, a)
-    h = scala.util.hashing.MurmurHash3.mix(h, b)
-    h = scala.util.hashing.MurmurHash3.mixLast(h, c)
-    scala.util.hashing.MurmurHash3.finalizeHash(h, data.length)
+    SortedTagMap.computeHashCode(data, data.length)
+  }
+
+  /**
+    * True if this map's backing array equals the first `length` entries of `other`. Lets a caller
+    * probe an interner with a reusable buffer (see [[SortedTagMap.computeHashCode]]) and confirm a
+    * candidate without constructing a map. `length` must be the `2 * numTags` flat-pair length.
+    */
+  def dataEquals(other: Array[String], length: Int): Boolean = {
+    data.length == length &&
+    java.util.Arrays.equals(
+      data.asInstanceOf[Array[AnyRef]],
+      0,
+      length,
+      other.asInstanceOf[Array[AnyRef]],
+      0,
+      length
+    )
   }
 
   /**
@@ -319,6 +322,30 @@ object SortedTagMap {
       new SortedTagMap(java.util.Arrays.copyOf(data, length))
     else
       new SortedTagMap(data)
+  }
+
+  /**
+    * Compute the hash code that a `SortedTagMap` built from the first `length` entries of `data`
+    * would have. Lets a caller probe an interner using a reusable buffer (paired with
+    * [[SortedTagMap.dataEquals]]) without constructing a map. Must stay consistent with the
+    * instance `computeHashCode`.
+    */
+  def computeHashCode(data: Array[String], length: Int): Int = {
+    var a, b = 0
+    var c = 1
+    var i = 0
+    while (i < length) {
+      val h = data(i).hashCode
+      a += h
+      b ^= h
+      if (h != 0) c *= h
+      i += 1
+    }
+    var h = 0x3C074A61
+    h = scala.util.hashing.MurmurHash3.mix(h, a)
+    h = scala.util.hashing.MurmurHash3.mix(h, b)
+    h = scala.util.hashing.MurmurHash3.mixLast(h, c)
+    scala.util.hashing.MurmurHash3.finalizeHash(h, length)
   }
 
   /**

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/SortedTagMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/SortedTagMap.scala
@@ -167,7 +167,7 @@ final class SortedTagMap private (private val data: Array[String])
 
   /**
     * True if this map's backing array equals the first `length` entries of `other`. Lets a caller
-    * probe an interner with a reusable buffer (see [[SortedTagMap.computeHashCode]]) and confirm a
+    * probe an interner with a reusable buffer (see `SortedTagMap.computeHashCode`) and confirm a
     * candidate without constructing a map. `length` must be the `2 * numTags` flat-pair length.
     */
   def dataEquals(other: Array[String], length: Int): Boolean = {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/InternMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/InternMapSuite.scala
@@ -64,6 +64,50 @@ class InternMapSuite extends FunSuite {
     assert(b1 eq interner.intern(b2))
   }
 
+  test("open hash get does not insert on miss") {
+    val i = new OpenHashInternMap[String](16)
+    assertEquals(i.get("foo".hashCode, _ == "foo", 0L), null.asInstanceOf[String])
+    assertEquals(i.size, 0)
+  }
+
+  test("open hash get returns interned value on hit") {
+    val i = new OpenHashInternMap[String](16)
+    val s1 = new String("foo")
+    assert(i.intern(s1) eq s1)
+    assert(i.get("foo".hashCode, _ == "foo", 0L) eq s1)
+    assertEquals(i.size, 1)
+  }
+
+  test("open hash get with non-matching predicate is a miss") {
+    val i = new OpenHashInternMap[String](16)
+    i.intern(new String("foo"))
+    // Probe lands on the same slot by hash, but the predicate rejects it.
+    assertEquals(i.get("foo".hashCode, _ == "bar", 0L), null.asInstanceOf[String])
+  }
+
+  test("open hash get refreshes recency so retain keeps the entry") {
+    val c = new ManualClock()
+    val interner = new OpenHashInternMap[String](16, c)
+    val f1 = new String("foo")
+    interner.intern(f1) // interned at time 0
+
+    // Access only via get with a later timestamp; recency should advance.
+    assert(interner.get("foo".hashCode, _ == "foo", 42L) eq f1)
+
+    // retain dropping anything older than 21 must keep the get-refreshed entry.
+    interner.retain(_ > 21L)
+    assert(interner.get("foo".hashCode, _ == "foo", 42L) eq f1)
+  }
+
+  test("concurrent get probes without inserting") {
+    val i = InternMap.concurrent[String](16)
+    assertEquals(i.get("foo".hashCode, _ == "foo", 0L), null.asInstanceOf[String])
+    assertEquals(i.size, 0)
+    val s1 = new String("foo")
+    assert(i.intern(s1) eq s1)
+    assert(i.get("foo".hashCode, _ == "foo", 0L) eq s1)
+  }
+
   test("concurrent") {
     val i = InternMap.concurrent[String](2)
     val s1 = new String("foo")

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/webapi/PublishPayloadsBench.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/webapi/PublishPayloadsBench.scala
@@ -65,8 +65,12 @@ class PublishPayloadsBench {
   )
 
   private val datapoints = {
+    // Vary the tag count per datapoint (9..14 tags) so the decode sees a mix of sizes rather than
+    // a constant width, which is what stresses the reusable scratch buffer in the intern path.
+    val base = tagMap.toList
     (0 until 10_000).toList.map { i =>
-      val tags = SortedTagMap(tagMap + ("i" -> i.toString))
+      val n = 8 + (i % 6)
+      val tags = SortedTagMap(base.take(n).toMap + ("i" -> i.toString))
       Datapoint(tags, 1636116180000L, Math.PI).toTuple
     }
   }
@@ -95,6 +99,12 @@ class PublishPayloadsBench {
   private def decodeCompactBatch(data: Array[Byte], consumer: PublishConsumer): Unit = {
     Using.resource(Json.newSmileParser(new ByteArrayInputStream(data))) { parser =>
       PublishPayloads.decodeCompactBatch(parser, consumer)
+    }
+  }
+
+  private def decodeCompactBatchIntern(data: Array[Byte], consumer: PublishConsumer): Unit = {
+    Using.resource(Json.newSmileParser(new ByteArrayInputStream(data))) { parser =>
+      PublishPayloads.decodeCompactBatch(parser, consumer, intern = true)
     }
   }
 
@@ -146,6 +156,14 @@ class PublishPayloadsBench {
   def decodeCompactBatch(bh: Blackhole): Unit = {
     val consumer = new BlackholePublishConsumer(bh)
     decodeCompactBatch(encodedCompactBatch, consumer)
+  }
+
+  // Interning path with a high hit rate: the global tags interner is populated during warmup,
+  // so steady-state measurement iterations re-decode the same series and probe-hit the interner.
+  @Benchmark
+  def decodeCompactBatchIntern(bh: Blackhole): Unit = {
+    val consumer = new BlackholePublishConsumer(bh)
+    decodeCompactBatchIntern(encodedCompactBatch, consumer)
   }
 
   @Benchmark

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishPayloads.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishPayloads.scala
@@ -48,6 +48,43 @@ object PublishPayloads {
   // arrays to be reused to reduce allocations.
   private final val stringArrays = new ThreadLocal[Array[String]]
 
+  // Reusable per-thread probe for building each datapoint's tag map in the compact batch decode.
+  // The grow-only `buffer` holds the flat key/value strings; the probe doubles as the equality
+  // predicate for the interner lookup so a hit allocates nothing (no scratch map, no reallocation
+  // when the tag count varies between datapoints).
+  private final class TagsProbe extends (Map[String, String] => Boolean) {
+
+    private[this] var buffer = new Array[String](32)
+    private[this] var length = 0
+
+    /**
+      * Grow the buffer to hold at least `n` entries and mark `n` as the active prefix the probe
+      * compares against, returning the buffer for the caller to fill. Setting the length here
+      * keeps it from drifting out of sync with the buffer.
+      */
+    def prepare(n: Int): Array[String] = {
+      if (buffer.length < n) buffer = new Array[String](n)
+      length = n
+      buffer
+    }
+
+    def apply(m: Map[String, String]): Boolean = m match {
+      case s: SortedTagMap => s.dataEquals(buffer, length)
+      case _               => false
+    }
+  }
+
+  private final val tagProbes = new ThreadLocal[TagsProbe]
+
+  private def tagsProbe(): TagsProbe = {
+    var probe = tagProbes.get()
+    if (probe == null) {
+      probe = new TagsProbe
+      tagProbes.set(probe)
+    }
+    probe
+  }
+
   private def decodeTags(parser: JsonParser, commonTags: TagMap, intern: Boolean): TagMap = {
     val strInterner = Interner.forStrings
     val b = SortedTagMap.builder(maxPermittedTags)
@@ -285,27 +322,73 @@ object PublishPayloads {
     }
 
     val numDatapointTuples = nextInt(parser)
-    i = 0
-    while (i < numDatapointTuples) {
-      val idRaw = ItemId(nextString(parser))
-      val id = if (intern) TaggedItem.internId(idRaw) else idRaw
+    // `intern` is fixed for the whole batch, so branch once and run a specialized loop rather
+    // than re-checking it per datapoint.
+    if (intern) decodeCompactTuplesInterned(parser, table, numDatapointTuples, consumer)
+    else decodeCompactTuplesRaw(parser, table, numDatapointTuples, consumer)
+  }
 
+  private def decodeCompactTuplesRaw(
+    parser: JsonParser,
+    table: Array[String],
+    numTuples: Int,
+    consumer: PublishConsumer
+  ): Unit = {
+    var i = 0
+    while (i < numTuples) {
+      val id = ItemId(nextString(parser))
       val numTags = nextArraySize(parser)
-      val tagsArray = new Array[String](2 * numTags)
+      val len = 2 * numTags
+      val tagsArray = new Array[String](len)
       var j = 0
       while (j < numTags) {
-        val k = table(nextInt(parser))
-        val v = table(nextInt(parser))
-        tagsArray(2 * j) = k
-        tagsArray(2 * j + 1) = v
+        tagsArray(2 * j) = table(nextInt(parser))
+        tagsArray(2 * j + 1) = table(nextInt(parser))
         j += 1
       }
-      val tagMap = SortedTagMap.createUnsafe(tagsArray, tagsArray.length)
-      val tags = if (intern) TaggedItem.internTagsShallow(tagMap) else tagMap
-
+      val tags = SortedTagMap.createUnsafe(tagsArray, len)
       val timestamp = nextLong(parser)
       val value = getValue(parser)
+      consumer.consume(id, tags, timestamp, value)
+      i += 1
+    }
+  }
 
+  private def decodeCompactTuplesInterned(
+    parser: JsonParser,
+    table: Array[String],
+    numTuples: Int,
+    consumer: PublishConsumer
+  ): Unit = {
+    // One timestamp and one reusable probe for the whole batch. For steady-state publishes the
+    // same series report repeatedly, so the probe usually hits the interner and the per-datapoint
+    // `String[]` + map allocation is avoided entirely; on a miss a permanent exact-size copy is
+    // interned.
+    val wallTime = TaggedItem.currentWallTime
+    val probe = tagsProbe()
+    var i = 0
+    while (i < numTuples) {
+      val id = TaggedItem.internId(ItemId(nextString(parser)), wallTime)
+      val numTags = nextArraySize(parser)
+      val len = 2 * numTags
+      val buffer = probe.prepare(len)
+      var j = 0
+      while (j < numTags) {
+        buffer(2 * j) = table(nextInt(parser))
+        buffer(2 * j + 1) = table(nextInt(parser))
+        j += 1
+      }
+      val hashCode = SortedTagMap.computeHashCode(buffer, len)
+      val existing = TaggedItem.lookupTagsShallow(hashCode, probe, wallTime)
+      val tags =
+        if (existing != null) existing
+        else
+          TaggedItem.internTagsShallow(
+            SortedTagMap.createUnsafe(java.util.Arrays.copyOf(buffer, len), len),
+            wallTime
+          )
+      val timestamp = nextLong(parser)
+      val value = getValue(parser)
       consumer.consume(id, tags, timestamp, value)
       i += 1
     }

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishPayloadsSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishPayloadsSuite.scala
@@ -181,6 +181,36 @@ class PublishPayloadsSuite extends FunSuite {
     assertEquals(decoded.tail, input.tail)
   }
 
+  test("decode compact batch with interning returns canonical tag maps") {
+    val input = datapointTuples(10)
+    val encoded = PublishPayloads.encodeCompactBatch(input)
+
+    def decodeInterned(): List[DatapointTuple] = {
+      val parser = com.netflix.atlas.json3.Json.newJsonParser(encoded)
+      val consumer = PublishConsumer.datapointList
+      try PublishPayloads.decodeCompactBatch(parser, consumer, intern = true)
+      finally parser.close()
+      consumer.toList
+    }
+
+    // Correctness: interned decode yields the same content as the input.
+    val first = decodeInterned()
+    assert(first.head.value.isNaN)
+    assertEquals(first.head.tags, input.head.tags)
+    assertEquals(first.tail, input.tail)
+
+    // Decoding again must hit the interner via the scratch probe and return the same canonical
+    // tag map instances rather than freshly allocated copies.
+    val second = decodeInterned()
+    first.zip(second).foreach {
+      case (a, b) =>
+        assert(
+          a.tags.asInstanceOf[AnyRef] eq b.tags.asInstanceOf[AnyRef],
+          s"tags not canonical across decodes: ${a.tags}"
+        )
+    }
+  }
+
   test("encode and decode empty compact batch tuples") {
     val input = datapointTuples(0)
     val encoded = PublishPayloads.encodeCompactBatch(input)


### PR DESCRIPTION
In `decodeCompactBatch` the publish path allocated a `String[]` and a `SortedTagMap` for every datapoint, then `internTagsShallow` discarded both whenever the series was already interned (the common case for steady-state publishes). The `String[]` was a top allocation leaf.

Add a non-inserting `InternMap.get(hashCode, isEqual, timestamp)` probe that locates the slot from a precomputed hash and confirms with a predicate, so a caller can probe with a reusable buffer and only allocate on a miss. The compact-batch decode now keeps one grow-only scratch buffer per thread and a reusable probe object (no per-datapoint scratch map, no reallocation when the tag count varies), backed by new `SortedTagMap.computeHashCode(data, length)` and `dataEquals(other, length)` slice helpers.

Also thread an explicit batch timestamp through `intern`/`get` so the interner is not read from the clock once per datapoint, and split the decode into specialized interned/raw loops so `intern` is branched on once per batch.

No behaviour change: interned results are identical and the non-intern path is untouched.