### PR TITLE
core: in-place backward-shift retain for interner

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/InternMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/InternMap.scala
@@ -101,7 +101,85 @@ class OpenHashInternMap[K <: AnyRef](initialCapacity: Int, clock: Clock = Clock.
   }
 
   def retain(f: Long => Boolean): Unit = {
+    val n = data.length
+    // Anchor the scan just after an empty slot. A backward-shift removal never moves an entry
+    // past an empty slot, so anchoring there guarantees a removal cannot push an un-scanned
+    // (possibly expired) entry behind the scan cursor into an already-visited slot.
+    var anchor = 0
+    while (anchor < n && data(anchor) != null) anchor += 1
+    if (anchor == n) {
+      // Table is completely full (cannot happen below the 3/4 load factor); fall back to a rehash.
+      resize(n, f)
+    } else {
+      var count = 0
+      var i = if (anchor + 1 < n) anchor + 1 else 0
+      while (count < n) {
+        // A removal may shift another entry (also possibly expired) into slot `i`, so drain
+        // until the slot is empty or holds a kept entry.
+        while (data(i) != null && !f(timestamps(i))) {
+          removeAt(i)
+        }
+        i = if (i + 1 < n) i + 1 else 0
+        count += 1
+      }
+    }
+  }
+
+  // Backward-shift deletion for linear probing (Knuth Algorithm R): remove the entry at `idx`
+  // and slide back any following entry that can legally fill the gap, so no probe chain is
+  // broken and no tombstone is left behind.
+  private def removeAt(idx: Int): Unit = {
+    val n = data.length
+    var gap = idx
+    var j = if (idx + 1 < n) idx + 1 else 0
+    while (data(j) != null) {
+      val h = hash(data(j))
+      // Move the entry at `j` back into the gap unless its home slot `h` lies in `(gap, j]`
+      // (cyclically); moving it then would place it before its home and make it unreachable.
+      val homeInRange =
+        if (gap < j) h > gap && h <= j
+        else h > gap || h <= j
+      if (!homeInRange) {
+        data(gap) = data(j)
+        timestamps(gap) = timestamps(j)
+        gap = j
+      }
+      j = if (j + 1 < n) j + 1 else 0
+    }
+    data(gap) = null.asInstanceOf[K]
+    currentSize -= 1
+  }
+
+  // Reference implementation of retain via full rehash, kept for differential testing and
+  // benchmarking against the in-place [[retain]].
+  private[util] def retainByRehash(f: Long => Boolean): Unit = {
     resize(data.length, f)
+  }
+
+  /** Probe for `k`; true if present and reachable. Test/benchmark helper. */
+  private[util] def contains(k: K): Boolean = {
+    val n = data.length
+    var j = hash(k)
+    var count = 0
+    while (count < n) {
+      val d = data(j)
+      if (d == null) return false
+      else if (d == k) return true
+      j = if (j + 1 < n) j + 1 else 0
+      count += 1
+    }
+    false
+  }
+
+  /** Snapshot of the current entries (array contents). Test helper. */
+  private[util] def snapshot: Set[K] = {
+    val builder = Set.newBuilder[K]
+    var i = 0
+    while (i < data.length) {
+      if (data(i) != null) builder += data(i)
+      i += 1
+    }
+    builder.result()
   }
 
   def size: Int = currentSize

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/InternMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/InternMapSuite.scala
@@ -64,6 +64,164 @@ class InternMapSuite extends FunSuite {
     assert(b1 eq interner.intern(b2))
   }
 
+  test("retain (backward-shift) matches rehash and keeps survivors reachable") {
+    val rnd = new scala.util.Random(20260617L)
+    var trial = 0
+    while (trial < 300) {
+      val size = rnd.nextInt(2000) + 1
+      // Small initial capacity forces resizes, high load factors, long collision chains, and
+      // wrap-around clusters — the cases where backward-shift is easy to get wrong.
+      val initCap = rnd.nextInt(64) + 2
+      val clock = new ManualClock()
+      val shift = new OpenHashInternMap[String](initCap, clock)
+      val rehash = new OpenHashInternMap[String](initCap, clock)
+      val times = scala.collection.mutable.HashMap.empty[String, Long]
+      var i = 0
+      while (i < size) {
+        val key = s"t$trial-k$i-${rnd.nextInt(1000000)}"
+        val t = rnd.nextInt(1000).toLong + 1
+        times(key) = t
+        clock.setWallTime(t)
+        shift.intern(key)
+        rehash.intern(key)
+        i += 1
+      }
+      // Cutoff spans below-all (keep everything) .. above-all (drop everything).
+      val cutoff = rnd.nextInt(1002).toLong
+      shift.retain(_ > cutoff)
+      rehash.retainByRehash(_ > cutoff)
+
+      val expected = times.collect { case (k, t) if t > cutoff => k }.toSet
+      assertEquals(shift.snapshot, rehash.snapshot, s"trial $trial cutoff $cutoff: shift vs rehash")
+      assertEquals(shift.snapshot, expected, s"trial $trial cutoff $cutoff: snapshot vs expected")
+      assertEquals(shift.size, expected.size, s"trial $trial: size")
+      // Survivors must remain reachable by probing (backward-shift must not orphan any chain).
+      expected.foreach(k => assert(shift.contains(k), s"trial $trial: survivor $k unreachable"))
+      // Removed keys must be gone.
+      times.foreach {
+        case (k, t) =>
+          if (t <= cutoff) assert(!shift.contains(k), s"trial $trial: removed $k still present")
+      }
+      trial += 1
+    }
+  }
+
+  test("interner fully usable after backward-shift retain") {
+    val c = new ManualClock()
+    val m = new OpenHashInternMap[String](16, c)
+    c.setWallTime(100)
+    val survivors = (0 until 500).map { i =>
+      val s = s"keep-$i"; m.intern(s); s
+    }
+    c.setWallTime(1)
+    val removed = (0 until 500).map { i =>
+      val s = s"drop-$i"; m.intern(s); s
+    }
+
+    m.retain(_ > 50) // drops the t=1 entries, keeps the t=100 entries
+    assertEquals(m.size, survivors.size)
+
+    // Membership is exactly the survivors and they are all probe-reachable.
+    survivors.foreach(s => assert(m.contains(s), s"survivor $s lost"))
+    removed.foreach(s => assert(!m.contains(s), s"removed $s still present"))
+
+    // Dedup still works for survivors (re-intern returns the canonical instance, no new entry).
+    val sizeAfterRetain = m.size
+    survivors.foreach(s => assert(m.intern(new String(s)) eq s, s"dedup broken for $s"))
+    assertEquals(m.size, sizeAfterRetain)
+
+    // Freed slots are reusable: new keys (and previously removed ones) insert cleanly.
+    c.setWallTime(200)
+    val fresh = new String("brand-new")
+    assert(m.intern(fresh) eq fresh)
+    assert(m.intern(new String("brand-new")) eq fresh)
+    assert(m.intern(new String(removed.head)) ne survivors.head)
+  }
+
+  test("repeated intern + backward-shift retain stays consistent over churn") {
+    val c = new ManualClock()
+    val m = new OpenHashInternMap[String](16, c)
+    val expected = scala.collection.mutable.HashMap.empty[String, Long]
+    val rnd = new scala.util.Random(99)
+    var cycle = 0
+    while (cycle < 300) {
+      val now = (cycle + 1) * 10L
+      c.setWallTime(now)
+      // Bounded keyspace so keys recur across cycles (exercising timestamp refresh + dedup).
+      val batch = rnd.nextInt(60) + 1
+      var b = 0
+      while (b < batch) {
+        val key = s"k${rnd.nextInt(3000)}"
+        m.intern(key)
+        expected(key) = now
+        b += 1
+      }
+      val cutoff = now - 50 // sliding window: drop anything not seen in the last 5 cycles
+      m.retain(_ > cutoff)
+      expected.filterInPlace((_, t) => t > cutoff)
+
+      assertEquals(m.size, expected.size, s"cycle $cycle: size")
+      expected.keysIterator.foreach(k => assert(m.contains(k), s"cycle $cycle: missing $k"))
+      cycle += 1
+    }
+  }
+
+  test("backward-shift keeps a forced collision chain reachable") {
+    // All keys hash to the same home slot, forming one long probe chain; removing interior
+    // entries must leave the rest reachable (the case naive in-place removal would orphan).
+    final class FixedHash(val v: Int) {
+      override def hashCode(): Int = 0
+      override def equals(o: Any): Boolean = o match {
+        case f: FixedHash => f.v == v
+        case _            => false
+      }
+    }
+    val c = new ManualClock()
+    val m = new OpenHashInternMap[FixedHash](8, c)
+    val keys = (0 until 10).map { v =>
+      // Even v older (will be dropped), odd v newer (kept).
+      c.setWallTime(if (v % 2 == 0) 1L else 100L)
+      val k = new FixedHash(v)
+      m.intern(k)
+      k
+    }
+    m.retain(_ > 50L)
+    keys.foreach { k =>
+      if (k.v % 2 == 0) assert(!m.contains(k), s"dropped ${k.v} still present")
+      else assert(m.contains(k), s"kept ${k.v} unreachable")
+    }
+    assertEquals(m.size, 5)
+  }
+
+  test("backward-shift handles a collision chain that wraps the table end") {
+    final class FixedHash(val v: Int, h: Int) {
+      override def hashCode(): Int = h
+      override def equals(o: Any): Boolean = o match {
+        case f: FixedHash => f.v == v
+        case _            => false
+      }
+    }
+    val c = new ManualClock()
+    val m = new OpenHashInternMap[FixedHash](8, c)
+    val len = m.capacity
+    // Pick a hashCode whose home slot is the last slot, so a collision chain wraps to slot 0.
+    var hc = 0
+    while (Hash.reduce(Hash.lowbias32(hc), len) != len - 1) hc += 1
+    // v0 lands at len-1, v1 at 0, v2 at 1, v3 at 2 (a wrapped cluster). Expire only v0 so its
+    // removal backward-shifts the wrapped tail, exercising the gap > j (wrapped) range check.
+    val keys = (0 until 4).map { v =>
+      c.setWallTime(if (v == 0) 1L else 100L)
+      val k = new FixedHash(v, hc)
+      m.intern(k)
+      k
+    }
+    require(m.capacity == len, "unexpected resize; lower the entry count")
+    m.retain(_ > 50L)
+    assert(!m.contains(keys(0)), "dropped wrapped-head still present")
+    (1 until 4).foreach(v => assert(m.contains(keys(v)), s"kept v$v unreachable after wrap shift"))
+    assertEquals(m.size, 3)
+  }
+
   test("concurrent") {
     val i = InternMap.concurrent[String](2)
     val s1 = new String("foo")

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/InternMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/InternMapSuite.scala
@@ -169,19 +169,12 @@ class InternMapSuite extends FunSuite {
   test("backward-shift keeps a forced collision chain reachable") {
     // All keys hash to the same home slot, forming one long probe chain; removing interior
     // entries must leave the rest reachable (the case naive in-place removal would orphan).
-    final class FixedHash(val v: Int) {
-      override def hashCode(): Int = 0
-      override def equals(o: Any): Boolean = o match {
-        case f: FixedHash => f.v == v
-        case _            => false
-      }
-    }
     val c = new ManualClock()
-    val m = new OpenHashInternMap[FixedHash](8, c)
+    val m = new OpenHashInternMap[FixedHashKey](8, c)
     val keys = (0 until 10).map { v =>
       // Even v older (will be dropped), odd v newer (kept).
       c.setWallTime(if (v % 2 == 0) 1L else 100L)
-      val k = new FixedHash(v)
+      val k = new FixedHashKey(v, 0)
       m.intern(k)
       k
     }
@@ -194,15 +187,8 @@ class InternMapSuite extends FunSuite {
   }
 
   test("backward-shift handles a collision chain that wraps the table end") {
-    final class FixedHash(val v: Int, h: Int) {
-      override def hashCode(): Int = h
-      override def equals(o: Any): Boolean = o match {
-        case f: FixedHash => f.v == v
-        case _            => false
-      }
-    }
     val c = new ManualClock()
-    val m = new OpenHashInternMap[FixedHash](8, c)
+    val m = new OpenHashInternMap[FixedHashKey](8, c)
     val len = m.capacity
     // Pick a hashCode whose home slot is the last slot, so a collision chain wraps to slot 0.
     var hc = 0
@@ -211,7 +197,7 @@ class InternMapSuite extends FunSuite {
     // removal backward-shifts the wrapped tail, exercising the gap > j (wrapped) range check.
     val keys = (0 until 4).map { v =>
       c.setWallTime(if (v == 0) 1L else 100L)
-      val k = new FixedHash(v, hc)
+      val k = new FixedHashKey(v, hc)
       m.intern(k)
       k
     }
@@ -263,5 +249,17 @@ class InternMapSuite extends FunSuite {
     assert(f1 ne interner.intern(f2))
     assert(f2 eq interner.intern(f2))
     assert(b1 eq interner.intern(b2))
+  }
+}
+
+// Top-level (not a local class, so Scala 3 can check the type test in `equals`) key with a
+// caller-supplied hashCode, used to force collision chains in the retain tests.
+private final class FixedHashKey(val v: Int, h: Int) {
+
+  override def hashCode(): Int = h
+
+  override def equals(o: Any): Boolean = o match {
+    case f: FixedHashKey => f.v == v
+    case _               => false
   }
 }

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/InternerRetainBench.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/InternerRetainBench.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.UUID
+
+/**
+  * Compares the cost of `OpenHashInternMap.retain` via in-place backward-shift deletion vs the
+  * full rehash, in the case that dominates production: the index rebuild calls `retain` every
+  * `rebuild-frequency` (~40s) but entries expire on the data-window timescale (~days), so almost
+  * every retain drops nothing. Here `keep = _ => true` (nothing expired): backward-shift should be
+  * a cheap O(n) scan with no allocation, while the rehash re-inserts every entry into fresh arrays.
+  *
+  * Both operations leave the interner contents unchanged for the keep-all case, so a single
+  * pre-built interner is reused across invocations.
+  *
+  * ```
+  * > jmh:run -wi 5 -i 10 -f1 -t1 -prof gc .*InternerRetainBench.*
+  * ```
+  */
+@State(Scope.Thread)
+class InternerRetainBench {
+
+  private val n = 1_000_000
+  private var interner: OpenHashInternMap[String] = _
+
+  @Setup
+  def setup(): Unit = {
+    interner = new OpenHashInternMap[String](n)
+    var i = 0
+    while (i < n) {
+      interner.intern(UUID.randomUUID().toString)
+      i += 1
+    }
+  }
+
+  @Benchmark
+  def retainBackwardShift(bh: Blackhole): Unit = {
+    interner.retain(_ => true)
+    bh.consume(interner.size)
+  }
+
+  @Benchmark
+  def retainRehash(bh: Blackhole): Unit = {
+    interner.retainByRehash(_ => true)
+    bh.consume(interner.size)
+  }
+}


### PR DESCRIPTION
`OpenHashInternMap.retain` (called by `TaggedItem.retain` at the end of every `MemoryDatabase` index rebuild, ~40s) dropped expired entries by rehashing the whole table into fresh arrays. But entries only expire on the data-window timescale (~days), so almost every rebuild re-interned ~1M survivors and allocated two large arrays per interner to remove little or nothing — a top allocation/CPU leaf in rebuild profiles, and a periodic GC spike.

Remove expired entries in place using backward-shift deletion (linear probing, Knuth Algorithm R): for each removed slot, slide back any following entry whose home slot allows it to fill the gap, so probe chains stay intact with no tombstones. The hot `get`/`intern` probe path is therefore unaffected (no tombstone-lengthened chains), and when nothing expires `retain` is just a cheap O(n) scan with no allocation. The mutation runs under the existing per-segment lock, so no reader observes an intermediate state.

JMH (InternerRetainBench, 1M entries, keep-all — the dominant per-rebuild case): throughput 49 -> 152 ops/s (+210%) and allocation 25.7 MB/op -> ~0.

Verified against the previous full-rehash behavior by a randomized differential test (identical surviving set, every survivor probe-reachable) plus churn, post-retain usability, and forced collision/wrap-around chain tests. `retainByRehash` is kept as the differential-test/benchmark reference.