### PR TITLE
core: make escape/unescape exact inverses

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
@@ -166,7 +166,7 @@ object Strings {
     while (i < length) {
       val cp = input.codePointAt(i)
       val len = Character.charCount(cp)
-      if (isSpecial(cp))
+      if (isSpecial(cp) || (cp == '\\' && beginsUnicodeEscape(input, i)))
         escapeCodePoint(cp, builder)
       else
         builder.appendCodePoint(cp)
@@ -174,9 +174,36 @@ object Strings {
     }
   }
 
+  /**
+    * Check if the backslash at position `i` begins a `\uXXXX` sequence that `unescape` would
+    * decode. Such a backslash must itself be escaped so that `escape` is a true inverse of
+    * `unescape` (otherwise a value literally containing `\uXXXX` text would be decoded on the
+    * round-trip). Mirrors the decode condition in `unescape`; other backslashes (e.g. the `\d`
+    * in a regex) are left untouched for readability.
+    */
+  private def beginsUnicodeEscape(input: String, i: Int): Boolean = {
+    input.length - i > 5 && input.charAt(i + 1) == 'u' &&
+    isHexDigit(input.charAt(i + 2)) && isHexDigit(input.charAt(i + 3)) &&
+    isHexDigit(input.charAt(i + 4)) && isHexDigit(input.charAt(i + 5))
+  }
+
+  private def isHexDigit(c: Char): Boolean = {
+    (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+  }
+
   private def escapeCodePoint(cp: Int, builder: java.lang.StringBuilder): Unit = {
-    builder.append("\\u")
-    builder.append(zeroPad(cp, 4))
+    if (Character.isBmpCodePoint(cp)) {
+      builder.append("\\u")
+      builder.append(zeroPad(cp, 4))
+    } else {
+      // Supplementary code points do not fit in four hex digits. Emit a UTF-16 surrogate
+      // pair so that `unescape` (which decodes each `\uXXXX` to a char and recombines the
+      // surrogates) stays an exact inverse; a single `\uXXXXX` would leave a stray digit.
+      builder.append("\\u")
+      builder.append(zeroPad(Character.highSurrogate(cp).toInt, 4))
+      builder.append("\\u")
+      builder.append(zeroPad(Character.lowSurrogate(cp).toInt, 4))
+    }
   }
 
   /**
@@ -195,14 +222,13 @@ object Strings {
         if (length - i <= 5) {
           builder.append(input.substring(i))
           i = length
-        } else if (input.charAt(i + 1) == 'u') {
-          try {
-            val cp = Integer.parseInt(input.substring(i + 2, i + 6), 16)
-            builder.appendCodePoint(cp)
-            i += 5
-          } catch {
-            case _: NumberFormatException => builder.append(c)
-          }
+        } else if (beginsUnicodeEscape(input, i)) {
+          // `beginsUnicodeEscape` guarantees four hex digits, so the parse always yields a
+          // value in [0, 0xFFFF] and cannot throw. Using the same predicate that `escape`
+          // uses to decide what to escape keeps the two exact inverses (issue #1926).
+          val cp = Integer.parseInt(input.substring(i + 2, i + 6), 16)
+          builder.appendCodePoint(cp)
+          i += 5
         } else {
           // Some other escape, copy into buffer and move on
           builder.append(c)

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/DataExprSuite.scala
@@ -41,6 +41,25 @@ class DataExprSuite extends FunSuite {
     assertEquals(dataExpr(expr.exprString), expr)
   }
 
+  test("Equal exprString round-trips a value containing a literal unicode escape (#1926)") {
+    val interpreter = Interpreter(StyleVocabulary.allWords)
+    def dataExpr(s: String): DataExpr = interpreter.execute(s).stack match {
+      case ModelDataTypes.PresentationType(t) :: Nil => t.expr.asInstanceOf[DataExpr]
+      case _                                         => throw new IllegalArgumentException(s)
+    }
+
+    // The query value literally contains backslash-u-0041 (six chars), NOT the character 'A'.
+    // escape now escapes the leading backslash, so the rendered exprString re-parses (via
+    // unescape) back to the same value instead of decoding to "A".
+    val eq = DataExpr.Sum(Query.Equal("name", "\\" + "u0041"))
+    assertEquals(dataExpr(eq.exprString), eq)
+
+    // `:in` renders its values through a different escape path (Interpreter.append over a
+    // list); a literal unicode escape in a list value must round-trip there too.
+    val in = DataExpr.Sum(Query.In("name", List("\\" + "u0041", "bar")))
+    assertEquals(dataExpr(in.exprString), in)
+  }
+
   test("allKeys") {
     val expr = DataExpr.Sum(Query.Equal("k1", "v1"))
     assertEquals(DataExpr.allKeys(expr), Set("k1"))

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/InterpreterSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/stacklang/InterpreterSuite.scala
@@ -187,7 +187,9 @@ class InterpreterSuite extends FunSuite {
     val escaped = s"$space${space}a$nl,$nl${tab}b$space,c"
     val actual = Interpreter.splitAndTrim(escaped)
     assertEquals(actual, List(s"$space${space}a$nl", s"$nl${tab}b$space", "c"))
-    assertEquals(Interpreter.toString(actual.reverse), escaped)
+    // escape/unescape are true inverses (issue #1926): the escaped separators keep each
+    // multi-character value as a single token, and unescape recovers the intended value.
+    assertEquals(actual.map(t => Interpreter.unescape(t)), List("  a\n", "\n\tb ", "c"))
   }
 
   test("splitAndTrim with escaped comma") {
@@ -195,7 +197,9 @@ class InterpreterSuite extends FunSuite {
     val escaped = s"a${comma}b${comma}c,d"
     val actual = Interpreter.splitAndTrim(escaped)
     assertEquals(actual, List(s"a${comma}b${comma}c", "d"))
-    assertEquals(Interpreter.toString(actual.reverse), escaped)
+    // escape/unescape are true inverses (issue #1926): the escaped commas keep "a,b,c" as a
+    // single token, and unescape recovers the intended value.
+    assertEquals(actual.map(t => Interpreter.unescape(t)), List("a,b,c", "d"))
   }
 
   test("splitAndTrim with comments") {
@@ -268,6 +272,40 @@ class InterpreterSuite extends FunSuite {
     val escaped = Interpreter.escape(input)
     assertEquals(escaped, "a\\u002f*b")
     assertEquals(Interpreter.unescape(escaped), input)
+  }
+
+  test("escape: value containing a literal unicode escape round-trips (#1926)") {
+    // The value literally contains backslash-u-0041 (six chars), NOT the character 'A'.
+    // (Built via concatenation so the Scala source itself does not contain a \\uXXXX sequence.)
+    // escape must escape the backslash that begins the \\uXXXX run so unescape does not decode
+    // it back to 'A'; escape and unescape are true inverses.
+    val input = "\\" + "u0041"
+    val escaped = Interpreter.escape(input)
+    assertEquals(escaped, "\\" + "u005cu0041")
+    assertEquals(Interpreter.unescape(escaped), input)
+  }
+
+  test("escape: backslash not beginning a unicode escape stays readable (#1926)") {
+    // A regex-style backslash (\\d) must not be escaped: only a backslash that begins a
+    // \\uXXXX run needs escaping for the round-trip, so common expressions stay readable.
+    val input = "\\" + "d+"
+    val escaped = Interpreter.escape(input)
+    assertEquals(escaped, input)
+    assertEquals(Interpreter.unescape(escaped), input)
+  }
+
+  test("escape: incomplete or non-hex unicode escape stays literal (#1926)") {
+    // A backslash followed by `u` but not a full four-hex run is not something unescape would
+    // decode, so escape must leave it untouched and the value round-trips unchanged. This locks
+    // the beginsUnicodeEscape guard, including the sign-prefixed forms that Integer.parseInt
+    // would otherwise accept (`\\u-fff` used to throw on unescape), keeping the two exact
+    // inverses.
+    val cases = List("\\" + "u041", "\\" + "u041x", "\\" + "u+fff", "\\" + "u-fff")
+    cases.foreach { input =>
+      val escaped = Interpreter.escape(input)
+      assertEquals(escaped, input)
+      assertEquals(Interpreter.unescape(escaped), input)
+    }
   }
 
   //

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StringsSuite.scala
@@ -186,6 +186,16 @@ class StringsSuite extends FunSuite {
     assertEquals(unescape(decoded), decoded)
   }
 
+  test("escape, supplementary code point round-trips") {
+    // U+1F600 is above the BMP, so escape must emit a UTF-16 surrogate pair that unescape can
+    // decode back; a single five-hex `\uXXXXX` would leave a stray digit (escape/unescape must
+    // be exact inverses).
+    val emoji = new String(Character.toChars(0x1F600))
+    val escaped = escape(emoji, _ => true)
+    assertEquals(escaped, "\\ud83d\\ude00")
+    assertEquals(unescape(escaped), emoji)
+  }
+
   test("unescape") {
     var i = 0
     while (i < Short.MaxValue) {


### PR DESCRIPTION
escape did not escape a backslash that begins a \uXXXX run, so a value literally containing \uXXXX text was decoded by unescape on the round-trip (#1926). escape now escapes such a backslash; unescape shares the same predicate so the two stay exact inverses, and supplementary code points are emitted as UTF-16 surrogate pairs. Regex backslashes (\d) are left readable.

Fixes #1926