### PR TITLE
pekko: return 400 for regex features the matcher rejects (UnsupportedOperationException)

### DIFF
--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/ExprApiSuite.scala
@@ -48,6 +48,16 @@ class ExprApiSuite extends MUnitRouteSuite {
     assertEquals(response.status, StatusCodes.BadRequest)
   }
 
+  // Regex features rejected by the matcher (inline flags, back references) must surface as a
+  // client error, not a 500. `(?i)` is url-encoded as %28%3Fi%29 and `\1` as %5C1.
+  testGet("/api/v1/expr/normalize?q=a,%28%3Fi%29b,:re") {
+    assertEquals(response.status, StatusCodes.BadRequest)
+  }
+
+  testGet("/api/v1/expr/normalize?q=a,%5C1,:re") {
+    assertEquals(response.status, StatusCodes.BadRequest)
+  }
+
   testGet("/api/v1/expr?q=name,sps,:eq") {
     assertEquals(response.status, StatusCodes.OK)
     val data = Json.decode[List[ExprApiSuite.Output]](responseAs[String])


### PR DESCRIPTION
## Problem
A query whose regex uses a feature the matcher does not support — e.g. an inline flag
(`name,(?i)foo,:re`) or a back reference (`name,\1,:re`) — returns **HTTP 500 Internal Server
Error**. This is invalid client input and should be a **400**.

## Root cause
`com.netflix.spectator.impl.PatternMatcher` throws `java.lang.UnsupportedOperationException` for
regex constructs it doesn't implement. `RequestHandler.errorResponse` maps
`IllegalArgumentException` / `IllegalStateException` / `JacksonException` / `DateTimeException` to
`BadRequest`, but `UnsupportedOperationException` isn't in that set, so it falls through to the
catch-all that returns `InternalServerError`.

## Fix
Add `UnsupportedOperationException` to the set of exceptions mapped to `BadRequest`. Reachable on
the query-parsing endpoints (`/api/v1/expr/*`, `/api/v1/graph`, `/api/v1/tags`).

## Tests
`ExprApiSuite` now asserts that `(?i)` (inline flag) and `\1` (back reference) values return
`BadRequest` instead of `InternalServerError`.

## Note
This touches the same exception-map line as a separate change adding `ArithmeticException`
(divide-by-zero hardening). If both land, the second is a one-line rebase.
