### PR TITLE
core: add :approx-distinct operator

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -30,6 +30,7 @@ import com.netflix.atlas.core.util.Hash
 import com.netflix.atlas.core.util.Math
 import com.netflix.atlas.core.util.Strings
 import com.netflix.spectator.api.histogram.PercentileBuckets
+import com.netflix.spectator.api.patterns.DistinctCountSketch
 
 import scala.collection.immutable.ArraySeq
 
@@ -1020,6 +1021,148 @@ object MathExpr {
             val tags = data.head.tags + (TagKey.percentile -> p)
             TimeSeries(tags, f"percentile($baseLabel, $p)", seq)
         }
+      }
+    }
+  }
+
+  /**
+    * Estimate the number of distinct values recorded into a distinct count sketch. The data
+    * must have been published as a set of per-register max-gauges tagged with
+    * `statistic=distinct` and a `distinct=R##` register id, for example via the
+    * `DistinctCountSketch` helper in spectator. Each register holds the max rho seen for that
+    * register and merges across sources by taking the max, so the input is grouped on the
+    * `distinct` register key with a `:max` aggregate. The registers are then collapsed to a
+    * single cardinality estimate using the same HyperLogLog estimator as the client.
+    *
+    * The estimate is computed independently for each interval. Any surviving group by keys
+    * (everything other than `distinct`) are preserved on the output.
+    *
+    * @param expr
+    *     Grouped data expression that includes the `distinct` register key. The registers are
+    *     always aggregated with `:max`, the native HLL merge.
+    */
+  case class ApproxDistinct(expr: DataExpr.GroupBy) extends TimeSeriesExpr {
+
+    require(
+      expr.keys.contains(TagKey.distinct),
+      s"key list for group by must contain '${TagKey.distinct}'"
+    )
+
+    private val evalGroupKeys = expr.keys.filter(_ != TagKey.distinct)
+
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      // Base expr
+      if (evalGroupKeys.nonEmpty)
+        Interpreter.append(builder, expr.af.query, evalGroupKeys, Interpreter.WordToken(":by"))
+      else
+        Interpreter.append(builder, expr.af.query)
+
+      builder.append(",:approx-distinct")
+
+      // Offset
+      if (!expr.offset.isZero)
+        builder.append(',').append(Strings.toString(expr.offset)).append(",:offset")
+    }
+
+    override def dataExprs: List[DataExpr] = List(expr)
+
+    override def isGrouped: Boolean = evalGroupKeys.nonEmpty
+
+    override def groupByKey(tags: Map[String, String]): Option[String] = {
+      // Option(...) rather than Some(...): keyString returns null when a group key is missing
+      // from the tags, matching DataExpr.GroupBy.groupByKey and the other grouped expressions.
+      if (evalGroupKeys.isEmpty) None else Option(DataExpr.keyString(evalGroupKeys, tags))
+    }
+
+    def finalGrouping: List[String] = evalGroupKeys
+
+    override def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
+      val inner = expr.eval(context, data)
+      if (inner.data.isEmpty) {
+        inner
+      } else if (evalGroupKeys.isEmpty) {
+        val label = s"approx-distinct(${expr.af.query.labelString})"
+        ResultSet(this, estimateDistinct(context, label, inner.data), context.state)
+      } else {
+        val groups = inner.data.groupBy(_.tags - TagKey.distinct)
+        val rs = groups.values.toList.flatMap { ts =>
+          if (ts.isEmpty) ts
+          else {
+            val tags = ts.head.tags - TagKey.distinct
+            // Grouped output is one line per group, so the group key string is the natural
+            // label, matching a normal grouped aggregate.
+            val label = DataExpr.keyString(evalGroupKeys, tags)
+            estimateDistinct(context, label, ts)
+          }
+        }
+        ResultSet(this, rs, context.state)
+      }
+    }
+
+    private def estimateDistinct(
+      context: EvalContext,
+      label: String,
+      data: List[TimeSeries]
+    ): List[TimeSeries] = {
+
+      // As with percentiles, a "no data" placeholder series without the register tag can be
+      // present. Filter them out so the estimate can still be computed from the real data.
+      val filtered = data.filter(_.tags.contains(TagKey.distinct))
+      if (filtered.isEmpty) {
+        List(TimeSeries.noData(context.step))
+      } else {
+        val length = ((context.end - context.start) / context.step).toInt
+        val m = DistinctCountSketch.REGISTERS
+
+        // Output sequence for the collapsed cardinality estimate
+        val buf = ArrayHelper.fill(length, Double.NaN)
+        val output = new ArrayTimeSeq(DsType.Gauge, context.start, context.step, buf)
+
+        // Map each input series to its register index. The value stored in a register is the
+        // max rho; missing or NaN registers are treated as unset (0), matching the client. Only
+        // in-range registers are kept so the per-interval loop below needs no bounds check; an
+        // out-of-range id (e.g. from a client/backend register-count mismatch) is dropped.
+        val byRegister = filtered
+          .groupBy(t => Integer.parseInt(t.tags(TagKey.distinct).substring(1), 16))
+          .filter { case (idx, _) => idx >= 0 && idx < m }
+        val usedRegisters = byRegister.keys.toArray
+        java.util.Arrays.sort(usedRegisters)
+
+        val bounded = new Array[ArrayTimeSeq](usedRegisters.length)
+        var i = 0
+        while (i < usedRegisters.length) {
+          val vs = byRegister(usedRegisters(i))
+          require(
+            vs.lengthCompare(1) == 0,
+            s"invalid distinct encoding: [${vs.map(_.tags(TagKey.distinct)).mkString(",")}]"
+          )
+          bounded(i) = vs.head.data.bounded(context.start, context.end)
+          i += 1
+        }
+
+        // Register array reused across intervals. Used registers are (re)assigned each interval
+        // so the reset is folded into the assignment; registers with no series stay 0. If no
+        // register has data for an interval the sketch is absent, so the estimate is left as NaN
+        // (no data) rather than reporting a spurious 0 distinct values.
+        val registers = new Array[Double](m)
+        i = 0
+        while (i < length) {
+          var anySet = false
+          var j = 0
+          while (j < usedRegisters.length) {
+            val v = bounded(j).data(i)
+            val rho = if (v.isFinite && v > 0.0) v else 0.0
+            registers(usedRegisters(j)) = rho
+            if (rho > 0.0) anySet = true
+            j += 1
+          }
+          if (anySet)
+            output.data(i) = DistinctCountSketch.cardinality(registers)
+          i += 1
+        }
+
+        val tags = data.head.tags - TagKey.distinct
+        List(TimeSeries(tags, label, output))
       }
     }
   }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -80,6 +80,7 @@ object MathVocabulary extends Vocabulary {
     Min,
     Max,
     Percentiles,
+    ApproxDistinct,
     SampleCount,
     TypedMacro(
       "sample-count",
@@ -1308,6 +1309,62 @@ object MathVocabulary extends Vocabulary {
 
     override def examples: List[String] = List(
       "name,requestLatency,:eq,(,25,50,90,)"
+    )
+  }
+
+  case object ApproxDistinct extends SimpleWord {
+
+    override def name: String = "approx-distinct"
+
+    protected def matcher: PartialFunction[List[Any], Boolean] = {
+      case DataExprType(expr) :: _ =>
+        expr match {
+          case _: DataExpr.All => false
+          case _               => true
+        }
+    }
+
+    protected def executor: PartialFunction[List[Any], List[Any]] = {
+      case DataExprType(t) :: stack =>
+        // Registers merge across sources by taking the max, so force a max aggregate and
+        // group by the register key regardless of the aggregate the user specified.
+        val expr = t match {
+          case af: AggregateFunction => DataExpr.GroupBy(toMax(af), List(TagKey.distinct))
+          case by: DataExpr.GroupBy  => DataExpr.GroupBy(toMax(by.af), TagKey.distinct :: by.keys)
+          case _ =>
+            throw new IllegalArgumentException(":approx-distinct cannot be used with :all")
+        }
+        MathExpr.ApproxDistinct(expr) :: stack
+    }
+
+    // Not yet stable: the distinct count sketch statistic still needs cross-team sign-off, so
+    // gate the operator behind the unstable features flag until the API is finalized.
+    override def isStable: Boolean = false
+
+    private def toMax(af: AggregateFunction): DataExpr.Max = {
+      DataExpr.Max(af.query, offset = af.offset)
+    }
+
+    override def summary: String =
+      """
+        |Estimate the number of distinct values recorded into a distinct count sketch. The data
+        |must have been published appropriately to allow the approximation, as a set of
+        |per-register max-gauges tagged with `statistic=distinct` and a `distinct=R##` register
+        |id. If using [spectator](http://netflix.github.io/spectator/en/latest/), then see the
+        |`DistinctCountSketch` helper class.
+        |
+        |The registers are merged across all matching sources (by taking the max per register)
+        |and then collapsed to a single cardinality estimate using the same HyperLogLog estimator
+        |as the client. The result is an estimate, not an exact count, with a relative standard
+        |error of roughly 13%. Add `(,key,),:by` before the operator to break the estimate out by
+        |another dimension.
+      """.stripMargin.trim
+
+    override def signature: String = "DataExpr -- Expr"
+
+    override def examples: List[String] = List(
+      "name,server.uniqueUsers,:eq",
+      "name,server.uniqueUsers,:eq,(,nf.region,),:by"
     )
   }
 

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/TagKey.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/TagKey.scala
@@ -90,6 +90,9 @@ object TagKey {
   /** Used to store the bucket id for percentile approximation. */
   final val percentile = "percentile"
 
+  /** Used to store the register id for a distinct count sketch approximation. */
+  final val distinct = "distinct"
+
   /**
     * Returns true if the name uses a restricted prefix that is managed by the system. These
     * tag keys should not be set or used directly by users

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ApproxDistinctSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ApproxDistinctSuite.scala
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import java.util.stream.Collectors
+import com.netflix.atlas.core.stacklang.Interpreter
+import com.netflix.atlas.core.util.Features
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.Gauge
+import com.netflix.spectator.api.patterns.DistinctCountSketch
+import munit.FunSuite
+
+class ApproxDistinctSuite extends FunSuite {
+
+  private val interpreter = Interpreter(MathVocabulary.allWords)
+
+  private val start = 0L
+  private val step = 60000L
+  private val context = EvalContext(start, start + step * 2, step)
+
+  private val registers = DistinctCountSketch.REGISTERS
+
+  // Build a register series for register `idx` (encoded as the R## tag) with a constant value
+  // across the eval window. Extra tags allow testing group by.
+  private def ts(
+    idx: Int,
+    value: Double,
+    extraTags: Map[String, String] = Map.empty
+  ): TimeSeries = {
+    val seq = new ArrayTimeSeq(DsType.Gauge, start, step, Array(value, value))
+    val tags = Map("name" -> "test", "statistic" -> "distinct", "distinct" -> f"R$idx%02X")
+    TimeSeries(tags ++ extraTags, seq)
+  }
+
+  private def parseExpr(str: String): TimeSeriesExpr = {
+    // :approx-distinct is not yet a stable word, so enable unstable features.
+    interpreter.execute(str, Map.empty[String, Any], Features.UNSTABLE).stack match {
+      case (v: TimeSeriesExpr) :: _ => v
+      case _                        => throw new IllegalArgumentException("invalid expr")
+    }
+  }
+
+  private def eval(str: String, input: List[TimeSeries]): List[TimeSeries] = {
+    val expr = parseExpr(str)
+    // Verify we can reparse the string representation and get an identical expression.
+    val e2 = parseExpr(expr.toString)
+    val e3 = parseExpr(e2.toString)
+    assertEquals(e2, e3)
+    expr.eval(context, input).data
+  }
+
+  // Record the given distinct values into a real sketch and return the published register
+  // series along with the client side cardinality estimate for the same registers.
+  private def sketchInput(
+    values: Iterable[Long],
+    extraTags: Map[String, String] = Map.empty
+  ): (List[TimeSeries], Double) = {
+    import scala.jdk.CollectionConverters.*
+    val r = new DefaultRegistry()
+    val sketch = DistinctCountSketch.get(r, r.createId("test"))
+    values.foreach(v => sketch.record(v))
+    val gauges = r.gauges.collect(Collectors.toList[Gauge]).asScala.toList
+    val input = gauges.map { g =>
+      val v = g.value()
+      val seq = new ArrayTimeSeq(DsType.Gauge, start, step, Array(v, v))
+      val tags = g.id.tags.asScala.map(t => t.key -> t.value).toMap + ("name" -> g.id.name)
+      TimeSeries(tags ++ extraTags, seq)
+    }
+    (input, sketch.cardinality())
+  }
+
+  test("estimate matches client for a single interval") {
+    val (input, expected) = sketchInput(0L until 1000L)
+    val data = eval("name,test,:eq,:approx-distinct", input)
+
+    assertEquals(data.size, 1)
+    val t = data.head
+    assertEquals(t.label, "approx-distinct(name=test)")
+    // Backend must produce exactly the same estimate as the client for the merged registers.
+    assertEqualsDouble(t.data(0L), expected, 1e-9)
+    assertEqualsDouble(t.data(step), expected, 1e-9)
+    // Sanity check the estimate is within a few sigma of the true cardinality (sigma ~13%).
+    assertEqualsDouble(t.data(0L), 1000.0, 400.0)
+  }
+
+  test("estimate merges registers across sources") {
+    // Two sources covering disjoint value ranges. Merging registers (max per register) and
+    // estimating should approximate the union (2000 distinct), not either half alone.
+    val (a, _) = sketchInput(0L until 1000L)
+    val (b, _) = sketchInput(1000L until 2000L)
+    val data = eval("name,test,:eq,:approx-distinct", a ::: b)
+
+    assertEquals(data.size, 1)
+    assertEqualsDouble(data.head.data(0L), 2000.0, 800.0)
+  }
+
+  test("group by another dimension") {
+    val (a, ea) = sketchInput(0L until 1000L, Map("region" -> "us-east-1"))
+    val (b, eb) = sketchInput(0L until 100L, Map("region" -> "us-west-2"))
+    val data = eval("name,test,:eq,(,region,),:by,:approx-distinct", a ::: b)
+
+    assertEquals(data.size, 2)
+    val byRegion = data.map(t => t.tags("region") -> t).toMap
+    assertEquals(byRegion.keySet, Set("us-east-1", "us-west-2"))
+    assert(!byRegion("us-east-1").tags.contains("distinct"))
+    assertEqualsDouble(byRegion("us-east-1").data(0L), ea, 1e-9)
+    assertEqualsDouble(byRegion("us-west-2").data(0L), eb, 1e-9)
+    assertEquals(byRegion("us-east-1").label, "(region=us-east-1)")
+  }
+
+  test("all-unset registers are no data (NaN), not zero") {
+    // A real published register always has rho >= 1, so an interval where every register is 0
+    // means the sketch was absent for that interval. It must read as no data (NaN), not a
+    // spurious 0 distinct values, matching how :percentiles and the aggregates report gaps.
+    val input = (0 until registers).map(i => ts(i, 0.0)).toList
+    val data = eval("name,test,:eq,:approx-distinct", input)
+    assertEquals(data.size, 1)
+    assert(data.head.data(0L).isNaN)
+  }
+
+  test("no-data interval reads as NaN when other intervals have data") {
+    // Register set in interval 0, all NaN in interval 1 (source stopped publishing).
+    val seq = new ArrayTimeSeq(DsType.Gauge, start, step, Array(5.0, Double.NaN))
+    val tags = Map("name" -> "test", "statistic" -> "distinct", "distinct" -> "R03")
+    val data = eval("name,test,:eq,:approx-distinct", List(TimeSeries(tags, seq)))
+    assertEquals(data.size, 1)
+    assert(data.head.data(0L) > 0.0)
+    assert(data.head.data(step).isNaN)
+  }
+
+  test("no matching data") {
+    val data = eval("name,test,:eq,:approx-distinct", Nil)
+    assertEquals(data.size, 0)
+  }
+
+  test("NaN register values treated as unset") {
+    // A single register set to a large rho, the rest NaN. Should match feeding the same
+    // registers (with NaN as 0) to the client estimator.
+    val rhoArray = new Array[Double](registers)
+    rhoArray(3) = 5.0
+    val expected = DistinctCountSketch.cardinality(rhoArray)
+
+    val input = ts(3, 5.0) :: (0 until registers)
+      .filter(_ != 3)
+      .map(i => ts(i, Double.NaN))
+      .toList
+    val data = eval("name,test,:eq,:approx-distinct", input)
+    assertEqualsDouble(data.head.data(0L), expected, 1e-9)
+  }
+
+  test("bad data with duplicate register") {
+    val e = intercept[IllegalArgumentException] {
+      // R0A and R0a decode to the same register index (10).
+      val bad = List(
+        TimeSeries(
+          Map("name" -> "test", "statistic" -> "distinct", "distinct" -> "R0A"),
+          new ArrayTimeSeq(DsType.Gauge, start, step, Array(1.0, 1.0))
+        ),
+        TimeSeries(
+          Map("name" -> "test", "statistic" -> "distinct", "distinct" -> "R0a"),
+          new ArrayTimeSeq(DsType.Gauge, start, step, Array(1.0, 1.0))
+        )
+      )
+      eval("name,test,:eq,:approx-distinct", bad)
+    }
+    assertEquals(e.getMessage, "requirement failed: invalid distinct encoding: [R0A,R0a]")
+  }
+
+  test("round trip toString") {
+    assertEquals(
+      parseExpr("name,test,:eq,:approx-distinct").toString,
+      "name,test,:eq,:approx-distinct"
+    )
+    assertEquals(
+      parseExpr("name,test,:eq,(,region,),:by,:approx-distinct").toString,
+      "name,test,:eq,(,region,),:by,:approx-distinct"
+    )
+  }
+
+  test("forces max aggregate regardless of input aggregate") {
+    // Even if the user writes :sum, the registers must be merged with :max.
+    val expr = parseExpr("name,test,:eq,:sum,:approx-distinct")
+    expr match {
+      case MathExpr.ApproxDistinct(gb) =>
+        assert(gb.af.isInstanceOf[DataExpr.Max])
+        assert(gb.keys.contains(TagKey.distinct))
+      case _ => fail("expected ApproxDistinct")
+    }
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
@@ -34,7 +34,7 @@ class ModelExtractorsSuite extends FunSuite {
 
   completionTest("name", 7)
   completionTest("name,sps", 25)
-  completionTest("name,sps,:eq", 56)
-  completionTest("name,sps,:eq,app,foo,:eq", 80)
+  completionTest("name,sps,:eq", 57)
+  completionTest("name,sps,:eq,app,foo,:eq", 81)
   completionTest("name,sps,:eq,app,foo,:eq,:and,(,asg,)", 15)
 }


### PR DESCRIPTION
Estimate distinct counts from a HyperLogLog sketch published as per-register max-gauges (statistic=distinct, distinct=R##), mirroring the :percentiles operator. Registers are merged with :max across sources and time and collapsed to a single cardinality estimate per interval using the same estimator as the spectator DistinctCountSketch client. Intervals with no register data read as NaN. Marked unstable pending sign-off.