### PR TITLE
pekko: lazily build request authenticator

### DIFF
--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/RequestHandler.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/RequestHandler.scala
@@ -130,7 +130,11 @@ object RequestHandler extends StrictLogging {
       config.getDouble("atlas.pekko.request-handler.close-probability")
     }
 
-    val requestAuthenticator: RequestAuthenticator = {
+    // Lazy so the authenticator is built only when the routes are actually wired (the real
+    // `Settings(config)` path), not eagerly for the `defaultSettings` singleton built from
+    // `ConfigFactory.load()` at object init. A stateful authenticator otherwise gets constructed
+    // early from the wrong config source (and twice).
+    lazy val requestAuthenticator: RequestAuthenticator = {
       RequestAuthenticator(config)
     }
   }


### PR DESCRIPTION
Settings.requestAuthenticator was an eager val reflectively built from config. Because defaultSettings = Settings(ConfigFactory.load()) is an object-init singleton and the default argument of standardOptions, a configured authenticator was constructed early from the wrong config source, and again for the real Settings(config). A stateful authenticator would run its construction side effects twice/early.

Make it a lazy val so it is built only when first used on the real dependency-injected config path.