### PR TITLE
pekko: add caller identity seam

### DIFF
--- a/atlas-pekko/src/main/resources/reference.conf
+++ b/atlas-pekko/src/main/resources/reference.conf
@@ -54,6 +54,21 @@ atlas.pekko {
     # Probability for adding connection close header to response. A value of 0.0
     # means it will never be added, 1.0 means it will always be added.
     close-probability = 0.0
+
+    # Fully qualified class name of a `RequestAuthenticator` used to establish the
+    # identity of the caller from the transport or an upstream proxy. The class must
+    # have a constructor that takes a Config or that is empty. If not set, no caller
+    # identity is established and endpoints will see the anonymous caller when using
+    # the `extractCaller` directive.
+    # authenticator = "com.netflix.atlas.pekko.ExampleRequestAuthenticator"
+  }
+
+  # Settings for the access log
+  access-log {
+    # Request header names (case-insensitive) whose values should be redacted in the access
+    # log. Use for secrets or bearer tokens forwarded by an upstream proxy so they are not
+    # written to the logs. Empty by default.
+    sensitive-headers = []
   }
 
   # Settings for the StaticPages API

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/AccessLogger.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/AccessLogger.scala
@@ -46,6 +46,30 @@ class AccessLogger private (entry: IpcLogEntry) {
     this
   }
 
+  /**
+    * Add the caller identity extracted by a `RequestAuthenticator` to the log entry. The direct
+    * and initial callers are added as log-only tags (`addLogTag`) so the full identity, including
+    * potentially high cardinality user ids, is captured on the access log without adding a metric
+    * dimension. An application direct caller is additionally recorded as the client app so that
+    * the bounded `ipc.client.app` metric dimension is populated.
+    */
+  def withCaller(caller: CallerContext): AccessLogger = {
+    val direct = caller.direct
+    val original = caller.original
+    if (direct.kind == Principal.Kind.App) {
+      entry.withClientApp(direct.id)
+    }
+    if (direct.kind != Principal.Kind.Unknown) {
+      entry.addLogTag("caller", direct.id)
+    }
+    // Only record the initial caller separately when it differs from the direct caller, e.g.
+    // an application calling on behalf of a user.
+    if (original.kind != Principal.Kind.Unknown && original != direct) {
+      entry.addLogTag("caller.origin", original.id)
+    }
+    this
+  }
+
   /** Complete the log entry and write out the result. */
   def complete(request: HttpRequest, result: Try[HttpResponse]): Unit = {
     AccessLogger.addRequestInfo(entry, request)
@@ -76,6 +100,19 @@ class AccessLogger private (entry: IpcLogEntry) {
 object AccessLogger {
 
   private val owner = "atlas-pekko"
+
+  // Request header names (lower-cased) whose values should be redacted in the access log. Used
+  // to keep secrets and bearer tokens forwarded by an upstream proxy (e.g. a proxy auth secret
+  // or an end-to-end token) out of the logs. Empty by default; deployments opt in via config.
+  private val sensitiveHeaders: Set[String] = {
+    import scala.jdk.CollectionConverters.*
+    val config = ConfigManager.get()
+    val path = "atlas.pekko.access-log.sensitive-headers"
+    if (config.hasPath(path))
+      config.getStringList(path).asScala.map(_.toLowerCase(java.util.Locale.US)).toSet
+    else
+      Set.empty
+  }
 
   private[pekko] val ipcLogger = new IpcLogger(
     Spectator.globalRegistry(),
@@ -145,7 +182,10 @@ object AccessLogger {
     entry
       .withHttpMethod(request.method.name)
       .withUri(request.uri.toString(), request.uri.path.toString())
-    request.headers.foreach(h => entry.addRequestHeader(h.name, h.value))
+    request.headers.foreach { h =>
+      val value = if (sensitiveHeaders.contains(h.lowercaseName())) "<redacted>" else h.value
+      entry.addRequestHeader(h.name, value)
+    }
     entry.addRequestHeader("Content-Type", request.entity.contentType.value)
     request.entity.contentLengthOption.foreach(entry.withRequestContentLength)
   }

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/CallerContext.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/CallerContext.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.pekko
+
+import org.apache.pekko.http.scaladsl.model.AttributeKey
+
+/**
+  * Identity of the caller as established by an upstream authentication layer, typically a
+  * proxy that terminates authentication in front of the service. This is a neutral model:
+  * the actual extraction of the identity from the transport or request headers is provided
+  * by a [[RequestAuthenticator]], which is expected to be Netflix or deployment specific.
+  * Routes read the context with the `extractCaller` directive.
+  *
+  * @param direct
+  *     The immediate caller that made the request to this service. For an application call
+  *     it will be the application, for a user call it will be the user.
+  * @param original
+  *     The caller that initiated the overall chain of requests. When a request is made on
+  *     behalf of another party (for example an application acting for a user), this will be
+  *     that original party. When there is no such delegation, it is the same as `direct`.
+  * @param forwardedToken
+  *     Raw end-to-end token, if one was forwarded with the request. It is retained as an
+  *     opaque value so that it can be relayed on any subsequent requests the service makes.
+  */
+case class CallerContext(
+  direct: Principal,
+  original: Principal,
+  forwardedToken: Option[String]
+)
+
+object CallerContext {
+
+  /** Request attribute used to propagate the caller context to the inner routes. */
+  val attr: AttributeKey[CallerContext] = AttributeKey[CallerContext]("atlas-caller")
+
+  /** Context used when the caller could not be determined. */
+  val Anonymous: CallerContext = CallerContext(Principal.Anonymous, Principal.Anonymous, None)
+}
+
+/**
+  * A party associated with a request.
+  *
+  * @param kind
+  *     Whether the party is an application, a user, or could not be determined.
+  * @param id
+  *     Identifier for the party. For an application this will be the application name, for a
+  *     user it will typically be their email address.
+  */
+case class Principal(kind: Principal.Kind, id: String)
+
+object Principal {
+
+  /** Indicates whether a [[Principal]] is an application, a user, or unknown. */
+  sealed trait Kind
+
+  object Kind {
+
+    /** The party is an application. */
+    case object App extends Kind
+
+    /** The party is a user. */
+    case object User extends Kind
+
+    /** The party could not be determined. */
+    case object Unknown extends Kind
+  }
+
+  /** Principal used when the party could not be determined. */
+  val Anonymous: Principal = Principal(Kind.Unknown, "unknown")
+}

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/CustomDirectives.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/CustomDirectives.scala
@@ -62,6 +62,14 @@ object CustomDirectives {
     */
   private val endpointAttr = AttributeKey[AtomicReference[String]]("atlas-endpoint")
 
+  /**
+    * Request attribute holding the mutable slot used to propagate the caller established by a
+    * `RequestAuthenticator` (via [[recordCaller]]) out to the `accessLog` directive. Uses the
+    * same holder pattern as [[endpointAttr]] so the caller is available on the access log even
+    * though the authenticator runs inside the access log wrapper.
+    */
+  private val callerAttr = AttributeKey[AtomicReference[CallerContext]]("atlas-caller-holder")
+
   private def isSmile(mediaType: MediaType): Boolean = {
     mediaType == CustomMediaTypes.`application/x-jackson-smile`
   }
@@ -136,6 +144,29 @@ object CustomDirectives {
         val entity = request.entity
         entity.dataBytes.runReduce(_ ++ _).map(parse(entity.contentType.mediaType))
       }
+    }
+  }
+
+  /**
+    * Extract the [[CallerContext]] that was populated by a [[RequestAuthenticator]]. If no
+    * authenticator is configured, or it did not set the context, then the anonymous context
+    * is provided. This allows endpoints to depend on the caller identity without a compile
+    * time dependency on the mechanism used to establish it.
+    */
+  def extractCaller: Directive1[CallerContext] = {
+    optionalAttribute(CallerContext.attr).map(_.getOrElse(CallerContext.Anonymous))
+  }
+
+  /**
+    * Record the caller established by a [[RequestAuthenticator]] so that it is available to the
+    * inner routes via [[extractCaller]] and to the access log. It both sets the [[CallerContext]]
+    * request attribute (read by `extractCaller`) and, when present, populates the holder installed
+    * by `accessLog` so the caller is logged even though the authenticator runs inside it.
+    */
+  def recordCaller(caller: CallerContext): Directive0 = {
+    optionalAttribute(callerAttr).flatMap { holder =>
+      holder.foreach(_.set(caller))
+      mapRequest(_.addAttribute(CallerContext.attr, caller))
     }
   }
 
@@ -232,8 +263,14 @@ object CustomDirectives {
     corsPreflight(hosts) ~ respondWithCorsHeaders(hosts) { inner }
   }
 
-  // Helper function to finish constructing the log entry and writing to the logger.
-  private def log(logger: AccessLogger)(req: HttpRequest)(result: RouteResult): Unit = {
+  // Helper function to finish constructing the log entry and writing to the logger. The caller
+  // holder is read at completion time so that an identity recorded by an inner authenticator is
+  // applied to the log entry.
+  private def log(
+    logger: AccessLogger,
+    caller: AtomicReference[CallerContext]
+  )(req: HttpRequest)(result: RouteResult): Unit = {
+    logger.withCaller(caller.get())
     result match {
       case RouteResult.Complete(res) => logger.complete(req, Success(res))
       case RouteResult.Rejected(vs)  => logger.complete(req, Failure(new Exception(vs.toString)))
@@ -254,16 +291,17 @@ object CustomDirectives {
       val entry = AccessLogger.ipcLogger.createServerEntry.withRemoteAddress(addr)
       val logger = AccessLogger.newServerLogger(entry)
 
-      // Holder for the endpoint matched by an inner `endpointPath*` directive. It is
-      // made available to the inner routes via a request attribute and is applied to
-      // the response below so that the endpoint is captured on the access log even for
-      // responses produced by an error handler (exception or rejection) that runs
-      // outside the scope of the `endpointPath*` directive.
-      // Note the ordering: `logRequestResult` must wrap `addRecordedEndpointHeader` so
-      // that the logged response reflects the endpoint header that was added.
+      // Holders for values recorded by inner directives while the request is handled, so they
+      // can still be applied to the access log even when the response is produced by an error
+      // handler (exception or rejection) that runs outside the recording directive's scope.
+      // `endpoint` is set by the `endpointPath*` directives; `caller` is set by a
+      // `RequestAuthenticator` via `recordCaller`. Both run inside this `accessLog` wrapper.
+      // Note the ordering: `logRequestResult` must wrap `addRecordedEndpointHeader` so that the
+      // logged response reflects the endpoint header that was added.
       val endpoint = new AtomicReference[String]()
-      mapRequest(_.addAttribute(endpointAttr, endpoint)) &
-        logRequestResult(LoggingMagnet(_ => log(logger))) &
+      val caller = new AtomicReference[CallerContext](CallerContext.Anonymous)
+      mapRequest(_.addAttribute(endpointAttr, endpoint).addAttribute(callerAttr, caller)) &
+        logRequestResult(LoggingMagnet(_ => log(logger, caller))) &
         addRecordedEndpointHeader(endpoint) &
         respondWithDefaultHeaders(headers)
     }

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/RequestAuthenticator.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/RequestAuthenticator.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.pekko
+
+import com.typesafe.config.Config
+import org.apache.pekko.http.scaladsl.server.Route
+
+/**
+  * Wraps the routes to establish the identity of the caller before a request is handled. An
+  * implementation is expected to record the caller with `CustomDirectives.recordCaller` so that
+  * it can be read by the inner routes via the `extractCaller` directive and included on the
+  * access log. It may also reject the request if it is missing information that is required by
+  * the deployment; such rejections are handled by the standard error handling because the
+  * authenticator is applied inside it (see `RequestHandler.standardOptions`).
+  *
+  * The extraction of the identity is Netflix or deployment specific and lives outside of the
+  * open source project. This trait is the neutral seam that lets such an implementation be
+  * plugged in by class name (see [[RequestAuthenticator.apply]]). Implementations must have a
+  * constructor that takes a Config object or that is empty.
+  */
+trait RequestAuthenticator {
+
+  /** Wrap the route so that the caller identity is established before it is handled. */
+  def apply(route: Route): Route
+}
+
+object RequestAuthenticator {
+
+  /** Config key used to specify the implementation class. */
+  private val configKey = "atlas.pekko.request-handler.authenticator"
+
+  /** Authenticator that passes the route through unchanged. Used when none is configured. */
+  val passthrough: RequestAuthenticator = new RequestAuthenticator {
+    override def apply(route: Route): Route = route
+  }
+
+  /**
+    * Create a request authenticator based on the config. If the implementation class is set,
+    * then it is loaded by name. Otherwise the [[passthrough]] authenticator is used and no
+    * caller identity will be established.
+    */
+  def apply(config: Config): RequestAuthenticator = {
+    if (config.hasPath(configKey)) {
+      val cls = Class.forName(config.getString(configKey)).asInstanceOf[Class[RequestAuthenticator]]
+      try {
+        // Look for a constructor that takes a config object
+        cls.getConstructor(classOf[Config]).newInstance(config)
+      } catch {
+        case _: NoSuchMethodException =>
+          // Use an empty constructor
+          cls.getConstructor().newInstance()
+      }
+    } else {
+      passthrough
+    }
+  }
+}

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/RequestHandler.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/RequestHandler.scala
@@ -129,6 +129,10 @@ object RequestHandler extends StrictLogging {
     val closeProbability: Double = {
       config.getDouble("atlas.pekko.request-handler.close-probability")
     }
+
+    val requestAuthenticator: RequestAuthenticator = {
+      RequestAuthenticator(config)
+    }
   }
 
   // Custom set of encoders, same as the default set used with the `encodeResponse` directive
@@ -160,7 +164,12 @@ object RequestHandler extends StrictLogging {
       }
     }
 
-    val finalRoutes = ok ~ route
+    // Establish the caller identity for the user routes. The health-check `ok` route is left
+    // outside the authenticator so that a strict authenticator cannot fail load-balancer probes.
+    // Placing the authenticator here, inside the exception/rejection handling, the access log, and
+    // the CORS wrapper below, ensures its rejections are rendered by the standard error handling,
+    // included in the access log, and carry CORS headers.
+    val finalRoutes = ok ~ settings.requestAuthenticator(route)
 
     // Automatically deal with compression
     val gzip =

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/RequestAuthenticatorSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/RequestAuthenticatorSuite.scala
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.pekko
+
+import com.netflix.atlas.pekko.testkit.MUnitRouteSuite
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.Spectator
+import com.netflix.spectator.api.Utils
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.server.Directives.*
+import org.apache.pekko.http.scaladsl.server.Route
+
+class RequestAuthenticatorSuite extends MUnitRouteSuite {
+
+  import CustomDirectives.*
+  import RequestAuthenticatorSuite.*
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    val registry = Spectator.globalRegistry()
+    registry.removeAll()
+    registry.add(new DefaultRegistry())
+  }
+
+  private def clientAppTag: Option[String] = {
+    import scala.jdk.CollectionConverters.*
+    Spectator
+      .globalRegistry()
+      .iterator()
+      .asScala
+      .map(_.id())
+      .filter(_.name() == "ipc.server.call")
+      .flatMap(id => Option(Utils.getTagValue(id, "ipc.client.app")))
+      .nextOption()
+  }
+
+  private def serverCallRecorded: Boolean = {
+    import scala.jdk.CollectionConverters.*
+    Spectator
+      .globalRegistry()
+      .iterator()
+      .asScala
+      .map(_.id())
+      .exists(_.name() == "ipc.server.call")
+  }
+
+  private def configWith(authenticator: Option[String], accessLog: Boolean = false): Config = {
+    val auth = authenticator.fold("")(c => s"""authenticator = "$c"""")
+    ConfigFactory.parseString(s"""
+        |atlas.pekko.api-endpoints = []
+        |atlas.pekko.cors-host-patterns = []
+        |atlas.pekko.diagnostic-headers = []
+        |atlas.pekko.request-handler {
+        |  cors = false
+        |  compression = false
+        |  access-log = $accessLog
+        |  close-probability = 0.0
+        |  $auth
+        |}
+      """.stripMargin)
+  }
+
+  test("passthrough when no authenticator configured") {
+    val authenticator = RequestAuthenticator(configWith(None))
+    assertEquals(authenticator, RequestAuthenticator.passthrough)
+  }
+
+  test("load authenticator with config constructor") {
+    val cls = classOf[ConfigCtorAuthenticator].getName
+    val authenticator = RequestAuthenticator(configWith(Some(cls)))
+    assert(authenticator.isInstanceOf[ConfigCtorAuthenticator])
+  }
+
+  test("load authenticator with empty constructor") {
+    val cls = classOf[EmptyCtorAuthenticator].getName
+    val authenticator = RequestAuthenticator(configWith(Some(cls)))
+    assert(authenticator.isInstanceOf[EmptyCtorAuthenticator])
+  }
+
+  test("extractCaller: anonymous when nothing set") {
+    val route = extractCaller { caller =>
+      complete(caller.direct.id)
+    }
+    Get("/") ~> route ~> check {
+      assertEquals(responseAs[String], "unknown")
+    }
+  }
+
+  test("extractCaller: reads context set on the request") {
+    val route = mapRequest(_.addAttribute(CallerContext.attr, testCaller)) {
+      extractCaller { caller =>
+        complete(
+          s"${caller.direct.id},${caller.original.id},${caller.forwardedToken.getOrElse("")}"
+        )
+      }
+    }
+    Get("/") ~> route ~> check {
+      assertEquals(responseAs[String], "test_app,test_user,raw-token")
+    }
+  }
+
+  test("standardOptions applies the configured authenticator") {
+    val cls = classOf[FixedCallerAuthenticator].getName
+    val settings = RequestHandler.Settings(configWith(Some(cls)))
+    val inner = extractCaller { caller =>
+      complete(caller.original.id)
+    }
+    val route = RequestHandler.standardOptions(inner, settings)
+    Get("/") ~> route ~> check {
+      assertEquals(response.status, StatusCodes.OK)
+      assertEquals(responseAs[String], "test_user")
+    }
+  }
+
+  test("access log: app caller recorded as client app") {
+    val cls = classOf[FixedCallerAuthenticator].getName
+    val settings = RequestHandler.Settings(configWith(Some(cls), accessLog = true))
+    // Use a non-"/ok" path so the request goes through the authenticator (the health-check
+    // `ok` route is intentionally left outside the authenticator).
+    val route = RequestHandler.standardOptions(complete("ok"), settings)
+    Get("/") ~> route ~> check {
+      assertEquals(response.status, StatusCodes.OK)
+      assertEquals(clientAppTag, Some("test_app"))
+    }
+  }
+
+  test("access log: user caller not added to metrics") {
+    val cls = classOf[UserCallerAuthenticator].getName
+    val settings = RequestHandler.Settings(configWith(Some(cls), accessLog = true))
+    val route = RequestHandler.standardOptions(complete("ok"), settings)
+    Get("/") ~> route ~> check {
+      assertEquals(response.status, StatusCodes.OK)
+      assertEquals(clientAppTag, None)
+    }
+  }
+
+  test("rejecting authenticator: rejection rendered by standard handler") {
+    val cls = classOf[RejectingAuthenticator].getName
+    val settings = RequestHandler.Settings(configWith(Some(cls)))
+    val route = RequestHandler.standardOptions(complete("secret"), settings)
+    Get("/") ~> route ~> check {
+      assertEquals(response.status, StatusCodes.Forbidden)
+      assert(responseAs[String].contains("denied"))
+    }
+  }
+
+  test("rejecting authenticator: health-check ok route is exempt") {
+    val cls = classOf[RejectingAuthenticator].getName
+    val settings = RequestHandler.Settings(configWith(Some(cls)))
+    val route = RequestHandler.standardOptions(complete("secret"), settings)
+    Get("/ok") ~> route ~> check {
+      assertEquals(response.status, StatusCodes.OK)
+    }
+  }
+
+  test("withCaller: direct and initial callers added as log-only tags") {
+    val entry = AccessLogger.ipcLogger.createServerEntry
+    val caller = CallerContext(
+      Principal(Principal.Kind.App, "app1"),
+      Principal(Principal.Kind.User, "user1"),
+      None
+    )
+    AccessLogger.newServerLogger(entry).withCaller(caller)
+    val json = entry.toString
+    // Both callers appear in the log-only additionalLogTags; the origin (a user) is not a
+    // metric field, so its presence proves the log tag was written.
+    assert(json.contains("caller.origin"), json)
+    assert(json.contains("user1"), json)
+    // App direct caller is also recorded as the bounded client-app metric dimension.
+    assert(json.contains("clientApp"), json)
+    assert(json.contains("app1"), json)
+  }
+
+  test("withCaller: no origin tag when initial caller matches direct") {
+    val entry = AccessLogger.ipcLogger.createServerEntry
+    val user = Principal(Principal.Kind.User, "user1")
+    AccessLogger.newServerLogger(entry).withCaller(CallerContext(user, user, None))
+    val json = entry.toString
+    assert(json.contains("user1"), json)
+    assert(!json.contains("caller.origin"), json)
+  }
+
+  test("rejecting authenticator: rejected request is still access-logged") {
+    val cls = classOf[RejectingAuthenticator].getName
+    val settings = RequestHandler.Settings(configWith(Some(cls), accessLog = true))
+    val route = RequestHandler.standardOptions(complete("secret"), settings)
+    Get("/") ~> route ~> check {
+      assertEquals(response.status, StatusCodes.Forbidden)
+      assert(serverCallRecorded)
+    }
+  }
+}
+
+object RequestAuthenticatorSuite {
+
+  private val testCaller: CallerContext = CallerContext(
+    Principal(Principal.Kind.App, "test_app"),
+    Principal(Principal.Kind.User, "test_user"),
+    Some("raw-token")
+  )
+
+  class ConfigCtorAuthenticator(config: Config) extends RequestAuthenticator {
+
+    // Reference the config so the parameter is not flagged as unused
+    require(config != null)
+    override def apply(route: Route): Route = route
+  }
+
+  class EmptyCtorAuthenticator extends RequestAuthenticator {
+    override def apply(route: Route): Route = route
+  }
+
+  class FixedCallerAuthenticator extends RequestAuthenticator {
+
+    override def apply(route: Route): Route = {
+      CustomDirectives.recordCaller(testCaller) { route }
+    }
+  }
+
+  class UserCallerAuthenticator extends RequestAuthenticator {
+
+    private val caller = CallerContext(
+      Principal(Principal.Kind.User, "test_user"),
+      Principal(Principal.Kind.User, "test_user"),
+      None
+    )
+
+    override def apply(route: Route): Route = {
+      CustomDirectives.recordCaller(caller) { route }
+    }
+  }
+
+  class RejectingAuthenticator extends RequestAuthenticator {
+
+    override def apply(route: Route): Route = {
+      reject(CustomRejection(StatusCodes.Forbidden, "denied"))
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
     val otel        = "1.63.0"
     val scala       = "2.13.18"
     val slf4j       = "2.0.18"
-    val spectator   = "1.10.1"
+    val spectator   = "1.10.4"
     val spring      = "7.0.8"
 
     val crossScala  = Seq(scala, "3.8.4")


### PR DESCRIPTION
Add a neutral seam for propagating caller identity established by an upstream authentication layer (e.g. a proxy):

- CallerContext / Principal: direct and original callers plus the raw forwarded token, carried on a request attribute.
- RequestAuthenticator: SPI trait loaded by class name via atlas.pekko.request-handler.authenticator (default passthrough). Implementations record the caller with CustomDirectives.recordCaller and may reject; standardOptions applies it inside the exception, rejection, access-log, and CORS handling, wrapping only the user routes so the health-check ok route stays reachable.
- extractCaller: directive for endpoints to read the caller, defaulting to anonymous with no compile-time dependency on the mechanism.
- AccessLogger: log the direct and initial callers as log-only tags (IpcLogEntry.addLogTag, spectator 1.10.4) so full identity is on the access log without adding a metric dimension; an app direct caller is also recorded as the bounded ipc.client.app dimension. Add atlas.pekko.access-log.sensitive-headers to redact secrets/tokens.

Bump spectator to 1.10.4 for addLogTag.