### PR TITLE
core: add :approx-distinct-cumulative operator

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -26,6 +26,7 @@ import com.netflix.atlas.core.stacklang.ast.IsNumber
 import com.netflix.atlas.core.stacklang.Context
 import com.netflix.atlas.core.stacklang.Interpreter
 import com.netflix.atlas.core.util.ArrayHelper
+import com.netflix.atlas.core.util.Features
 import com.netflix.atlas.core.util.Hash
 import com.netflix.atlas.core.util.Math
 import com.netflix.atlas.core.util.Strings
@@ -1030,41 +1031,54 @@ object MathExpr {
     * must have been published as a set of per-register max-gauges tagged with
     * `statistic=distinct` and a `distinct=R##` register id, for example via the
     * `DistinctCountSketch` helper in spectator. Each register holds the max rho seen for that
-    * register and merges across sources by taking the max, so the input is grouped on the
-    * `distinct` register key with a `:max` aggregate. The registers are then collapsed to a
-    * single cardinality estimate using the same HyperLogLog estimator as the client.
+    * register and merges across sources by taking the max. The estimator reshapes `expr` to
+    * group on the `distinct` register key with a `:max` aggregate (see `registerExpr`), then
+    * collapses the registers to a single cardinality estimate using the same HyperLogLog
+    * estimator as the client.
     *
     * The estimate is computed independently for each interval. Any surviving group by keys
     * (everything other than `distinct`) are preserved on the output.
     *
+    * The register grouping is derived internally, so `expr` is the input as provided (not the
+    * register-grouped form): typically an aggregate or group by, optionally wrapped (for example
+    * by [[StatefulExpr.CumulativeMax]] to max the registers across time before the estimate). It
+    * is kept as-is so the operator renders as `<expr>,:approx-distinct` and round trips.
+    *
     * @param expr
-    *     Grouped data expression that includes the `distinct` register key. The registers are
-    *     always aggregated with `:max`, the native HLL merge.
+    *     Input expression to estimate the distinct count over. Typically an aggregate or group
+    *     by, optionally wrapped (for example by `:cumulative-max`). It is kept as provided so the
+    *     operator renders as `<expr>,:approx-distinct` and round trips regardless of what
+    *     produced it; the register grouping is derived internally for evaluation.
     */
-  case class ApproxDistinct(expr: DataExpr.GroupBy) extends TimeSeriesExpr {
+  case class ApproxDistinct(expr: TimeSeriesExpr) extends TimeSeriesExpr {
+
+    // Registers merge across sources (and time) by taking the max, so the data expressions are
+    // reshaped to group by the register key with a max aggregate. The reshape is applied through
+    // any wrappers (e.g. :cumulative-max) so the running max is applied per register. This
+    // reshaped form is what gets evaluated and fetched; `expr` itself is left untouched for
+    // rendering.
+    private val registerExpr: TimeSeriesExpr = expr
+      .rewrite {
+        case gb: DataExpr.GroupBy  => DataExpr.GroupBy(toMax(gb.af), TagKey.distinct :: gb.keys)
+        case af: AggregateFunction => DataExpr.GroupBy(toMax(af), List(TagKey.distinct))
+      }
+      .asInstanceOf[TimeSeriesExpr]
 
     require(
-      expr.keys.contains(TagKey.distinct),
-      s"key list for group by must contain '${TagKey.distinct}'"
+      registerExpr.finalGrouping.contains(TagKey.distinct),
+      s"input must have an aggregate that can be grouped by '${TagKey.distinct}'"
     )
 
-    private val evalGroupKeys = expr.keys.filter(_ != TagKey.distinct)
+    private def toMax(af: AggregateFunction): DataExpr.Max =
+      DataExpr.Max(af.query, offset = af.offset)
+
+    private val evalGroupKeys = registerExpr.finalGrouping.filter(_ != TagKey.distinct)
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      // Base expr
-      if (evalGroupKeys.nonEmpty)
-        Interpreter.append(builder, expr.af.query, evalGroupKeys, Interpreter.WordToken(":by"))
-      else
-        Interpreter.append(builder, expr.af.query)
-
-      builder.append(",:approx-distinct")
-
-      // Offset
-      if (!expr.offset.isZero)
-        builder.append(',').append(Strings.toString(expr.offset)).append(",:offset")
+      Interpreter.append(builder, expr, Interpreter.WordToken(":approx-distinct"))
     }
 
-    override def dataExprs: List[DataExpr] = List(expr)
+    override val dataExprs: List[DataExpr] = registerExpr.dataExprs
 
     override def isGrouped: Boolean = evalGroupKeys.nonEmpty
 
@@ -1077,11 +1091,11 @@ object MathExpr {
     def finalGrouping: List[String] = evalGroupKeys
 
     override def eval(context: EvalContext, data: Map[DataExpr, List[TimeSeries]]): ResultSet = {
-      val inner = expr.eval(context, data)
+      val inner = registerExpr.eval(context, data)
       if (inner.data.isEmpty) {
         inner
       } else if (evalGroupKeys.isEmpty) {
-        val label = s"approx-distinct(${expr.af.query.labelString})"
+        val label = s"approx-distinct(${dataExprs.head.query.labelString})"
         ResultSet(this, estimateDistinct(context, label, inner.data), context.state)
       } else {
         val groups = inner.data.groupBy(_.tags - TagKey.distinct)
@@ -1273,7 +1287,12 @@ object MathExpr {
         super.rewrite(f)
       } else {
         val newDisplayExpr = displayExpr.rewrite(f)
-        val ctxt = context.interpreter.execute(toString(newDisplayExpr))
+        // Re-materialize the rewrite from its display string. This is reconstructing an
+        // expression that was already accepted, so it must not re-enforce the stability gate;
+        // otherwise rewrites such as normalization or `:cq` would fail for a named rewrite built
+        // from an unstable operator (e.g. :approx-distinct-cumulative).
+        val ctxt =
+          context.interpreter.execute(toString(newDisplayExpr), Map.empty, Features.UNSTABLE)
         ctxt.stack match {
           case (r: NamedRewrite) :: Nil => r
           case _ => throw new IllegalStateException(s"invalid stack for :$name")

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -1317,33 +1317,21 @@ object MathVocabulary extends Vocabulary {
     override def name: String = "approx-distinct"
 
     protected def matcher: PartialFunction[List[Any], Boolean] = {
-      case DataExprType(expr) :: _ =>
-        expr match {
-          case _: DataExpr.All => false
-          case _               => true
-        }
+      case TimeSeriesExprType(t) :: _ =>
+        t.dataExprs.nonEmpty && !t.dataExprs.exists(_.isInstanceOf[DataExpr.All])
     }
 
     protected def executor: PartialFunction[List[Any], List[Any]] = {
-      case DataExprType(t) :: stack =>
-        // Registers merge across sources by taking the max, so force a max aggregate and
-        // group by the register key regardless of the aggregate the user specified.
-        val expr = t match {
-          case af: AggregateFunction => DataExpr.GroupBy(toMax(af), List(TagKey.distinct))
-          case by: DataExpr.GroupBy  => DataExpr.GroupBy(toMax(by.af), TagKey.distinct :: by.keys)
-          case _ =>
-            throw new IllegalArgumentException(":approx-distinct cannot be used with :all")
-        }
-        MathExpr.ApproxDistinct(expr) :: stack
+      // The estimator reshapes the input to the register grouping internally (forcing a max
+      // aggregate grouped by the register key), including through wrappers such as
+      // :cumulative-max. That is how :approx-distinct-cumulative composes.
+      case TimeSeriesExprType(t) :: stack =>
+        MathExpr.ApproxDistinct(t) :: stack
     }
 
     // Not yet stable: the distinct count sketch statistic still needs cross-team sign-off, so
     // gate the operator behind the unstable features flag until the API is finalized.
     override def isStable: Boolean = false
-
-    private def toMax(af: AggregateFunction): DataExpr.Max = {
-      DataExpr.Max(af.query, offset = af.offset)
-    }
 
     override def summary: String =
       """
@@ -1360,7 +1348,7 @@ object MathVocabulary extends Vocabulary {
         |another dimension.
       """.stripMargin.trim
 
-    override def signature: String = "DataExpr -- Expr"
+    override def signature: String = "TimeSeriesExpr -- Expr"
 
     override def examples: List[String] = List(
       "name,server.uniqueUsers,:eq",

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
@@ -49,6 +49,7 @@ object StatefulVocabulary extends Vocabulary {
     Integral,
     CumulativeMax,
     Derivative,
+    approxDistinctCumulative,
     desTypedMacro("des-simple", List("10", "0.1", "0.5", ":des")),
     desTypedMacro("des-fast", List("10", "0.1", "0.02", ":des")),
     desTypedMacro("des-slower", List("10", "0.05", "0.03", ":des")),
@@ -59,6 +60,43 @@ object StatefulVocabulary extends Vocabulary {
     desTypedMacro("sdes-slow", List("10", "0.03", "0.04", ":sdes")),
     Macro("des-epic-signal", desEpicSignal, List("name,sps,:eq,:sum,10,0.1,0.5,0.2,0.2,4"))
   )
+
+  // Cumulative distinct count: max the sketch registers across time before estimating. This is
+  // a macro over the existing operators: apply :cumulative-max to the register series and then
+  // :approx-distinct to collapse them. :approx-distinct rewrites the data expression to the
+  // register grouping through the :cumulative-max wrapper, so the running max is applied per
+  // register (maxing per-interval estimates would be wrong). The estimator itself is unaware of
+  // the cumulative step. It is stateful (via :cumulative-max), hence it lives here rather than
+  // with :approx-distinct in the math vocabulary.
+  private def approxDistinctCumulative: TypedMacro = {
+    TypedMacro(
+      "approx-distinct-cumulative",
+      List(
+        ":dup",
+        ":cumulative-max",
+        ":approx-distinct",
+        "approx-distinct-cumulative",
+        ":named-rewrite"
+      ),
+      ArraySeq(Parameter("", "distinct count sketch query", TimeSeriesExprType)),
+      ArraySeq(TimeSeriesExprType),
+      """
+        |Estimate the cumulative number of distinct values recorded into a distinct count sketch
+        |from the start of the graph window up to each point in time. Unlike `:approx-distinct`,
+        |which estimates each interval independently, this maxes the sketch registers across time
+        |(via `:cumulative-max`) before estimating, giving a non-decreasing running count of the
+        |distinct values seen so far. This answers questions like "how many unique viewers have we
+        |seen so far" for a live event. Add `(,key,),:by` before the operator to break the estimate
+        |out by another dimension.
+      """.stripMargin.trim,
+      List(
+        "name,server.uniqueUsers,:eq",
+        "name,server.uniqueUsers,:eq,(,nf.region,),:by"
+      ),
+      // Unstable: it expands to :approx-distinct, which is not yet stable.
+      stable = false
+    )
+  }
 
   private def desTypedMacro(name: String, body: List[String]): TypedMacro = {
     val fullBody = (":dup" :: body) ::: List(name, ":named-rewrite")

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/TypedMacro.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/TypedMacro.scala
@@ -41,8 +41,14 @@ case class TypedMacro(
   parameters: IndexedSeq[Parameter],
   outputs: IndexedSeq[DataType],
   summary: String,
-  examples: List[String] = Nil
+  examples: List[String] = Nil,
+  stable: Boolean = true
 ) extends TypedWord {
+
+  // A macro should not present itself as stable if its expansion uses an unstable word,
+  // otherwise it would be offered in stable completions and skip the unstable diagnostic while
+  // still failing at execution time.
+  override def isStable: Boolean = stable
 
   // Pass through raw stack values without coercion — the body must see the
   // original values (e.g. a raw Query, not DataExpr.Sum(query)).

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ApproxDistinctCumulativeSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ApproxDistinctCumulativeSuite.scala
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.core.model
+
+import com.netflix.atlas.core.stacklang.Interpreter
+import com.netflix.atlas.core.util.Features
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.Gauge
+import com.netflix.spectator.api.patterns.DistinctCountSketch
+import munit.FunSuite
+
+import java.util.stream.Collectors
+
+class ApproxDistinctCumulativeSuite extends FunSuite {
+
+  private val interpreter = Interpreter(StatefulVocabulary.allWords)
+
+  private val start = 0L
+  private val step = 60000L
+
+  private def parseExpr(str: String): TimeSeriesExpr = {
+    interpreter.execute(str, Map.empty[String, Any], Features.UNSTABLE).stack match {
+      case (v: TimeSeriesExpr) :: _ => v
+      case _                        => throw new IllegalArgumentException("invalid expr")
+    }
+  }
+
+  // Record the given values into a sketch and return the published register value (max rho) by
+  // register index.
+  private def registers(values: Iterable[Long]): Map[Int, Double] = {
+    import scala.jdk.CollectionConverters.*
+    val r = new DefaultRegistry()
+    val sketch = DistinctCountSketch.get(r, r.createId("test"))
+    values.foreach(v => sketch.record(v))
+    r.gauges
+      .collect(Collectors.toList[Gauge])
+      .asScala
+      .map(g =>
+        Integer.parseInt(
+          g.id.tags.asScala.find(_.key == "distinct").get.value.substring(1),
+          16
+        ) -> g.value()
+      )
+      .toMap
+  }
+
+  // Build the 64 register series, where interval i takes its rho values from perInterval(i).
+  private def sketchSeries(perInterval: Seq[Map[Int, Double]]): List[TimeSeries] = {
+    (0 until DistinctCountSketch.REGISTERS).map { idx =>
+      val values = perInterval.map(_.getOrElse(idx, 0.0)).toArray
+      val seq = new ArrayTimeSeq(DsType.Gauge, start, step, values)
+      val tags = Map("name" -> "test", "statistic" -> "distinct", "distinct" -> f"R$idx%02X")
+      TimeSeries(tags, seq)
+    }.toList
+  }
+
+  test("expands to cumulative-max wrapping the register group by") {
+    val expr = parseExpr("name,test,:eq,:approx-distinct-cumulative")
+    // NamedRewrite display, but the eval expression is ApproxDistinct(CumulativeMax(GroupBy...)).
+    val eval = expr match {
+      case nr: MathExpr.NamedRewrite => nr.evalExpr
+      case other                     => other
+    }
+    // The estimator wraps a cumulative-max (the running max over time)...
+    eval match {
+      case MathExpr.ApproxDistinct(_: StatefulExpr.CumulativeMax) => ()
+      case other => fail(s"unexpected eval expr: $other")
+    }
+    // ...and the data it fetches is grouped by the register key with a max aggregate.
+    eval.dataExprs.head match {
+      case gb: DataExpr.GroupBy =>
+        assert(gb.af.isInstanceOf[DataExpr.Max])
+        assert(gb.keys.contains(TagKey.distinct))
+      case other => fail(s"expected register group by, got $other")
+    }
+  }
+
+  test("round trip toString") {
+    assertEquals(
+      parseExpr("name,test,:eq,:approx-distinct-cumulative").toString,
+      "name,test,:eq,:approx-distinct-cumulative"
+    )
+    // Group by is applied before the operator and round trips.
+    val grouped = parseExpr("name,test,:eq,(,region,),:by,:approx-distinct-cumulative")
+    assertEquals(parseExpr(grouped.toString), grouped)
+  }
+
+  test("group by applied after the operator") {
+    val e = parseExpr("name,test,:eq,:approx-distinct-cumulative,(,region,),:by")
+    assertEquals(e.finalGrouping, List("region"))
+    assertEquals(parseExpr(e.toString), e)
+  }
+
+  test("raw cumulative-max composition preserves the wrapper in toString") {
+    // Regression: :approx-distinct renders as <input>,:approx-distinct, so a wrapping
+    // :cumulative-max is preserved rather than dropped (which would have collapsed it to a plain
+    // :approx-distinct and silently lost the cumulative behavior on round trip).
+    val e = parseExpr("name,test,:eq,:cumulative-max,:approx-distinct")
+    assertEquals(e.toString, "name,test,:eq,:sum,:cumulative-max,:approx-distinct")
+    assertEquals(parseExpr(e.toString), e)
+  }
+
+  test("cumulative unions distinct values across time") {
+    // Two intervals covering disjoint value ranges. The cumulative estimate at the second
+    // interval should approximate the union (2000), larger than either interval alone (~1000).
+    val i0 = registers(0L until 1000L)
+    val i1 = registers(1000L until 2000L)
+    val input = sketchSeries(Seq(i0, i1))
+    val context = EvalContext(start, start + step * 2, step)
+
+    val perInterval = parseExpr("name,test,:eq,:approx-distinct").eval(context, input).data
+    val cumulative =
+      parseExpr("name,test,:eq,:approx-distinct-cumulative").eval(context, input).data
+
+    assertEquals(perInterval.size, 1)
+    assertEquals(cumulative.size, 1)
+
+    // Per-interval: each interval sees ~1000 distinct.
+    assertEqualsDouble(perInterval.head.data(0L), 1000.0, 400.0)
+    assertEqualsDouble(perInterval.head.data(step), 1000.0, 400.0)
+
+    // Cumulative: interval 0 ~1000, interval 1 ~2000 (union), and non-decreasing.
+    assertEqualsDouble(cumulative.head.data(0L), 1000.0, 400.0)
+    assertEqualsDouble(cumulative.head.data(step), 2000.0, 800.0)
+    assert(cumulative.head.data(step) >= cumulative.head.data(0L))
+    // And strictly larger than the per-interval estimate for the second interval.
+    assert(cumulative.head.data(step) > perInterval.head.data(step))
+  }
+
+  test("group by dimension") {
+    val i0 = registers(0L until 500L)
+    val i1 = registers(500L until 1000L)
+    val series = sketchSeries(Seq(i0, i1)).map { t =>
+      TimeSeries(t.tags + ("region" -> "us-east-1"), t.data)
+    }
+    val context = EvalContext(start, start + step * 2, step)
+    val data = parseExpr("name,test,:eq,(,region,),:by,:approx-distinct-cumulative")
+      .eval(context, series)
+      .data
+    assertEquals(data.size, 1)
+    assertEquals(data.head.tags.get("region"), Some("us-east-1"))
+    assert(!data.head.tags.contains("distinct"))
+    // Cumulative over the two disjoint halves approximates the full 1000.
+    assertEqualsDouble(data.head.data(step), 1000.0, 400.0)
+  }
+}

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ApproxDistinctSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ApproxDistinctSuite.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.core.model
 
+import java.time.Duration
 import java.util.stream.Collectors
 import com.netflix.atlas.core.stacklang.Interpreter
 import com.netflix.atlas.core.util.Features
@@ -180,24 +181,43 @@ class ApproxDistinctSuite extends FunSuite {
   }
 
   test("round trip toString") {
-    assertEquals(
-      parseExpr("name,test,:eq,:approx-distinct").toString,
-      "name,test,:eq,:approx-distinct"
-    )
-    assertEquals(
-      parseExpr("name,test,:eq,(,region,),:by,:approx-distinct").toString,
-      "name,test,:eq,(,region,),:by,:approx-distinct"
-    )
+    // The operator renders as <input>,:approx-distinct, so the input aggregate is shown. The
+    // important property is that it re-parses to an equal expression.
+    val e1 = parseExpr("name,test,:eq,:approx-distinct")
+    assertEquals(e1.toString, "name,test,:eq,:sum,:approx-distinct")
+    assertEquals(parseExpr(e1.toString), e1)
+
+    val e2 = parseExpr("name,test,:eq,(,region,),:by,:approx-distinct")
+    assertEquals(e2.toString, "name,test,:eq,:sum,(,region,),:by,:approx-distinct")
+    assertEquals(parseExpr(e2.toString), e2)
   }
 
   test("forces max aggregate regardless of input aggregate") {
-    // Even if the user writes :sum, the registers must be merged with :max.
+    // Even if the user writes :sum, the fetched data is grouped by the register key with :max.
     val expr = parseExpr("name,test,:eq,:sum,:approx-distinct")
-    expr match {
-      case MathExpr.ApproxDistinct(gb) =>
+    expr.dataExprs.head match {
+      case gb: DataExpr.GroupBy =>
         assert(gb.af.isInstanceOf[DataExpr.Max])
         assert(gb.keys.contains(TagKey.distinct))
-      case _ => fail("expected ApproxDistinct")
+      case other => fail(s"expected register group by, got $other")
+    }
+  }
+
+  test("offset round trips and reaches the register data expr") {
+    val e = parseExpr("name,test,:eq,:approx-distinct,1h,:offset")
+    assertEquals(parseExpr(e.toString), e)
+    assertEquals(e.dataExprs.head.offset, Duration.ofHours(1))
+  }
+
+  test("group by applied after the operator") {
+    // The input is kept as provided, so a `:by` after the operator groups the underlying
+    // aggregate and the register grouping is re-derived; the surviving group key is preserved.
+    val e = parseExpr("name,test,:eq,:approx-distinct,(,region,),:by")
+    assertEquals(e.finalGrouping, List("region"))
+    assertEquals(parseExpr(e.toString), e)
+    e.dataExprs.head match {
+      case gb: DataExpr.GroupBy => assertEquals(gb.keys, List(TagKey.distinct, "region"))
+      case other                => fail(s"expected register group by, got $other")
     }
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ExprNormalizerSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ExprNormalizerSuite.scala
@@ -16,6 +16,7 @@
 package com.netflix.atlas.core.model
 
 import com.netflix.atlas.core.stacklang.Interpreter
+import com.netflix.atlas.core.util.Features
 import com.typesafe.config.ConfigFactory
 import munit.FunSuite
 
@@ -28,7 +29,10 @@ class ExprNormalizerSuite extends FunSuite {
   private val interpreter = Interpreter(StyleVocabulary.allWords)
 
   private def normalize(expr: String): List[String] = {
-    val exprs = interpreter.execute(expr).stack.collect {
+    // Unstable features are enabled so operators that are not yet stable (such as
+    // :approx-distinct) can be normalized. Normalization must work regardless of the stability
+    // of the operators involved.
+    val exprs = interpreter.execute(expr, Map.empty[String, Any], Features.UNSTABLE).stack.collect {
       case ModelDataTypes.PresentationType(t) => t
     }
     exprs.map(normalizer.normalizeToString).reverse
@@ -124,5 +128,50 @@ class ExprNormalizerSuite extends FunSuite {
 
   test("normalize removes :line") {
     assertEquals(normalize("name,sps,:eq,:sum"), List("name,sps,:eq,:sum"))
+  }
+
+  test("approx-distinct preserves operator and normalizes query") {
+    // Renders as <input>,:approx-distinct, so the input aggregate (:sum here) is shown.
+    assertEquals(
+      normalize("name,sps,:eq,:approx-distinct"),
+      List("name,sps,:eq,:sum,:approx-distinct")
+    )
+  }
+
+  test("approx-distinct normalizes prefix key order") {
+    val expr = "nf.cluster,c,:eq,name,n,:eq,:and,:approx-distinct"
+    val expected = "name,n,:eq,nf.cluster,c,:eq,:and,:sum,:approx-distinct"
+    assertEquals(normalize(expr), List(expected))
+  }
+
+  test("approx-distinct with group by") {
+    assertEquals(
+      normalize("name,sps,:eq,(,nf.cluster,),:by,:approx-distinct"),
+      List("name,sps,:eq,:sum,(,nf.cluster,),:by,:approx-distinct")
+    )
+  }
+
+  test("approx-distinct-cumulative preserves operator and normalizes query") {
+    // Regression: normalizing rewrites the query inside the named rewrite, which re-materializes
+    // it. That must not re-enforce the stability gate for the unstable operator.
+    assertEquals(
+      normalize("name,sps,:eq,:approx-distinct-cumulative"),
+      List("name,sps,:eq,:approx-distinct-cumulative")
+    )
+  }
+
+  test("approx-distinct-cumulative normalizes prefix key order") {
+    val expr = "nf.cluster,c,:eq,name,n,:eq,:and,:approx-distinct-cumulative"
+    val expected = "name,n,:eq,nf.cluster,c,:eq,:and,:approx-distinct-cumulative"
+    assertEquals(normalize(expr), List(expected))
+  }
+
+  test("approx-distinct-cumulative with group by") {
+    // The grouped form displays the explicit :sum aggregate of the input group by; it round trips
+    // and normalizes deterministically.
+    assertEquals(
+      normalize("name,sps,:eq,(,nf.cluster,),:by,:approx-distinct-cumulative"),
+      List("name,sps,:eq,:sum,(,nf.cluster,),:by,:approx-distinct-cumulative")
+    )
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ModelExtractorsSuite.scala
@@ -34,7 +34,7 @@ class ModelExtractorsSuite extends FunSuite {
 
   completionTest("name", 7)
   completionTest("name,sps", 25)
-  completionTest("name,sps,:eq", 58)
-  completionTest("name,sps,:eq,app,foo,:eq", 82)
+  completionTest("name,sps,:eq", 59)
+  completionTest("name,sps,:eq,app,foo,:eq", 83)
   completionTest("name,sps,:eq,app,foo,:eq,:and,(,asg,)", 15)
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/NamedRewriteSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/NamedRewriteSuite.scala
@@ -17,6 +17,7 @@ package com.netflix.atlas.core.model
 
 import java.time.Duration
 import com.netflix.atlas.core.stacklang.Interpreter
+import com.netflix.atlas.core.util.Features
 import com.typesafe.config.ConfigFactory
 import munit.FunSuite
 
@@ -37,17 +38,18 @@ class NamedRewriteSuite extends FunSuite {
 
   private val interpreter = Interpreter(new CustomVocabulary(config).allWords)
 
-  private def rawEval(program: String): List[StyleExpr] = {
-    interpreter.execute(program).stack.flatMap {
+  private def rawEval(program: String, features: Features = Features.STABLE): List[StyleExpr] = {
+    interpreter.execute(program, Map.empty[String, Any], features).stack.flatMap {
       case ModelDataTypes.PresentationType(t) => t.perOffset
       case v                                  => throw new MatchError(v)
     }
   }
 
-  private def eval(program: String): List[StyleExpr] = {
+  private def eval(program: String, features: Features = Features.STABLE): List[StyleExpr] = {
     // Eval and re-encode to make sure display expression is consistent with the
     // original expression.
-    interpreter.execute(rawEval(program).mkString(",")).stack.flatMap {
+    val encoded = rawEval(program, features).mkString(",")
+    interpreter.execute(encoded, Map.empty[String, Any], features).stack.flatMap {
       case ModelDataTypes.PresentationType(t) =>
         val expanded = t.rewrite {
           case nr: MathExpr.NamedRewrite => nr.evalExpr
@@ -287,5 +289,72 @@ class NamedRewriteSuite extends FunSuite {
     val expected = rawEval(s"$q,(,a,b,),:by,:des-fast")
     assertEquals(exprs, expected)
     assertEquals(exprs2, expected)
+  }
+
+  private val U = Features.UNSTABLE
+
+  // Expand named rewrites to their eval expression without re-encoding to a string. The macro
+  // is compared against the equivalent explicit `:cumulative-max,:approx-distinct` composition;
+  // that raw composition is not compared via toString because the agnostic :approx-distinct
+  // display does not preserve the wrapping :cumulative-max (only the named rewrite does).
+  private def expand(program: String): List[StyleExpr] = {
+    rawEval(program, U).map { se =>
+      se.rewrite { case nr: MathExpr.NamedRewrite => nr.evalExpr }.asInstanceOf[StyleExpr]
+    }
+  }
+
+  test("approx-distinct-cumulative") {
+    val actual = expand("name,a,:eq,:approx-distinct-cumulative")
+    val expected = rawEval("name,a,:eq,:cumulative-max,:approx-distinct", U)
+    assertEquals(actual, expected)
+  }
+
+  test("approx-distinct-cumulative with group by") {
+    val actual = expand("name,a,:eq,(,b,),:by,:approx-distinct-cumulative")
+    val expected = rawEval("name,a,:eq,(,b,),:by,:cumulative-max,:approx-distinct", U)
+    assertEquals(actual, expected)
+  }
+
+  test("approx-distinct-cumulative with offset") {
+    val actual = expand("name,a,:eq,:approx-distinct-cumulative,1h,:offset")
+    val expected = rawEval("name,a,:eq,:cumulative-max,:approx-distinct,1h,:offset", U)
+    assertEquals(actual, expected)
+  }
+
+  test("approx-distinct-cumulative with cq") {
+    val actual = expand("name,a,:eq,:approx-distinct-cumulative,foo,bar,:eq,:cq")
+    val expected = rawEval("name,a,:eq,foo,bar,:eq,:and,:cumulative-max,:approx-distinct", U)
+    assertEquals(actual, expected)
+  }
+
+  test("approx-distinct-cumulative, display preserved in toString") {
+    val actual = rawEval("name,a,:eq,:approx-distinct-cumulative", U).mkString(",")
+    assertEquals(actual, "name,a,:eq,:approx-distinct-cumulative")
+  }
+
+  test("approx-distinct-cumulative, offset maintained after query rewrite") {
+    val exprs = rawEval("name,a,:eq,:approx-distinct-cumulative,1h,:offset", U).map { expr =>
+      expr.rewrite {
+        case q: Query => Query.And(q, Query.Equal("region", "east"))
+      }
+    }
+    val offsets = exprs
+      .collect {
+        case t: StyleExpr => t.expr.dataExprs.map(_.offset)
+      }
+      .flatten
+      .distinct
+    assertEquals(offsets, List(Duration.ofHours(1)))
+  }
+
+  test("approx-distinct-cumulative, query rewrite maintained in toString") {
+    val exprs = rawEval("name,a,:eq,:approx-distinct-cumulative", U).map { expr =>
+      expr.rewrite {
+        case q: Query => Query.And(q, Query.Equal("region", "east"))
+      }
+    }
+    val actual = exprs.mkString(",")
+    val expected = "name,a,:eq,region,east,:eq,:and,:approx-distinct-cumulative"
+    assertEquals(actual, expected)
   }
 }

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/ExprInterpreter.scala
@@ -22,6 +22,7 @@ import com.netflix.atlas.core.model.EventExpr
 import com.netflix.atlas.core.model.EventVocabulary
 import com.netflix.atlas.core.model.Expr
 import com.netflix.atlas.core.model.FilterExpr
+import com.netflix.atlas.core.model.MathExpr
 import com.netflix.atlas.core.model.ModelDataTypes
 import com.netflix.atlas.core.model.StatefulExpr
 import com.netflix.atlas.core.model.StyleExpr
@@ -85,17 +86,25 @@ class ExprInterpreter(config: Config) {
     */
   private def validate(styleExpr: StyleExpr): Unit = {
     styleExpr.perOffset.foreach { s =>
-      // Use rewrite as a helper for searching the expression for invalid operations
-      s.expr.rewrite {
-        case op: StatefulExpr.Integral         => invalidOperator(op); op
-        case op: StatefulExpr.CumulativeMax    => invalidOperator(op); op
-        case op: FilterExpr                    => invalidOperator(op); op
-        case op: DataExpr if !op.offset.isZero => invalidOperator(op); op
-      }
+      validateExpr(s.expr)
 
       // Double check all data expressions do not have an offset. In some cases for named rewrites
       // the check above may not detect the offset.
       s.expr.dataExprs.filterNot(_.offset.isZero).foreach(invalidOperator)
+    }
+  }
+
+  // Search the expression for invalid operations. For a named rewrite the evaluated form is
+  // checked rather than the display form: the display can hide operators that are actually
+  // evaluated (for example :approx-distinct-cumulative expands to a :cumulative-max), so
+  // inspecting the eval expression avoids gaps and per-operator special cases.
+  private def validateExpr(expr: Expr): Unit = {
+    expr.rewrite {
+      case nr: MathExpr.NamedRewrite         => validateExpr(nr.evalExpr); nr
+      case op: StatefulExpr.Integral         => invalidOperator(op); op
+      case op: StatefulExpr.CumulativeMax    => invalidOperator(op); op
+      case op: FilterExpr                    => invalidOperator(op); op
+      case op: DataExpr if !op.offset.isZero => invalidOperator(op); op
     }
   }
 


### PR DESCRIPTION
Cumulative distinct count over the graph window: max the sketch registers across time before estimating, giving a non-decreasing running count of the distinct values seen so far (e.g. unique viewers so far in a live event).

Implemented as a macro over existing operators, :cumulative-max followed by :approx-distinct. :approx-distinct now reshapes the data expression to the register grouping through wrappers (via rewrite), so the running max is applied per register before the estimator collapses them; the estimator stays unaware of the cumulative step.

Named rewrites are re-materialized with unstable features enabled so operations that rewrite the expression (normalization, :cq) work for rewrites built from not-yet-stable operators such as :approx-distinct-cumulative.

Streaming validation now inspects the eval expression of named rewrites so operators hidden behind a rewrite (like the :cumulative-max here) are rejected without per-operator special cases.