### PR TITLE
webapi: attribute read requests to caller

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/GraphConfig.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/GraphConfig.scala
@@ -28,6 +28,7 @@ import com.netflix.atlas.core.model.StyleExpr
 import com.netflix.atlas.core.util.Features
 import com.netflix.atlas.core.util.Step
 import com.netflix.atlas.core.util.Strings
+import com.netflix.atlas.pekko.CallerContext
 
 import scala.util.Try
 
@@ -45,7 +46,10 @@ case class GraphConfig(
   features: Features,
   isBrowser: Boolean,
   isAllowedFromBrowser: Boolean,
-  uri: String
+  uri: String,
+  // Identity of the caller, populated from the request by the endpoint so downstream data access
+  // can be attributed to a caller. Defaults to the anonymous caller when not established.
+  caller: CallerContext = CallerContext.Anonymous
 ) {
 
   import GraphConfig.*

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/graph/Grapher.scala
@@ -46,6 +46,7 @@ import com.netflix.atlas.core.util.Features
 import com.netflix.atlas.core.util.Strings
 import com.netflix.atlas.core.util.UnitPrefix
 import com.netflix.atlas.eval.util.IdParamSanitizer
+import com.netflix.atlas.pekko.CallerContext
 import com.netflix.atlas.pekko.Cors
 import com.typesafe.config.Config
 
@@ -58,9 +59,13 @@ case class Grapher(settings: DefaultSettings) {
 
   /**
     * Create a graph config from a request object. This will look at the URI and try to
-    * extract some context from the headers.
+    * extract some context from the headers. The `caller`, if established by an upstream
+    * authenticator, is recorded on the config so downstream data access can be attributed.
     */
-  def toGraphConfig(request: HttpRequest): GraphConfig = {
+  def toGraphConfig(
+    request: HttpRequest,
+    caller: CallerContext = CallerContext.Anonymous
+  ): GraphConfig = {
     val config = rewriteBasedOnHost(request, toGraphConfig(request.uri))
 
     // Check if the request is coming from a browser
@@ -76,9 +81,9 @@ case class Grapher(settings: DefaultSettings) {
         .find(_.is("origin"))
         .flatMap(h => Cors.normalizedOrigin(h.value()))
         .getOrElse("default")
-      config.copy(isBrowser = isBrowser, id = IdParamSanitizer.sanitize(origin))
+      config.copy(isBrowser = isBrowser, id = IdParamSanitizer.sanitize(origin), caller = caller)
     } else {
-      config.copy(isBrowser = isBrowser)
+      config.copy(isBrowser = isBrowser, caller = caller)
     }
   }
 

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/GraphApi.scala
@@ -36,19 +36,23 @@ class GraphApi(config: Config, implicit val actorRefFactory: ActorRefFactory) ex
 
   def routes: Route = {
     endpointPath("api" / "v1" / "graph") {
-      get { ctx =>
-        val reqHandler = actorRefFactory.actorOf(Props(new GraphRequestActor(grapher, registry)))
-        val graphCfg = grapher.toGraphConfig(ctx.request)
-        val rc = ImperativeRequestContext(graphCfg, ctx)
-        reqHandler ! rc
-        rc.promise.future
+      get {
+        extractCaller { caller => ctx =>
+          val reqHandler = actorRefFactory.actorOf(Props(new GraphRequestActor(grapher, registry)))
+          val graphCfg = grapher.toGraphConfig(ctx.request, caller)
+          val rc = ImperativeRequestContext(graphCfg, ctx)
+          reqHandler ! rc
+          rc.promise.future
+        }
       }
     } ~
     endpointPath("api" / "v2" / "fetch") {
       get {
-        extractRequest { request =>
-          val graphCfg = grapher.toGraphConfig(request)
-          complete(FetchRequestSource.createResponse(actorRefFactory, graphCfg))
+        extractCaller { caller =>
+          extractRequest { request =>
+            val graphCfg = grapher.toGraphConfig(request, caller)
+            complete(FetchRequestSource.createResponse(actorRefFactory, graphCfg))
+          }
         }
       }
     }

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalDatabaseActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalDatabaseActor.scala
@@ -35,10 +35,12 @@ class LocalDatabaseActor(db: Database) extends Actor with ActorLogging {
   }
 
   private def innerReceive: Receive = {
-    case ListTagsRequest(tq)   => sender() ! TagListResponse(db.index.findTags(tq))
-    case ListKeysRequest(tq)   => sender() ! KeyListResponse(db.index.findKeys(tq))
-    case ListValuesRequest(tq) => sender() ! ValueListResponse(db.index.findValues(tq))
-    case req: DataRequest      => sender() ! executeDataRequest(req)
+    // The `caller` carried on these requests (and on DataRequest via its GraphConfig) is available
+    // for attribution but is not consumed by this local database; a remote database can read it.
+    case r: ListTagsRequest   => sender() ! TagListResponse(db.index.findTags(r.q))
+    case r: ListKeysRequest   => sender() ! KeyListResponse(db.index.findKeys(r.q))
+    case r: ListValuesRequest => sender() ! ValueListResponse(db.index.findValues(r.q))
+    case req: DataRequest     => sender() ! executeDataRequest(req)
   }
 
   private def executeDataRequest(req: DataRequest): DataResponse = {

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsApi.scala
@@ -33,6 +33,7 @@ import com.netflix.atlas.core.model.QueryVocabulary
 import com.netflix.atlas.core.model.Tag
 import com.netflix.atlas.core.stacklang.Interpreter
 import com.netflix.atlas.json3.Json
+import com.netflix.atlas.pekko.CallerContext
 import com.netflix.atlas.pekko.CustomDirectives.*
 import com.netflix.atlas.pekko.WebApi
 
@@ -60,22 +61,25 @@ class TagsApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi {
 
   private def handleReq(path: Option[String]): Route = {
     get {
-      extractRequestContext { ctx =>
-        val req = toRequest(ctx, path)
-        val limit = req.actualLimit
-        _ =>
-          ask(dbRef, req.toDbRequest)(60.seconds).map {
-            case TagListResponse(vs) if req.useText => asText(tagString(vs), offsetTag(limit, vs))
-            case KeyListResponse(vs) if req.useText =>
-              asText(vs.mkString("\n"), offsetString(limit, vs))
-            case ValueListResponse(vs) if req.useText =>
-              asText(vs.mkString("\n"), offsetString(limit, vs))
-            case TagListResponse(vs) if req.useJson   => asJson(vs, offsetTag(limit, vs))
-            case KeyListResponse(vs) if req.useJson   => asJson(vs, offsetString(limit, vs))
-            case ValueListResponse(vs) if req.useJson => asJson(vs, offsetString(limit, vs))
-            case Failure(t)                           => throw t
-            case v                                    => throw new MatchError(v)
-          }
+      extractCaller { caller =>
+        extractRequestContext { ctx =>
+          val req = toRequest(ctx, path)
+          val limit = req.actualLimit
+          _ =>
+            ask(dbRef, req.toDbRequest(caller))(60.seconds).map {
+              case TagListResponse(vs) if req.useText =>
+                asText(tagString(vs), offsetTag(limit, vs))
+              case KeyListResponse(vs) if req.useText =>
+                asText(vs.mkString("\n"), offsetString(limit, vs))
+              case ValueListResponse(vs) if req.useText =>
+                asText(vs.mkString("\n"), offsetString(limit, vs))
+              case TagListResponse(vs) if req.useJson   => asJson(vs, offsetTag(limit, vs))
+              case KeyListResponse(vs) if req.useJson   => asJson(vs, offsetString(limit, vs))
+              case ValueListResponse(vs) if req.useJson => asJson(vs, offsetString(limit, vs))
+              case Failure(t)                           => throw t
+              case v                                    => throw new MatchError(v)
+            }
+        }
       }
     }
   }
@@ -146,12 +150,12 @@ object TagsApi {
 
     def useJson: Boolean = !useText
 
-    def toDbRequest: AnyRef = {
+    def toDbRequest(caller: CallerContext): AnyRef = {
       (key -> verbose) match {
-        case (Some(k), true)  => ListTagsRequest(toTagQuery(Query.HasKey(k)))
-        case (Some(k), false) => ListValuesRequest(toTagQuery(Query.HasKey(k)))
-        case (None, true)     => ListTagsRequest(toTagQuery(Query.True))
-        case (None, false)    => ListKeysRequest(toTagQuery(Query.True))
+        case (Some(k), true)  => ListTagsRequest(toTagQuery(Query.HasKey(k)), caller)
+        case (Some(k), false) => ListValuesRequest(toTagQuery(Query.HasKey(k)), caller)
+        case (None, true)     => ListTagsRequest(toTagQuery(Query.True), caller)
+        case (None, false)    => ListKeysRequest(toTagQuery(Query.True), caller)
       }
     }
 
@@ -170,11 +174,13 @@ object TagsApi {
     }
   }
 
-  case class ListTagsRequest(q: TagQuery)
+  // The `caller` on these requests is propagated from the endpoint so downstream data access can
+  // be attributed to a caller. It defaults to the anonymous caller when not provided.
+  case class ListTagsRequest(q: TagQuery, caller: CallerContext = CallerContext.Anonymous)
 
-  case class ListKeysRequest(q: TagQuery)
+  case class ListKeysRequest(q: TagQuery, caller: CallerContext = CallerContext.Anonymous)
 
-  case class ListValuesRequest(q: TagQuery)
+  case class ListValuesRequest(q: TagQuery, caller: CallerContext = CallerContext.Anonymous)
 
   case class KeyListResponse(vs: List[String])
 


### PR DESCRIPTION
Extract the caller identity in the graph, fetch, and tags read APIs via the extractCaller directive and propagate it to the backend so data access can be attributed to a caller.

For graph and fetch the caller is carried on GraphConfig, which already flows to the data layer via DataRequest, so no per-message threading is needed. Grapher.toGraphConfig takes the caller and folds it into the copy it already performs. Tags has no GraphConfig, so the caller is threaded onto ListTagsRequest/ListKeysRequest/ListValuesRequest.

The local database does not consume the caller; it is available for a remote database to use for attribution. Defaults to the anonymous caller when no identity was established, so behavior is unchanged when no authenticator is configured.