### PR TITLE
eval: partition stream data sources by host

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/EvaluatorImpl.scala
@@ -285,7 +285,7 @@ private[stream] abstract class EvaluatorImpl(
 
       val intermediateEval = createInputFlow(context)
         .via(context.monitorFlow("10_InputBatches"))
-        .via(new LwcToAggrDatapoint(context))
+        .via(new LwcToAggrDatapoint(context, host))
         .flatMapConcat { t =>
           Source(t.groupByStep)
         }
@@ -312,7 +312,7 @@ private[stream] abstract class EvaluatorImpl(
       .map(ReplayLogging.log)
       .map { s =>
         val validated = context.validate(s)
-        context.setDataSources(validated)
+        context.setDataSources(host, validated)
         validated
       }
       .via(g)
@@ -337,9 +337,9 @@ private[stream] abstract class EvaluatorImpl(
     // Flow used for logging diagnostic messages
     val (logSrc, context) = createStreamContextSource
 
-    // Initialize context with fixed data sources
+    // Initialize context with fixed data sources, grouped by host to match the streaming path.
     context.validate(sources)
-    context.setDataSources(sources)
+    groupByHost(sources).foreach { case (host, dss) => context.setDataSources(host, dss) }
     val interpreter = context.interpreter
 
     // Extract data expressions to reuse for creating time groups

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapoint.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapoint.scala
@@ -45,7 +45,7 @@ import com.netflix.atlas.eval.model.LwcDataExpr
   * Process the SSE output from an LWC service and convert it into a stream of
   * [[AggrDatapoint]]s that can be used for evaluation.
   */
-private[stream] class LwcToAggrDatapoint(context: StreamContext)
+private[stream] class LwcToAggrDatapoint(context: StreamContext, host: String)
     extends GraphStage[FlowShape[List[AnyRef], DatapointsTuple]] {
 
   import LwcToAggrDatapoint.*
@@ -135,7 +135,7 @@ private[stream] class LwcToAggrDatapoint(context: StreamContext)
 
       private def pushEvent(event: LwcEvent): List[Evaluator.MessageEnvelope] = {
         eventState.get(event.id) match {
-          case Some(sub) => context.messagesForDataSource(sub, EventMessage(event.payload))
+          case Some(sub) => context.messagesForDataSource(host, sub, EventMessage(event.payload))
           case None      => unknown.increment(); Nil
         }
       }
@@ -145,10 +145,10 @@ private[stream] class LwcToAggrDatapoint(context: StreamContext)
       ): List[Evaluator.MessageEnvelope] = {
         tsState.get(diagMsg.id) match {
           case Some(sub) =>
-            context.messagesForDataSource(sub.dataExprStr, diagMsg.message)
+            context.messagesForDataSource(host, sub.dataExprStr, diagMsg.message)
           case None =>
             eventState.get(diagMsg.id) match {
-              case Some(sub) => context.messagesForDataSource(sub, diagMsg.message)
+              case Some(sub) => context.messagesForDataSource(host, sub, diagMsg.message)
               case None      => unknown.increment(); Nil
             }
         }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -18,6 +18,7 @@ package com.netflix.atlas.eval.stream
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import org.apache.pekko.NotUsed
 import org.apache.pekko.http.scaladsl.model.Uri
 import org.apache.pekko.stream.IOResult
@@ -132,20 +133,25 @@ private[stream] class StreamContext(
   }
 
   /**
-    * Current set of data sources being processed by the stream. This may be updated while
-    * there are still some in-flight data for a given data source that was previously being
-    * processed.
+    * State for the data sources being processed by the stream, tracked per backend host.
+    * `createStreamsFlow` groups data sources by host and runs a per-host processor over this
+    * shared context, so each host must update its own state independently. Partitioning by host
+    * prevents one host from clobbering another's data sources and lets message delivery be scoped
+    * to the host that produced the data. Each host's data sources and derived expression map are
+    * held together and updated with a single atomic operation so a reader never sees them
+    * disagree. This may be updated while there are still some in-flight data for a given data
+    * source that was previously being processed.
     */
-  @volatile private var dataSources: DataSources = DataSources.empty()
+  private val stateByHost = new ConcurrentHashMap[String, StreamContext.HostState]()
 
-  /** Map of DataExpr to data sources for being able to quickly log information. */
-  @volatile private var dataExprMap: Map[String, List[DataSource]] = Map.empty
-
-  def setDataSources(ds: DataSources): Unit = {
-    if (dataSources != ds) {
-      dataSources = ds
-      dataExprMap = interpreter.dataExprMap(ds)
-    }
+  def setDataSources(host: String, ds: DataSources): Unit = {
+    stateByHost.compute(
+      host,
+      (_, prev) =>
+        // Reuse the previous state, and its already-computed expression map, if unchanged.
+        if (prev != null && prev.dataSources == ds) prev
+        else StreamContext.HostState(ds, interpreter.dataExprMap(ds))
+    )
   }
 
   /**
@@ -247,37 +253,69 @@ private[stream] class StreamContext(
     * Emit an error to the sources where the number of input
     * or intermediate datapoints exceed for an expression.
     */
+  /** Report exceeded limits to the data sources for `dataExpr` on a specific host. */
+  def logDatapointsExceeded(host: String, timestamp: Long, dataExpr: String): Unit = {
+    log(host, dataExpr, datapointsExceededMessage(timestamp, dataExpr))
+  }
+
+  /**
+    * Report exceeded limits to the data sources for `dataExpr` across all hosts. Used by the
+    * combined datapoint processor, where evaluation is not partitioned by host.
+    */
   def logDatapointsExceeded(timestamp: Long, dataExpr: String): Unit = {
-    val diagnosticMessage = DiagnosticMessage.error(
+    log(dataExpr, datapointsExceededMessage(timestamp, dataExpr))
+  }
+
+  private def datapointsExceededMessage(timestamp: Long, dataExpr: String): DiagnosticMessage = {
+    DiagnosticMessage.error(
       s"expression: $dataExpr exceeded the configured max input datapoints limit" +
         s" '$maxInputDatapointsPerExpression' or max intermediate" +
         s" datapoints limit '$maxIntermediateDatapointsPerExpression'" +
         s" for timestamp '$timestamp}"
     )
-    log(dataExpr, diagnosticMessage)
   }
 
   /**
-    * Send a diagnostic message to all data sources that use a particular data expression.
+    * Send a diagnostic message to the data sources on the given host that use a particular data
+    * expression.
     */
-  def log(expr: String, msg: JsonSupport): Unit = {
-    dataExprMap.get(expr).foreach { ds =>
-      ds.foreach(s => dsLogger(s, msg))
+  def log(host: String, expr: String, msg: JsonSupport): Unit = {
+    val state = stateByHost.get(host)
+    if (state != null) {
+      state.dataExprMap.get(expr).foreach(ds => ds.foreach(s => dsLogger(s, msg)))
     }
   }
 
   /**
-    * Creates a set of messages for each data source that uses a given expression.
+    * Send a diagnostic message to all data sources that use a particular data expression across
+    * all hosts. Used where the expression is not tied to a specific host.
     */
-  def messagesForDataSource(expr: String, msg: JsonSupport): List[Evaluator.MessageEnvelope] = {
-    dataExprMap.get(expr) match {
+  def log(expr: String, msg: JsonSupport): Unit = {
+    stateByHost.values.forEach { state =>
+      state.dataExprMap.get(expr).foreach(ds => ds.foreach(s => dsLogger(s, msg)))
+    }
+  }
+
+  /**
+    * Creates a set of messages for each data source on the given host that uses a given
+    * expression. Scoping to the host avoids delivering data produced by one backend to a data
+    * source pointed at a different backend that happens to use the same expression.
+    */
+  def messagesForDataSource(
+    host: String,
+    expr: String,
+    msg: JsonSupport
+  ): List[Evaluator.MessageEnvelope] = {
+    val state = stateByHost.get(host)
+    val dataSources = if (state == null) None else state.dataExprMap.get(expr)
+    dataSources match {
       case Some(ds) =>
         ds.map(s => new Evaluator.MessageEnvelope(s.id, msg))
       case None =>
         // No active data source maps to this expression, so the message would be dropped.
         // Track it and log the details to make this observable rather than silent.
         unmatchedMessages.increment()
-        logger.debug(s"dropping message, no data source for expression [$expr]")
+        logger.debug(s"dropping message, no data source for expression [$expr] on host [$host]")
         Nil
     }
   }
@@ -295,6 +333,9 @@ private[stream] class StreamContext(
 }
 
 private[stream] object StreamContext {
+
+  /** Per-host data sources and the expression map derived from them, updated together. */
+  case class HostState(dataSources: DataSources, dataExprMap: Map[String, List[DataSource]])
 
   sealed trait Backend {
 

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/TimeGrouped.scala
@@ -145,7 +145,7 @@ private[stream] class TimeGrouped(
         val aggregateMapForExpWithinLimits = aggrMap.asScala
           .filter {
             case (expr, aggr) if aggr.limitExceeded =>
-              context.logDatapointsExceeded(ts, expr.toString)
+              context.logDatapointsExceeded(host, ts, expr.toString)
               false
             case _ =>
               true

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/LwcToAggrDatapointSuite.scala
@@ -74,6 +74,7 @@ class LwcToAggrDatapointSuite extends FunSuite {
   )
 
   context.setDataSources(
+    "_",
     DataSources.of(
       new DataSource("abc", java.time.Duration.ofMinutes(1), "/api/v1/graph?q=name,cpu,:eq,:avg")
     )
@@ -84,7 +85,7 @@ class LwcToAggrDatapointSuite extends FunSuite {
       .map(ByteString.apply)
       .map(LwcMessages.parse)
       .map(msg => List(msg))
-      .via(new LwcToAggrDatapoint(context))
+      .via(new LwcToAggrDatapoint(context, "_"))
       .flatMapConcat { t =>
         t.messages.foreach(m => logMessages.add(m))
         Source(t.data)

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/StreamContextSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/StreamContextSuite.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.eval.stream
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model.Uri
+import org.apache.pekko.stream.Materializer
+import com.netflix.atlas.eval.stream.Evaluator.DataSource
+import com.netflix.atlas.eval.stream.Evaluator.DataSources
+import com.netflix.atlas.json3.JsonSupport
+import com.netflix.atlas.pekko.DiagnosticMessage
+import com.typesafe.config.ConfigFactory
+import munit.FunSuite
+
+import scala.collection.mutable
+
+class StreamContextSuite extends FunSuite {
+
+  private implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)
+  private implicit val materializer: Materializer = Materializer(system)
+
+  private def newContext: StreamContext =
+    new StreamContext(ConfigFactory.load(), materializer, dsLogger = DataSourceLogger.Noop)
+
+  // A log-events data source (the "logs.prod" host in the incident) and a time-series data
+  // source on a different host (the "atlas" metrics hosts).
+  private val eventsUri = "http://logs/api/v1/events?q=name,foo,:eq,(,message,),:table"
+  private val eventsDs = new DataSource("logs", java.time.Duration.ofMinutes(1), eventsUri)
+  private val metricsUri = "http://atlas/api/v1/graph?q=name,cpu,:eq,:sum"
+  private val metricsDs = new DataSource("metrics", java.time.Duration.ofMinutes(1), metricsUri)
+
+  private val msg = DiagnosticMessage.info("test")
+
+  test("messagesForDataSource finds an expression from the active data sources") {
+    val context = newContext
+    context.setDataSources("logs", DataSources.of(eventsDs))
+    val expr = context.interpreter.dataExprs(Uri(eventsUri)).head
+    assertEquals(context.messagesForDataSource("logs", expr, msg).map(_.id), List("logs"))
+  }
+
+  // createStreamsFlow groups data sources by host and runs a per-host processor over a single
+  // shared StreamContext, so each host substream calls setDataSources with only its host's data
+  // sources. State must be partitioned by host so a second host does not clobber the first and
+  // silently drop messages for the clobbered host.
+  test("data sources for one host survive setDataSources for another host") {
+    val context = newContext
+    val eventExpr = context.interpreter.dataExprs(Uri(eventsUri)).head
+
+    // Host A substream registers the events data source.
+    context.setDataSources("logs", DataSources.of(eventsDs))
+    assertEquals(context.messagesForDataSource("logs", eventExpr, msg).map(_.id), List("logs"))
+
+    // Host B substream registers its own time-series data source on a different host.
+    context.setDataSources("atlas", DataSources.of(metricsDs))
+
+    // The events data source must still be resolvable on its host.
+    assertEquals(context.messagesForDataSource("logs", eventExpr, msg).map(_.id), List("logs"))
+  }
+
+  // Two hosts with the identical expression string must not cross-deliver: an event produced on
+  // one host should only reach that host's data source.
+  test("messagesForDataSource is scoped to the host that produced the data") {
+    val context = newContext
+    val sharedUri = "http://logs/api/v1/events?q=name,foo,:eq,(,message,),:table"
+    val expr = context.interpreter.dataExprs(Uri(sharedUri)).head
+    val dsA = new DataSource("a", java.time.Duration.ofMinutes(1), sharedUri)
+    val dsB = new DataSource("b", java.time.Duration.ofMinutes(1), sharedUri)
+
+    context.setDataSources("hostA", DataSources.of(dsA))
+    context.setDataSources("hostB", DataSources.of(dsB))
+
+    // An event produced on hostA is delivered only to hostA's data source, not hostB's.
+    assertEquals(context.messagesForDataSource("hostA", expr, msg).map(_.id), List("a"))
+    assertEquals(context.messagesForDataSource("hostB", expr, msg).map(_.id), List("b"))
+  }
+
+  // An expression with no data source on the requested host is dropped (and counted), even if
+  // another host has it.
+  test("messagesForDataSource drops when the host has no matching data source") {
+    val context = newContext
+    val eventExpr = context.interpreter.dataExprs(Uri(eventsUri)).head
+    context.setDataSources("logs", DataSources.of(eventsDs))
+    assertEquals(context.messagesForDataSource("atlas", eventExpr, msg), Nil)
+    assertEquals(context.messagesForDataSource("unknown-host", eventExpr, msg), Nil)
+  }
+
+  // logDatapointsExceeded on the streaming path (which has the host) must notify only the host
+  // that exceeded the limit, not another host that happens to use the same expression. The
+  // host-agnostic overload notifies all hosts (used by the combined datapoint processor).
+  test("logDatapointsExceeded is scoped to the host, with a union overload") {
+    val logged = mutable.ListBuffer.empty[String]
+    val capturing = new DataSourceLogger {
+      override def apply(ds: DataSource, msg: JsonSupport): Unit = logged += ds.id()
+      override def close(): Unit = ()
+    }
+    val context = new StreamContext(ConfigFactory.load(), materializer, dsLogger = capturing)
+    val sharedUri = "http://logs/api/v1/events?q=name,foo,:eq,(,message,),:table"
+    val expr = context.interpreter.dataExprs(Uri(sharedUri)).head
+    context.setDataSources(
+      "hostA",
+      DataSources.of(new DataSource("a", java.time.Duration.ofMinutes(1), sharedUri))
+    )
+    context.setDataSources(
+      "hostB",
+      DataSources.of(new DataSource("b", java.time.Duration.ofMinutes(1), sharedUri))
+    )
+
+    context.logDatapointsExceeded("hostA", 0L, expr)
+    assertEquals(logged.toList, List("a"))
+
+    logged.clear()
+    context.logDatapointsExceeded(0L, expr)
+    assertEquals(logged.toList.sorted, List("a", "b"))
+  }
+}


### PR DESCRIPTION
createStreamsFlow groups data sources by host and runs a per-host processor over a shared StreamContext, but the data-source state was global: each host substream overwrote it, so events were only deliverable to whichever host wrote last. On a multi-host node (e.g. metrics hosts plus a log-events host) this silently dropped the log-events stream while time-series was unaffected.

Track data sources and their derived expression map per host in a single holder updated atomically, and scope messagesForDataSource and the datapoint limit diagnostics to the host that produced the data so an expression shared across backends is not cross-delivered.