### PR TITLE
remove default-dispatcher parallelism override

### DIFF
--- a/atlas-pekko/src/main/resources/reference.conf
+++ b/atlas-pekko/src/main/resources/reference.conf
@@ -139,12 +139,6 @@ pekko {
       lifecycle = on
     }
 
-    default-dispatcher {
-      fork-join-executor {
-        parallelism-factor = 8.0
-      }
-    }
-
     deployment {
       /request-handler {
         router = round-robin-pool


### PR DESCRIPTION
The default-dispatcher fork-join-executor parallelism-factor has been 8.0 since the initial commit ~12 years ago, when hosts had far fewer cores. On current 16-vCPU instances that factor resolves to 128, clamped by parallelism-max to 64 worker threads on a box with only 8 physical cores.

CPU profiles at ~1k RPS/instance showed roughly a third of on-CPU time spent in ForkJoinPool scheduling overhead: ~19% in runWorker (idle workers scanning queues for work) plus context-switch churn, rather than in actual request handling. The workload is dominated by small per-message actor hand-offs, so the oversized pool added scheduling storms without adding throughput.

This is a library reference.conf, so the override was the effective default for every atlas-pekko consumer. Drop it and inherit the Pekko default (factor 1.0, sizing the pool to the vCPU count); no rationale for the original tuning survives. A single-variable test instance showed:

- runWorker self-time fell from ~19% to ~5.7%
- ~15-20% lower CPU at peak, at identical RPS with no latency change