### PR TITLE
webapi: validate non-positive limit on the tags API

### DIFF
--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsApi.scala
@@ -62,7 +62,7 @@ class TagsApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi {
     get {
       extractRequestContext { ctx =>
         val req = toRequest(ctx, path)
-        val limit = req.limit
+        val limit = req.actualLimit
         _ =>
           ask(dbRef, req.toDbRequest)(60.seconds).map {
             case TagListResponse(vs) if req.useText => asText(tagString(vs), offsetTag(limit, vs))
@@ -137,6 +137,8 @@ object TagsApi {
     verbose: Boolean = false,
     limit: Int = 1000
   ) {
+
+    require(limit > 0, s"limit must be positive (got $limit)")
 
     def actualLimit: Int = if (limit > ApiSettings.maxTagLimit) ApiSettings.maxTagLimit else limit
 

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/TagsApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/TagsApiSuite.scala
@@ -106,6 +106,14 @@ class TagsApiSuite extends MUnitRouteSuite {
     assertEquals(response.status, StatusCodes.BadRequest)
   }
 
+  testGet("/api/v1/tags?limit=-1") {
+    assertEquals(response.status, StatusCodes.BadRequest)
+  }
+
+  testGet("/api/v1/tags?limit=0") {
+    assertEquals(response.status, StatusCodes.BadRequest)
+  }
+
   testGet("/api/v1/tags?verbose=1") {
     assertEquals(responseAs[String], "[]")
   }


### PR DESCRIPTION
## Problem
`/api/v1/tags?limit=-1` (or `limit=0`) returns **HTTP 404** carrying an internal
`NoSuchElementException` ("last of empty list") rather than a clean client error.

## Root cause
`limit` is parsed with no positivity check. The pagination guard in `offsetTag` / `offsetString`,
`if (vs.size < limit) None else vs.last`, calls `vs.last` on an empty result list when
`limit <= 0` (e.g. `0 < -1` is false), throwing `NoSuchElementException`. Separately, the existing
`actualLimit` clamp (which caps `limit` at `maxTagLimit`) was defined but never used, so the upper
bound was not enforced either.

## Fix
- Reject a non-positive `limit` with `require(limit > 0, ...)` → `BadRequest`, matching the existing
  handling of non-positive graph `w`/`h` parameters.
- Use `req.actualLimit` at the call site so the `maxTagLimit` upper bound is actually applied.

## Tests
`TagsApiSuite` adds cases asserting `limit=-1` and `limit=0` return `BadRequest` (alongside the
existing `limit=foo` case).
