### PR TITLE
build: harden standalone one-jar build on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ WIKI_PRG        := atlas-wiki/runMain com.netflix.atlas.wiki.Main
 WIKI_INPUT_DIR  := $(shell pwd)/atlas-wiki/src/main/resources
 WIKI_OUTPUT_DIR := $(shell pwd)/target/atlas.wiki
 
-LAUNCHER_JAR_URL := https://repo1.maven.org/maven2/com/netflix/iep/iep-launcher/5.1.1/iep-launcher-5.1.1.jar
+LAUNCHER_JAR_URL := https://repo1.maven.org/maven2/com/netflix/iep/iep-launcher/6.0.6/iep-launcher-6.0.6.jar
 
 .PHONY: build snapshot release clean format update-wiki publish-wiki
 
@@ -56,11 +56,13 @@ publish-wiki: update-wiki
 	cd $(WIKI_OUTPUT_DIR) && git commit -a -m "update wiki"
 	cd $(WIKI_OUTPUT_DIR) && git push origin master
 
+# Build a single runnable jar. The classpath is extracted from sbt by keeping only
+# .jar entries, which relies on exportJars being set (see project/BuildSettings.scala)
+# so every runtime classpath entry is a packaged jar rather than a classes directory.
 one-jar:
 	mkdir -p target
-	curl -L $(LAUNCHER_JAR_URL) -o target/iep-launcher.jar
-	classpath=`$(SBT) --error "export atlas-standalone/runtime:fullClasspath" | tail -n1 | tr -d '\r'`; \
-	test -n "$$classpath" || { echo "error: empty classpath from sbt export" >&2; exit 1; }; \
+	curl -fL $(LAUNCHER_JAR_URL) -o target/iep-launcher.jar
+	classpath=`$(SBT) --error "export atlas-standalone/runtime:fullClasspath" | tr -d '\r' | tr ':' '\n' | grep '\.jar$$'`; \
+	test -n "$$classpath" || { echo "error: no jars in classpath from sbt export" >&2; exit 1; }; \
 	java -classpath target/iep-launcher.jar com.netflix.iep.launcher.JarBuilder \
-		target/standalone.jar com.netflix.atlas.standalone.Main \
-		`echo "$$classpath" | sed 's/:/ /g'`
+		target/standalone.jar com.netflix.atlas.standalone.Main $$classpath

--- a/project/sbt
+++ b/project/sbt
@@ -3,8 +3,12 @@
 # Additional options to add in when calling java
 OPTIONS=""
 
-# On jenkins the colors should be disabled for the console log
-[ -n "$BUILD_ID" ] && OPTIONS="$OPTIONS -Dsbt.log.noformat=true"
+# Disable log formatting on CI so terminal control sequences (e.g. sbt's trailing
+# ESC[0J) do not corrupt output parsed by scripts, such as the classpath used by the
+# one-jar target. BUILD_ID is set by Jenkins; CI by GitHub Actions and most CI systems.
+if [ -n "$BUILD_ID" ] || [ -n "$CI" ]; then
+  OPTIONS="$OPTIONS -Dsbt.log.noformat=true"
+fi
 
 java \
   -XX:+UseG1GC \


### PR DESCRIPTION
Three fixes for the standalone one-jar build failing on GitHub Actions:

- Extract the classpath by splitting on the path separator and keeping only entries ending in .jar, instead of `tail -n1 | sed`. All runtime classpath entries are jars (exportJars is set), so this drops any stray token regardless of what else sbt writes to stdout.
- Disable sbt log formatting when CI is set. project/sbt previously did this only for Jenkins (BUILD_ID); on GitHub Actions sbt left formatting on and emitted a trailing ESC[0J escape after command output that `tail -n1` captured instead of the classpath.
- Bump the pinned iep-launcher from 5.1.1 to 6.0.6, which ignores empty classpath entries and fails fast on an empty classpath.