### PR TITLE
scalafmt 3.11.5

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.7.4
+version = 3.11.5
 runner.dialect = Scala213Source3
 
 style = defaultWithAlign

--- a/atlas-chart/src/main/scala/com/netflix/atlas/chart/util/PngImage.scala
+++ b/atlas-chart/src/main/scala/com/netflix/atlas/chart/util/PngImage.scala
@@ -197,7 +197,7 @@ object PngImage {
   private def newBufferedImage(img: RenderedImage): BufferedImage = {
     img match {
       case bi: BufferedImage => bi
-      case _ =>
+      case _                 =>
         val w = img.getWidth
         val h = img.getHeight
         val bi = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Block.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Block.scala
@@ -120,7 +120,7 @@ object Block {
     (block1, block2) match {
       case (b1: ArrayBlock, _) => b1.add(block2); b1
       case (_, b2: ArrayBlock) => b2.add(block1); b2
-      case _ =>
+      case _                   =>
         val b1 = block1.toArrayBlock
         b1.add(block2)
         b1

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/ExprNormalizer.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/ExprNormalizer.scala
@@ -116,7 +116,7 @@ object ExprNormalizer {
     queries match {
       case Nil      => queries
       case _ :: Nil => queries
-      case _ =>
+      case _        =>
         val indexed = queries.map(q => q -> q.toSet)
         indexed
           .filterNot {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathExpr.scala
@@ -844,7 +844,7 @@ object MathExpr {
       val newData = sorted.flatMap {
         case (null, _) => Nil
         case (_, Nil)  => List(TimeSeries.noData(context.step))
-        case (k, ts) =>
+        case (k, ts)   =>
           val tags = ts.head.tags.filter(e => ks.contains(e._1))
           val aggr = expr.aggregator(context.start, context.end)
           ts.foreach(aggr.update)

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/MathVocabulary.scala
@@ -1280,7 +1280,7 @@ object MathVocabulary extends Vocabulary {
         val expr = t match {
           case af: AggregateFunction => DataExpr.GroupBy(toSum(af), List(TagKey.percentile))
           case by: DataExpr.GroupBy  => DataExpr.GroupBy(toSum(by.af), TagKey.percentile :: by.keys)
-          case _ =>
+          case _                     =>
             throw new IllegalArgumentException(":percentiles can only be used with :sum and :by")
         }
         MathExpr.Percentiles(expr, pcts) :: stack

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/stacklang/Interpreter.scala
@@ -505,7 +505,7 @@ object Interpreter {
     val escaped = str match {
       case "(" => "\\u0028"
       case ")" => "\\u0029"
-      case s =>
+      case s   =>
         val f = indexOfNonWhitespace(s)
         val l = lastIndexOfNonWhitespace(s)
         if (f >= 0 && l >= 0) {
@@ -529,7 +529,7 @@ object Interpreter {
     str match {
       case "(" => builder.append("\\u0028")
       case ")" => builder.append("\\u0029")
-      case s =>
+      case s   =>
         val f = indexOfNonWhitespace(s)
         val l = lastIndexOfNonWhitespace(s)
         if (f >= 0 && l >= 0) {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/SortedTagMap.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/SortedTagMap.scala
@@ -304,7 +304,7 @@ object SortedTagMap {
     */
   def apply(data: IterableOnce[(String, String)]): SortedTagMap = {
     data match {
-      case m: SortedTagMap => m
+      case m: SortedTagMap                   => m
       case m: Map[String, String] @unchecked =>
         builder(m.size).addAll(m).result()
       case _ =>

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/StringFormatter.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/StringFormatter.scala
@@ -187,7 +187,7 @@ object StringFormatter {
       val maxPrecision = formatType match {
         case 's' => MaxStringPrecision
         case 'f' => MaxFloatPrecision
-        case _ =>
+        case _   =>
           throw new IllegalArgumentException(s"precision not allowed for type $formatType")
       }
       if (p < 0 || p > maxPrecision) {

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/Strings.scala
@@ -138,7 +138,7 @@ object Strings {
     else {
       conversions.get(c) match {
         case Some(f) => f(v).asInstanceOf[T]
-        case None =>
+        case None    =>
           throw new IllegalArgumentException(
             "unsupported property type " +
               c.getName + ", must be one of " +

--- a/atlas-core/src/main/scala/com/netflix/atlas/core/util/UnitPrefix.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/util/UnitPrefix.scala
@@ -126,7 +126,7 @@ object UnitPrefix {
     math.abs(value) match {
       case v if isNearlyZero(v)      => sec
       case v if !JDouble.isFinite(v) => sec
-      case v if v >= sec.factor =>
+      case v if v >= sec.factor      =>
         durationBigPrefixes.find(_.factor <= v).getOrElse(year)
       case v if v < 1.0 =>
         durationSmallPrefixes.find(_.factor <= v).getOrElse(picos)
@@ -176,7 +176,7 @@ object UnitPrefix {
       case v if isNearlyZero(v)          => sec
       case v if !JDouble.isFinite(v)     => sec
       case v if v < sec.factor && v >= 1 => sec
-      case v if v >= sec.factor =>
+      case v if v >= sec.factor          =>
         var last = sec
         var found: UnitPrefix = null
         durationBigPrefixes.reverse.foreach { prefix =>

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/PercentilesSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/PercentilesSuite.scala
@@ -25,8 +25,6 @@ import com.netflix.spectator.api.histogram.PercentileDistributionSummary
 import com.netflix.spectator.api.histogram.PercentileTimer
 import munit.FunSuite
 
-import scala.language.postfixOps
-
 class PercentilesSuite extends FunSuite {
 
   private val interpreter = Interpreter(MathVocabulary.allWords)
@@ -62,7 +60,7 @@ class PercentilesSuite extends FunSuite {
       val bucket = f"D${PercentileBuckets.indexOf(i)}%04X"
       val v = 1.0 / 60.0
       ts(bucket, v, v)
-    } toList
+    }.toList
   }
 
   private val inputNaN100 = {
@@ -70,7 +68,7 @@ class PercentilesSuite extends FunSuite {
       val bucket = f"D${PercentileBuckets.indexOf(i)}%04X"
       val v = 1.0 / 60.0
       ts(bucket, v, Double.NaN)
-    } toList
+    }.toList
   }
 
   private val inputBad100 = {
@@ -79,7 +77,7 @@ class PercentilesSuite extends FunSuite {
       val bucket = f"D${PercentileBuckets.indexOf(i)}%04x"
       val v = 1.0 / 60.0
       ts(bucket, v, v)
-    } toList
+    }.toList
   }
 
   private val inputTimer100 = {
@@ -87,7 +85,7 @@ class PercentilesSuite extends FunSuite {
       val bucket = f"T${PercentileBuckets.indexOf(i)}%04X"
       val v = 1.0 / 60.0
       ts(bucket, v, v)
-    } toList
+    }.toList
   }
 
   private val inputNaN = {
@@ -95,7 +93,7 @@ class PercentilesSuite extends FunSuite {
       val bucket = f"D${PercentileBuckets.indexOf(i)}%04X"
       val v = Double.NaN
       ts(bucket, v, v)
-    } toList
+    }.toList
   }
 
   private val inputSpectatorTimer = {

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/TimeSeriesExprSuite.scala
@@ -68,27 +68,27 @@ class TimeSeriesExprSuite extends FunSuite {
     ":true,10,:mul"              -> const(ts(unknownTag, "name=unknown", 55.0 * 10)),
     ":true,10,:div"              -> const(ts(unknownTag, "name=unknown", 55.0 / 10)),
     ":true,2,:pow"               -> const(ts(unknownTag, "name=unknown", math.pow(55.0, 2.0))),
-    "2,:true,:pow" -> const(
+    "2,:true,:pow"               -> const(
       ts(Map("name" -> "2.0"), "name=2.0", math.pow(2.0, 55.0))
     ),
-    ":true,0,:div"   -> const(ts(unknownTag, "name=unknown", Double.NaN)),
-    ":true,55,:gt"   -> const(ts(unknownTag, "name=unknown", 0.0)),
-    ":true,0,:gt"    -> const(ts(unknownTag, "name=unknown", 1.0)),
-    ":true,55.1,:ge" -> const(ts(unknownTag, "name=unknown", 0.0)),
-    ":true,55,:ge"   -> const(ts(unknownTag, "name=unknown", 1.0)),
-    ":true,0,:ge"    -> const(ts(unknownTag, "name=unknown", 1.0)),
-    ":true,55,:lt"   -> const(ts(unknownTag, "name=unknown", 0.0)),
-    ":true,56,:lt"   -> const(ts(unknownTag, "name=unknown", 1.0)),
-    ":true,55.1,:le" -> const(ts(unknownTag, "name=unknown", 1.0)),
-    ":true,55,:le"   -> const(ts(unknownTag, "name=unknown", 1.0)),
-    ":true,0,:le"    -> const(ts(unknownTag, "name=unknown", 0.0)),
-    ":true,0,:and"   -> const(ts(unknownTag, "name=unknown", 0.0)),
-    ":true,1,:and"   -> const(ts(unknownTag, "name=unknown", 1.0)),
-    ":true,0,:or"    -> const(ts(unknownTag, "name=unknown", 1.0)),
-    ":true,1,:or"    -> const(ts(unknownTag, "name=unknown", 1.0)),
-    "0,0,:or"        -> const(ts("name" -> "0.0", "0.0", 0.0)),
-    "1,:per-step"    -> const(ts(Map("name" -> "1.0"), "name=1.0", 60)),
-    "1,:integral"    -> const(integral(Map("name" -> "1.0"), "integral(1.0)", 1.0)),
+    ":true,0,:div"             -> const(ts(unknownTag, "name=unknown", Double.NaN)),
+    ":true,55,:gt"             -> const(ts(unknownTag, "name=unknown", 0.0)),
+    ":true,0,:gt"              -> const(ts(unknownTag, "name=unknown", 1.0)),
+    ":true,55.1,:ge"           -> const(ts(unknownTag, "name=unknown", 0.0)),
+    ":true,55,:ge"             -> const(ts(unknownTag, "name=unknown", 1.0)),
+    ":true,0,:ge"              -> const(ts(unknownTag, "name=unknown", 1.0)),
+    ":true,55,:lt"             -> const(ts(unknownTag, "name=unknown", 0.0)),
+    ":true,56,:lt"             -> const(ts(unknownTag, "name=unknown", 1.0)),
+    ":true,55.1,:le"           -> const(ts(unknownTag, "name=unknown", 1.0)),
+    ":true,55,:le"             -> const(ts(unknownTag, "name=unknown", 1.0)),
+    ":true,0,:le"              -> const(ts(unknownTag, "name=unknown", 0.0)),
+    ":true,0,:and"             -> const(ts(unknownTag, "name=unknown", 0.0)),
+    ":true,1,:and"             -> const(ts(unknownTag, "name=unknown", 1.0)),
+    ":true,0,:or"              -> const(ts(unknownTag, "name=unknown", 1.0)),
+    ":true,1,:or"              -> const(ts(unknownTag, "name=unknown", 1.0)),
+    "0,0,:or"                  -> const(ts("name" -> "0.0", "0.0", 0.0)),
+    "1,:per-step"              -> const(ts(Map("name" -> "1.0"), "name=1.0", 60)),
+    "1,:integral"              -> const(integral(Map("name" -> "1.0"), "integral(1.0)", 1.0)),
     "minuteOfDay,:time,1,:add" -> const(
       integral(Map("name" -> "minuteOfDay"), "name=minuteOfDay", 1.0)
     ),
@@ -117,7 +117,7 @@ class TimeSeriesExprSuite extends FunSuite {
     ":true,:min,(,name,),:by,:min" -> const(ts(Map.empty[String, String], "min(NO TAGS)", 0)),
     ":true,:max,(,name,),:by,:max" -> const(ts(Map.empty[String, String], "max(NO TAGS)", 10)),
     ":true,:max,(,type,),:by,:sum" -> const(ts(Map.empty[String, String], "sum(NO TAGS)", 10)),
-    ":true,(,name,),:by,:avg" -> const(
+    ":true,(,name,),:by,:avg"      -> const(
       ts(Map.empty[String, String], "NO TAGS", 5)
     ),
     ":true,(,foo,),:by"            -> const(Nil),
@@ -198,10 +198,10 @@ class TimeSeriesExprSuite extends FunSuite {
 
   // Tests that cannot be executed with incremental evaluation
   private val globalTests = List(
-    "1,:integral,min,:stat"  -> const(ts(Map("name" -> "1.0"), "stat-min(integral(1.0))", 1.0)),
-    "1,:integral,max,:stat"  -> const(ts(Map("name" -> "1.0"), "stat-max(integral(1.0))", 10.0)),
-    "1,:integral,avg,:stat"  -> const(ts(Map("name" -> "1.0"), "stat-avg(integral(1.0))", 5.5)),
-    "1,:integral,last,:stat" -> const(ts(Map("name" -> "1.0"), "stat-last(integral(1.0))", 10.0)),
+    "1,:integral,min,:stat"   -> const(ts(Map("name" -> "1.0"), "stat-min(integral(1.0))", 1.0)),
+    "1,:integral,max,:stat"   -> const(ts(Map("name" -> "1.0"), "stat-max(integral(1.0))", 10.0)),
+    "1,:integral,avg,:stat"   -> const(ts(Map("name" -> "1.0"), "stat-avg(integral(1.0))", 5.5)),
+    "1,:integral,last,:stat"  -> const(ts(Map("name" -> "1.0"), "stat-last(integral(1.0))", 10.0)),
     "1,:integral,total,:stat" -> const(
       ts(Map("name" -> "1.0"), "stat-total(integral(1.0))", 55.0)
     ),

--- a/atlas-lsp/src/main/scala/com/netflix/atlas/lsp/AslDocumentAnalyzer.scala
+++ b/atlas-lsp/src/main/scala/com/netflix/atlas/lsp/AslDocumentAnalyzer.scala
@@ -234,8 +234,8 @@ class AslDocumentAnalyzer(
   /** Format a stack value briefly for diagnostic messages. */
   private def formatValueBrief(value: Any): String = {
     value match {
-      case s: String => s"""String "$s""""
-      case n: Number => s"${n.getClass.getSimpleName} $n"
+      case s: String      => s"""String "$s""""
+      case n: Number      => s"${n.getClass.getSimpleName} $n"
       case items: List[?] =>
         val inner = items.map(formatValueBrief).mkString(", ")
         s"List ($inner)"
@@ -617,7 +617,7 @@ class AslDocumentAnalyzer(
   private val maxLineLength = 78
 
   private def renderNode(node: FormatNode, indent: Boolean): String = node match {
-    case SimpleNode(text) => text
+    case SimpleNode(text)    => text
     case ParenNode(children) =>
       val rendered = children.map(n => renderNode(n, indent = false))
       val inline = s"(,${rendered.mkString(",")},)"
@@ -880,7 +880,7 @@ class AslDocumentAnalyzer(
       case s: String                  => s"\"$s\""
       case n: Number                  => n.toString
       case items: List[?]             => items.map(formatStackItem).mkString("(", ", ", ")")
-      case other =>
+      case other                      =>
         val s = other.toString
         if (s.length > 60) s.take(57) + "..." else s
     }

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/ExprApi.scala
@@ -99,7 +99,7 @@ class ExprApi extends WebApi {
         // Expectation is that there would be a single query on the stack
         stack match {
           case _ :: Nil =>
-          case _ :: _ =>
+          case _ :: _   =>
             val summary = Interpreter.typeSummary(stack)
             throw new IllegalArgumentException(s"expected a single query, found $summary")
           case Nil =>

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalPublishActor.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/LocalPublishActor.scala
@@ -71,7 +71,7 @@ class LocalPublishActor(registry: Registry, db: Database) extends Actor with Act
 
   private def updateStats(failures: List[ValidationResult]): Unit = {
     failures.foreach {
-      case ValidationResult.Pass => // Ignored
+      case ValidationResult.Pass              => // Ignored
       case ValidationResult.Fail(error, _, _) =>
         registry.counter(numInvalid.withTag("error", error)).increment()
     }

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishPayloads.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishPayloads.scala
@@ -129,7 +129,7 @@ object PublishPayloads {
       case "value"     => value = nextDouble(parser)
       case "start"     => timestamp = nextLong(parser) // Legacy support
       case "values"    => value = getValue(parser)
-      case _ => // Ignore unknown fields
+      case _           => // Ignore unknown fields
         parser.nextToken()
         parser.skipChildren()
     }
@@ -174,7 +174,7 @@ object PublishPayloads {
     var metrics: List[DatapointTuple] = null
     var tagsLoadedFirst = false
     foreachField(parser) {
-      case "tags" => tags = decodeTags(parser, null, intern)
+      case "tags"    => tags = decodeTags(parser, null, intern)
       case "metrics" =>
         tagsLoadedFirst = tags != null
         val builder = List.newBuilder[DatapointTuple]
@@ -215,7 +215,7 @@ object PublishPayloads {
       case "value"     => value = nextDouble(parser)
       case "start"     => timestamp = nextLong(parser) // Legacy support
       case "values"    => value = getValue(parser)
-      case _ => // Ignore unknown fields
+      case _           => // Ignore unknown fields
         parser.nextToken()
         parser.skipChildren()
     }
@@ -235,7 +235,7 @@ object PublishPayloads {
     var metrics: List[Datapoint] = null
     var tagsLoadedFirst = false
     foreachField(parser) {
-      case "tags" => tags = decodeTags(parser, null, intern = false)
+      case "tags"    => tags = decodeTags(parser, null, intern = false)
       case "metrics" =>
         tagsLoadedFirst = tags != null
         val builder = List.newBuilder[Datapoint]

--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsApi.scala
@@ -168,7 +168,7 @@ object TagsApi {
       val c = queryInterpreter.execute(s)
       c.stack match {
         case (q: Query) :: Nil => q
-        case _ =>
+        case _                 =>
           throw new IllegalStateException(s"expected a single query on the stack")
       }
     }


### PR DESCRIPTION
Prerequisite for the sbt 2 upgrade, split out to keep the change self contained.

The sbt 2 build of `sbt-scalafmt` runs on Scala 3, and scalafmt only publishes a Scala 3 core from 3.11.1 onward, so the pinned 3.7.4 fails with `last of empty IndexedSeq` on every file under sbt 2.

Verified green under sbt 1, so this stands on its own ahead of the migration.