### PR TITLE
core: mark approx-distinct operators as stable

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -1290,7 +1290,7 @@ object MathExpr {
         // Re-materialize the rewrite from its display string. This is reconstructing an
         // expression that was already accepted, so it must not re-enforce the stability gate;
         // otherwise rewrites such as normalization or `:cq` would fail for a named rewrite built
-        // from an unstable operator (e.g. :approx-distinct-cumulative).
+        // from an operator gated behind the unstable features flag.
         val ctxt =
           context.interpreter.execute(toString(newDisplayExpr), Map.empty, Features.UNSTABLE)
         ctxt.stack match {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -1329,10 +1329,6 @@ object MathVocabulary extends Vocabulary {
         MathExpr.ApproxDistinct(t) :: stack
     }
 
-    // Not yet stable: the distinct count sketch statistic still needs cross-team sign-off, so
-    // gate the operator behind the unstable features flag until the API is finalized.
-    override def isStable: Boolean = false
-
     override def summary: String =
       """
         |Estimate the number of distinct values recorded into a distinct count sketch. The data

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/StatefulVocabulary.scala
@@ -92,9 +92,7 @@ object StatefulVocabulary extends Vocabulary {
       List(
         "name,server.uniqueUsers,:eq",
         "name,server.uniqueUsers,:eq,(,nf.region,),:by"
-      ),
-      // Unstable: it expands to :approx-distinct, which is not yet stable.
-      stable = false
+      )
     )
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ApproxDistinctCumulativeSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ApproxDistinctCumulativeSuite.scala
@@ -32,7 +32,7 @@ class ApproxDistinctCumulativeSuite extends FunSuite {
   private val step = 60000L
 
   private def parseExpr(str: String): TimeSeriesExpr = {
-    interpreter.execute(str, Map.empty[String, Any], Features.UNSTABLE).stack match {
+    interpreter.execute(str, Map.empty[String, Any], Features.STABLE).stack match {
       case (v: TimeSeriesExpr) :: _ => v
       case _                        => throw new IllegalArgumentException("invalid expr")
     }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ApproxDistinctSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ApproxDistinctSuite.scala
@@ -47,8 +47,7 @@ class ApproxDistinctSuite extends FunSuite {
   }
 
   private def parseExpr(str: String): TimeSeriesExpr = {
-    // :approx-distinct is not yet a stable word, so enable unstable features.
-    interpreter.execute(str, Map.empty[String, Any], Features.UNSTABLE).stack match {
+    interpreter.execute(str, Map.empty[String, Any], Features.STABLE).stack match {
       case (v: TimeSeriesExpr) :: _ => v
       case _                        => throw new IllegalArgumentException("invalid expr")
     }


### PR DESCRIPTION
Remove the unstable gate from :approx-distinct and :approx-distinct-cumulative now that the distinct count sketch API is finalized. Drops the ApproxDistinct.isStable=false override and the approx-distinct-cumulative TypedMacro stable=false argument; both default to stable.

The two suites now execute with Features.STABLE instead of UNSTABLE, verifying the operators work without the flag. NamedRewrite.rewrite still re-materializes with UNSTABLE (general safety so re-parsing an already-accepted rewrite never re-checks the gate); only its stale example comment was generalized.