### PR TITLE
core: add :cumulative-max operator

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineAlgorithm.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineAlgorithm.scala
@@ -50,20 +50,21 @@ object OnlineAlgorithm {
     */
   def apply(state: AlgoState): OnlineAlgorithm = {
     state.algorithm match {
-      case "delay"         => OnlineDelay(state)
-      case "derivative"    => OnlineDerivative(state)
-      case "des"           => OnlineDes(state)
-      case "ignore"        => OnlineIgnoreN(state)
-      case "integral"      => OnlineIntegral(state)
-      case "pipeline"      => Pipeline(state)
-      case "rolling-count" => OnlineRollingCount(state)
-      case "rolling-sum"   => OnlineRollingSum(state)
-      case "rolling-max"   => OnlineRollingMax(state)
-      case "rolling-mean"  => OnlineRollingMean(state)
-      case "rolling-min"   => OnlineRollingMin(state)
-      case "sliding-des"   => OnlineSlidingDes(state)
-      case "trend"         => OnlineTrend(state)
-      case t               => throw new IllegalArgumentException(s"unknown type: '$t'")
+      case "cumulative-max" => OnlineCumulativeMax(state)
+      case "delay"          => OnlineDelay(state)
+      case "derivative"     => OnlineDerivative(state)
+      case "des"            => OnlineDes(state)
+      case "ignore"         => OnlineIgnoreN(state)
+      case "integral"       => OnlineIntegral(state)
+      case "pipeline"       => Pipeline(state)
+      case "rolling-count"  => OnlineRollingCount(state)
+      case "rolling-sum"    => OnlineRollingSum(state)
+      case "rolling-max"    => OnlineRollingMax(state)
+      case "rolling-mean"   => OnlineRollingMean(state)
+      case "rolling-min"    => OnlineRollingMin(state)
+      case "sliding-des"    => OnlineSlidingDes(state)
+      case "trend"          => OnlineTrend(state)
+      case t                => throw new IllegalArgumentException(s"unknown type: '$t'")
     }
   }
 }

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineCumulativeMax.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/algorithm/OnlineCumulativeMax.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+import com.netflix.atlas.core.util.Math
+
+/**
+  * Compute the maximum value across the evaluation context. Each datapoint for the output
+  * line represents the maximum value seen on the input line from the start of the graph up
+  * to and including the time for that datapoint. This is the max analogue of
+  * [[OnlineIntegral]]. Missing values, `NaN`, are ignored and leave the running max
+  * unchanged.
+  */
+case class OnlineCumulativeMax(private var value: Double) extends OnlineAlgorithm {
+
+  override def next(v: Double): Double = {
+    value = Math.maxNaN(value, v)
+    value
+  }
+
+  override def reset(): Unit = {
+    value = Double.NaN
+  }
+
+  override def isEmpty: Boolean = false
+
+  override def state: AlgoState = {
+    AlgoState("cumulative-max", "value" -> value)
+  }
+}
+
+object OnlineCumulativeMax {
+
+  def apply(state: AlgoState): OnlineCumulativeMax = {
+    apply(state.getDouble("value"))
+  }
+}

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulExpr.scala
@@ -27,6 +27,7 @@ import com.netflix.atlas.core.algorithm.Pipeline
 import com.netflix.atlas.core.algorithm.AlgoState
 import com.netflix.atlas.core.algorithm.OnlineDerivative
 import com.netflix.atlas.core.algorithm.OnlineIntegral
+import com.netflix.atlas.core.algorithm.OnlineCumulativeMax
 import com.netflix.atlas.core.algorithm.OnlineRollingCount
 import com.netflix.atlas.core.algorithm.OnlineRollingMean
 import com.netflix.atlas.core.algorithm.OnlineRollingSum
@@ -69,6 +70,26 @@ object StatefulExpr {
 
     override protected def newAlgorithmInstance(context: EvalContext): OnlineAlgorithm = {
       OnlineIntegral(Double.NaN)
+    }
+
+    override def append(builder: java.lang.StringBuilder): Unit = {
+      Interpreter.append(builder, expr, Interpreter.WordToken(s":$name"))
+    }
+  }
+
+  /**
+    * Compute the maximum value across the evaluation context. Each datapoint for the output
+    * line represents the maximum value seen on the input line from the start of the graph up
+    * to the time for that datapoint. This is the max analogue of `:integral`: a running max
+    * from the window start rather than a sliding window like `:rolling-max`. Missing values,
+    * `NaN`, are ignored and leave the running max unchanged.
+    */
+  case class CumulativeMax(expr: TimeSeriesExpr) extends OnlineExpr {
+
+    override protected def name: String = "cumulative-max"
+
+    override protected def newAlgorithmInstance(context: EvalContext): OnlineAlgorithm = {
+      OnlineCumulativeMax(Double.NaN)
     }
 
     override def append(builder: java.lang.StringBuilder): Unit = {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
@@ -47,6 +47,7 @@ object StatefulVocabulary extends Vocabulary {
     SlidingDes,
     Trend,
     Integral,
+    CumulativeMax,
     Derivative,
     desTypedMacro("des-simple", List("10", "0.1", "0.5", ":des")),
     desTypedMacro("des-fast", List("10", "0.1", "0.02", ":des")),
@@ -561,6 +562,43 @@ object StatefulVocabulary extends Vocabulary {
       """.stripMargin.trim
 
     override def examples: List[String] = List("1", "name,requestsPerSecond,:eq,:sum,:per-step")
+  }
+
+  case object CumulativeMax extends TypedWord with StylePassthrough {
+
+    override def name: String = "cumulative-max"
+
+    override def parameters: IndexedSeq[Parameter] = ArraySeq(
+      Parameter("", "input time series", TimeSeriesExprType)
+    )
+
+    override def outputs: IndexedSeq[DataType] = ArraySeq(TimeSeriesExprType)
+
+    override def execute(context: Context, params: IndexedSeq[Any]): Context = {
+      val t = params(0).asInstanceOf[TimeSeriesExpr]
+      context.copy(stack = StatefulExpr.CumulativeMax(t) :: context.stack)
+    }
+
+    override def summary: String =
+      """
+        |Compute the maximum value across the evaluation context. Each datapoint for the output
+        |line represents the maximum value seen on the input line from the start of the graph up
+        |to the time for that datapoint. This is the max analogue of
+        |[:integral](stateful-integral): a running max from the window start rather than a sliding
+        |window like [:rolling-max](stateful-rolling‐max). Missing values, `NaN`, are ignored and
+        |leave the running max unchanged. For example:
+        |
+        || Input | :cumulative-max |
+        ||-------|-----------------|
+        || 1     | 1               |
+        || 2     | 2               |
+        || 0     | 2               |
+        || NaN   | 2               |
+        || 5     | 5               |
+        || 3     | 5               |
+      """.stripMargin.trim
+
+    override def examples: List[String] = List("1", "name,activeUsers,:eq,:sum")
   }
 
   case object Derivative extends TypedWord with StylePassthrough {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineCumulativeMaxSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/algorithm/OnlineCumulativeMaxSuite.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.algorithm
+
+class OnlineCumulativeMaxSuite extends BaseOnlineAlgorithmSuite {
+
+  override def newInstance: OnlineAlgorithm = OnlineCumulativeMax(Double.NaN)
+
+  test("init") {
+    val algo = OnlineCumulativeMax(Double.NaN)
+    assertEquals(algo.next(1.0), 1.0)
+    assertEquals(algo.next(1.0), 1.0)
+  }
+
+  test("increase") {
+    val algo = OnlineCumulativeMax(Double.NaN)
+    assertEquals(algo.next(1.0), 1.0)
+    assertEquals(algo.next(2.0), 2.0)
+    assertEquals(algo.next(3.0), 3.0)
+    assertEquals(algo.next(7.0), 7.0)
+  }
+
+  test("decrease keeps the running max") {
+    val algo = OnlineCumulativeMax(Double.NaN)
+    assertEquals(algo.next(10.0), 10.0)
+    assertEquals(algo.next(9.0), 10.0)
+    assertEquals(algo.next(8.0), 10.0)
+    assertEquals(algo.next(4.0), 10.0)
+  }
+
+  test("mixed") {
+    val algo = OnlineCumulativeMax(Double.NaN)
+    assertEquals(algo.next(1.0), 1.0)
+    assertEquals(algo.next(3.0), 3.0)
+    assertEquals(algo.next(2.0), 3.0)
+    assertEquals(algo.next(5.0), 5.0)
+    assertEquals(algo.next(0.0), 5.0)
+  }
+
+  test("negative values") {
+    val algo = OnlineCumulativeMax(Double.NaN)
+    assertEquals(algo.next(-5.0), -5.0)
+    assertEquals(algo.next(-9.0), -5.0)
+    assertEquals(algo.next(-2.0), -2.0)
+  }
+
+  test("NaN values ignored") {
+    val algo = OnlineCumulativeMax(Double.NaN)
+    assertEquals(algo.next(1.0), 1.0)
+    assertEquals(algo.next(2.0), 2.0)
+    assertEquals(algo.next(Double.NaN), 2.0)
+    assertEquals(algo.next(1.0), 2.0)
+    assertEquals(algo.next(3.0), 3.0)
+  }
+
+  test("leading NaN") {
+    val algo = OnlineCumulativeMax(Double.NaN)
+    assert(algo.next(Double.NaN).isNaN)
+    assertEquals(algo.next(4.0), 4.0)
+    assertEquals(algo.next(2.0), 4.0)
+  }
+
+  test("infinity") {
+    val algo = OnlineCumulativeMax(Double.NaN)
+    assertEquals(algo.next(Double.NegativeInfinity), Double.NegativeInfinity)
+    assertEquals(algo.next(5.0), 5.0)
+    assertEquals(algo.next(Double.PositiveInfinity), Double.PositiveInfinity)
+    assertEquals(algo.next(1e300), Double.PositiveInfinity)
+    assertEquals(algo.next(Double.NaN), Double.PositiveInfinity)
+  }
+
+  test("reset") {
+    val algo = OnlineCumulativeMax(Double.NaN)
+    assertEquals(algo.next(5.0), 5.0)
+    assertEquals(algo.next(9.0), 9.0)
+    algo.reset()
+    assertEquals(algo.next(3.0), 3.0)
+    assertEquals(algo.next(1.0), 3.0)
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/CumulativeMaxSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/CumulativeMaxSuite.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.atlas.core.stacklang.Interpreter
+import munit.FunSuite
+
+class CumulativeMaxSuite extends FunSuite {
+
+  private val interpreter = Interpreter(StatefulVocabulary.allWords)
+
+  private val start = 0L
+  private val step = 60000L
+
+  private def ts(tags: Map[String, String], values: Double*): TimeSeries = {
+    val seq = new ArrayTimeSeq(DsType.Gauge, start, step, values.toArray)
+    TimeSeries(tags, seq)
+  }
+
+  private def ts(values: Double*): TimeSeries = ts(Map("name" -> "test"), values*)
+
+  private def eval(input: TimeSeries, n: Int): TimeSeries = {
+    val context = EvalContext(start, start + step * n, step)
+    val expr = StatefulExpr.CumulativeMax(DataExpr.Sum(Query.True))
+    expr.eval(context, List(input)).data.head
+  }
+
+  test("increasing") {
+    val input = ts(1.0, 2.0, 3.0)
+    assertEquals(eval(input, 3).data, ts(1.0, 2.0, 3.0).data)
+  }
+
+  test("decreasing keeps the running max") {
+    val input = ts(3.0, 2.0, 1.0)
+    assertEquals(eval(input, 3).data, ts(3.0, 3.0, 3.0).data)
+  }
+
+  test("mixed") {
+    val input = ts(1.0, 3.0, 2.0, 5.0, 0.0)
+    assertEquals(eval(input, 5).data, ts(1.0, 3.0, 3.0, 5.0, 5.0).data)
+  }
+
+  test("NaN values ignored") {
+    val input = ts(Double.NaN, 2.0, Double.NaN, 1.0, 5.0)
+    assertEquals(eval(input, 5).data, ts(Double.NaN, 2.0, 2.0, 2.0, 5.0).data)
+  }
+
+  test("negative values") {
+    val input = ts(-5.0, -9.0, -2.0)
+    assertEquals(eval(input, 3).data, ts(-5.0, -5.0, -2.0).data)
+  }
+
+  test("all NaN series stays NaN") {
+    val input = ts(Double.NaN, Double.NaN, Double.NaN)
+    assertEquals(eval(input, 3).data, ts(Double.NaN, Double.NaN, Double.NaN).data)
+  }
+
+  test("per series state when grouped") {
+    // Two series: running max is tracked independently per series.
+    val a = ts(Map("name" -> "test", "id" -> "a"), 1.0, 5.0, 2.0)
+    val b = ts(Map("name" -> "test", "id" -> "b"), 9.0, 3.0, 4.0)
+    val context = EvalContext(start, start + step * 3, step)
+    val expr = StatefulExpr.CumulativeMax(DataExpr.GroupBy(DataExpr.Sum(Query.True), List("id")))
+    val rs = expr.eval(context, List(a, b)).data
+    val byId = rs.map(t => t.tags("id") -> t.data).toMap
+    assertEquals(byId("a"), ts(1.0, 5.0, 5.0).data)
+    assertEquals(byId("b"), ts(9.0, 9.0, 9.0).data)
+  }
+
+  test("round trip toString") {
+    val expr = interpreter.execute("name,test,:eq,:sum,:cumulative-max").stack match {
+      case (v: TimeSeriesExpr) :: Nil => v
+      case _                          => fail("unexpected stack")
+    }
+    assertEquals(expr.toString, "name,test,:eq,:sum,:cumulative-max")
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
@@ -34,7 +34,7 @@ class ModelExtractorsSuite extends FunSuite {
 
   completionTest("name", 7)
   completionTest("name,sps", 25)
-  completionTest("name,sps,:eq", 57)
-  completionTest("name,sps,:eq,app,foo,:eq", 81)
+  completionTest("name,sps,:eq", 58)
+  completionTest("name,sps,:eq,app,foo,:eq", 82)
   completionTest("name,sps,:eq,app,foo,:eq,:and,(,asg,)", 15)
 }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
@@ -79,14 +79,16 @@ class ExprInterpreter(config: Config) {
 
   /**
     * Check that data expressions are supported. The streaming path doesn't support
-    * time shifts, filters, and integral. The filters and integral are excluded because
-    * they can be confusing as the time window for evaluation is not bounded.
+    * time shifts, filters, and cumulative operators (integral, cumulative-max). The
+    * filters and cumulative operators are excluded because they can be confusing as the
+    * time window for evaluation is not bounded.
     */
   private def validate(styleExpr: StyleExpr): Unit = {
     styleExpr.perOffset.foreach { s =>
       // Use rewrite as a helper for searching the expression for invalid operations
       s.expr.rewrite {
         case op: StatefulExpr.Integral         => invalidOperator(op); op
+        case op: StatefulExpr.CumulativeMax    => invalidOperator(op); op
         case op: FilterExpr                    => invalidOperator(op); op
         case op: DataExpr if !op.offset.isZero => invalidOperator(op); op
       }

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/EvaluatorSuite.scala
@@ -594,6 +594,10 @@ class EvaluatorSuite extends FunSuite {
     invalidOperator("integral", "name,jvm.gc.pause,:eq,:sum,:integral")
   }
 
+  test("validate: unsupported operation `:cumulative-max`") {
+    invalidOperator("cumulative-max", "name,jvm.gc.pause,:eq,:sum,:cumulative-max")
+  }
+
   test("validate: unsupported operation `:filter`") {
     invalidOperator("filter", "name,jvm.gc.pause,:eq,:sum,:stat-max,5,:gt,:filter")
   }


### PR DESCRIPTION
Running max from the start of the evaluation window, the max analogue of :integral (as opposed to the sliding :rolling-max). Each output point is the maximum value seen on the input line up to that point; NaN values are ignored. Backed by a new OnlineCumulativeMax online algorithm.

Like :integral, it is rejected for streaming evaluation since the running max over an unbounded window is not meaningful.