### PR TITLE
pekko: bound how long a penalty can last

### DIFF
--- a/atlas-pekko/src/main/resources/reference.conf
+++ b/atlas-pekko/src/main/resources/reference.conf
@@ -104,6 +104,13 @@ atlas.pekko {
       # Rate at which a caller's demerit decays while it is not being denied.
       decay-per-second = 0.3
 
+      # Longest a caller can stay penalized after its last denial. Demerit accumulates one step per
+      # denial and is clamped only where more of it could not contain a hog any further, so that a
+      # hog is held right down to its floor however large the budget is. Decay alone therefore
+      # bounds the penalty only by how much was accrued: a sustained burst keeps a caller penalized
+      # for far longer than the burst itself. Should be well above `window`.
+      max-penalty-duration = 60s
+
       # Cap on the number of callers tracked individually within a bucket. Callers beyond the cap
       # share a single overflow entry, counting as one contending caller between them. This bounds
       # the state retained per bucket, so that a caller able to present many identities cannot grow

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/FairShareLimiter.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/FairShareLimiter.scala
@@ -32,8 +32,9 @@ import scala.collection.mutable
   * over a threshold it is treated as a hog: it is held below its fair share (floored at one permit,
   * never starved to zero) so headroom stays free for the others, and its own denials no longer
   * count as contention that would block others from borrowing. The demerit decays over time, so a
-  * caller that stops hammering recovers its full share and the ability to borrow. Recent denial,
-  * not current usage, is what marks a caller as wanting more capacity.
+  * caller that stops hammering recovers its full share and the ability to borrow, and in any case
+  * recovers once its demerit reaches `maxPenaltyDuration` past its last denial. Recent denial, not
+  * current usage, is what marks a caller as wanting more capacity.
   *
   * Fairness acts on admission decisions as permits churn rather than by preempting held permits, so
   * it converges to a fair allocation as requests complete.
@@ -69,6 +70,10 @@ import scala.collection.mutable
   *     Amount added to a caller's demerit each time it is denied.
   * @param decayPerSecond
   *     Rate at which a caller's demerit decays while it is not being denied.
+  * @param maxPenaltyDuration
+  *     Longest a caller stays penalized after its last denial. Demerit is clamped only at the point
+  *     where more of it can no longer contain a hog any further, so this bounds how long a penalty
+  *     lasts rather than how severe it gets.
   * @param maxTrackedCallers
   *     Cap on the number of sub-keys tracked individually, which bounds the retained state. Must be
   *     positive.
@@ -80,6 +85,7 @@ final class FairShareLimiter(
   penalizedThreshold: Double,
   demeritPerDenial: Double,
   decayPerSecond: Double,
+  maxPenaltyDuration: Duration,
   maxTrackedCallers: Int
 ) extends ConcurrencyLimiter {
 
@@ -95,10 +101,16 @@ final class FairShareLimiter(
   // tests, silently disabling contention detection and with it the fairness policy.
   require(decayPerSecond > 0.0, s"decayPerSecond must be positive: $decayPerSecond")
   require(demeritPerDenial > 0.0, s"demeritPerDenial must be positive: $demeritPerDenial")
+
+  require(
+    !maxPenaltyDuration.isNegative && !maxPenaltyDuration.isZero,
+    s"maxPenaltyDuration must be positive: $maxPenaltyDuration"
+  )
   require(!window.isNegative && !window.isZero, s"window must be positive: $window")
 
   private val windowNanos = window.toNanos
   private val decayPerNano = decayPerSecond / 1e9
+  private val penaltyNanos = maxPenaltyDuration.toNanos
 
   // Demerit past this point has no further effect on the cap: `share` never exceeds `budget`, so
   // the penalty is already at its floor. All the excess does is extend how long the caller stays
@@ -135,7 +147,7 @@ final class FairShareLimiter(
   // caller keeps its demerit until it fully decays, even after it ages out of the window, so a hog
   // cannot shed a penalty just by pausing for one window.
   private val scan: (String, CallerState) => Boolean = { (k, s) =>
-    val d = s.demerit(scanNow, decayPerNano)
+    val d = s.demerit(scanNow, decayPerNano, penaltyNanos)
     val active = s.used > 0 || scanNow - s.lastSeen <= windowNanos
     val keep = active || d > 0.0
     if (keep) {
@@ -180,7 +192,7 @@ final class FairShareLimiter(
   // which mirrors the pruning done by `scan`.
   private def observeOverflow(now: Long, current: CallerState): Unit = {
     if (overflowInUse) {
-      val d = overflow.demerit(now, decayPerNano)
+      val d = overflow.demerit(now, decayPerNano, penaltyNanos)
       val active = overflow.used > 0 || now - overflow.lastSeen <= windowNanos
       if (active) {
         scanActive += 1
@@ -222,7 +234,7 @@ final class FairShareLimiter(
 
     val active = math.max(1, scanActive)
     val share = math.ceil(budget.toDouble / active).toInt
-    val d = state.demerit(now, decayPerNano)
+    val d = state.demerit(now, decayPerNano, penaltyNanos)
     val cap =
       if (d >= penalizedThreshold)
         // A hog is contained below its fair share so headroom stays free for well-behaved bursts,
@@ -300,10 +312,19 @@ object FairShareLimiter {
       demeritTime = 0L
     }
 
-    /** Demerit decayed to `now`. */
-    def demerit(now: Long, decayPerNano: Double): Double = {
+    /**
+      * Demerit decayed to `now`. It decays linearly and is also dropped outright once it is older
+      * than `horizonNanos`, which bounds how long a penalty can last. Decay alone bounds it only by
+      * how much demerit was accrued, so without the horizon a burst of denials would hold a caller
+      * over the threshold for far longer than the burst itself.
+      */
+    def demerit(now: Long, decayPerNano: Double, horizonNanos: Long): Double = {
       if (demeritValue <= 0.0) 0.0
-      else math.max(0.0, demeritValue - (now - demeritTime) * decayPerNano)
+      else {
+        val age = now - demeritTime
+        if (age > horizonNanos) 0.0
+        else math.max(0.0, demeritValue - age * decayPerNano)
+      }
     }
   }
 }

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/RequestLimiter.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/RequestLimiter.scala
@@ -112,6 +112,7 @@ class RequestLimiter(config: Config, registry: Registry) {
           fairShare.penalizedThreshold,
           fairShare.demeritPerDenial,
           fairShare.decayPerSecond,
+          fairShare.maxPenaltyDuration,
           fairShare.maxTrackedCallers
         )
       else ConcurrencyLimiter(limits.defaultBucketBudget)
@@ -267,6 +268,7 @@ object RequestLimiter {
     penalizedThreshold: Double,
     demeritPerDenial: Double,
     decayPerSecond: Double,
+    maxPenaltyDuration: Duration,
     maxTrackedCallers: Int
   )
 
@@ -281,6 +283,7 @@ object RequestLimiter {
         |penalized-threshold = 3.0
         |demerit-per-denial = 1.0
         |decay-per-second = 0.3
+        |max-penalty-duration = 60s
         |max-tracked-callers = 1000
         |""".stripMargin
     )
@@ -293,6 +296,7 @@ object RequestLimiter {
         c.getDouble("penalized-threshold"),
         c.getDouble("demerit-per-denial"),
         c.getDouble("decay-per-second"),
+        c.getDuration("max-penalty-duration"),
         c.getInt("max-tracked-callers")
       )
     }

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/FairShareLimiterSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/FairShareLimiterSuite.scala
@@ -24,6 +24,8 @@ class FairShareLimiterSuite extends FunSuite {
 
   private val window = Duration.ofSeconds(5)
 
+  private val penaltyDuration = Duration.ofSeconds(60)
+
   private def newLimiter(
     budget: Int,
     clock: ManualClock,
@@ -36,6 +38,7 @@ class FairShareLimiterSuite extends FunSuite {
       penalizedThreshold = 3.0,
       demeritPerDenial = 1.0,
       decayPerSecond = 0.3,
+      maxPenaltyDuration = penaltyDuration,
       maxTrackedCallers = maxTrackedCallers
     )
   }
@@ -205,11 +208,12 @@ class FairShareLimiterSuite extends FunSuite {
 
   // Build a limiter with one knob overridden, for the validation and edge-case tests below.
   private def tunedLimiter(
-    clock: ManualClock,
+    clock: ManualClock = new ManualClock(),
     budget: Int = 100,
     penalizedThreshold: Double = 3.0,
-    demeritPerDenial: Double,
-    decayPerSecond: Double = 0.3
+    demeritPerDenial: Double = 1.0,
+    decayPerSecond: Double = 0.3,
+    maxPenaltyDuration: Duration = penaltyDuration
   ): FairShareLimiter = {
     new FairShareLimiter(
       budget,
@@ -218,6 +222,7 @@ class FairShareLimiterSuite extends FunSuite {
       penalizedThreshold,
       demeritPerDenial,
       decayPerSecond,
+      maxPenaltyDuration,
       maxTrackedCallers = 1000
     )
   }
@@ -255,7 +260,16 @@ class FairShareLimiterSuite extends FunSuite {
 
   test("window must be positive") {
     intercept[IllegalArgumentException] {
-      new FairShareLimiter(100, new ManualClock(), Duration.ZERO, 3.0, 1.0, 0.3, 1000)
+      new FairShareLimiter(
+        100,
+        new ManualClock(),
+        Duration.ZERO,
+        3.0,
+        1.0,
+        0.3,
+        penaltyDuration,
+        1000
+      )
     }
   }
 
@@ -464,5 +478,54 @@ class FairShareLimiterSuite extends FunSuite {
     advance(clock, 30)
     assert(limiter.tryAcquire("tracked", 100))
     assertEquals(limiter.usedPermits, 100)
+  }
+
+  test("a penalty does not outlast the maximum penalty duration") {
+    val clock = new ManualClock()
+    val limiter = newLimiter(100, clock)
+
+    // Drive the demerit as far above the threshold as it will go. Decaying that at 0.3 per second
+    // would keep this caller penalized for minutes.
+    assert(limiter.tryAcquire("hog", 100))
+    (1 to 500).foreach(_ => assert(!limiter.tryAcquire("hog", 1)))
+    limiter.release("hog", 100)
+
+    // Still penalized part way through the horizon, so it is held to its floor. Note this attempt
+    // is itself denied, which restarts the horizon: it runs from the last denial, so a caller that
+    // keeps hammering stays penalized for as long as it keeps it up.
+    advance(clock, 30)
+    assert(limiter.tryAcquire("victim", 1))
+    assert(!limiter.tryAcquire("hog", 50))
+
+    // Once it stops being denied for the horizon the penalty is gone, whatever the demerit reached.
+    advance(clock, 61)
+    assert(limiter.tryAcquire("hog", 50))
+  }
+
+  test("the horizon runs from the last denial, not the first") {
+    val clock = new ManualClock()
+    val limiter = newLimiter(100, clock)
+
+    // Enough denials that the horizon, rather than the decay, is what would end the penalty.
+    assert(limiter.tryAcquire("hog", 100))
+    (1 to 500).foreach(_ => assert(!limiter.tryAcquire("hog", 1)))
+    limiter.release("hog", 100)
+
+    // Denied again most of the way through the horizon, which restarts it, so the caller is still
+    // penalized at a point well past the horizon measured from where it began.
+    advance(clock, 59)
+    assert(limiter.tryAcquire("victim", 1))
+    assert(!limiter.tryAcquire("hog", 50))
+    advance(clock, 30)
+    assert(!limiter.tryAcquire("hog", 50))
+  }
+
+  test("max penalty duration must be positive") {
+    intercept[IllegalArgumentException] {
+      tunedLimiter(maxPenaltyDuration = Duration.ofSeconds(0))
+    }
+    intercept[IllegalArgumentException] {
+      tunedLimiter(maxPenaltyDuration = Duration.ofSeconds(-1))
+    }
   }
 }

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/FairShareLimiterSybilSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/FairShareLimiterSybilSuite.scala
@@ -42,6 +42,7 @@ class FairShareLimiterSybilSuite extends FunSuite {
        |  penalized-threshold = 3.0
        |  demerit-per-denial = 1.0
        |  decay-per-second = 0.3
+       |  max-penalty-duration = 60s
        |  max-tracked-callers = 1000
        |}
        |endpoints {
@@ -70,6 +71,7 @@ class FairShareLimiterSybilSuite extends FunSuite {
       penalizedThreshold = 3.0,
       demeritPerDenial = 1.0,
       decayPerSecond = 0.3,
+      maxPenaltyDuration = Duration.ofSeconds(60),
       maxTrackedCallers = maxTracked
     )
   }


### PR DESCRIPTION
Demerit grows by one step per denial and decays at a fixed rate, so how long a caller stays penalized is set by how much demerit it accrued. It is clamped only where more of it could no longer contain a hog any further, which for a budget of 100 is 103, and at the default decay of 0.3 per second that is close to six minutes of penalty bought by a burst lasting a second. A larger budget raises the clamp and with it the duration.

Lowering the clamp is the wrong fix. The containment formula is `share - demerit`, so demerit has to be able to reach the size of the share for a hog to be held down to its floor; capping it lower would leave a hog on a large budget almost unconstrained.

Bound the duration instead. Demerit is dropped outright once it is older than `max-penalty-duration` (default 60s), measured from the last denial, so a caller that keeps hammering stays penalized for as long as it keeps it up but recovers within the horizon of backing off. The magnitude is untouched, so containment is exactly as strong as it was.

Expiring the value rather than time-boxing a separate "is penalized" test means every reader picks the bound up for free: the cap, the contention check, and the pruning of callers that have gone idle all go through `demerit`. The pruning matters here, since a caller whose demerit is still decaying is retained rather than reclaimed.