### PR TITLE
pekko: add caller-aware request limiter

### DIFF
--- a/atlas-pekko/src/main/resources/reference.conf
+++ b/atlas-pekko/src/main/resources/reference.conf
@@ -71,6 +71,44 @@ atlas.pekko {
     sensitive-headers = []
   }
 
+  # Caller aware, weighted concurrency limits for request handling. A request reserves capacity
+  # proportional to its estimated cost for the duration it is in flight, from both the per-bucket
+  # limiter for its caller and the endpoint's total limiter. Budgets are absolute for a single
+  # instance; for a fleet the values should already reflect the per-instance share.
+  #
+  # Limiting is opt-in per endpoint: an endpoint that is not listed under `endpoints` is not
+  # limited at all.
+  request-limits {
+    # How limit decisions are applied:
+    #   off     - disabled, every request is permitted and no capacity is reserved
+    #   shadow  - decisions are computed and reported, and capacity is reserved for requests that
+    #             would be permitted; requests the policy would deny are still admitted without
+    #             reserving capacity, so limits can be observed before enforcing
+    #   enforce - requests the policy denies are shed with a 429
+    mode = "off"
+
+    # Per-endpoint budgets. The endpoint name is chosen by the endpoint applying the limit, for
+    # example "graph" or "tags".
+    endpoints {
+      # graph {
+      #   # Cap on the combined cost across all buckets of this endpoint. Zero or absent means
+      #   # there is no endpoint wide cap and only the per-bucket limits apply.
+      #   total-budget = 100
+      #
+      #   # Budget for the shared default bucket used by callers without a dedicated budget.
+      #   # Required for any listed endpoint.
+      #   default-bucket-budget = 20
+      #
+      #   # Dedicated budgets for provisioned callers, keyed by caller id. A value of zero blocks
+      #   # the caller entirely.
+      #   caller-budgets {
+      #     dashboards = 0
+      #     atlas_ui   = 40
+      #   }
+      # }
+    }
+  }
+
   # Settings for the StaticPages API
   static {
     # Default page to redirect to when hitting /

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/ConcurrencyLimiter.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/ConcurrencyLimiter.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.pekko
+
+import java.util.concurrent.Semaphore
+
+/**
+  * Limits the number of concurrent operations that can be in flight at once. The limit is on
+  * concurrency rather than a request rate: a permit is held for the full lifetime of an
+  * operation and released when it completes. The limit is weighted, so an operation acquires a
+  * number of permits equal to its estimated cost; a more expensive operation therefore consumes
+  * a larger share of the budget for as long as it runs.
+  *
+  * Acquisition is non-blocking. This limiter is intended to be used from the request handling
+  * path, where blocking a dispatcher thread waiting for capacity would be harmful. A caller that
+  * cannot acquire immediately should shed the request rather than wait.
+  *
+  * Implementations must be safe for use by multiple threads.
+  */
+trait ConcurrencyLimiter {
+
+  /**
+    * Attempt to acquire `cost` permits without blocking. Returns true only if all of the permits
+    * were available at the time of the call, in which case the caller must eventually call
+    * [[release]] with the same cost. A cost that exceeds the total budget is clamped to the
+    * budget so that a single large operation can still be admitted when the limiter is otherwise
+    * idle.
+    *
+    * @param subKey
+    *     Identifies the individual caller within this limiter. Ignored by limiters that do not
+    *     provide per-caller fairness.
+    * @param cost
+    *     Number of permits to acquire. Values less than one are treated as one.
+    */
+  def tryAcquire(subKey: String, cost: Int): Boolean
+
+  /**
+    * Release `cost` permits previously acquired by [[tryAcquire]]. The cost must match the value
+    * passed to the corresponding successful acquire.
+    */
+  def release(subKey: String, cost: Int): Unit
+
+  /** Number of permits currently held. Intended for reporting via gauges. */
+  def usedPermits: Int
+
+  /** Total number of permits, or [[Int.MaxValue]] when there is no limit. */
+  def maxPermits: Int
+}
+
+object ConcurrencyLimiter {
+
+  /**
+    * Create a limiter for the given budget. A budget of zero or less produces a limiter that
+    * rejects every request, which can be used to fully block a caller. Otherwise a weighted
+    * semaphore backed limiter is returned.
+    */
+  def apply(budget: Int): ConcurrencyLimiter = {
+    if (budget <= 0) NoneLimiter else new SemaphoreLimiter(budget)
+  }
+
+  /** Limiter that permits every request without bound. */
+  val Unlimited: ConcurrencyLimiter = AllowLimiter
+}
+
+/**
+  * Weighted concurrency limiter backed by a [[java.util.concurrent.Semaphore]]. An operation
+  * acquires a number of permits equal to its cost and releases the same number on completion.
+  */
+final class SemaphoreLimiter(budget: Int) extends ConcurrencyLimiter {
+
+  require(budget > 0, s"budget must be positive: $budget")
+
+  private val semaphore = new Semaphore(budget)
+
+  private def clamp(cost: Int): Int = math.min(budget, math.max(1, cost))
+
+  override def tryAcquire(subKey: String, cost: Int): Boolean = {
+    semaphore.tryAcquire(clamp(cost))
+  }
+
+  override def release(subKey: String, cost: Int): Unit = {
+    semaphore.release(clamp(cost))
+  }
+
+  override def usedPermits: Int = budget - semaphore.availablePermits()
+
+  override def maxPermits: Int = budget
+}
+
+/** Limiter that always permits, used when an endpoint has no configured limit. */
+object AllowLimiter extends ConcurrencyLimiter {
+
+  override def tryAcquire(subKey: String, cost: Int): Boolean = true
+  override def release(subKey: String, cost: Int): Unit = ()
+  override def usedPermits: Int = 0
+  override def maxPermits: Int = Int.MaxValue
+}
+
+/** Limiter that always denies, used to fully block a bucket by configuring a budget of zero. */
+object NoneLimiter extends ConcurrencyLimiter {
+
+  override def tryAcquire(subKey: String, cost: Int): Boolean = false
+  override def release(subKey: String, cost: Int): Unit = ()
+  override def usedPermits: Int = 0
+  override def maxPermits: Int = 0
+}

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/ConcurrencyLimiter.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/ConcurrencyLimiter.scala
@@ -56,7 +56,7 @@ trait ConcurrencyLimiter {
   /** Number of permits currently held. Intended for reporting via gauges. */
   def usedPermits: Int
 
-  /** Total number of permits, or [[Int.MaxValue]] when there is no limit. */
+  /** Total number of permits, or `Int.MaxValue` when there is no limit. */
   def maxPermits: Int
 }
 

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/LimitKey.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/LimitKey.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.pekko
+
+/**
+  * Identifies how a request maps onto the limiting policy. The `bucket` selects the configured
+  * concurrency budget that will be enforced. The `subKey` identifies the individual caller
+  * within that budget; a single bucket is commonly shared by many callers, so the `subKey`
+  * distinguishes them for per-caller fairness and diagnostics. For a caller that has its own
+  * dedicated bucket the two values are typically the same.
+  *
+  * @param bucket
+  *     Name of the concurrency budget to enforce. Resolved against the per-endpoint
+  *     configuration, falling back to the endpoint default budget when not explicitly listed.
+  * @param subKey
+  *     Identifier for the individual caller within the bucket. Used for per-caller fairness
+  *     within a shared bucket and for diagnostic messages. Not used as a metric dimension to
+  *     avoid unbounded cardinality.
+  * @param endpoint
+  *     Logical endpoint the request is being made against, for example `graph` or `tags`.
+  *     Budgets are configured per endpoint so the same caller can have different limits on
+  *     different endpoints.
+  */
+case class LimitKey(bucket: String, subKey: String, endpoint: String)
+
+object LimitKey {
+
+  /** Name of the bucket shared by all callers that do not have a dedicated budget. */
+  val DefaultBucket: String = "default"
+
+  /** Sub-key used for a caller whose identity could not be determined. */
+  val Anonymous: String = "anonymous"
+}

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/LimitKeyResolver.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/LimitKeyResolver.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.pekko
+
+import org.apache.pekko.http.scaladsl.model.HttpRequest
+
+/**
+  * Maps a caller and request onto the [[LimitKey]] used to enforce concurrency limits. Isolating
+  * this mapping behind a trait lets the way a caller is identified evolve independently of the
+  * limiter, for example while migrating from a query parameter based identity to an authenticated
+  * one established by a [[RequestAuthenticator]].
+  */
+trait LimitKeyResolver {
+
+  /**
+    * @param caller
+    *     Caller identity established for the request, or [[CallerContext.Anonymous]] when it could
+    *     not be determined.
+    * @param endpoint
+    *     Logical endpoint being requested, for example `graph` or `tags`.
+    * @param request
+    *     The request being limited, available for identity hints beyond the caller context.
+    */
+  def resolve(caller: CallerContext, endpoint: String, request: HttpRequest): LimitKey
+}
+
+/**
+  * Default resolver. The caller identity is taken from the authenticated [[CallerContext]] when
+  * available, falling back to the legacy `id` query parameter and finally to an anonymous marker.
+  * A caller is given its own bucket only when it has been provisioned with a dedicated budget on
+  * the endpoint; all other callers share [[LimitKey.DefaultBucket]] but retain their own sub-key
+  * so they can be told apart within the shared bucket.
+  *
+  * @param dedicatedBuckets
+  *     Given an endpoint, the set of caller ids that have a dedicated budget on it. Typically
+  *     [[RequestLimiter.dedicatedBuckets]].
+  */
+class DefaultLimitKeyResolver(dedicatedBuckets: String => Set[String]) extends LimitKeyResolver {
+
+  override def resolve(caller: CallerContext, endpoint: String, request: HttpRequest): LimitKey = {
+    val id = callerId(caller, request)
+    val bucket = if (dedicatedBuckets(endpoint).contains(id)) id else LimitKey.DefaultBucket
+    LimitKey(bucket, id, endpoint)
+  }
+
+  private def callerId(caller: CallerContext, request: HttpRequest): String = {
+    caller.direct.kind match {
+      case Principal.Kind.Unknown => legacyId(request).getOrElse(LimitKey.Anonymous)
+      case _                      => caller.direct.id
+    }
+  }
+
+  private def legacyId(request: HttpRequest): Option[String] = {
+    request.uri.query().get("id").filter(_.nonEmpty)
+  }
+}

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/RequestLimiter.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/RequestLimiter.scala
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.pekko
+
+import com.netflix.spectator.api.Counter
+import com.netflix.spectator.api.DistributionSummary
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.patterns.PolledMeter
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigUtil
+
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.jdk.CollectionConverters.*
+
+/**
+  * Enforces caller aware, weighted concurrency limits on requests. Each request maps to a
+  * [[LimitKey]] and carries an estimated cost. Limiting is opt-in per endpoint: a request against
+  * a configured endpoint must acquire capacity from both the per-bucket limiter selected by
+  * [[LimitKey.bucket]] and the endpoint's total limiter, and both are released together when the
+  * returned [[LimitToken]] is released. Acquisition is non-blocking, so a request that cannot get
+  * capacity immediately is rejected rather than queued.
+  *
+  * Budgets are absolute for a single instance. When operating a fleet the configured budgets
+  * should already account for the per-instance share of the overall capacity.
+  *
+  * All state is derived from configuration at construction time. Because both the set of endpoints
+  * and, after collapsing unprovisioned callers onto the shared default bucket, the set of buckets
+  * are fixed by configuration, the limiters and meters are pre-built and the request path performs
+  * only lookups. This keeps `acquire` allocation free except for the token returned to a permitted
+  * request.
+  *
+  * @param config
+  *     Configuration subtree rooted at `atlas.pekko.request-limits`.
+  * @param registry
+  *     Registry used to report limiter activity.
+  */
+class RequestLimiter(config: Config, registry: Registry) {
+
+  import RequestLimiter.*
+
+  private val mode: Mode = Mode.fromString(config.getString("mode"))
+
+  // When disabled there is nothing to enforce, so no limiters or gauges are built.
+  private val endpoints: Map[String, EndpointLimiter] = {
+    if (mode == Mode.Off) Map.empty
+    else readEndpoints(config).map { case (name, limits) => name -> buildEndpoint(name, limits) }
+  }
+
+  // Reused for every request that is not subject to limiting, so those paths allocate nothing.
+  private val permit: Option[LimitToken] = Some(LimitToken.NoOp)
+
+  /**
+    * Attempt to reserve capacity for a request. Returns a [[LimitToken]] that must be released
+    * when the request completes, or `None` if the request should be shed. In `shadow` mode a
+    * token is always returned even when the policy would deny the request, so that limits can be
+    * observed against real traffic before being enforced.
+    */
+  def acquire(key: LimitKey, cost: Int): Option[LimitToken] = {
+    // Limiting is opt-in per endpoint. When disabled globally, or when the endpoint has no
+    // configured limits, the request is permitted without reserving capacity or recording metrics.
+    if (mode == Mode.Off) permit
+    else
+      endpoints.get(key.endpoint) match {
+        case Some(endpoint) => endpoint.acquire(key.bucket, key.subKey, cost)
+        case None           => permit
+      }
+  }
+
+  /**
+    * Bucket names that have a dedicated budget on the given endpoint. A [[LimitKeyResolver]] uses
+    * this to decide whether a caller gets its own bucket or shares the default bucket. Callers
+    * not listed here share [[LimitKey.DefaultBucket]].
+    */
+  def dedicatedBuckets(endpoint: String): Set[String] = {
+    endpoints.get(endpoint).map(_.dedicatedBuckets).getOrElse(Set.empty)
+  }
+
+  private def buildEndpoint(name: String, limits: EndpointLimits): EndpointLimiter = {
+    val total =
+      if (limits.totalBudget <= 0) ConcurrencyLimiter.Unlimited
+      else ConcurrencyLimiter(limits.totalBudget)
+    monitorInflight(total, name, "__total__")
+
+    val default = ConcurrencyLimiter(limits.defaultBucketBudget)
+    monitorInflight(default, name, LimitKey.DefaultBucket)
+
+    // A caller budget named "default" is reserved for the shared bucket and does not create a
+    // dedicated one; it is dropped here so the shared budget comes only from default-bucket-budget.
+    val dedicated = (limits.callerBudgets - LimitKey.DefaultBucket).map {
+      case (bucket, budget) =>
+        val limiter = ConcurrencyLimiter(budget)
+        monitorInflight(limiter, name, bucket)
+        bucket -> limiter
+    }
+
+    new EndpointLimiter(
+      total = total,
+      default = default,
+      dedicated = dedicated,
+      enforce = mode == Mode.Enforce,
+      cost = registry.distributionSummary("atlas.limiter.cost", "endpoint", name),
+      permitted = requestCounter(name, "permitted", "none"),
+      deniedBucket = requestCounter(name, "denied", "bucket"),
+      deniedTotal = requestCounter(name, "denied", "total")
+    )
+  }
+
+  private def requestCounter(endpoint: String, result: String, reason: String): Counter = {
+    registry.counter(
+      "atlas.limiter.requests",
+      "endpoint",
+      endpoint,
+      "result",
+      result,
+      "reason",
+      reason
+    )
+  }
+
+  // Only bounded limiters are worth a gauge; an unlimited or fully blocked limiter would report a
+  // constant value.
+  private def monitorInflight(
+    limiter: ConcurrencyLimiter,
+    endpoint: String,
+    bucket: String
+  ): Unit = {
+    if (limiter.maxPermits > 0 && limiter.maxPermits < Int.MaxValue) {
+      PolledMeter
+        .using(registry)
+        .withName("atlas.limiter.inflight")
+        .withTag("endpoint", endpoint)
+        .withTag("bucket", bucket)
+        .monitorValue(limiter, (l: ConcurrencyLimiter) => l.usedPermits.toDouble)
+    }
+  }
+}
+
+object RequestLimiter {
+
+  /** How limit decisions are applied. */
+  sealed trait Mode
+
+  object Mode {
+
+    /** Limiting is disabled; every request is permitted and no capacity is reserved. */
+    case object Off extends Mode
+
+    /**
+      * Limit decisions are computed and reported, and capacity is reserved for permitted
+      * requests, but requests the policy would deny are still admitted. Used to observe the
+      * effect of a configuration against live traffic before enforcing it.
+      */
+    case object Shadow extends Mode
+
+    /** Requests the policy denies are shed. */
+    case object Enforce extends Mode
+
+    def fromString(s: String): Mode = s.toLowerCase match {
+      case "off"     => Off
+      case "shadow"  => Shadow
+      case "enforce" => Enforce
+      case other     => throw new IllegalArgumentException(s"unknown request-limits mode: $other")
+    }
+  }
+
+  /**
+    * Pre-built limiters and meters for a single endpoint. The request path is confined to lookups
+    * and counter increments so that only the permitted case allocates.
+    */
+  private class EndpointLimiter(
+    total: ConcurrencyLimiter,
+    default: ConcurrencyLimiter,
+    dedicated: Map[String, ConcurrencyLimiter],
+    enforce: Boolean,
+    cost: DistributionSummary,
+    permitted: Counter,
+    deniedBucket: Counter,
+    deniedTotal: Counter
+  ) {
+
+    // Result returned when the policy denies a request: nothing in enforce mode, a no-op token in
+    // shadow mode so the request is still admitted. Reused so the denied path allocates nothing.
+    private val denied: Option[LimitToken] = if (enforce) None else Some(LimitToken.NoOp)
+
+    def dedicatedBuckets: Set[String] = dedicated.keySet
+
+    def acquire(bucket: String, subKey: String, requestCost: Int): Option[LimitToken] = {
+      cost.record(math.max(1, requestCost).toLong)
+
+      // Any bucket that is not a provisioned dedicated caller shares the default bucket.
+      val bucketLimiter = dedicated.getOrElse(bucket, default)
+      if (!bucketLimiter.tryAcquire(subKey, requestCost)) {
+        deniedBucket.increment()
+        return denied
+      }
+      if (!total.tryAcquire(subKey, requestCost)) {
+        bucketLimiter.release(subKey, requestCost)
+        deniedTotal.increment()
+        return denied
+      }
+
+      permitted.increment()
+      Some(LimitToken { () =>
+        total.release(subKey, requestCost)
+        bucketLimiter.release(subKey, requestCost)
+      })
+    }
+  }
+
+  /**
+    * Concurrency budgets for a single endpoint.
+    *
+    * @param totalBudget
+    *     Cap on the combined cost across all buckets of the endpoint. A value of zero or less
+    *     means there is no endpoint wide cap and only the per-bucket limits apply.
+    * @param defaultBucketBudget
+    *     Budget for the shared default bucket, applied to any bucket without a dedicated budget.
+    * @param callerBudgets
+    *     Dedicated budgets keyed by bucket name. Presence of an entry provisions a dedicated
+    *     bucket for that caller. A value of zero blocks the bucket entirely.
+    */
+  private case class EndpointLimits(
+    totalBudget: Int,
+    defaultBucketBudget: Int,
+    callerBudgets: Map[String, Int]
+  )
+
+  private def readEndpoints(config: Config): Map[String, EndpointLimits] = {
+    if (!config.hasPath("endpoints")) Map.empty
+    else {
+      val obj = config.getConfig("endpoints")
+      obj
+        .root()
+        .keySet()
+        .asScala
+        .map { name =>
+          // Quote the key so an endpoint name that happens to contain a dot is looked up
+          // literally rather than being interpreted as a nested config path.
+          val ec = obj.getConfig(ConfigUtil.joinPath(name))
+          val totalBudget = if (ec.hasPath("total-budget")) ec.getInt("total-budget") else 0
+          name -> EndpointLimits(totalBudget, ec.getInt("default-bucket-budget"), readBudgets(ec))
+        }
+        .toMap
+    }
+  }
+
+  private def readBudgets(config: Config): Map[String, Int] = {
+    if (!config.hasPath("caller-budgets")) Map.empty
+    else {
+      // Read each budget with getInt for consistent type coercion and path-qualified errors,
+      // mirroring readEndpoints. Keys are quoted so caller ids containing dots (for example an
+      // application name or user email) are treated as a single literal key.
+      val cb = config.getConfig("caller-budgets")
+      cb.root()
+        .keySet()
+        .asScala
+        .map(k => k -> cb.getInt(ConfigUtil.joinPath(k)))
+        .toMap
+    }
+  }
+}
+
+/**
+  * Handle for capacity reserved by [[RequestLimiter.acquire]]. The reserved permits are returned
+  * when [[release]] is called. Release is idempotent, so it is safe to attach it to more than one
+  * completion signal for a request.
+  */
+sealed trait LimitToken {
+  def release(): Unit
+}
+
+object LimitToken {
+
+  /** Token that holds no capacity, returned when limiting is not applied to a request. */
+  case object NoOp extends LimitToken {
+    override def release(): Unit = ()
+  }
+
+  def apply(fn: () => Unit): LimitToken = new Impl(fn)
+
+  private final class Impl(fn: () => Unit) extends LimitToken {
+
+    private val released = new AtomicBoolean(false)
+    override def release(): Unit = if (released.compareAndSet(false, true)) fn()
+  }
+}

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/ConcurrencyLimiterSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/ConcurrencyLimiterSuite.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.pekko
+
+import munit.FunSuite
+
+class ConcurrencyLimiterSuite extends FunSuite {
+
+  test("acquire and release a single permit") {
+    val limiter = ConcurrencyLimiter(2)
+    assert(limiter.tryAcquire("a", 1))
+    assertEquals(limiter.usedPermits, 1)
+    limiter.release("a", 1)
+    assertEquals(limiter.usedPermits, 0)
+  }
+
+  test("weighted acquire consumes multiple permits") {
+    val limiter = ConcurrencyLimiter(10)
+    assert(limiter.tryAcquire("a", 4))
+    assertEquals(limiter.usedPermits, 4)
+    assert(limiter.tryAcquire("b", 6))
+    assertEquals(limiter.usedPermits, 10)
+    assert(!limiter.tryAcquire("c", 1))
+  }
+
+  test("acquire fails when insufficient permits remain") {
+    val limiter = ConcurrencyLimiter(5)
+    assert(limiter.tryAcquire("a", 3))
+    assert(!limiter.tryAcquire("b", 3))
+    assertEquals(limiter.usedPermits, 3)
+    limiter.release("a", 3)
+    assert(limiter.tryAcquire("b", 3))
+  }
+
+  test("cost is clamped to the budget so a large request can still be admitted when idle") {
+    val limiter = ConcurrencyLimiter(4)
+    assert(limiter.tryAcquire("a", 100))
+    assertEquals(limiter.usedPermits, 4)
+    // A second request cannot get in until the first releases.
+    assert(!limiter.tryAcquire("b", 1))
+    limiter.release("a", 100)
+    assertEquals(limiter.usedPermits, 0)
+  }
+
+  test("cost below one is treated as one") {
+    val limiter = ConcurrencyLimiter(2)
+    assert(limiter.tryAcquire("a", 0))
+    assertEquals(limiter.usedPermits, 1)
+    assert(limiter.tryAcquire("b", -5))
+    assertEquals(limiter.usedPermits, 2)
+  }
+
+  test("budget of zero or less produces a limiter that always denies") {
+    assertEquals(ConcurrencyLimiter(0), NoneLimiter)
+    assertEquals(ConcurrencyLimiter(-1), NoneLimiter)
+    assert(!NoneLimiter.tryAcquire("a", 1))
+    assertEquals(NoneLimiter.maxPermits, 0)
+  }
+
+  test("unlimited limiter always permits") {
+    val limiter = ConcurrencyLimiter.Unlimited
+    assert(limiter.tryAcquire("a", Int.MaxValue))
+    assertEquals(limiter.usedPermits, 0)
+    assertEquals(limiter.maxPermits, Int.MaxValue)
+    limiter.release("a", Int.MaxValue)
+  }
+
+  test("maxPermits reflects the configured budget") {
+    assertEquals(ConcurrencyLimiter(7).maxPermits, 7)
+  }
+}

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/LimitKeyResolverSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/LimitKeyResolverSuite.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.pekko
+
+import munit.FunSuite
+import org.apache.pekko.http.scaladsl.model.HttpRequest
+
+class LimitKeyResolverSuite extends FunSuite {
+
+  private val resolver = new DefaultLimitKeyResolver(_ => Set("vip"))
+
+  private def app(id: String): CallerContext = {
+    CallerContext(Principal(Principal.Kind.App, id), Principal.Anonymous, None)
+  }
+
+  private def user(id: String): CallerContext = {
+    CallerContext(Principal(Principal.Kind.User, id), Principal.Anonymous, None)
+  }
+
+  test("provisioned caller gets its own bucket") {
+    val key = resolver.resolve(app("vip"), "graph", HttpRequest())
+    assertEquals(key, LimitKey("vip", "vip", "graph"))
+  }
+
+  test("authenticated but unprovisioned caller shares the default bucket") {
+    val key = resolver.resolve(app("some-app"), "graph", HttpRequest())
+    assertEquals(key, LimitKey(LimitKey.DefaultBucket, "some-app", "graph"))
+  }
+
+  test("user identity is used as the sub-key") {
+    val key = resolver.resolve(user("user@example.com"), "graph", HttpRequest())
+    assertEquals(key, LimitKey(LimitKey.DefaultBucket, "user@example.com", "graph"))
+  }
+
+  test("anonymous caller falls back to the legacy id query parameter") {
+    val request = HttpRequest(uri = "/api/v1/graph?id=legacy-app&q=name,sps,:eq")
+    val key = resolver.resolve(CallerContext.Anonymous, "graph", request)
+    assertEquals(key, LimitKey(LimitKey.DefaultBucket, "legacy-app", "graph"))
+  }
+
+  test("legacy id can select a provisioned bucket") {
+    val request = HttpRequest(uri = "/api/v1/graph?id=vip")
+    val key = resolver.resolve(CallerContext.Anonymous, "graph", request)
+    assertEquals(key, LimitKey("vip", "vip", "graph"))
+  }
+
+  test("anonymous caller with no legacy id uses the anonymous marker") {
+    val key = resolver.resolve(CallerContext.Anonymous, "graph", HttpRequest(uri = "/api/v1/graph"))
+    assertEquals(key, LimitKey(LimitKey.DefaultBucket, LimitKey.Anonymous, "graph"))
+  }
+
+  test("provisioning is scoped per endpoint") {
+    val perEndpoint =
+      new DefaultLimitKeyResolver(ep => if (ep == "graph") Set("vip") else Set.empty)
+    assertEquals(
+      perEndpoint.resolve(app("vip"), "graph", HttpRequest()),
+      LimitKey("vip", "vip", "graph")
+    )
+    assertEquals(
+      perEndpoint.resolve(app("vip"), "tags", HttpRequest()),
+      LimitKey(LimitKey.DefaultBucket, "vip", "tags")
+    )
+  }
+}

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/RequestLimiterSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/RequestLimiterSuite.scala
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.pekko
+
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import munit.FunSuite
+
+class RequestLimiterSuite extends FunSuite {
+
+  private def config(s: String): Config = ConfigFactory.parseString(s)
+
+  private def graphKey(subKey: String, bucket: String = LimitKey.DefaultBucket): LimitKey = {
+    LimitKey(bucket, subKey, "graph")
+  }
+
+  private def requests(
+    registry: Registry,
+    endpoint: String,
+    result: String,
+    reason: String
+  ): Long = {
+    registry
+      .counter(
+        "atlas.limiter.requests",
+        "endpoint",
+        endpoint,
+        "result",
+        result,
+        "reason",
+        reason
+      )
+      .count()
+  }
+
+  private val graphConfig =
+    """
+      |mode = enforce
+      |endpoints {
+      |  graph {
+      |    total-budget = 100
+      |    default-bucket-budget = 2
+      |    caller-budgets {
+      |      vip     = 4
+      |      blocked = 0
+      |    }
+      |  }
+      |}
+      |""".stripMargin
+
+  private def limiterMeterCount(registry: Registry): Int = {
+    import scala.jdk.CollectionConverters.*
+    registry.iterator().asScala.count(_.id().name().startsWith("atlas.limiter."))
+  }
+
+  test("off mode is a zero-cost bypass that permits everything and registers no meters") {
+    val registry = new DefaultRegistry()
+    val cfg = graphConfig.replace("mode = enforce", "mode = off")
+    val limiter = new RequestLimiter(config(cfg), registry)
+    val tokens = (1 to 100).flatMap(i => limiter.acquire(graphKey(s"u$i"), 10))
+    assertEquals(tokens.size, 100)
+    tokens.foreach(t => assertEquals(t, LimitToken.NoOp))
+    // Disabled limiting must not build limiters, gauges, or counters.
+    assertEquals(limiterMeterCount(registry), 0)
+  }
+
+  test("unlisted endpoint is not limited and records nothing even in enforce mode") {
+    val registry = new DefaultRegistry()
+    val limiter = new RequestLimiter(config(graphConfig), registry)
+    val key = LimitKey(LimitKey.DefaultBucket, "u1", "tags")
+    val tokens = (1 to 50).flatMap(_ => limiter.acquire(key, 1000))
+    assertEquals(tokens.size, 50)
+    assertEquals(requests(registry, "tags", "permitted", "none"), 0L)
+  }
+
+  test("shared default bucket is exhausted across distinct callers") {
+    val registry = new DefaultRegistry()
+    val limiter = new RequestLimiter(config(graphConfig), registry)
+    assert(limiter.acquire(graphKey("u1"), 1).isDefined)
+    assert(limiter.acquire(graphKey("u2"), 1).isDefined)
+    // Budget of 2 for the default bucket is now full.
+    assert(limiter.acquire(graphKey("u3"), 1).isEmpty)
+    assertEquals(requests(registry, "graph", "denied", "bucket"), 1L)
+  }
+
+  test("dedicated bucket has its own budget separate from the default bucket") {
+    val registry = new DefaultRegistry()
+    val limiter = new RequestLimiter(config(graphConfig), registry)
+    // Fill the default bucket.
+    assert(limiter.acquire(graphKey("u1"), 2).isDefined)
+    assert(limiter.acquire(graphKey("u2"), 1).isEmpty)
+    // The vip caller has its own dedicated bucket and is unaffected.
+    val vip = graphKey("vip", "vip")
+    assert(limiter.acquire(vip, 4).isDefined)
+    assert(limiter.acquire(vip, 1).isEmpty)
+  }
+
+  test("a bucket with a budget of zero blocks the caller") {
+    val registry = new DefaultRegistry()
+    val limiter = new RequestLimiter(config(graphConfig), registry)
+    val blocked = graphKey("blocked", "blocked")
+    assert(limiter.acquire(blocked, 1).isEmpty)
+    assertEquals(requests(registry, "graph", "denied", "bucket"), 1L)
+  }
+
+  test("endpoint total budget caps combined cost across buckets") {
+    val cfg =
+      """
+        |mode = enforce
+        |endpoints {
+        |  graph {
+        |    total-budget = 3
+        |    default-bucket-budget = 10
+        |    caller-budgets { vip = 2 }
+        |  }
+        |}
+        |""".stripMargin
+    val registry = new DefaultRegistry()
+    val limiter = new RequestLimiter(config(cfg), registry)
+
+    val d = limiter.acquire(graphKey("u1"), 2)
+    assert(d.isDefined)
+    // vip bucket would allow this, but the endpoint total (3) cannot fit another 2.
+    assert(limiter.acquire(graphKey("vip", "vip"), 2).isEmpty)
+    assertEquals(requests(registry, "graph", "denied", "total"), 1L)
+
+    // The vip bucket permits reserved before the total check must have been released: after
+    // freeing the total budget, a full vip request succeeds.
+    d.get.release()
+    assert(limiter.acquire(graphKey("vip", "vip"), 2).isDefined)
+  }
+
+  test("shadow mode reports denials but still admits the request") {
+    val cfg = graphConfig.replace("mode = enforce", "mode = shadow")
+    val registry = new DefaultRegistry()
+    val limiter = new RequestLimiter(config(cfg), registry)
+    assert(limiter.acquire(graphKey("u1"), 1).isDefined)
+    assert(limiter.acquire(graphKey("u2"), 1).isDefined)
+    // Would be denied in enforce mode, but shadow admits with a no-op token.
+    val shed = limiter.acquire(graphKey("u3"), 1)
+    assertEquals(shed, Some(LimitToken.NoOp))
+    assertEquals(requests(registry, "graph", "denied", "bucket"), 1L)
+  }
+
+  test("releasing a token frees the reserved capacity") {
+    val registry = new DefaultRegistry()
+    val limiter = new RequestLimiter(config(graphConfig), registry)
+    val t = limiter.acquire(graphKey("u1"), 2).get
+    assert(limiter.acquire(graphKey("u2"), 1).isEmpty)
+    t.release()
+    assert(limiter.acquire(graphKey("u2"), 2).isDefined)
+  }
+
+  test("token release is idempotent") {
+    val registry = new DefaultRegistry()
+    val limiter = new RequestLimiter(config(graphConfig), registry)
+    val a = limiter.acquire(graphKey("u1"), 1).get
+    val b = limiter.acquire(graphKey("u2"), 1).get
+    a.release()
+    a.release()
+    // Only b should still be holding a permit; a double release must not free b's slot.
+    assert(limiter.acquire(graphKey("u3"), 2).isEmpty)
+    b.release()
+    assert(limiter.acquire(graphKey("u3"), 2).isDefined)
+  }
+
+  test("dedicatedBuckets lists provisioned callers for an endpoint") {
+    val registry = new DefaultRegistry()
+    val limiter = new RequestLimiter(config(graphConfig), registry)
+    assertEquals(limiter.dedicatedBuckets("graph"), Set("vip", "blocked"))
+    assertEquals(limiter.dedicatedBuckets("tags"), Set.empty[String])
+  }
+
+  test("an unprovisioned bucket name collapses onto the shared default bucket") {
+    val registry = new DefaultRegistry()
+    val limiter = new RequestLimiter(config(graphConfig), registry)
+    // A bucket that is not provisioned must not mint its own limiter; it shares the default
+    // bucket (budget 2), so it competes for the same budget as other unprovisioned callers.
+    assert(limiter.acquire(graphKey("u1"), 1).isDefined)
+    assert(limiter.acquire(LimitKey("adhoc", "u2", "graph"), 1).isDefined)
+    assert(limiter.acquire(graphKey("u3"), 1).isEmpty)
+  }
+
+  test("a caller budget named default does not override the shared default bucket") {
+    val cfg =
+      """
+        |mode = enforce
+        |endpoints {
+        |  graph {
+        |    default-bucket-budget = 2
+        |    caller-budgets { default = 100 }
+        |  }
+        |}
+        |""".stripMargin
+    val registry = new DefaultRegistry()
+    val limiter = new RequestLimiter(config(cfg), registry)
+    // The reserved default bucket keeps default-bucket-budget (2), not the caller budget (100).
+    assert(limiter.acquire(graphKey("u1"), 1).isDefined)
+    assert(limiter.acquire(graphKey("u2"), 1).isDefined)
+    assert(limiter.acquire(graphKey("u3"), 1).isEmpty)
+  }
+
+  test("caller budget keys containing a dot are read literally") {
+    val cfg =
+      """
+        |mode = enforce
+        |endpoints {
+        |  graph {
+        |    default-bucket-budget = 1
+        |    caller-budgets { "app.with.dots" = 3 }
+        |  }
+        |}
+        |""".stripMargin
+    val registry = new DefaultRegistry()
+    val limiter = new RequestLimiter(config(cfg), registry)
+    assertEquals(limiter.dedicatedBuckets("graph"), Set("app.with.dots"))
+    val key = LimitKey("app.with.dots", "app.with.dots", "graph")
+    assert(limiter.acquire(key, 3).isDefined)
+    assert(limiter.acquire(key, 1).isEmpty)
+  }
+
+  test("unknown mode is rejected") {
+    intercept[IllegalArgumentException] {
+      new RequestLimiter(config("mode = bogus\nendpoints {}"), new DefaultRegistry())
+    }
+  }
+}


### PR DESCRIPTION
Add a weighted, non-blocking concurrency limiter for the web APIs, built on the existing extractCaller/CallerContext seam.

A request maps to a LimitKey (bucket, subKey, endpoint) and carries an estimated cost. It must acquire capacity, proportional to that cost, from both the per-bucket limiter for its caller and the endpoint's total limiter, holding the permits for the request lifetime and releasing both via an idempotent LimitToken.

Design:
- Concurrency, not RPS. Acquisition is non-blocking so a request that cannot get capacity is shed rather than queued on a dispatcher.
- Opt-in per endpoint: an endpoint not listed under atlas.pekko.request-limits.endpoints is unlimited. The second tier is a per-endpoint total budget, not one instance-wide global.
- Shared default bucket is the norm; only explicitly provisioned callers get a dedicated bucket. Unprovisioned bucket names collapse onto the default bucket, bounding the limiter and gauge cardinality.
- Modes: off (zero-cost bypass), shadow (compute, report, reserve, but admit would-deny requests), enforce (shed with a 429).
- LimitKeyResolver isolates how a caller is identified from the limiter, easing migration off the legacy id-parameter path.

Limiters and meters are pre-built at construction so the request path is only lookups plus a counter increment, allocating just the token on the permitted path. Reports atlas.limiter.{requests,cost,inflight}.

Not wired into any endpoint yet: cost functions, the rateLimited directive, and per-caller fairness within a shared bucket are follow-ups.