### PR TITLE
pekko: bound fair-share caller identity

### DIFF
--- a/atlas-pekko/src/main/resources/reference.conf
+++ b/atlas-pekko/src/main/resources/reference.conf
@@ -103,6 +103,22 @@ atlas.pekko {
 
       # Rate at which a caller's demerit decays while it is not being denied.
       decay-per-second = 0.3
+
+      # Cap on the number of callers tracked individually within a bucket. Callers beyond the cap
+      # share a single overflow entry, counting as one contending caller between them. This bounds
+      # the state retained per bucket, so that a caller able to present many identities cannot grow
+      # it without limit. It is close to a memory bound and nothing more: a caller presenting this
+      # many identities still collects that many shares, and honest callers arriving after the cap
+      # is reached are folded onto the shared entry and inherit its demerit. Fairness depends on the
+      # sub-key being trustworthy, not on this.
+      #
+      # It should be comfortably above the number of distinct callers that can be tracked at once,
+      # which is not the same as the number in flight: a caller keeps its entry for `window` after
+      # its last attempt, and longer if it is carrying demerit, so the working set is roughly the
+      # arrival rate times the window rather than the concurrency. The cap is also the worst case
+      # for the per-request pass over the tracked callers, which is done under a single lock, so
+      # raising it well past what a bucket needs is not free.
+      max-tracked-callers = 1000
     }
 
     # Per-endpoint budgets. The endpoint name is chosen by the endpoint applying the limit, for
@@ -121,10 +137,19 @@ atlas.pekko {
       #   default-bucket-budget = 20
       #
       #   # Dedicated budgets for provisioned callers, keyed by caller id. A value of zero blocks
-      #   # the caller entirely.
+      #   # the caller entirely. An authenticated caller is keyed by its identity; a caller still
+      #   # using the legacy `id` query parameter is keyed by that value prefixed with "legacy.",
+      #   # which keeps self-asserted ids in a namespace of their own so they cannot name an
+      #   # authenticated caller and reach its budget.
+      #   #
+      #   # The two namespaces are separate budgets, so an entry blocks or provisions only the one
+      #   # it names: "dashboards = 0" blocks the authenticated caller "dashboards" and does not
+      #   # touch a caller sending "?id=dashboards", which needs a "legacy.dashboards" entry of its
+      #   # own. Anything unauthenticated and unprovisioned shares the anonymous sub-key.
       #   caller-budgets {
-      #     dashboards = 0
-      #     atlas_ui   = 40
+      #     dashboards       = 0
+      #     atlas_ui         = 40
+      #     "legacy.old_app" = 10
       #   }
       # }
     }

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/FairShareLimiter.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/FairShareLimiter.scala
@@ -38,11 +38,23 @@ import scala.collection.mutable
   * Fairness acts on admission decisions as permits churn rather than by preempting held permits, so
   * it converges to a fair allocation as requests complete.
   *
-  * Performance: all per-caller state lives in a single map keyed by `subKey`, and the running total
-  * is maintained incrementally. `tryAcquire` makes one pass over the recent callers, reusing a
-  * pre-allocated scan function, so it allocates nothing on the request path except a state object
-  * the first time a new caller is seen. The pass, the total, and all state are guarded by a single
-  * monitor; the section is O(number of recently active callers), which is bounded by concurrency.
+  * Fairness is only as trustworthy as the `subKey`: a caller that can present many identities is
+  * granted one share per identity, so the sub-key must be derived from an authenticated identity or
+  * from an otherwise bounded set (see [[DefaultLimitKeyResolver]]). The number of tracked sub-keys
+  * is capped as a safeguard against a resolver that lets an untrusted value through, with callers
+  * beyond the cap sharing a single overflow state so they count as one contending caller between
+  * them. Note that the cap bounds the state retained, not the dilution: a caller presenting as many
+  * identities as the cap allows still gets that many shares, so the resolver is the defence and
+  * this is the backstop.
+  *
+  * Performance: all per-caller state lives in a single map keyed by `subKey`, plus one shared state
+  * for the callers past the cap, and the running total is maintained incrementally. `tryAcquire`
+  * makes one pass over the tracked callers, reusing a pre-allocated scan function, so it allocates
+  * nothing on the request path except a state object the first time a new caller is seen and a map
+  * entry while a caller holds permits against the shared state. The pass, the total, and all state
+  * are guarded by a single monitor; the section is O(number of tracked callers), which is bounded
+  * by `maxTrackedCallers` and, in the intended configuration, by concurrency well below it. Set the
+  * cap with that in mind: it is the worst case for the critical section, not just for memory.
   *
   * @param budget
   *     Total number of permits shared by the bucket. Must be positive.
@@ -57,6 +69,9 @@ import scala.collection.mutable
   *     Amount added to a caller's demerit each time it is denied.
   * @param decayPerSecond
   *     Rate at which a caller's demerit decays while it is not being denied.
+  * @param maxTrackedCallers
+  *     Cap on the number of sub-keys tracked individually, which bounds the retained state. Must be
+  *     positive.
   */
 final class FairShareLimiter(
   budget: Int,
@@ -64,18 +79,48 @@ final class FairShareLimiter(
   window: Duration,
   penalizedThreshold: Double,
   demeritPerDenial: Double,
-  decayPerSecond: Double
+  decayPerSecond: Double,
+  maxTrackedCallers: Int
 ) extends ConcurrencyLimiter {
 
   import FairShareLimiter.*
 
   require(budget > 0, s"budget must be positive: $budget")
+  require(maxTrackedCallers > 0, s"maxTrackedCallers must be positive: $maxTrackedCallers")
+
+  require(penalizedThreshold > 0.0, s"penalizedThreshold must be positive: $penalizedThreshold")
+  // Zero decay would leave every demerit permanent, which also makes the state carrying it
+  // unprunable, so the tracked set would wedge at `maxTrackedCallers` and every later caller would
+  // be folded onto the shared state for good. Zero window would leave nothing inside the recency
+  // tests, silently disabling contention detection and with it the fairness policy.
+  require(decayPerSecond > 0.0, s"decayPerSecond must be positive: $decayPerSecond")
+  require(demeritPerDenial > 0.0, s"demeritPerDenial must be positive: $demeritPerDenial")
+  require(!window.isNegative && !window.isZero, s"window must be positive: $window")
 
   private val windowNanos = window.toNanos
   private val decayPerNano = decayPerSecond / 1e9
 
+  // Demerit past this point has no further effect on the cap: `share` never exceeds `budget`, so
+  // the penalty is already at its floor. All the excess does is extend how long the caller stays
+  // penalized and how long its state is retained, both of which the caller sets by how hard it
+  // hammers. Clamping keeps recovery proportional to the budget rather than to the size of a burst.
+  private val maxDemerit = penalizedThreshold + budget
+
   private val callers = new mutable.HashMap[String, CallerState]()
   private var total = 0
+
+  // State shared by every caller seen while the map is already at `maxTrackedCallers`. Folding them
+  // onto one state keeps the tracked set bounded and makes them count as a single contending caller
+  // rather than one per sub-key. It lives outside the map so it is never pruned; `overflowInUse`
+  // records whether any caller is currently using it, since a state that has never been used must
+  // not be counted as active.
+  private val overflow = new CallerState()
+  private var overflowInUse = false
+
+  // Sub-keys that currently hold permits against the shared state, and how much each holds, so a
+  // release can be charged to the state that actually holds the caller's permits. Bounded by
+  // `budget`, since a holder holds at least one permit.
+  private val overflowHolders = new mutable.HashMap[String, Int]()
 
   // Scratch state for the single scan pass. Only touched while the monitor is held, so a single
   // reusable scan function can read it without capturing per-call variables (which would allocate).
@@ -83,6 +128,7 @@ final class FairShareLimiter(
   private var scanSubKey: String = ""
   private var scanActive = 0
   private var scanContended = false
+  private var scanCurrentActive = false
 
   // Prune callers that are no longer active and no longer carry demerit, count the active callers,
   // and detect whether another well-behaved caller was recently denied (and so wants capacity). A
@@ -93,7 +139,12 @@ final class FairShareLimiter(
     val active = s.used > 0 || scanNow - s.lastSeen <= windowNanos
     val keep = active || d > 0.0
     if (keep) {
-      if (active) scanActive += 1
+      if (active) {
+        scanActive += 1
+        // Recorded so the caller in hand is not counted twice: the scan runs before its state is
+        // refreshed, so `tryAcquire` has to count it separately when the scan did not.
+        if (k == scanSubKey) scanCurrentActive = true
+      }
       if (
         !scanContended && k != scanSubKey && d < penalizedThreshold &&
         s.lastDenied != NeverDenied && scanNow - s.lastDenied <= windowNanos
@@ -106,17 +157,68 @@ final class FairShareLimiter(
 
   private def clamp(cost: Int): Int = math.min(budget, math.max(1, cost))
 
+  // State for a caller, tracked individually while there is room and folded onto the shared
+  // overflow state once the cap is reached. `getOrElse` with a null default avoids the `Option`
+  // that `get` would allocate on the request path.
+  private def stateFor(subKey: String): CallerState = {
+    val existing = callers.getOrElse(subKey, null)
+    if (existing != null) existing
+    // Tracking a caller that still holds permits against the shared state would strand them, since
+    // `release` would then look the caller up in the map and never reach the overflow state.
+    else if (callers.size < maxTrackedCallers && !overflowHolders.contains(subKey)) {
+      val state = new CallerState()
+      callers.put(subKey, state)
+      state
+    } else {
+      overflowInUse = true
+      overflow
+    }
+  }
+
+  // The overflow state is not in the map, so the accounting the scan does for a tracked caller is
+  // applied to it by hand. It is reset rather than removed once it is idle and free of demerit,
+  // which mirrors the pruning done by `scan`.
+  private def observeOverflow(now: Long, current: CallerState): Unit = {
+    if (overflowInUse) {
+      val d = overflow.demerit(now, decayPerNano)
+      val active = overflow.used > 0 || now - overflow.lastSeen <= windowNanos
+      if (active) {
+        scanActive += 1
+        if (
+          !scanContended && (current ne overflow) && d < penalizedThreshold &&
+          overflow.lastDenied != NeverDenied && now - overflow.lastDenied <= windowNanos
+        ) {
+          scanContended = true
+        }
+      } else if (d <= 0.0) {
+        overflow.reset()
+        overflowInUse = false
+      }
+    }
+  }
+
   override def tryAcquire(subKey: String, cost: Int): Boolean = synchronized {
     val now = clock.monotonicTime()
     val c = clamp(cost)
-    val state = callers.getOrElseUpdate(subKey, new CallerState())
-    state.lastSeen = now
 
+    // Prune before choosing the caller's state so the cap is tested against the callers actually
+    // being tracked, not against entries this same pass is about to sweep. Choosing first would
+    // fold a caller onto the shared state while every slot it needed sat free, and
+    // `overflowHolders` would then keep it there for as long as it holds a permit.
     scanNow = now
     scanSubKey = subKey
     scanActive = 0
     scanContended = false
+    scanCurrentActive = false
     callers.filterInPlace(scan)
+
+    val state = stateFor(subKey)
+    state.lastSeen = now
+    // The caller in hand is active by definition, but the scan ran before its state was refreshed,
+    // so count it here unless the scan already did. A caller on the shared state is counted once,
+    // by `observeOverflow`, however many sub-keys are folded onto it.
+    if ((state ne overflow) && !scanCurrentActive) scanActive += 1
+    observeOverflow(now, state)
 
     val active = math.max(1, scanActive)
     val share = math.ceil(budget.toDouble / active).toInt
@@ -126,40 +228,53 @@ final class FairShareLimiter(
         // A hog is contained below its fair share so headroom stays free for well-behaved bursts,
         // floored at one permit rather than starved to zero. It is only penalized while its demerit
         // is elevated; once it stops being denied the demerit decays and it recovers.
-        math.max(1, share - math.round(d).toInt)
+        math.max(1, share - math.min(share.toLong, math.round(d)).toInt)
       else if (scanContended)
         share
       else
         budget
 
     if (total + c > budget || state.used + c > cap) {
-      state.demeritValue = d + demeritPerDenial
+      state.demeritValue = math.min(maxDemerit, d + demeritPerDenial)
       state.demeritTime = now
       state.lastDenied = now
       false
     } else {
       state.used += c
       total += c
+      if (state eq overflow) {
+        overflowHolders.update(subKey, overflowHolders.getOrElse(subKey, 0) + c)
+      }
       true
     }
   }
 
   override def release(subKey: String, cost: Int): Unit = synchronized {
     val c = clamp(cost)
-    // Decrement `total` only by what this caller actually held, so a mis-paired or duplicate
-    // release cannot drive `total` below the real usage (which would let the bucket over-admit).
-    // The state object is left in place so demerit and recency survive until it is pruned.
-    callers.get(subKey).foreach { state =>
-      if (state.used > 0) {
-        val released = math.min(state.used, c)
-        state.used -= released
-        total = math.max(0, total - released)
+    // Charge the release to whichever state actually holds this caller's permits, and only up to
+    // what it holds, so a mis-paired or duplicate release cannot drive `total` below the real usage
+    // (which would let the bucket over-admit) nor take permits from another caller sharing the
+    // overflow state. The state object is left in place so demerit and recency survive until it is
+    // pruned.
+    val viaOverflow = overflowHolders.getOrElse(subKey, 0)
+    val state = if (viaOverflow > 0) overflow else callers.getOrElse(subKey, null)
+    val held = if (viaOverflow > 0) viaOverflow else if (state != null) state.used else 0
+    if (held > 0) {
+      val released = math.min(held, c)
+      state.used -= released
+      total = math.max(0, total - released)
+      if (viaOverflow > 0) {
+        if (released == viaOverflow) overflowHolders.remove(subKey)
+        else overflowHolders.update(subKey, viaOverflow - released)
       }
     }
   }
 
   override def usedPermits: Int = synchronized(total)
   override def maxPermits: Int = budget
+
+  /** Number of callers being tracked individually, at most `maxTrackedCallers`. */
+  private[pekko] def trackedCallers: Int = synchronized(callers.size)
 }
 
 object FairShareLimiter {
@@ -175,6 +290,15 @@ object FairShareLimiter {
     var lastDenied: Long = NeverDenied
     var demeritValue: Double = 0.0
     var demeritTime: Long = 0L
+
+    /** Return to the initial state so a shared state object can be reused once it is idle. */
+    def reset(): Unit = {
+      used = 0
+      lastSeen = 0L
+      lastDenied = NeverDenied
+      demeritValue = 0.0
+      demeritTime = 0L
+    }
 
     /** Demerit decayed to `now`. */
     def demerit(now: Long, decayPerNano: Double): Double = {

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/LimitKey.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/LimitKey.scala
@@ -43,4 +43,16 @@ object LimitKey {
 
   /** Sub-key used for a caller whose identity could not be determined. */
   val Anonymous: String = "anonymous"
+
+  /**
+    * Prefix applied to an identity taken from the legacy `id` query parameter, which is asserted
+    * by the caller rather than authenticated. It keeps those identities in a namespace of their
+    * own, so that presenting `?id=x` does not resolve to the same key as an authenticated caller
+    * `x` and so cannot reach that caller's budget. A dedicated budget for a legacy caller is
+    * therefore configured under the prefixed name.
+    *
+    * A bucket name is published as a metric dimension, so the separator has to be a character
+    * Atlas accepts in a tag value; `:` is not one.
+    */
+  val LegacyPrefix: String = "legacy."
 }

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/LimitKeyResolver.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/LimitKeyResolver.scala
@@ -39,10 +39,35 @@ trait LimitKeyResolver {
 
 /**
   * Default resolver. The caller identity is taken from the authenticated [[CallerContext]] when
-  * available, falling back to the legacy `id` query parameter and finally to an anonymous marker.
-  * A caller is given its own bucket only when it has been provisioned with a dedicated budget on
-  * the endpoint; all other callers share [[LimitKey.DefaultBucket]] but retain their own sub-key
-  * so they can be told apart within the shared bucket.
+  * available, and otherwise from the legacy `id` query parameter if it names a provisioned caller,
+  * falling back to an anonymous marker. A caller is given its own bucket only when it has been
+  * provisioned with a dedicated budget on the endpoint; all other callers share
+  * [[LimitKey.DefaultBucket]], with authenticated callers keeping their own sub-key so they can be
+  * told apart within the shared bucket.
+  *
+  * The sub-key decides how a shared budget is divided, so it must not be something an
+  * unauthenticated caller can choose freely: a caller able to mint identities would be granted one
+  * share of the bucket per identity it invents. The legacy `id` parameter is therefore honored only
+  * when it names a caller that has been provisioned a dedicated budget on the endpoint, which
+  * bounds the set of values that can reach the limiter to the configured ones. Every other
+  * unauthenticated caller shares [[LimitKey.Anonymous]], so unauthenticated traffic contends for a
+  * single share no matter how many distinct values it presents.
+  *
+  * Where it is honored the parameter is still asserted by the caller rather than authenticated, so
+  * it is kept in a namespace of its own via [[LimitKey.LegacyPrefix]]. `?id=x` resolves to
+  * `legacy.x`, which does not collide with the key of an authenticated caller `x`, so a legacy
+  * caller cannot reach an authenticated caller's budget and an authenticated caller is not charged
+  * for legacy traffic. An authenticated identity that itself starts with the prefix is kept out of
+  * the namespace here rather than assumed away, since nothing constrains what a
+  * [[RequestAuthenticator]] may produce. Within that namespace the values remain self-asserted and
+  * one legacy caller can still claim another's budget; the parameter exists to carry callers that
+  * predate authentication and is expected to be retired once they have moved over.
+  *
+  * One consequence is worth stating plainly: unauthenticated callers without a provisioned budget
+  * are no longer told apart, so one of them behaving badly drives the shared anonymous sub-key over
+  * the penalty threshold and holds the others down with it. That is the cost of keeping a legacy
+  * unauthenticated path at all, and it resolves itself once callers arrive with an authenticated
+  * [[CallerContext]] and each gets a sub-key of its own.
   *
   * @param dedicatedBuckets
   *     Given an endpoint, the set of caller ids that have a dedicated budget on it. Typically
@@ -51,19 +76,35 @@ trait LimitKeyResolver {
 class DefaultLimitKeyResolver(dedicatedBuckets: String => Set[String]) extends LimitKeyResolver {
 
   override def resolve(caller: CallerContext, endpoint: String, request: HttpRequest): LimitKey = {
-    val id = callerId(caller, request)
-    val bucket = if (dedicatedBuckets(endpoint).contains(id)) id else LimitKey.DefaultBucket
+    val provisioned = dedicatedBuckets(endpoint)
+    val authenticated = caller.direct.kind != Principal.Kind.Unknown
+    val id = if (authenticated) caller.direct.id else legacyId(request, provisioned)
+    // The legacy namespace is reserved for self-asserted ids, and nothing constrains what a
+    // [[RequestAuthenticator]] may produce, so an authenticated identity that happens to start with
+    // the prefix keeps a sub-key of its own but is not allowed to match a legacy caller's budget.
+    // Without this the namespacing would hold in one direction only.
+    val reserved = authenticated && id.startsWith(LimitKey.LegacyPrefix)
+    val bucket = if (!reserved && provisioned.contains(id)) id else LimitKey.DefaultBucket
     LimitKey(bucket, id, endpoint)
   }
 
-  private def callerId(caller: CallerContext, request: HttpRequest): String = {
-    caller.direct.kind match {
-      case Principal.Kind.Unknown => legacyId(request).getOrElse(LimitKey.Anonymous)
-      case _                      => caller.direct.id
+  // Only a provisioned id is trusted from the query parameter, and it is namespaced so that it
+  // cannot name an authenticated caller. Anything else, including a missing or empty value, is
+  // treated as anonymous rather than as an identity of its own. Written without `filter` so that
+  // the request path does not allocate a closure capturing `provisioned`. The query is parsed only
+  // for an endpoint that has provisioned callers at all, since with none of them there is nothing
+  // a value could match.
+  private def legacyId(request: HttpRequest, provisioned: Set[String]): String = {
+    if (provisioned.isEmpty) LimitKey.Anonymous
+    else {
+      val id = request.uri.query().get("id")
+      // `?id=` parses to `Some("")`, which is not an identity, so the value is checked rather than
+      // just the presence of the parameter.
+      if (id.isEmpty || id.get.isEmpty) LimitKey.Anonymous
+      else {
+        val namespaced = LimitKey.LegacyPrefix + id.get
+        if (provisioned.contains(namespaced)) namespaced else LimitKey.Anonymous
+      }
     }
-  }
-
-  private def legacyId(request: HttpRequest): Option[String] = {
-    request.uri.query().get("id").filter(_.nonEmpty)
   }
 }

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/RequestLimiter.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/RequestLimiter.scala
@@ -111,7 +111,8 @@ class RequestLimiter(config: Config, registry: Registry) {
           fairShare.window,
           fairShare.penalizedThreshold,
           fairShare.demeritPerDenial,
-          fairShare.decayPerSecond
+          fairShare.decayPerSecond,
+          fairShare.maxTrackedCallers
         )
       else ConcurrencyLimiter(limits.defaultBucketBudget)
     monitorInflight(default, name, LimitKey.DefaultBucket)
@@ -265,7 +266,8 @@ object RequestLimiter {
     window: Duration,
     penalizedThreshold: Double,
     demeritPerDenial: Double,
-    decayPerSecond: Double
+    decayPerSecond: Double,
+    maxTrackedCallers: Int
   )
 
   private object FairShareConfig {
@@ -279,6 +281,7 @@ object RequestLimiter {
         |penalized-threshold = 3.0
         |demerit-per-denial = 1.0
         |decay-per-second = 0.3
+        |max-tracked-callers = 1000
         |""".stripMargin
     )
 
@@ -289,7 +292,8 @@ object RequestLimiter {
         c.getDuration("window"),
         c.getDouble("penalized-threshold"),
         c.getDouble("demerit-per-denial"),
-        c.getDouble("decay-per-second")
+        c.getDouble("decay-per-second"),
+        c.getInt("max-tracked-callers")
       )
     }
   }

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/FairShareLimiterSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/FairShareLimiterSuite.scala
@@ -24,14 +24,19 @@ class FairShareLimiterSuite extends FunSuite {
 
   private val window = Duration.ofSeconds(5)
 
-  private def newLimiter(budget: Int, clock: ManualClock): FairShareLimiter = {
+  private def newLimiter(
+    budget: Int,
+    clock: ManualClock,
+    maxTrackedCallers: Int = 1000
+  ): FairShareLimiter = {
     new FairShareLimiter(
       budget,
       clock,
       window,
       penalizedThreshold = 3.0,
       demeritPerDenial = 1.0,
-      decayPerSecond = 0.3
+      decayPerSecond = 0.3,
+      maxTrackedCallers = maxTrackedCallers
     )
   }
 
@@ -179,5 +184,285 @@ class FairShareLimiterSuite extends FunSuite {
     intercept[IllegalArgumentException] {
       newLimiter(0, new ManualClock())
     }
+  }
+
+  test("a hog is still held to its floor while penalized, however large the budget") {
+    val clock = new ManualClock()
+    val limiter = newLimiter(1000, clock)
+
+    // Demerit is clamped only at `penalizedThreshold + budget`, which is still enough for
+    // `share - demerit` to reach the floor however large the share is. With two callers the share
+    // is 500, so a ceiling below that would leave the hog almost unconstrained.
+    assert(limiter.tryAcquire("hog", 1000))
+    assert(!limiter.tryAcquire("victim", 1))
+    (1 to 600).foreach(_ => assert(!limiter.tryAcquire("hog", 1)))
+    limiter.release("hog", 1000)
+
+    var admitted = 0
+    while (admitted < 1000 && limiter.tryAcquire("hog", 1)) admitted += 1
+    assertEquals(admitted, 1)
+  }
+
+  // Build a limiter with one knob overridden, for the validation and edge-case tests below.
+  private def tunedLimiter(
+    clock: ManualClock,
+    budget: Int = 100,
+    penalizedThreshold: Double = 3.0,
+    demeritPerDenial: Double,
+    decayPerSecond: Double = 0.3
+  ): FairShareLimiter = {
+    new FairShareLimiter(
+      budget,
+      clock,
+      window,
+      penalizedThreshold,
+      demeritPerDenial,
+      decayPerSecond,
+      maxTrackedCallers = 1000
+    )
+  }
+
+  test("a huge demerit still floors the hog rather than wrapping into a licence") {
+    val clock = new ManualClock()
+    // One denial would otherwise push the demerit past what an `Int` can hold, and narrowing that
+    // without clamping would wrap it negative and turn `share - demerit` into a cap far above the
+    // budget. Both the ceiling on the accumulator and the clamp on the narrowing prevent it.
+    val limiter = tunedLimiter(clock, demeritPerDenial = 3.0e9)
+
+    assert(limiter.tryAcquire("hog", 100))
+    assert(!limiter.tryAcquire("victim", 1))
+    assert(!limiter.tryAcquire("hog", 1))
+    limiter.release("hog", 100)
+
+    var admitted = 0
+    while (admitted < 100 && limiter.tryAcquire("hog", 1)) admitted += 1
+    assertEquals(admitted, 1)
+  }
+
+  test("max tracked callers must be positive") {
+    intercept[IllegalArgumentException] {
+      newLimiter(4, new ManualClock(), maxTrackedCallers = 0)
+    }
+  }
+
+  test("decay must be positive") {
+    // Zero decay makes every demerit permanent, which also makes the state carrying it unprunable,
+    // so the tracked set would wedge at the cap and never let another caller in.
+    intercept[IllegalArgumentException] {
+      tunedLimiter(new ManualClock(), demeritPerDenial = 1.0, decayPerSecond = 0.0)
+    }
+  }
+
+  test("window must be positive") {
+    intercept[IllegalArgumentException] {
+      new FairShareLimiter(100, new ManualClock(), Duration.ZERO, 3.0, 1.0, 0.3, 1000)
+    }
+  }
+
+  test("demerit is bounded so a burst cannot buy an unbounded penalty") {
+    val clock = new ManualClock()
+    val limiter = newLimiter(100, clock)
+
+    // A hog that hammers for a long time accrues demerit at one per denial, but the ceiling is
+    // `penalizedThreshold + budget`, so recovery stays proportional to the budget instead of to how
+    // long the caller kept at it. Uncapped, these 10k denials would hold it down for over nine
+    // hours; the ceiling of 103 clears in under six minutes.
+    assert(limiter.tryAcquire("victim", 100))
+    (1 to 10000).foreach(_ => assert(!limiter.tryAcquire("hog", 1)))
+    limiter.release("victim", 100)
+
+    advance(clock, 6 * 60)
+    assert(limiter.tryAcquire("hog", 100))
+    assertEquals(limiter.usedPermits, 100)
+  }
+
+  test("a caller arriving after the tracked set goes stale is tracked, not folded in") {
+    val clock = new ManualClock()
+    val limiter = newLimiter(100, clock, maxTrackedCallers = 1)
+
+    // Poison the shared entry, then let the tracked set go stale. The pruning pass has to run
+    // before the tracked-or-shared decision, or the first caller to arrive is handed the crowd's
+    // demerit and floored at one permit while the slot it needed sits free.
+    assert(limiter.tryAcquire("filler", 100))
+    (1 to 500).foreach(i => assert(!limiter.tryAcquire(s"flood-$i", 1)))
+    limiter.release("filler", 100)
+    advance(clock, 30)
+
+    assert(limiter.tryAcquire("honest", 100))
+    assertEquals(limiter.trackedCallers, 1)
+  }
+
+  test("callers beyond the cap share one overflow entry") {
+    val limiter = newLimiter(100, new ManualClock(), maxTrackedCallers = 4)
+
+    // Fill the tracked set, then keep going with fresh sub-keys. The extra callers must not add
+    // tracked state, so the share seen by a caller stops shrinking once the cap is reached.
+    (1 to 500).foreach { i =>
+      val key = s"c$i"
+      assert(limiter.tryAcquire(key, 1))
+      limiter.release(key, 1)
+    }
+
+    assertEquals(limiter.trackedCallers, 4)
+
+    // Deny one of the tracked callers so that everyone is held to their share rather than free to
+    // borrow the whole budget; without that the cap below is `budget` and proves nothing.
+    assert(limiter.tryAcquire("c1", 100))
+    assert(!limiter.tryAcquire("c2", 1))
+    limiter.release("c1", 100)
+
+    // Four tracked callers plus the overflow entry is five active callers, so the share is 20. The
+    // next caller lands in overflow and is capped at the share the crowd holds jointly - neither
+    // starved to one permit nor free to take more than a share between them.
+    assert(!limiter.tryAcquire("c501", 21))
+    assert(limiter.tryAcquire("c501", 20))
+    assertEquals(limiter.usedPermits, 20)
+  }
+
+  test("permits held through the overflow entry survive the tracked set draining") {
+    val clock = new ManualClock()
+    val limiter = newLimiter(100, clock, maxTrackedCallers = 1)
+
+    // "filler" holds the one tracked slot, so "z" holds its permits against the shared entry.
+    assert(limiter.tryAcquire("filler", 1))
+    assert(limiter.tryAcquire("z", 10))
+    limiter.release("filler", 1)
+
+    // "filler" goes idle and is swept away, freeing the slot while "z" is still in flight. "z" must
+    // not be taken into the tracked set here: its release would then be charged to the new state
+    // and the permits it still holds against the shared entry would be lost from the budget.
+    advance(clock, 30)
+    assert(limiter.tryAcquire("sweeper", 1))
+    limiter.release("sweeper", 1)
+
+    assert(limiter.tryAcquire("z", 1))
+    limiter.release("z", 1)
+    limiter.release("z", 10)
+    assertEquals(limiter.usedPermits, 0)
+  }
+
+  test("one in-flight overflow request does not freeze the tracked set") {
+    val clock = new ManualClock()
+    val limiter = newLimiter(1000, clock, maxTrackedCallers = 4)
+
+    // Fill the tracked set, then push one caller onto the shared entry holding a long request.
+    (1 to 4).foreach { i =>
+      assert(limiter.tryAcquire(s"old-$i", 1))
+      limiter.release(s"old-$i", 1)
+    }
+    assert(limiter.tryAcquire("longrunner", 1))
+
+    // The old callers go idle and are swept away. Only "longrunner" is pinned to the shared entry;
+    // the callers arriving now must take the slots it freed rather than all being folded in behind
+    // it, which would collapse them onto a single share for as long as that one request runs.
+    advance(clock, 30)
+    (1 to 20).foreach { i =>
+      val key = s"new-$i"
+      assert(limiter.tryAcquire(key, 1))
+      limiter.release(key, 1)
+    }
+    assertEquals(limiter.trackedCallers, 4)
+  }
+
+  test("a release from a sub-key that holds nothing cannot take overflow permits") {
+    val limiter = newLimiter(100, new ManualClock(), maxTrackedCallers = 1)
+    assert(limiter.tryAcquire("tracked", 1))
+    assert(limiter.tryAcquire("holder", 40))
+    assertEquals(limiter.usedPermits, 41)
+
+    // "holder" reached the shared entry, but the entry is not a pool anyone may draw down: a
+    // release for a sub-key that never acquired must be a no-op, or the bucket over-admits by as
+    // much as the real holders are still holding.
+    limiter.release("never-acquired", 100)
+    assertEquals(limiter.usedPermits, 41)
+  }
+
+  test("permits are fully returned when many callers churn past the cap") {
+    // Every acquire is paired with exactly one release of the same cost, so once the run drains,
+    // `usedPermits` must be zero. Far more callers than slots, so callers cross between the tracked
+    // set and the shared entry constantly - which is where an accounting slip strands permits and
+    // shrinks the effective budget for the life of the process.
+    val rng = new scala.util.Random(20260810)
+    val clock = new ManualClock()
+    val limiter = newLimiter(1000, clock, maxTrackedCallers = 6)
+    val held = Array.fill(40)(List.empty[Int])
+
+    (1 to 20000).foreach { _ =>
+      clock.setMonotonicTime(clock.monotonicTime() + rng.nextInt(400000000).toLong)
+      val i = rng.nextInt(held.length)
+      val key = s"caller-$i"
+      if (held(i).nonEmpty && rng.nextInt(100) < 50) {
+        limiter.release(key, held(i).head)
+        held(i) = held(i).tail
+      } else {
+        val cost = 1 + rng.nextInt(20)
+        if (limiter.tryAcquire(key, cost)) held(i) = cost :: held(i)
+      }
+    }
+
+    held.indices.foreach(i => held(i).foreach(c => limiter.release(s"caller-$i", c)))
+    assertEquals(limiter.usedPermits, 0)
+  }
+
+  test("permits held through the overflow entry are released") {
+    val limiter = newLimiter(100, new ManualClock(), maxTrackedCallers = 1)
+    assert(limiter.tryAcquire("tracked", 1))
+
+    // "extra" is past the cap so it holds its permits against the shared overflow state. Release
+    // has to find that state by falling back to overflow, or the permits leak from the budget.
+    assert(limiter.tryAcquire("extra", 40))
+    assertEquals(limiter.usedPermits, 41)
+    limiter.release("extra", 40)
+    limiter.release("tracked", 1)
+    assertEquals(limiter.usedPermits, 0)
+  }
+
+  test("overflow callers count as one contending caller between them") {
+    val clock = new ManualClock()
+    val limiter = newLimiter(100, clock, maxTrackedCallers = 1)
+
+    // A crowd of untracked callers collapses onto a single overflow entry, so it marks contention
+    // once however large it is. Two denials keep its demerit below the penalty threshold, leaving
+    // it counted as a well-behaved caller that wants capacity.
+    assert(limiter.tryAcquire("honest", 100))
+    assert(!limiter.tryAcquire("flood-1", 1))
+    assert(!limiter.tryAcquire("flood-2", 1))
+    limiter.release("honest", 100)
+
+    // Two active callers, so the tracked caller is held to half the budget. Without the overflow
+    // entry the crowd would present one caller per sub-key and drive the share down to one.
+    var admitted = 0
+    while (admitted < 100 && limiter.tryAcquire("honest", 1)) admitted += 1
+    assertEquals(admitted, 50)
+  }
+
+  test("an overflow crowd that keeps hammering is penalized as a single hog") {
+    val clock = new ManualClock()
+    val limiter = newLimiter(100, clock, maxTrackedCallers = 1)
+
+    // Demerit accrues to the shared entry, so a sustained flood of untracked callers is penalized
+    // collectively rather than each sub-key arriving with a clean slate. Once over the threshold it
+    // no longer counts as contention, and the tracked caller is free to use the spare capacity.
+    assert(limiter.tryAcquire("honest", 100))
+    (1 to 500).foreach(i => assert(!limiter.tryAcquire(s"flood-$i", 1)))
+    limiter.release("honest", 100)
+
+    assert(limiter.tryAcquire("honest", 100))
+    assertEquals(limiter.usedPermits, 100)
+  }
+
+  test("the overflow entry is reset once it goes idle") {
+    val clock = new ManualClock()
+    val limiter = newLimiter(100, clock, maxTrackedCallers = 1)
+    assert(limiter.tryAcquire("tracked", 1))
+    assert(limiter.tryAcquire("extra", 1))
+    limiter.release("tracked", 1)
+    limiter.release("extra", 1)
+
+    // Once the untracked callers age out, the overflow entry stops counting as active and the
+    // tracked caller is alone again, free to use the whole budget.
+    advance(clock, 30)
+    assert(limiter.tryAcquire("tracked", 100))
+    assertEquals(limiter.usedPermits, 100)
   }
 }

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/FairShareLimiterSybilSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/FairShareLimiterSybilSuite.scala
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.pekko
+
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.ManualClock
+import com.typesafe.config.ConfigFactory
+import munit.FunSuite
+import org.apache.pekko.http.scaladsl.model.HttpRequest
+
+import java.time.Duration
+
+/**
+  * A caller that can choose its own `subKey` would otherwise be granted one share of a fair-share
+  * bucket per identity it invents, and one entry of tracked state to scan on every later request.
+  * These cover the two defences against that: the resolver refuses to take an identity from an
+  * unauthenticated caller, and the limiter caps how many sub-keys it will track no matter what a
+  * resolver hands it.
+  */
+class FairShareLimiterSybilSuite extends FunSuite {
+
+  private val budget = 100
+
+  private val limitsConfig = ConfigFactory.parseString(
+    s"""
+       |mode = "enforce"
+       |fair-share {
+       |  window = 5s
+       |  penalized-threshold = 3.0
+       |  demerit-per-denial = 1.0
+       |  decay-per-second = 0.3
+       |  max-tracked-callers = 1000
+       |}
+       |endpoints {
+       |  graph {
+       |    default-bucket-budget = $budget
+       |    fair-share = true
+       |  }
+       |}
+       |""".stripMargin
+  )
+
+  // The limiter takes its clock from the registry, so a manual one is the only way to keep the
+  // contention window from expiring mid-test. Under the wall clock a slow run would age the
+  // anonymous caller out of the window, leaving the honest caller alone with the whole budget --
+  // and the assertions below would then pass without the fairness policy doing anything.
+  private def newLimiter(): (RequestLimiter, LimitKeyResolver) = {
+    val limiter = new RequestLimiter(limitsConfig, new DefaultRegistry(new ManualClock()))
+    limiter -> new DefaultLimitKeyResolver(limiter.dedicatedBuckets)
+  }
+
+  private def newFairShareLimiter(maxTracked: Int): FairShareLimiter = {
+    new FairShareLimiter(
+      budget,
+      new ManualClock(),
+      Duration.ofSeconds(5),
+      penalizedThreshold = 3.0,
+      demeritPerDenial = 1.0,
+      decayPerSecond = 0.3,
+      maxTrackedCallers = maxTracked
+    )
+  }
+
+  private def request(id: String): HttpRequest = {
+    HttpRequest(uri = s"/api/v1/graph?q=name,sps,:eq&id=$id")
+  }
+
+  test("a flood of rotating ids cannot starve an honest caller") {
+    val (limiter, resolver) = newLimiter()
+
+    // The attacker sends a fresh id on every request, the way `?id=$RANDOM$RANDOM` would, and fills
+    // the bucket. A lone caller is allowed the whole budget, so this much is expected.
+    val held = (1 to budget).flatMap { i =>
+      val key = resolver.resolve(CallerContext.Anonymous, "graph", request(s"attacker-$i"))
+      limiter.acquire(key, 1)
+    }
+    assertEquals(held.size, budget)
+
+    // The honest caller is authenticated, so it gets a sub-key of its own. It is denied while the
+    // bucket is full, which marks it as wanting capacity.
+    val honest = CallerContext(Principal(Principal.Kind.App, "honest"), Principal.Anonymous, None)
+    val honestKey = resolver.resolve(honest, "graph", HttpRequest(uri = "/api/v1/graph"))
+    assert(limiter.acquire(honestKey, 1).isEmpty)
+
+    // The attacker keeps hammering under fresh ids. Every one of them lands on the same anonymous
+    // sub-key, so the denials accumulate against one caller and it is penalized as a hog, rather
+    // than each request arriving as an unpenalized identity with a share of its own.
+    (1 to 500).foreach { i =>
+      val key = resolver.resolve(CallerContext.Anonymous, "graph", request(s"attacker-more-$i"))
+      assert(limiter.acquire(key, 1).isEmpty)
+    }
+
+    // As permits free up they go to the honest caller, not back to the flood.
+    held.take(50).foreach(_.release())
+    val honestHeld = (1 to 50).flatMap(_ => limiter.acquire(honestKey, 1))
+    assertEquals(honestHeld.size, 50)
+
+    held.drop(50).foreach(_.release())
+    honestHeld.foreach(_.release())
+    assertEquals(limiter.acquire(honestKey, budget).map(_.release()).isDefined, true)
+  }
+
+  test("tracked sub-keys stay bounded however many distinct ids arrive") {
+    val limiter = newFairShareLimiter(maxTracked = 1000)
+
+    // Straight at the limiter, bypassing the resolver, as a resolver that trusts an unbounded value
+    // would. Each request arrives under a fresh sub-key and completes immediately; releasing leaves
+    // the state in place and it stays active for the whole window, so nothing is pruned.
+    (1 to 50000).foreach { i =>
+      val key = s"attacker-$i"
+      assert(limiter.tryAcquire(key, 1))
+      limiter.release(key, 1)
+    }
+
+    assertEquals(limiter.trackedCallers, 1000)
+  }
+
+  test("the tracked set holds at the cap rather than drifting past it") {
+    val maxTracked = 100
+    val limiter = newFairShareLimiter(maxTracked)
+
+    // `tryAcquire` does make a pass over the tracked callers, so the tracked set is what bounds the
+    // work a flood can cause per request as well as the memory it can retain. Check the bound holds
+    // throughout a long run of churn, not just at the end of it.
+    (1 to 5000).foreach { i =>
+      val key = s"attacker-$i"
+      assert(limiter.tryAcquire(key, 1))
+      limiter.release(key, 1)
+      if (i % 500 == 0) {
+        assert(
+          limiter.trackedCallers <= maxTracked,
+          s"tracked ${limiter.trackedCallers} callers after $i requests"
+        )
+      }
+    }
+    assertEquals(limiter.trackedCallers, maxTracked)
+  }
+
+  test("a denied request cannot grow the tracked set past the cap") {
+    val limiter = newFairShareLimiter(maxTracked = 8)
+
+    // State is still created before the budget check, so that a denial can be recorded against the
+    // caller. That is only safe because the cap applies to it too: an attacker needs no successful
+    // admission, but it also gains nothing from being refused.
+    assert(limiter.tryAcquire("a", budget))
+    (1 to 1000).foreach(i => assert(!limiter.tryAcquire(s"denied-$i", 1)))
+    assertEquals(limiter.trackedCallers, 8)
+  }
+}

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/LimitKeyResolverSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/LimitKeyResolverSuite.scala
@@ -20,7 +20,10 @@ import org.apache.pekko.http.scaladsl.model.HttpRequest
 
 class LimitKeyResolverSuite extends FunSuite {
 
-  private val resolver = new DefaultLimitKeyResolver(_ => Set("vip"))
+  // "vip" is provisioned in both namespaces so the tests below distinguish a legacy caller being
+  // kept out of an authenticated caller's budget from it merely naming something unconfigured.
+  private val resolver =
+    new DefaultLimitKeyResolver(_ => Set("vip", "legacy.vip", "legacy.old-app"))
 
   private def app(id: String): CallerContext = {
     CallerContext(Principal(Principal.Kind.App, id), Principal.Anonymous, None)
@@ -45,16 +48,68 @@ class LimitKeyResolverSuite extends FunSuite {
     assertEquals(key, LimitKey(LimitKey.DefaultBucket, "user@example.com", "graph"))
   }
 
-  test("anonymous caller falls back to the legacy id query parameter") {
-    val request = HttpRequest(uri = "/api/v1/graph?id=legacy-app&q=name,sps,:eq")
+  test("legacy id can select a provisioned bucket of its own") {
+    val request = HttpRequest(uri = "/api/v1/graph?id=old-app")
     val key = resolver.resolve(CallerContext.Anonymous, "graph", request)
-    assertEquals(key, LimitKey(LimitKey.DefaultBucket, "legacy-app", "graph"))
+    assertEquals(key, LimitKey("legacy.old-app", "legacy.old-app", "graph"))
   }
 
-  test("legacy id can select a provisioned bucket") {
+  test("legacy id cannot name an authenticated caller") {
+    // "vip" has a dedicated budget under both names, but the parameter is asserted rather than
+    // authenticated, so it is namespaced and lands in the legacy budget rather than in the one the
+    // authenticated caller "vip" would get.
     val request = HttpRequest(uri = "/api/v1/graph?id=vip")
     val key = resolver.resolve(CallerContext.Anonymous, "graph", request)
-    assertEquals(key, LimitKey("vip", "vip", "graph"))
+    assertEquals(key, LimitKey("legacy.vip", "legacy.vip", "graph"))
+    assertNotEquals(key, resolver.resolve(app("vip"), "graph", HttpRequest()))
+  }
+
+  test("an authenticated caller cannot reach a legacy budget by naming itself into it") {
+    // Nothing constrains what an authenticator produces, so the namespace has to be closed from
+    // both sides: an identity that already carries the prefix keeps its own sub-key but must not
+    // match the legacy caller's dedicated budget.
+    val key = resolver.resolve(app("legacy.old-app"), "graph", HttpRequest())
+    assertEquals(key, LimitKey(LimitKey.DefaultBucket, "legacy.old-app", "graph"))
+  }
+
+  test("an empty legacy id is not an identity") {
+    // `?id=` parses to a present but empty value, which must not be read as the bare prefix. The
+    // bare prefix is provisioned here so the value is what decides the outcome rather than the
+    // lookup happening to miss.
+    val bare = new DefaultLimitKeyResolver(_ => Set(LimitKey.LegacyPrefix))
+    val request = HttpRequest(uri = "/api/v1/graph?id=")
+    val key = bare.resolve(CallerContext.Anonymous, "graph", request)
+    assertEquals(key, LimitKey(LimitKey.DefaultBucket, LimitKey.Anonymous, "graph"))
+  }
+
+  test("a legacy caller and an authenticated caller of the same name stay separate") {
+    val legacy = resolver.resolve(
+      CallerContext.Anonymous,
+      "graph",
+      HttpRequest(uri = "/api/v1/graph?id=old-app")
+    )
+    val authenticated = resolver.resolve(app("old-app"), "graph", HttpRequest())
+    assertNotEquals(legacy.subKey, authenticated.subKey)
+    assertNotEquals(legacy.bucket, authenticated.bucket)
+  }
+
+  test("unprovisioned legacy id is not trusted as an identity") {
+    // The parameter is supplied by an unauthenticated caller, so honoring an arbitrary value would
+    // let one caller claim a share of a fair-share bucket for every value it invents.
+    val request = HttpRequest(uri = "/api/v1/graph?id=legacy-app&q=name,sps,:eq")
+    val key = resolver.resolve(CallerContext.Anonymous, "graph", request)
+    assertEquals(key, LimitKey(LimitKey.DefaultBucket, LimitKey.Anonymous, "graph"))
+  }
+
+  test("rotating the legacy id yields the same sub-key every time") {
+    val keys = (1 to 100).map { i =>
+      val request = HttpRequest(uri = s"/api/v1/graph?id=random-$i")
+      resolver.resolve(CallerContext.Anonymous, "graph", request)
+    }
+    assertEquals(
+      keys.distinct.toList,
+      List(LimitKey(LimitKey.DefaultBucket, LimitKey.Anonymous, "graph"))
+    )
   }
 
   test("anonymous caller with no legacy id uses the anonymous marker") {


### PR DESCRIPTION
The sub-key decides how a fair-share bucket is divided, so a caller that can mint identities is granted one share per identity it invents, along with one entry of tracked state. For an unauthenticated caller the sub-key was the `id` query parameter taken verbatim, which costs a few random bytes to vary.

DefaultLimitKeyResolver now honors the parameter only when it names a caller that has been provisioned a dedicated budget on the endpoint, which bounds the values that can reach the limiter to the configured ones. Every other unauthenticated caller shares LimitKey.Anonymous and so contends for a single share.

Where it is honored the value is still asserted rather than authenticated, so it is namespaced: `?id=x` resolves to `legacy.x`, which cannot collide with an authenticated caller `x`. A legacy caller can no longer reach an authenticated caller's budget, and an authenticated caller is never charged for legacy traffic. Within the legacy namespace the values remain self-asserted; the parameter is a shim for callers that predate authentication.

FairShareLimiter caps the number of sub-keys it tracks individually (`max-tracked-callers`, default 1000). Callers past the cap share one overflow state, so they count as a single contending caller and cannot grow the tracked set, which holds even for a resolver that lets an untrusted value through. The cap bounds the state retained, not the dilution; the resolver is the defence and this is the backstop.

Because a release has only the sub-key to go on, the limiter also records which sub-keys hold permits against the shared state. Without that a caller admitted through it and later taken into the tracked set has its release charged to the new state, stranding the permits it still holds and losing them from the budget for good, and a release from a sub-key holding nothing takes permits from the callers that do.

Note that a deployment relying on `?id=` for per-caller fairness within the shared bucket loses it; those callers now share one anonymous share. Provisioning a caller-budgets entry under the prefixed name restores per-caller treatment.

The prefix uses a dot rather than a colon because a dedicated bucket name is published verbatim as the `bucket` tag on `atlas.limiter.inflight`, and a colon is not in the tag character set, so the one bucket most worth watching during a migration would lose its metric.

Note also that a `caller-budgets` entry now blocks or provisions only the namespace it names. An existing `dashboards = 0` no longer refuses an unauthenticated caller sending `?id=dashboards`; that needs a `"legacy.dashboards"` entry of its own.