### PR TITLE
core: prevent a zero step size in Step.compute (and map ArithmeticException to 400)

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Step.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Step.scala
@@ -41,7 +41,10 @@ class Step private (allowedStepSizesForBlock: List[Long]) {
     */
   def compute(primary: Long, width: Int, start: Long, end: Long): Long = {
     val datapoints = (end - start) / primary
-    val minStep = datapointsPerPixel(datapoints, width) * primary
+    // Ensure at least one datapoint per pixel so the resulting step can never round down to
+    // zero. When the window is smaller than the primary step `datapoints` is 0, which would
+    // otherwise make `minStep` 0 and yield a zero step size (later used as a divisor).
+    val minStep = math.max(1L, datapointsPerPixel(datapoints, width)) * primary
     round(primary, minStep)
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/util/StepSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/util/StepSuite.scala
@@ -82,6 +82,21 @@ class StepSuite extends FunSuite {
     assertEquals(days(1), oneHourStep.compute(60000, 430, s.toEpochMilli, e.toEpochMilli))
   }
 
+  test("compute: window smaller than step does not yield a zero step") {
+    // Regression: a window narrower than the (rounded) primary step makes `datapoints` round
+    // to 0, which previously produced a zero step size that was later used as a divisor.
+    assert(oneHourStep.compute(days(1), 400, 0L, minutes(60)) > 0)
+  }
+
+  test("compute: always returns a positive step") {
+    val primaries = List(1000L, minutes(1), minutes(60), days(1))
+    val widths = List(1, 10, 400, 1500)
+    val windows = List(0L, 1L, minutes(60), days(1), days(400))
+    for (p <- primaries; w <- widths; win <- windows) {
+      assert(oneHourStep.compute(p, w, 0L, win) > 0, s"compute($p, $w, 0, $win) was not positive")
+    }
+  }
+
   test("roundToStepBoundary: 2ms step") {
     assertEquals(Step.roundToStepBoundary(0L, 2L), 0L)
     assertEquals(Step.roundToStepBoundary(1L, 2L), 2L)


### PR DESCRIPTION
## Problem
A graph request whose `step` is much larger than the time window — e.g.
`/api/v1/graph?q=1&step=1000w&s=2012-01-01T00:00&e=2012-01-01T00:01` — returns **HTTP 500**
(`ArithmeticException: / by zero`).

## Root cause
When the requested window is smaller than the (rounded) primary step, `Step.compute` computes
`datapoints = (end - start) / primary = 0`. `datapointsPerPixel(0, width)` then returns 0, so
`minStep` is 0 and the resolved step size becomes 0. That zero step is later used as a divisor
(rounding timestamps to step boundaries), raising `ArithmeticException`, which the request handler
does not map and so surfaces as a 500.

## Fix
Two parts, addressing cause and symptom:
1. `Step.compute`: require at least one datapoint per pixel (`math.max(1L, datapointsPerPixel(...))`)
   so the resolved step can never round down to zero. This only changes the degenerate
   window-smaller-than-step case; for all other inputs `datapointsPerPixel` is already >= 1.
2. `RequestHandler.errorResponse`: also map `ArithmeticException` to `BadRequest` as defense in
   depth, so any future divide-by-zero is a client error rather than a 500.

With the clamp, such requests now return **HTTP 200** with a single coarse bucket (the window is
smaller than one step) instead of failing.

## Tests
`StepSuite` adds a regression for the window-smaller-than-step case and a check that `compute`
returns a positive step across a range of primaries / widths / windows.

## Note
The `RequestHandler` change touches the same line as a separate change adding
`UnsupportedOperationException`. If both land, the second is a one-line rebase.
