### PR TITLE
pekko: add per-caller fair-share limiter

### DIFF
--- a/atlas-pekko/src/main/resources/reference.conf
+++ b/atlas-pekko/src/main/resources/reference.conf
@@ -87,6 +87,24 @@ atlas.pekko {
     #   enforce - requests the policy denies are shed with a 429
     mode = "off"
 
+    # Tuning for buckets that enable fair sharing (see the per-endpoint `fair-share` flag). When a
+    # bucket is shared by many callers, this keeps one caller from starving the others: each gets an
+    # equal share and may borrow spare capacity, while a caller that keeps getting denied without
+    # backing off is held below its share until it stops hammering.
+    fair-share {
+      # How long after its last attempt a caller still counts as contending.
+      window = 5s
+
+      # Demerit at or above which a caller is treated as a hog and held below its fair share.
+      penalized-threshold = 3.0
+
+      # Amount added to a caller's demerit each time it is denied.
+      demerit-per-denial = 1.0
+
+      # Rate at which a caller's demerit decays while it is not being denied.
+      decay-per-second = 0.3
+    }
+
     # Per-endpoint budgets. The endpoint name is chosen by the endpoint applying the limit, for
     # example "graph" or "tags".
     endpoints {
@@ -94,6 +112,9 @@ atlas.pekko {
       #   # Cap on the combined cost across all buckets of this endpoint. Zero or absent means
       #   # there is no endpoint wide cap and only the per-bucket limits apply.
       #   total-budget = 100
+      #
+      #   # Whether the shared default bucket enforces per-caller fairness. Defaults to false.
+      #   fair-share = true
       #
       #   # Budget for the shared default bucket used by callers without a dedicated budget.
       #   # Required for any listed endpoint.

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/FairShareLimiter.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/FairShareLimiter.scala
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.pekko
+
+import com.netflix.spectator.api.Clock
+
+import java.time.Duration
+import scala.collection.mutable
+
+/**
+  * Weighted concurrency limiter for a bucket shared by many callers that keeps one caller from
+  * starving the others. It is a drop-in [[ConcurrencyLimiter]] that uses the `subKey` to identify
+  * the individual caller within the bucket.
+  *
+  * Each caller is assigned an equal share of the budget based on the number of callers currently
+  * contending (holding permits or having attempted within a recent window). A well-behaved caller
+  * may borrow spare capacity above its share while no other well-behaved caller is waiting. A
+  * caller that keeps getting denied without backing off accrues a decaying demerit; once it is
+  * over a threshold it is treated as a hog: it is held below its fair share (floored at one permit,
+  * never starved to zero) so headroom stays free for the others, and its own denials no longer
+  * count as contention that would block others from borrowing. The demerit decays over time, so a
+  * caller that stops hammering recovers its full share and the ability to borrow. Recent denial,
+  * not current usage, is what marks a caller as wanting more capacity.
+  *
+  * Fairness acts on admission decisions as permits churn rather than by preempting held permits, so
+  * it converges to a fair allocation as requests complete.
+  *
+  * Performance: all per-caller state lives in a single map keyed by `subKey`, and the running total
+  * is maintained incrementally. `tryAcquire` makes one pass over the recent callers, reusing a
+  * pre-allocated scan function, so it allocates nothing on the request path except a state object
+  * the first time a new caller is seen. The pass, the total, and all state are guarded by a single
+  * monitor; the section is O(number of recently active callers), which is bounded by concurrency.
+  *
+  * @param budget
+  *     Total number of permits shared by the bucket. Must be positive.
+  * @param clock
+  *     Source of monotonic time used for the contention window and demerit decay.
+  * @param window
+  *     How long after its last attempt a caller still counts as contending, and how long a denial
+  *     still marks a caller as wanting more capacity.
+  * @param penalizedThreshold
+  *     Demerit at or above which a caller is treated as a hog.
+  * @param demeritPerDenial
+  *     Amount added to a caller's demerit each time it is denied.
+  * @param decayPerSecond
+  *     Rate at which a caller's demerit decays while it is not being denied.
+  */
+final class FairShareLimiter(
+  budget: Int,
+  clock: Clock,
+  window: Duration,
+  penalizedThreshold: Double,
+  demeritPerDenial: Double,
+  decayPerSecond: Double
+) extends ConcurrencyLimiter {
+
+  import FairShareLimiter.*
+
+  require(budget > 0, s"budget must be positive: $budget")
+
+  private val windowNanos = window.toNanos
+  private val decayPerNano = decayPerSecond / 1e9
+
+  private val callers = new mutable.HashMap[String, CallerState]()
+  private var total = 0
+
+  // Scratch state for the single scan pass. Only touched while the monitor is held, so a single
+  // reusable scan function can read it without capturing per-call variables (which would allocate).
+  private var scanNow = 0L
+  private var scanSubKey: String = ""
+  private var scanActive = 0
+  private var scanContended = false
+
+  // Prune callers that are no longer active and no longer carry demerit, count the active callers,
+  // and detect whether another well-behaved caller was recently denied (and so wants capacity). A
+  // caller keeps its demerit until it fully decays, even after it ages out of the window, so a hog
+  // cannot shed a penalty just by pausing for one window.
+  private val scan: (String, CallerState) => Boolean = { (k, s) =>
+    val d = s.demerit(scanNow, decayPerNano)
+    val active = s.used > 0 || scanNow - s.lastSeen <= windowNanos
+    val keep = active || d > 0.0
+    if (keep) {
+      if (active) scanActive += 1
+      if (
+        !scanContended && k != scanSubKey && d < penalizedThreshold &&
+        s.lastDenied != NeverDenied && scanNow - s.lastDenied <= windowNanos
+      ) {
+        scanContended = true
+      }
+    }
+    keep
+  }
+
+  private def clamp(cost: Int): Int = math.min(budget, math.max(1, cost))
+
+  override def tryAcquire(subKey: String, cost: Int): Boolean = synchronized {
+    val now = clock.monotonicTime()
+    val c = clamp(cost)
+    val state = callers.getOrElseUpdate(subKey, new CallerState())
+    state.lastSeen = now
+
+    scanNow = now
+    scanSubKey = subKey
+    scanActive = 0
+    scanContended = false
+    callers.filterInPlace(scan)
+
+    val active = math.max(1, scanActive)
+    val share = math.ceil(budget.toDouble / active).toInt
+    val d = state.demerit(now, decayPerNano)
+    val cap =
+      if (d >= penalizedThreshold)
+        // A hog is contained below its fair share so headroom stays free for well-behaved bursts,
+        // floored at one permit rather than starved to zero. It is only penalized while its demerit
+        // is elevated; once it stops being denied the demerit decays and it recovers.
+        math.max(1, share - math.round(d).toInt)
+      else if (scanContended)
+        share
+      else
+        budget
+
+    if (total + c > budget || state.used + c > cap) {
+      state.demeritValue = d + demeritPerDenial
+      state.demeritTime = now
+      state.lastDenied = now
+      false
+    } else {
+      state.used += c
+      total += c
+      true
+    }
+  }
+
+  override def release(subKey: String, cost: Int): Unit = synchronized {
+    val c = clamp(cost)
+    // Decrement `total` only by what this caller actually held, so a mis-paired or duplicate
+    // release cannot drive `total` below the real usage (which would let the bucket over-admit).
+    // The state object is left in place so demerit and recency survive until it is pruned.
+    callers.get(subKey).foreach { state =>
+      if (state.used > 0) {
+        val released = math.min(state.used, c)
+        state.used -= released
+        total = math.max(0, total - released)
+      }
+    }
+  }
+
+  override def usedPermits: Int = synchronized(total)
+  override def maxPermits: Int = budget
+}
+
+object FairShareLimiter {
+
+  /** Sentinel meaning a caller has not been denied. */
+  private final val NeverDenied: Long = Long.MinValue
+
+  /** Mutable per-caller bookkeeping held in the limiter's map; primitive fields avoid boxing. */
+  private final class CallerState {
+
+    var used: Int = 0
+    var lastSeen: Long = 0L
+    var lastDenied: Long = NeverDenied
+    var demeritValue: Double = 0.0
+    var demeritTime: Long = 0L
+
+    /** Demerit decayed to `now`. */
+    def demerit(now: Long, decayPerNano: Double): Double = {
+      if (demeritValue <= 0.0) 0.0
+      else math.max(0.0, demeritValue - (now - demeritTime) * decayPerNano)
+    }
+  }
+}

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/RequestLimiter.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/RequestLimiter.scala
@@ -20,8 +20,10 @@ import com.netflix.spectator.api.DistributionSummary
 import com.netflix.spectator.api.Registry
 import com.netflix.spectator.api.patterns.PolledMeter
 import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigUtil
 
+import java.time.Duration
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.jdk.CollectionConverters.*
 
@@ -52,6 +54,11 @@ class RequestLimiter(config: Config, registry: Registry) {
   import RequestLimiter.*
 
   private val mode: Mode = Mode.fromString(config.getString("mode"))
+
+  private val clock = registry.clock()
+
+  // Tuning shared by every bucket that enables fair sharing.
+  private val fairShare: FairShareConfig = FairShareConfig.from(config)
 
   // When disabled there is nothing to enforce, so no limiters or gauges are built.
   private val endpoints: Map[String, EndpointLimiter] = {
@@ -94,7 +101,19 @@ class RequestLimiter(config: Config, registry: Registry) {
       else ConcurrencyLimiter(limits.totalBudget)
     monitorInflight(total, name, "__total__")
 
-    val default = ConcurrencyLimiter(limits.defaultBucketBudget)
+    // The default bucket is shared by many callers, so it can enable fair sharing to keep one
+    // caller from starving the others. Dedicated buckets are per-caller and so gain nothing.
+    val default =
+      if (limits.fairShare && limits.defaultBucketBudget > 0)
+        new FairShareLimiter(
+          limits.defaultBucketBudget,
+          clock,
+          fairShare.window,
+          fairShare.penalizedThreshold,
+          fairShare.demeritPerDenial,
+          fairShare.decayPerSecond
+        )
+      else ConcurrencyLimiter(limits.defaultBucketBudget)
     monitorInflight(default, name, LimitKey.DefaultBucket)
 
     // A caller budget named "default" is reserved for the shared bucket and does not create a
@@ -231,12 +250,49 @@ object RequestLimiter {
     * @param callerBudgets
     *     Dedicated budgets keyed by bucket name. Presence of an entry provisions a dedicated
     *     bucket for that caller. A value of zero blocks the bucket entirely.
+    * @param fairShare
+    *     Whether the shared default bucket enforces per-caller fairness.
     */
   private case class EndpointLimits(
     totalBudget: Int,
     defaultBucketBudget: Int,
-    callerBudgets: Map[String, Int]
+    callerBudgets: Map[String, Int],
+    fairShare: Boolean
   )
+
+  /** Tuning for buckets that enable fair sharing. */
+  private case class FairShareConfig(
+    window: Duration,
+    penalizedThreshold: Double,
+    demeritPerDenial: Double,
+    decayPerSecond: Double
+  )
+
+  private object FairShareConfig {
+
+    // Fallbacks used when a caller supplies config without merging reference.conf (for example a
+    // programmatic Config), and for any key omitted from a partial `fair-share` block. Keep these
+    // in sync with the reference.conf defaults.
+    private val defaults: Config = ConfigFactory.parseString(
+      """
+        |window = 5s
+        |penalized-threshold = 3.0
+        |demerit-per-denial = 1.0
+        |decay-per-second = 0.3
+        |""".stripMargin
+    )
+
+    def from(config: Config): FairShareConfig = {
+      val base = if (config.hasPath("fair-share")) config.getConfig("fair-share") else defaults
+      val c = base.withFallback(defaults)
+      FairShareConfig(
+        c.getDuration("window"),
+        c.getDouble("penalized-threshold"),
+        c.getDouble("demerit-per-denial"),
+        c.getDouble("decay-per-second")
+      )
+    }
+  }
 
   private def readEndpoints(config: Config): Map[String, EndpointLimits] = {
     if (!config.hasPath("endpoints")) Map.empty
@@ -251,7 +307,13 @@ object RequestLimiter {
           // literally rather than being interpreted as a nested config path.
           val ec = obj.getConfig(ConfigUtil.joinPath(name))
           val totalBudget = if (ec.hasPath("total-budget")) ec.getInt("total-budget") else 0
-          name -> EndpointLimits(totalBudget, ec.getInt("default-bucket-budget"), readBudgets(ec))
+          val fair = ec.hasPath("fair-share") && ec.getBoolean("fair-share")
+          name -> EndpointLimits(
+            totalBudget,
+            ec.getInt("default-bucket-budget"),
+            readBudgets(ec),
+            fair
+          )
         }
         .toMap
     }

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/FairShareLimiterSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/FairShareLimiterSuite.scala
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.pekko
+
+import com.netflix.spectator.api.ManualClock
+import munit.FunSuite
+
+import java.time.Duration
+
+class FairShareLimiterSuite extends FunSuite {
+
+  private val window = Duration.ofSeconds(5)
+
+  private def newLimiter(budget: Int, clock: ManualClock): FairShareLimiter = {
+    new FairShareLimiter(
+      budget,
+      clock,
+      window,
+      penalizedThreshold = 3.0,
+      demeritPerDenial = 1.0,
+      decayPerSecond = 0.3
+    )
+  }
+
+  // Advance the clock by the given number of seconds.
+  private def advance(clock: ManualClock, seconds: Long): Unit = {
+    clock.setMonotonicTime(clock.monotonicTime() + seconds * 1_000_000_000L)
+  }
+
+  test("acquire and release within budget") {
+    val limiter = newLimiter(4, new ManualClock())
+    assert(limiter.tryAcquire("a", 2))
+    assertEquals(limiter.usedPermits, 2)
+    limiter.release("a", 2)
+    assertEquals(limiter.usedPermits, 0)
+  }
+
+  test("a lone caller may use the whole budget") {
+    val limiter = newLimiter(4, new ManualClock())
+    assert(limiter.tryAcquire("a", 4))
+    assertEquals(limiter.usedPermits, 4)
+    assert(!limiter.tryAcquire("a", 1))
+  }
+
+  test("a well-behaved caller may borrow above its share when nobody else is waiting") {
+    val limiter = newLimiter(4, new ManualClock())
+    // b has attempted, so it counts toward the active set (share becomes 2), but it has not been
+    // denied, so a may still borrow the spare capacity.
+    assert(limiter.tryAcquire("b", 1))
+    assert(limiter.tryAcquire("a", 3))
+    assertEquals(limiter.usedPermits, 4)
+  }
+
+  test("a hog is contained to a floor and a victim can still acquire") {
+    val clock = new ManualClock()
+    val limiter = newLimiter(4, clock)
+
+    // The hog grabs the whole budget while alone.
+    (1 to 4).foreach(_ => assert(limiter.tryAcquire("hog", 1)))
+    assertEquals(limiter.usedPermits, 4)
+
+    // The victim is denied because the bucket is full, which marks it as wanting more.
+    assert(!limiter.tryAcquire("victim", 1))
+
+    // The hog keeps hammering and, being denied without backing off, accrues demerit until it is
+    // penalized (threshold 3.0 with +1 per denial).
+    (1 to 3).foreach(_ => assert(!limiter.tryAcquire("hog", 1)))
+
+    // A permit frees up. The penalized hog cannot reclaim it (held to its reduced share)...
+    limiter.release("hog", 1)
+    assert(!limiter.tryAcquire("hog", 1))
+    // ...but the victim, which is under its share, can.
+    assert(limiter.tryAcquire("victim", 1))
+  }
+
+  test("a hog recovers once its demerit decays") {
+    val clock = new ManualClock()
+    val limiter = newLimiter(4, clock)
+
+    // Drive the hog over the penalty threshold while the victim contends for capacity.
+    (1 to 4).foreach(_ => assert(limiter.tryAcquire("hog", 1)))
+    assert(!limiter.tryAcquire("victim", 1))
+    (1 to 3).foreach(_ => assert(!limiter.tryAcquire("hog", 1)))
+    limiter.release("hog", 1)
+    assert(!limiter.tryAcquire("hog", 1))
+
+    // Free the bucket and let enough time pass for the demerit to decay below the threshold. The
+    // former hog, no longer penalized and with nobody waiting, can use the capacity again.
+    limiter.release("hog", 3)
+    advance(clock, 30)
+    assert(limiter.tryAcquire("hog", 4))
+    assertEquals(limiter.usedPermits, 4)
+  }
+
+  test("cost is clamped to the budget") {
+    val limiter = newLimiter(4, new ManualClock())
+    assert(limiter.tryAcquire("a", 100))
+    assertEquals(limiter.usedPermits, 4)
+    limiter.release("a", 100)
+    assertEquals(limiter.usedPermits, 0)
+  }
+
+  test("bookkeeping is pruned once callers age out of the window") {
+    val clock = new ManualClock()
+    val limiter = newLimiter(4, clock)
+    assert(limiter.tryAcquire("a", 1))
+    limiter.release("a", 1)
+    // After the window passes with no activity from "a", a new caller sees the full budget as its
+    // share (active count of one), confirming "a" is no longer counted.
+    advance(clock, 10)
+    assert(limiter.tryAcquire("b", 4))
+    assertEquals(limiter.usedPermits, 4)
+  }
+
+  test("borrowing is blocked while another well-behaved caller is waiting") {
+    val clock = new ManualClock()
+    val limiter = newLimiter(4, clock)
+
+    // a holds its equal share (2 of 4 for two active callers).
+    assert(limiter.tryAcquire("a", 2))
+    // b attempts and is denied, marking it as wanting more capacity.
+    assert(!limiter.tryAcquire("b", 3))
+    // a may not borrow above its share while b is waiting.
+    assert(!limiter.tryAcquire("a", 1))
+
+    // Once b ages out of the window it no longer counts as waiting, and a (now the only active
+    // caller) may use the rest of the budget.
+    advance(clock, 10)
+    assert(limiter.tryAcquire("a", 2))
+    assertEquals(limiter.usedPermits, 4)
+  }
+
+  test("concurrent acquire and release keep budget accounting consistent") {
+    val budget = 8
+    val limiter = newLimiter(budget, new ManualClock())
+    val threads = 8
+    val iterations = 5000
+    val violations = new java.util.concurrent.atomic.AtomicInteger(0)
+
+    val workers = (0 until threads).map { t =>
+      val thread = new Thread(() => {
+        val key = s"c$t"
+        var i = 0
+        while (i < iterations) {
+          val cost = 1 + (i % 2)
+          if (limiter.tryAcquire(key, cost)) {
+            val u = limiter.usedPermits
+            if (u < 0 || u > budget) violations.incrementAndGet()
+            limiter.release(key, cost)
+          }
+          i += 1
+        }
+      })
+      thread.start()
+      thread
+    }
+    workers.foreach(_.join())
+
+    // The budget invariant must hold at every observation, and with every acquire balanced by a
+    // release the accounting must return to exactly zero.
+    assertEquals(violations.get(), 0)
+    assertEquals(limiter.usedPermits, 0)
+  }
+
+  test("budget must be positive") {
+    intercept[IllegalArgumentException] {
+      newLimiter(0, new ManualClock())
+    }
+  }
+}

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/RequestLimiterSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/RequestLimiterSuite.scala
@@ -239,4 +239,48 @@ class RequestLimiterSuite extends FunSuite {
       new RequestLimiter(config("mode = bogus\nendpoints {}"), new DefaultRegistry())
     }
   }
+
+  test("fair-share default bucket contains a hog while a victim can still acquire") {
+    val cfg =
+      """
+        |mode = enforce
+        |endpoints {
+        |  graph {
+        |    fair-share = true
+        |    default-bucket-budget = 4
+        |  }
+        |}
+        |""".stripMargin
+    val registry = new DefaultRegistry()
+    val limiter = new RequestLimiter(config(cfg), registry)
+
+    // Hog fills the shared bucket, then keeps hammering until it is penalized.
+    val held = (1 to 4).flatMap(_ => limiter.acquire(graphKey("hog"), 1))
+    assertEquals(held.size, 4)
+    assert(limiter.acquire(graphKey("victim"), 1).isEmpty) // bucket full, marks victim as waiting
+    (1 to 3).foreach(_ => assert(limiter.acquire(graphKey("hog"), 1).isEmpty))
+
+    // A permit frees: the penalized hog cannot reclaim it, but the victim can.
+    held.head.release()
+    assert(limiter.acquire(graphKey("hog"), 1).isEmpty)
+    assert(limiter.acquire(graphKey("victim"), 1).isDefined)
+  }
+
+  test("fair-share is off by default so the default bucket is a plain shared limiter") {
+    val cfg =
+      """
+        |mode = enforce
+        |endpoints {
+        |  graph { default-bucket-budget = 4 }
+        |}
+        |""".stripMargin
+    val registry = new DefaultRegistry()
+    val limiter = new RequestLimiter(config(cfg), registry)
+    // Without fair sharing a single caller can take the whole bucket and is not penalized.
+    val held = (1 to 4).flatMap(_ => limiter.acquire(graphKey("hog"), 1))
+    assertEquals(held.size, 4)
+    held.head.release()
+    // The freed permit is available first-come, including back to the same caller.
+    assert(limiter.acquire(graphKey("hog"), 1).isDefined)
+  }
 }


### PR DESCRIPTION
Add FairShareLimiter, a ConcurrencyLimiter for a bucket shared by many callers that keeps one caller from starving the others. It uses the LimitKey subKey to identify the caller within the bucket.

Each contending caller (holding permits or seen within a recent window) gets an equal share of the budget. A well-behaved caller may borrow spare capacity above its share while no other well-behaved caller was recently denied. A caller that keeps getting denied without backing off accrues a decaying demerit; over a threshold it is treated as a hog and held below its share (floored at one permit, never zeroed) so headroom stays free for others, and its own denials no longer count as contention. The demerit decays so a caller that stops hammering recovers. Fairness acts on admission as permits churn rather than preempting held permits.

Wired into RequestLimiter behind a per-endpoint `fair-share` flag that applies to the shared default bucket only; dedicated buckets are per-caller and gain nothing. Tuning lives under
atlas.pekko.request-limits.fair-share and is off by default.

All per-caller state is a single map with primitive fields and an incrementally maintained total, so tryAcquire makes one pass over the recent callers with no per-request allocation once a caller is known.