### PR TITLE
make: fix one-jar classpath extraction in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,8 @@ publish-wiki: update-wiki
 one-jar:
 	mkdir -p target
 	curl -L $(LAUNCHER_JAR_URL) -o target/iep-launcher.jar
+	classpath=`$(SBT) --error "export atlas-standalone/runtime:fullClasspath" | tail -n1 | tr -d '\r'`; \
+	test -n "$$classpath" || { echo "error: empty classpath from sbt export" >&2; exit 1; }; \
 	java -classpath target/iep-launcher.jar com.netflix.iep.launcher.JarBuilder \
 		target/standalone.jar com.netflix.atlas.standalone.Main \
-		`$(SBT) "export atlas-standalone/runtime:fullClasspath" | tail -n1 | sed 's/:/ /g'`
+		`echo "$$classpath" | sed 's/:/ /g'`


### PR DESCRIPTION
The `one-jar` target built the fat-jar classpath from `sbt "export atlas-standalone/runtime:fullClasspath" | tail -n1`, which assumes the classpath is the last line sbt writes to stdout. That holds with a warm local sbt, but in the release-asset CI job the final stdout line was a log line instead, so `sed` turned it into a bogus token and JarBuilder failed with `FileNotFoundException` on an empty/garbage path.

Run the export at `--error` log level so the classpath value is the only thing on stdout, strip any CR, and fail with a clear message if the captured classpath is empty (which `--error` would otherwise hide).