### PR TITLE
core: fuse interner getOrIntern, raise segments

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TaggedItem.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TaggedItem.scala
@@ -34,8 +34,8 @@ object TaggedItem {
 
   /**
     * Current wall time from the interner clock. Code processing a batch can read this once and
-    * pass it to the timestamped `internId`/`internTagsShallow`/`lookupTagsShallow` variants to
-    * avoid a clock read per datapoint.
+    * pass it to the timestamped `internId`/`getOrInternTagsShallow` variants to avoid a clock read
+    * per datapoint.
     */
   def currentWallTime: Long = clock.wallTime
 
@@ -79,23 +79,19 @@ object TaggedItem {
     tagsInterner.intern(tags)
   }
 
-  /** Intern tags using an explicit batch timestamp rather than a per-call clock read. */
-  def internTagsShallow(tags: Map[String, String], timestamp: Long): Map[String, String] = {
-    tagsInterner.intern(tags, timestamp)
-  }
-
   /**
-    * Probe for an already-interned tag map without inserting. `hashCode` must equal the hash of
-    * the sought map (see `SortedTagMap.computeHashCode`) and `isEqual` confirms the candidate,
-    * so a caller can probe with a reusable buffer and allocate a permanent copy only on a miss.
-    * Returns the interned map or `null`; a hit refreshes recency with `timestamp`.
+    * Look up an interned tag map by `hashCode`/`probe`, interning a freshly built copy
+    * (`probe.create()`) only on a miss. Combines the probe and intern into a single chain walk so
+    * a miss does not scan the chain twice, and a hit allocates nothing. `hashCode` must equal the
+    * hash of the map `probe` matches and creates (see `SortedTagMap.computeHashCode`); otherwise
+    * the entry is stored where later lookups will not find it.
     */
-  def lookupTagsShallow(
+  def getOrInternTagsShallow(
     hashCode: Int,
-    isEqual: Map[String, String] => Boolean,
+    probe: InternMap.InternProbe[Map[String, String]],
     timestamp: Long
   ): Map[String, String] = {
-    tagsInterner.get(hashCode, isEqual, timestamp)
+    tagsInterner.getOrIntern(hashCode, probe, timestamp)
   }
 
   def retain(keep: Long => Boolean): Unit = {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/InternMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/InternMap.scala
@@ -21,13 +21,44 @@ import com.netflix.spectator.api.Clock
 
 object InternMap {
 
+  /**
+    * Create a concurrent interner backed by independently locked segments.
+    *
+    * @param initialCapacity
+    *     Total expected number of entries. It is divided across the segments.
+    * @param clock
+    *     Clock used to timestamp entries for recency-based [[InternMap.retain]].
+    * @param concurrencyLevel
+    *     Number of striped-lock segments. A larger value lowers the chance that concurrent
+    *     threads contend on the same lock, so it should comfortably exceed the number of threads
+    *     that intern at once. The default is chosen to keep contention low for common thread-pool
+    *     sizes (up to roughly 64 threads); use a larger value if more threads may intern
+    *     concurrently. Additional segments cost only a few locks, not data memory, since the
+    *     capacity is split among them.
+    */
   def concurrent[K <: AnyRef](
     initialCapacity: Int,
     clock: Clock = Clock.SYSTEM,
-    concurrencyLevel: Int = 16
+    concurrencyLevel: Int = 128
   ): InternMap[K] = {
     val segmentCapacity = initialCapacity / concurrencyLevel + concurrencyLevel
     new ConcurrentInternMap[K](new OpenHashInternMap[K](segmentCapacity, clock), concurrencyLevel)
+  }
+
+  /**
+    * Probe used by [[InternMap.getOrIntern]] to look up a value with a reusable buffer and build
+    * it only on a miss. `matches` confirms a candidate by content; `create` builds the value to
+    * insert when the slot is empty. Implemented as an abstract class with a primitive `Boolean`
+    * result rather than a `Function1[K, Boolean]` so the per-probe comparison does not box the
+    * result or allocate a closure for the factory.
+    */
+  abstract class InternProbe[K <: AnyRef] {
+
+    /** True if `value` is the one being sought (compared by content against the probe buffer). */
+    def matches(value: K): Boolean
+
+    /** Build the value to insert. Called only on a miss, so a hit allocates nothing. */
+    def create(): K
   }
 }
 
@@ -49,6 +80,18 @@ trait InternMap[K <: AnyRef] extends Interner[K] {
     * is not dropped by a subsequent [[retain]].
     */
   def get(hashCode: Int, isEqual: K => Boolean, timestamp: Long): K
+
+  /**
+    * Look up the value identified by `hashCode`/`probe` and return it, interning a newly built
+    * copy (`probe.create()`) if it is not already present. Combines the probe and insert into a
+    * single chain walk, so a miss does not scan twice, and a hit allocates nothing.
+    *
+    * `hashCode` must equal the `hashCode` of the value that `probe` matches and `create()` builds.
+    * The entry is stored at the slot derived from `hashCode`, so a mismatch would place it where
+    * neither a later `get`/`getOrIntern` (by the real hash) nor `intern` would look, silently
+    * defeating deduplication.
+    */
+  def getOrIntern(hashCode: Int, probe: InternMap.InternProbe[K], timestamp: Long): K
 
   def retain(f: Long => Boolean): Unit
 
@@ -89,14 +132,40 @@ class OpenHashInternMap[K <: AnyRef](initialCapacity: Int, clock: Clock = Clock.
     var j = slot(k.hashCode)
     var n = 0
     while (n < data.length) {
-      if (data(j) == null) {
+      val d = data(j)
+      if (d == null) {
         currentSize += 1
         data(j) = k
         timestamps(j) = t
         return k
-      } else if (data(j) == k) {
+      } else if ((d eq k) || d.equals(k)) {
+        // `K <: AnyRef`, so `d.equals(k)` is a direct virtual call. Using `==` here would route
+        // through `BoxesRunTime.equals`, adding a Number/Character instanceof dispatch on every
+        // comparison. The `eq` fast-path skips `equals` when the same instance is re-interned.
         timestamps(j) = t
-        return data(j)
+        return d
+      }
+      j = if (j + 1 < data.length) j + 1 else 0
+      n += 1
+    }
+    throw new IllegalStateException("failed to add entry to map")
+  }
+
+  def getOrIntern(hashCode: Int, probe: InternMap.InternProbe[K], timestamp: Long): K = {
+    if (currentSize + 1 > 3 * data.length / 4) resize(nextCapacity(2 * data.length), _ => true)
+    var j = slot(hashCode)
+    var n = 0
+    while (n < data.length) {
+      val d = data(j)
+      if (d == null) {
+        val k = probe.create()
+        currentSize += 1
+        data(j) = k
+        timestamps(j) = timestamp
+        return k
+      } else if (probe.matches(d)) {
+        timestamps(j) = timestamp
+        return d
       }
       j = if (j + 1 < data.length) j + 1 else 0
       n += 1
@@ -198,7 +267,7 @@ class OpenHashInternMap[K <: AnyRef](initialCapacity: Int, clock: Clock = Clock.
     while (count < n) {
       val d = data(j)
       if (d == null) return false
-      else if (d == k) return true
+      else if ((d eq k) || d.equals(k)) return true
       j = if (j + 1 < n) j + 1 else 0
       count += 1
     }
@@ -262,6 +331,15 @@ class ConcurrentInternMap[K <: AnyRef](newMap: => InternMap[K], concurrencyLevel
     val i = index(hashCode)
     locks(i).lock()
     try segments(i).get(hashCode, isEqual, timestamp)
+    finally {
+      locks(i).unlock()
+    }
+  }
+
+  def getOrIntern(hashCode: Int, probe: InternMap.InternProbe[K], timestamp: Long): K = {
+    val i = index(hashCode)
+    locks(i).lock()
+    try segments(i).getOrIntern(hashCode, probe, timestamp)
     finally {
       locks(i).unlock()
     }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/InternMapSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/InternMapSuite.scala
@@ -30,6 +30,114 @@ class InternMapSuite extends FunSuite {
     assertEquals(i.capacity, 3)
   }
 
+  // Probe for getOrIntern over String keys: matches by content, builds a fresh String on a miss,
+  // and counts how many times create was invoked so tests can assert no allocation on a hit.
+  private class StringProbe(target: String) extends InternMap.InternProbe[String] {
+
+    var created = 0
+    def matches(v: String): Boolean = v == target
+    def create(): String = { created += 1; new String(target) }
+  }
+
+  // Probe over FixedHashKey so a test can force two keys onto the same home slot (equal hashCode,
+  // unequal value) and exercise the collision-chain walk.
+  private class FixedHashProbe(target: FixedHashKey) extends InternMap.InternProbe[FixedHashKey] {
+
+    var created = 0
+    def matches(v: FixedHashKey): Boolean = v == target
+    def create(): FixedHashKey = { created += 1; target }
+  }
+
+  test("open hash getOrIntern: insert on miss, reuse on hit") {
+    val i = new OpenHashInternMap[String](16)
+    val p1 = new StringProbe("foo")
+    val a = i.getOrIntern("foo".hashCode, p1, 0L)
+    assertEquals(a, "foo")
+    assertEquals(p1.created, 1)
+    assertEquals(i.size, 1)
+
+    val p2 = new StringProbe("foo")
+    val b = i.getOrIntern("foo".hashCode, p2, 0L)
+    assert(b eq a) // returns the existing instance
+    assertEquals(p2.created, 0) // did not build a new value on a hit
+    assertEquals(i.size, 1)
+  }
+
+  test("open hash getOrIntern refreshes recency for retain") {
+    val c = new ManualClock()
+    val i = new OpenHashInternMap[String](16, c)
+    val first = i.getOrIntern("foo".hashCode, new StringProbe("foo"), 10L)
+    // Access via getOrIntern with a later timestamp; recency should advance to 42.
+    assert(i.getOrIntern("foo".hashCode, new StringProbe("foo"), 42L) eq first)
+    i.retain(_ > 21L) // would drop the t=10 entry, but recency was refreshed to 42
+    assert(i.getOrIntern("foo".hashCode, new StringProbe("foo"), 42L) eq first)
+    assertEquals(i.size, 1)
+  }
+
+  test("concurrent getOrIntern: insert on miss, reuse on hit") {
+    val i = InternMap.concurrent[String](16)
+    val a = i.getOrIntern("foo".hashCode, new StringProbe("foo"), 0L)
+    val p = new StringProbe("foo")
+    val b = i.getOrIntern("foo".hashCode, p, 0L)
+    assert(a eq b)
+    assertEquals(p.created, 0)
+    assertEquals(i.size, 1)
+  }
+
+  test("open hash getOrIntern walks a collision chain and inserts past non-matching entries") {
+    val m = new OpenHashInternMap[FixedHashKey](16)
+    // Same hashCode (same home slot) but unequal: `b` must be inserted past `a`, and both stay
+    // reachable. This is the probe.matches(d) == false branch the real TagsProbe relies on.
+    val a = new FixedHashKey(1, 42)
+    val b = new FixedHashKey(2, 42)
+    val pa = new FixedHashProbe(a)
+    assert(m.getOrIntern(42, pa, 0L) eq a)
+    assertEquals(pa.created, 1)
+    val pb = new FixedHashProbe(b)
+    assert(m.getOrIntern(42, pb, 0L) eq b) // collided with `a`, walked, inserted at next slot
+    assertEquals(pb.created, 1)
+    assertEquals(m.size, 2)
+    // Both still found on a hit, without building anything new.
+    val pa2 = new FixedHashProbe(a)
+    assert(m.getOrIntern(42, pa2, 0L) eq a)
+    assertEquals(pa2.created, 0)
+    val pb2 = new FixedHashProbe(b)
+    assert(m.getOrIntern(42, pb2, 0L) eq b)
+    assertEquals(pb2.created, 0)
+  }
+
+  test("getOrIntern dedups against values inserted via intern, and vice versa") {
+    // Production feeds one interner through both intern (internTagsShallow) and getOrIntern
+    // (getOrInternTagsShallow), plus internEntry on retain/resize, so the two paths must agree.
+    val m = new OpenHashInternMap[String](16)
+    val foo = new String("foo")
+    assert(m.intern(foo, 0L) eq foo) // inserted via intern
+    val p = new StringProbe("foo")
+    assert(m.getOrIntern("foo".hashCode, p, 0L) eq foo) // getOrIntern finds the intern'd instance
+    assertEquals(p.created, 0)
+
+    val bar = m.getOrIntern("bar".hashCode, new StringProbe("bar"), 0L) // inserted via getOrIntern
+    assert(m.intern(new String("bar"), 0L) eq bar) // intern finds the getOrIntern'd instance
+    assertEquals(m.size, 2)
+  }
+
+  test("open hash getOrIntern inserts through a resize and keeps all entries findable") {
+    val m = new OpenHashInternMap[String](4)
+    val n = 1000
+    (0 until n).foreach { i =>
+      val p = new StringProbe(i.toString)
+      assertEquals(m.getOrIntern(i.toString.hashCode, p, 0L), i.toString)
+      assertEquals(p.created, 1) // all distinct, so each is built and inserted
+    }
+    assertEquals(m.size, n)
+    // After the resizes, every entry is still found on a hit with no new builds.
+    (0 until n).foreach { i =>
+      val p = new StringProbe(i.toString)
+      assertEquals(m.getOrIntern(i.toString.hashCode, p, 0L), i.toString)
+      assertEquals(p.created, 0)
+    }
+  }
+
   test("open hash resize") {
     val interner = new OpenHashInternMap[String](2)
     (1 until 10000).foreach { i =>

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/ConcurrentInternBench.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/ConcurrentInternBench.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.TimeUnit
+
+/**
+  * Lock-contention test for the shared `ConcurrentInternMap`. All threads hit a pre-populated,
+  * shared interner so the working-set size is stable; the difference between the benchmarks is
+  * purely how many segment locks each op takes:
+  *
+  *  - `getOnly`       — one `get` (1 lock): the steady-state hit path.
+  *  - `getThenIntern` — a `get` then an `intern` (2 locks): models #1929's miss path lock count.
+  *  - `getOrIntern`   — the fused single chain walk (1 lock).
+  *
+  * Sweeping `concurrency` (the segment count) at a fixed thread count shows whether the shared
+  * lock is a bottleneck and how many segments are needed to relieve it. Run at several `-t`:
+  *
+  * > jmh:run -wi 5 -i 10 -f1 -t8 .*ConcurrentInternBench.*
+  * > jmh:run -wi 5 -i 10 -f1 -t1 .*ConcurrentInternBench.*
+  */
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+class ConcurrentInternBench {
+
+  import ConcurrentInternBench.*
+
+  // Segment count of the shared interner (the `concurrencyLevel`). 8 = r5.2xlarge vCPUs.
+  @Param(Array("8", "16", "32", "64"))
+  var concurrency: Int = 0
+
+  private final val numKeys = 50000
+  private var keys: Array[SortedTagMap] = _
+  private var hashes: Array[Int] = _
+  private var interner: InternMap[Map[String, String]] = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    keys = Array.tabulate(numKeys) { i =>
+      SortedTagMap(
+        "nf.app"     -> "atlas_backend",
+        "nf.cluster" -> "atlas_backend-dev",
+        "nf.asg"     -> "atlas_backend-dev-v001",
+        "nf.region"  -> "us-east-1",
+        "nf.zone"    -> "us-east-1e",
+        "nf.node"    -> "i-123456789",
+        "name"       -> "jvm.gc.pause",
+        "statistic"  -> "totalTime",
+        "id"         -> i.toString
+      )
+    }
+    hashes = keys.map(_.hashCode)
+    interner =
+      InternMap.concurrent[Map[String, String]](numKeys * 2, concurrencyLevel = concurrency)
+    var i = 0
+    while (i < numKeys) { interner.intern(keys(i), 0L); i += 1 }
+  }
+
+  @Benchmark
+  def getOnly(ts: ThreadState, bh: Blackhole): Unit = {
+    val i = ts.next(numKeys)
+    ts.key = keys(i)
+    bh.consume(interner.get(hashes(i), ts.isEqual, 0L))
+  }
+
+  @Benchmark
+  def getThenIntern(ts: ThreadState, bh: Blackhole): Unit = {
+    val i = ts.next(numKeys)
+    val k = keys(i)
+    ts.key = k
+    interner.get(hashes(i), ts.isEqual, 0L)
+    bh.consume(interner.intern(k, 0L))
+  }
+
+  @Benchmark
+  def getOrIntern(ts: ThreadState, bh: Blackhole): Unit = {
+    val i = ts.next(numKeys)
+    ts.key = keys(i)
+    bh.consume(interner.getOrIntern(hashes(i), ts.probe, 0L))
+  }
+}
+
+object ConcurrentInternBench {
+
+  /** Per-thread cursor and reusable predicates so the loop body allocates nothing. */
+  @State(Scope.Thread)
+  class ThreadState {
+
+    var cursor: Int = 0
+    var key: SortedTagMap = _
+
+    // Reusable predicate for `get`; reads the current `key` each call (still boxes the Boolean
+    // through the Function1 bridge, matching the #1929 probe, but allocates no per-call closure).
+    val isEqual: Map[String, String] => Boolean = m => m.equals(key)
+
+    // Reusable probe for `getOrIntern`; `create` is never reached here because every op hits.
+    val probe: InternMap.InternProbe[Map[String, String]] =
+      new InternMap.InternProbe[Map[String, String]] {
+
+        def matches(m: Map[String, String]): Boolean = m.equals(key)
+        def create(): Map[String, String] = key
+      }
+
+    def next(n: Int): Int = {
+      val i = cursor
+      cursor = if (i + 1 < n) i + 1 else 0
+      i
+    }
+  }
+}

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/GetOrInternBench.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/util/GetOrInternBench.scala
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.util
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.infra.Blackhole
+
+/**
+  * Compares interner strategies on publish-shaped tag maps: the pre-#1929 single `intern`, the
+  * #1929 two-step `get` + `intern` (probe, then intern on a miss), and the fused `getOrIntern`
+  * (one chain walk). Run with `-prof gc` and `-prof stack` to see where the miss-path cost goes.
+  *
+  * The `miss*` benchmarks intern N distinct series into a fresh interner each invocation (models a
+  * high-cardinality / cold box where the probe rarely hits). The `hit*` benchmarks re-look-up a
+  * pre-populated interner (models steady state where the probe should hit).
+  *
+  * > jmh:run -prof gc -wi 5 -i 10 -f1 -t1 .*GetOrInternBench.*
+  */
+@State(Scope.Thread)
+class GetOrInternBench {
+
+  // Number of distinct series interned per invocation.
+  @Param(Array("10000"))
+  var n: Int = 0
+
+  // "shared" = realistic publish maps that share a long common nf.* prefix and differ in one tag
+  // value (stresses equals, which must scan the shared prefix before reaching the difference).
+  // "distinct" = every tag differs (control: cheap equals, well-spread hashes).
+  @Param(Array("shared", "distinct"))
+  var shape: String = ""
+
+  private var keys: Array[SortedTagMap] = _
+  private var hashes: Array[Int] = _
+  private var warm: OpenHashInternMap[Map[String, String]] = _
+
+  private def buildKey(i: Int): SortedTagMap = shape match {
+    case "shared" =>
+      SortedTagMap(
+        "nf.app"     -> "atlas_backend",
+        "nf.cluster" -> "atlas_backend-dev",
+        "nf.asg"     -> "atlas_backend-dev-v001",
+        "nf.stack"   -> "dev",
+        "nf.region"  -> "us-east-1",
+        "nf.zone"    -> "us-east-1e",
+        "nf.node"    -> "i-123456789",
+        "nf.vmtype"  -> "r3.2xlarge",
+        "name"       -> "jvm.gc.pause",
+        "statistic"  -> "totalTime",
+        "id"         -> i.toString
+      )
+    case _ =>
+      SortedTagMap((0 until 11).map(j => s"k$j-$i" -> s"v$j-$i")*)
+  }
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    keys = Array.tabulate(n)(buildKey)
+    hashes = keys.map(_.hashCode)
+    // Pre-populated interner for the hit benchmarks.
+    warm = new OpenHashInternMap[Map[String, String]](n * 2)
+    var i = 0
+    while (i < n) { warm.intern(keys(i), 0L); i += 1 }
+  }
+
+  // Reusable probe that confirms a candidate by content and, on a miss, returns the prebuilt key.
+  private final class KeyProbe extends InternMap.InternProbe[Map[String, String]] {
+
+    var key: SortedTagMap = _
+    def matches(m: Map[String, String]): Boolean = m.equals(key)
+    def create(): Map[String, String] = key
+  }
+
+  // Pre-#1929: build the map (already built here) and intern it; dedup happens inside intern.
+  @Benchmark
+  def missIntern(bh: Blackhole): Unit = {
+    val m = new OpenHashInternMap[Map[String, String]](16)
+    var i = 0
+    while (i < n) { bh.consume(m.intern(keys(i), 0L)); i += 1 }
+  }
+
+  // #1929: probe with get, then intern on a miss (two chain walks on a miss).
+  @Benchmark
+  def missTwoStep(bh: Blackhole): Unit = {
+    val m = new OpenHashInternMap[Map[String, String]](16)
+    var i = 0
+    while (i < n) {
+      val k = keys(i)
+      val existing = m.get(hashes(i), candidate => candidate.equals(k), 0L)
+      bh.consume(if (existing != null) existing else m.intern(k, 0L))
+      i += 1
+    }
+  }
+
+  // Fused: a single chain walk.
+  @Benchmark
+  def missGetOrIntern(bh: Blackhole): Unit = {
+    val m = new OpenHashInternMap[Map[String, String]](16)
+    val probe = new KeyProbe
+    var i = 0
+    while (i < n) {
+      probe.key = keys(i)
+      bh.consume(m.getOrIntern(hashes(i), probe, 0L))
+      i += 1
+    }
+  }
+
+  // Steady state: every lookup hits the pre-populated interner.
+  @Benchmark
+  def hitTwoStep(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < n) {
+      val k = keys(i)
+      bh.consume(warm.get(hashes(i), candidate => candidate.equals(k), 0L))
+      i += 1
+    }
+  }
+
+  @Benchmark
+  def hitGetOrIntern(bh: Blackhole): Unit = {
+    val probe = new KeyProbe
+    var i = 0
+    while (i < n) {
+      probe.key = keys(i)
+      bh.consume(warm.getOrIntern(hashes(i), probe, 0L))
+      i += 1
+    }
+  }
+}

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishPayloads.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishPayloads.scala
@@ -21,6 +21,7 @@ import com.netflix.atlas.core.model.DatapointTuple
 import com.netflix.atlas.core.model.ItemId
 import com.netflix.atlas.core.model.TaggedItem
 import com.netflix.atlas.core.util.Interner
+import com.netflix.atlas.core.util.InternMap
 import com.netflix.atlas.core.util.RefIntHashMap
 import com.netflix.atlas.core.util.SortedTagMap
 import com.netflix.atlas.core.util.Streams
@@ -52,7 +53,7 @@ object PublishPayloads {
   // The grow-only `buffer` holds the flat key/value strings; the probe doubles as the equality
   // predicate for the interner lookup so a hit allocates nothing (no scratch map, no reallocation
   // when the tag count varies between datapoints).
-  private final class TagsProbe extends (Map[String, String] => Boolean) {
+  private final class TagsProbe extends InternMap.InternProbe[Map[String, String]] {
 
     private[this] var buffer = new Array[String](32)
     private[this] var length = 0
@@ -68,9 +69,15 @@ object PublishPayloads {
       buffer
     }
 
-    def apply(m: Map[String, String]): Boolean = m match {
+    def matches(m: Map[String, String]): Boolean = m match {
       case s: SortedTagMap => s.dataEquals(buffer, length)
       case _               => false
+    }
+
+    // Called only on an interner miss, so a hit allocates nothing. Copies the active prefix of
+    // the reusable buffer into a permanent, exact-size array for the interned map.
+    def create(): Map[String, String] = {
+      SortedTagMap.createUnsafe(java.util.Arrays.copyOf(buffer, length), length)
     }
   }
 
@@ -379,14 +386,9 @@ object PublishPayloads {
         j += 1
       }
       val hashCode = SortedTagMap.computeHashCode(buffer, len)
-      val existing = TaggedItem.lookupTagsShallow(hashCode, probe, wallTime)
-      val tags =
-        if (existing != null) existing
-        else
-          TaggedItem.internTagsShallow(
-            SortedTagMap.createUnsafe(java.util.Arrays.copyOf(buffer, len), len),
-            wallTime
-          )
+      // Single chain walk: returns the existing map on a hit (no allocation) or interns a copy
+      // built by `probe.create()` on a miss. Avoids the separate probe + intern double scan.
+      val tags = TaggedItem.getOrInternTagsShallow(hashCode, probe, wallTime)
       val timestamp = nextLong(parser)
       val value = getValue(parser)
       consumer.consume(id, tags, timestamp, value)


### PR DESCRIPTION
The publish path probed the tags interner then interned on a miss (#1929), taking two segment locks per miss and boxing the probe. Under the 64-thread publish pool against a 16-segment interner this halved throughput on the hot path.

Add InternMap.getOrIntern (single chain walk, no alloc on hit) with a non-boxing InternProbe, de-box the key comparison (eq + equals, not ==), and raise the default concurrencyLevel 16 -> 128. Remove the now-dead lookupTagsShallow and timestamped internTagsShallow that the fused path replaced. Adds getOrIntern tests and interner benchmarks.