### PR TITLE
pekko: evict stale callers instead of pooling them

### DIFF
--- a/atlas-pekko/src/main/resources/reference.conf
+++ b/atlas-pekko/src/main/resources/reference.conf
@@ -111,20 +111,14 @@ atlas.pekko {
       # for far longer than the burst itself. Should be well above `window`.
       max-penalty-duration = 60s
 
-      # Cap on the number of callers tracked individually within a bucket. Callers beyond the cap
-      # share a single overflow entry, counting as one contending caller between them. This bounds
-      # the state retained per bucket, so that a caller able to present many identities cannot grow
-      # it without limit. It is close to a memory bound and nothing more: a caller presenting this
-      # many identities still collects that many shares, and honest callers arriving after the cap
-      # is reached are folded onto the shared entry and inherit its demerit. Fairness depends on the
-      # sub-key being trustworthy, not on this.
-      #
-      # It should be comfortably above the number of distinct callers that can be tracked at once,
-      # which is not the same as the number in flight: a caller keeps its entry for `window` after
-      # its last attempt, and longer if it is carrying demerit, so the working set is roughly the
-      # arrival rate times the window rather than the concurrency. The cap is also the worst case
-      # for the per-request pass over the tracked callers, which is done under a single lock, so
-      # raising it well past what a bucket needs is not free.
+      # Target for the number of callers tracked individually within a bucket. On reaching it the
+      # least recently seen caller that holds no permits is forgotten to make room, so a caller
+      # able to present many identities cannot grow the tracked set without bound. A caller holding
+      # permits is never forgotten, since that would lose the permits it has yet to return, so this
+      # is a target rather than a hard ceiling and the set is bounded by the greater of it and the
+      # bucket budget. The work done per request does not depend on how many callers are tracked,
+      # so this is a memory bound rather than a throughput one. It should be comfortably above the
+      # number of distinct callers expected within `window`.
       max-tracked-callers = 1000
     }
 

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/FairShareLimiter.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/FairShareLimiter.scala
@@ -42,11 +42,13 @@ import scala.collection.mutable
   * Fairness is only as trustworthy as the `subKey`: a caller that can present many identities is
   * granted one share per identity, so the sub-key must be derived from an authenticated identity or
   * from an otherwise bounded set (see [[DefaultLimitKeyResolver]]). The number of tracked sub-keys
-  * is capped as a safeguard against a resolver that lets an untrusted value through, with callers
-  * beyond the cap sharing a single overflow state so they count as one contending caller between
-  * them. Note that the cap bounds the state retained, not the dilution: a caller presenting as many
-  * identities as the cap allows still gets that many shares, so the resolver is the defence and
-  * this is the backstop.
+  * is capped as a safeguard against a resolver that lets an untrusted value through: when the cap
+  * is reached the least recently seen caller that holds no permits is forgotten to make room, so
+  * every caller keeps a history of its own and an unfamiliar one never inherits another's demerit.
+  * A caller holding permits is never evicted, so the cap is a target rather than a hard ceiling and
+  * the set is bounded by the greater of the cap and the budget. Note that it bounds the state
+  * retained, not the dilution: a caller presenting as many identities as the cap allows still gets
+  * that many shares, so the resolver is the defence and this is the backstop.
   *
   * Performance: all per-caller state lives in a single map keyed by `subKey`, plus one shared state
   * for the callers past the cap, and the running total is maintained incrementally. `tryAcquire`
@@ -121,19 +123,6 @@ final class FairShareLimiter(
   private val callers = new mutable.HashMap[String, CallerState]()
   private var total = 0
 
-  // State shared by every caller seen while the map is already at `maxTrackedCallers`. Folding them
-  // onto one state keeps the tracked set bounded and makes them count as a single contending caller
-  // rather than one per sub-key. It lives outside the map so it is never pruned; `overflowInUse`
-  // records whether any caller is currently using it, since a state that has never been used must
-  // not be counted as active.
-  private val overflow = new CallerState()
-  private var overflowInUse = false
-
-  // Sub-keys that currently hold permits against the shared state, and how much each holds, so a
-  // release can be charged to the state that actually holds the caller's permits. Bounded by
-  // `budget`, since a holder holds at least one permit.
-  private val overflowHolders = new mutable.HashMap[String, Int]()
-
   // Scratch state for the single scan pass. Only touched while the monitor is held, so a single
   // reusable scan function can read it without capturing per-call variables (which would allocate).
   private var scanNow = 0L
@@ -141,6 +130,11 @@ final class FairShareLimiter(
   private var scanActive = 0
   private var scanContended = false
   private var scanCurrentActive = false
+
+  // Least recently seen caller that holds no permits, and so the one to evict if the cap is reached
+  // and a new caller has to be tracked. Chosen during the same pass rather than by a second walk.
+  private var scanStalestKey: String = null
+  private var scanStalestSeen = 0L
 
   // Prune callers that are no longer active and no longer carry demerit, count the active callers,
   // and detect whether another well-behaved caller was recently denied (and so wants capacity). A
@@ -163,49 +157,40 @@ final class FairShareLimiter(
       ) {
         scanContended = true
       }
+      // A caller holding permits is never a candidate: forgetting it would lose the permits it has
+      // yet to return. Everything else is fair game, oldest first.
+      if (s.used == 0 && (scanStalestKey == null || s.lastSeen < scanStalestSeen)) {
+        scanStalestKey = k
+        scanStalestSeen = s.lastSeen
+      }
     }
     keep
   }
 
   private def clamp(cost: Int): Int = math.min(budget, math.max(1, cost))
 
-  // State for a caller, tracked individually while there is room and folded onto the shared
-  // overflow state once the cap is reached. `getOrElse` with a null default avoids the `Option`
-  // that `get` would allocate on the request path.
+  // Every caller gets a state of its own. When the cap is reached the least recently seen caller
+  // that holds no permits is forgotten to make room, so an unfamiliar caller is never made to share
+  // another's history. A caller that is hammering is by definition recently seen, so it is never
+  // the one evicted and cannot shed a penalty by rotating identities; a caller quiet enough to be
+  // evicted has, by the same token, a demerit that has already decayed or is about to.
+  //
+  // `getOrElse` with a null default avoids the `Option` that `get` would allocate on the request
+  // path.
   private def stateFor(subKey: String): CallerState = {
     val existing = callers.getOrElse(subKey, null)
     if (existing != null) existing
-    // Tracking a caller that still holds permits against the shared state would strand them, since
-    // `release` would then look the caller up in the map and never reach the overflow state.
-    else if (callers.size < maxTrackedCallers && !overflowHolders.contains(subKey)) {
+    else {
+      // The cap is a target rather than a hard ceiling. If every tracked caller is holding permits
+      // there is nothing safe to evict, and the set is allowed past the cap; it stays bounded
+      // because a holder holds at least one permit, so there can be no more of them than `budget`.
+      if (callers.size >= maxTrackedCallers && scanStalestKey != null) {
+        callers.remove(scanStalestKey)
+        scanStalestKey = null
+      }
       val state = new CallerState()
       callers.put(subKey, state)
       state
-    } else {
-      overflowInUse = true
-      overflow
-    }
-  }
-
-  // The overflow state is not in the map, so the accounting the scan does for a tracked caller is
-  // applied to it by hand. It is reset rather than removed once it is idle and free of demerit,
-  // which mirrors the pruning done by `scan`.
-  private def observeOverflow(now: Long, current: CallerState): Unit = {
-    if (overflowInUse) {
-      val d = overflow.demerit(now, decayPerNano, penaltyNanos)
-      val active = overflow.used > 0 || now - overflow.lastSeen <= windowNanos
-      if (active) {
-        scanActive += 1
-        if (
-          !scanContended && (current ne overflow) && d < penalizedThreshold &&
-          overflow.lastDenied != NeverDenied && now - overflow.lastDenied <= windowNanos
-        ) {
-          scanContended = true
-        }
-      } else if (d <= 0.0) {
-        overflow.reset()
-        overflowInUse = false
-      }
     }
   }
 
@@ -214,23 +199,22 @@ final class FairShareLimiter(
     val c = clamp(cost)
 
     // Prune before choosing the caller's state so the cap is tested against the callers actually
-    // being tracked, not against entries this same pass is about to sweep. Choosing first would
-    // fold a caller onto the shared state while every slot it needed sat free, and
-    // `overflowHolders` would then keep it there for as long as it holds a permit.
+    // being tracked, not against entries this same pass is about to sweep, and so the eviction
+    // candidate is picked from what survives. Choosing first would evict a caller to make room the
+    // pass was about to free anyway.
     scanNow = now
     scanSubKey = subKey
     scanActive = 0
     scanContended = false
     scanCurrentActive = false
+    scanStalestKey = null
     callers.filterInPlace(scan)
 
     val state = stateFor(subKey)
     state.lastSeen = now
     // The caller in hand is active by definition, but the scan ran before its state was refreshed,
-    // so count it here unless the scan already did. A caller on the shared state is counted once,
-    // by `observeOverflow`, however many sub-keys are folded onto it.
-    if ((state ne overflow) && !scanCurrentActive) scanActive += 1
-    observeOverflow(now, state)
+    // so count it here unless the scan already did.
+    if (!scanCurrentActive) scanActive += 1
 
     val active = math.max(1, scanActive)
     val share = math.ceil(budget.toDouble / active).toInt
@@ -254,39 +238,33 @@ final class FairShareLimiter(
     } else {
       state.used += c
       total += c
-      if (state eq overflow) {
-        overflowHolders.update(subKey, overflowHolders.getOrElse(subKey, 0) + c)
-      }
       true
     }
   }
 
   override def release(subKey: String, cost: Int): Unit = synchronized {
     val c = clamp(cost)
-    // Charge the release to whichever state actually holds this caller's permits, and only up to
-    // what it holds, so a mis-paired or duplicate release cannot drive `total` below the real usage
-    // (which would let the bucket over-admit) nor take permits from another caller sharing the
-    // overflow state. The state object is left in place so demerit and recency survive until it is
-    // pruned.
-    val viaOverflow = overflowHolders.getOrElse(subKey, 0)
-    val state = if (viaOverflow > 0) overflow else callers.getOrElse(subKey, null)
-    val held = if (viaOverflow > 0) viaOverflow else if (state != null) state.used else 0
-    if (held > 0) {
-      val released = math.min(held, c)
+    // Charge the release only up to what the caller actually holds, so a mis-paired or duplicate
+    // release cannot drive `total` below the real usage, which would let the bucket over-admit. A
+    // caller holding permits is never evicted, so its state is always here to be found; a sub-key
+    // that holds nothing is a no-op. The state is left in place so demerit and recency survive
+    // until it is pruned.
+    val state = callers.getOrElse(subKey, null)
+    if (state != null && state.used > 0) {
+      val released = math.min(state.used, c)
       state.used -= released
       total = math.max(0, total - released)
-      if (viaOverflow > 0) {
-        if (released == viaOverflow) overflowHolders.remove(subKey)
-        else overflowHolders.update(subKey, viaOverflow - released)
-      }
     }
   }
 
   override def usedPermits: Int = synchronized(total)
   override def maxPermits: Int = budget
 
-  /** Number of callers being tracked individually, at most `maxTrackedCallers`. */
+  /** Number of callers being tracked individually. */
   private[pekko] def trackedCallers: Int = synchronized(callers.size)
+
+  /** Whether a state is currently held for the given sub-key. Exposed for tests. */
+  private[pekko] def isTracked(subKey: String): Boolean = synchronized(callers.contains(subKey))
 }
 
 object FairShareLimiter {
@@ -302,15 +280,6 @@ object FairShareLimiter {
     var lastDenied: Long = NeverDenied
     var demeritValue: Double = 0.0
     var demeritTime: Long = 0L
-
-    /** Return to the initial state so a shared state object can be reused once it is idle. */
-    def reset(): Unit = {
-      used = 0
-      lastSeen = 0L
-      lastDenied = NeverDenied
-      demeritValue = 0.0
-      demeritTime = 0L
-    }
 
     /**
       * Demerit decayed to `now`. It decays linearly and is also dropped outright once it is older

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/FairShareLimiterSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/FairShareLimiterSuite.scala
@@ -306,91 +306,6 @@ class FairShareLimiterSuite extends FunSuite {
     assertEquals(limiter.trackedCallers, 1)
   }
 
-  test("callers beyond the cap share one overflow entry") {
-    val limiter = newLimiter(100, new ManualClock(), maxTrackedCallers = 4)
-
-    // Fill the tracked set, then keep going with fresh sub-keys. The extra callers must not add
-    // tracked state, so the share seen by a caller stops shrinking once the cap is reached.
-    (1 to 500).foreach { i =>
-      val key = s"c$i"
-      assert(limiter.tryAcquire(key, 1))
-      limiter.release(key, 1)
-    }
-
-    assertEquals(limiter.trackedCallers, 4)
-
-    // Deny one of the tracked callers so that everyone is held to their share rather than free to
-    // borrow the whole budget; without that the cap below is `budget` and proves nothing.
-    assert(limiter.tryAcquire("c1", 100))
-    assert(!limiter.tryAcquire("c2", 1))
-    limiter.release("c1", 100)
-
-    // Four tracked callers plus the overflow entry is five active callers, so the share is 20. The
-    // next caller lands in overflow and is capped at the share the crowd holds jointly - neither
-    // starved to one permit nor free to take more than a share between them.
-    assert(!limiter.tryAcquire("c501", 21))
-    assert(limiter.tryAcquire("c501", 20))
-    assertEquals(limiter.usedPermits, 20)
-  }
-
-  test("permits held through the overflow entry survive the tracked set draining") {
-    val clock = new ManualClock()
-    val limiter = newLimiter(100, clock, maxTrackedCallers = 1)
-
-    // "filler" holds the one tracked slot, so "z" holds its permits against the shared entry.
-    assert(limiter.tryAcquire("filler", 1))
-    assert(limiter.tryAcquire("z", 10))
-    limiter.release("filler", 1)
-
-    // "filler" goes idle and is swept away, freeing the slot while "z" is still in flight. "z" must
-    // not be taken into the tracked set here: its release would then be charged to the new state
-    // and the permits it still holds against the shared entry would be lost from the budget.
-    advance(clock, 30)
-    assert(limiter.tryAcquire("sweeper", 1))
-    limiter.release("sweeper", 1)
-
-    assert(limiter.tryAcquire("z", 1))
-    limiter.release("z", 1)
-    limiter.release("z", 10)
-    assertEquals(limiter.usedPermits, 0)
-  }
-
-  test("one in-flight overflow request does not freeze the tracked set") {
-    val clock = new ManualClock()
-    val limiter = newLimiter(1000, clock, maxTrackedCallers = 4)
-
-    // Fill the tracked set, then push one caller onto the shared entry holding a long request.
-    (1 to 4).foreach { i =>
-      assert(limiter.tryAcquire(s"old-$i", 1))
-      limiter.release(s"old-$i", 1)
-    }
-    assert(limiter.tryAcquire("longrunner", 1))
-
-    // The old callers go idle and are swept away. Only "longrunner" is pinned to the shared entry;
-    // the callers arriving now must take the slots it freed rather than all being folded in behind
-    // it, which would collapse them onto a single share for as long as that one request runs.
-    advance(clock, 30)
-    (1 to 20).foreach { i =>
-      val key = s"new-$i"
-      assert(limiter.tryAcquire(key, 1))
-      limiter.release(key, 1)
-    }
-    assertEquals(limiter.trackedCallers, 4)
-  }
-
-  test("a release from a sub-key that holds nothing cannot take overflow permits") {
-    val limiter = newLimiter(100, new ManualClock(), maxTrackedCallers = 1)
-    assert(limiter.tryAcquire("tracked", 1))
-    assert(limiter.tryAcquire("holder", 40))
-    assertEquals(limiter.usedPermits, 41)
-
-    // "holder" reached the shared entry, but the entry is not a pool anyone may draw down: a
-    // release for a sub-key that never acquired must be a no-op, or the bucket over-admits by as
-    // much as the real holders are still holding.
-    limiter.release("never-acquired", 100)
-    assertEquals(limiter.usedPermits, 41)
-  }
-
   test("permits are fully returned when many callers churn past the cap") {
     // Every acquire is paired with exactly one release of the same cost, so once the run drains,
     // `usedPermits` must be zero. Far more callers than slots, so callers cross between the tracked
@@ -416,68 +331,6 @@ class FairShareLimiterSuite extends FunSuite {
 
     held.indices.foreach(i => held(i).foreach(c => limiter.release(s"caller-$i", c)))
     assertEquals(limiter.usedPermits, 0)
-  }
-
-  test("permits held through the overflow entry are released") {
-    val limiter = newLimiter(100, new ManualClock(), maxTrackedCallers = 1)
-    assert(limiter.tryAcquire("tracked", 1))
-
-    // "extra" is past the cap so it holds its permits against the shared overflow state. Release
-    // has to find that state by falling back to overflow, or the permits leak from the budget.
-    assert(limiter.tryAcquire("extra", 40))
-    assertEquals(limiter.usedPermits, 41)
-    limiter.release("extra", 40)
-    limiter.release("tracked", 1)
-    assertEquals(limiter.usedPermits, 0)
-  }
-
-  test("overflow callers count as one contending caller between them") {
-    val clock = new ManualClock()
-    val limiter = newLimiter(100, clock, maxTrackedCallers = 1)
-
-    // A crowd of untracked callers collapses onto a single overflow entry, so it marks contention
-    // once however large it is. Two denials keep its demerit below the penalty threshold, leaving
-    // it counted as a well-behaved caller that wants capacity.
-    assert(limiter.tryAcquire("honest", 100))
-    assert(!limiter.tryAcquire("flood-1", 1))
-    assert(!limiter.tryAcquire("flood-2", 1))
-    limiter.release("honest", 100)
-
-    // Two active callers, so the tracked caller is held to half the budget. Without the overflow
-    // entry the crowd would present one caller per sub-key and drive the share down to one.
-    var admitted = 0
-    while (admitted < 100 && limiter.tryAcquire("honest", 1)) admitted += 1
-    assertEquals(admitted, 50)
-  }
-
-  test("an overflow crowd that keeps hammering is penalized as a single hog") {
-    val clock = new ManualClock()
-    val limiter = newLimiter(100, clock, maxTrackedCallers = 1)
-
-    // Demerit accrues to the shared entry, so a sustained flood of untracked callers is penalized
-    // collectively rather than each sub-key arriving with a clean slate. Once over the threshold it
-    // no longer counts as contention, and the tracked caller is free to use the spare capacity.
-    assert(limiter.tryAcquire("honest", 100))
-    (1 to 500).foreach(i => assert(!limiter.tryAcquire(s"flood-$i", 1)))
-    limiter.release("honest", 100)
-
-    assert(limiter.tryAcquire("honest", 100))
-    assertEquals(limiter.usedPermits, 100)
-  }
-
-  test("the overflow entry is reset once it goes idle") {
-    val clock = new ManualClock()
-    val limiter = newLimiter(100, clock, maxTrackedCallers = 1)
-    assert(limiter.tryAcquire("tracked", 1))
-    assert(limiter.tryAcquire("extra", 1))
-    limiter.release("tracked", 1)
-    limiter.release("extra", 1)
-
-    // Once the untracked callers age out, the overflow entry stops counting as active and the
-    // tracked caller is alone again, free to use the whole budget.
-    advance(clock, 30)
-    assert(limiter.tryAcquire("tracked", 100))
-    assertEquals(limiter.usedPermits, 100)
   }
 
   test("a penalty does not outlast the maximum penalty duration") {
@@ -527,5 +380,105 @@ class FairShareLimiterSuite extends FunSuite {
     intercept[IllegalArgumentException] {
       tunedLimiter(maxPenaltyDuration = Duration.ofSeconds(-1))
     }
+  }
+
+  test("reaching the cap evicts the stalest idle caller, not the busiest") {
+    val clock = new ManualClock()
+    val limiter = newLimiter(100, clock, maxTrackedCallers = 3)
+
+    // Three callers, seen at increasing times, none holding anything.
+    assert(limiter.tryAcquire("oldest", 1))
+    limiter.release("oldest", 1)
+    advance(clock, 1)
+    assert(limiter.tryAcquire("middle", 1))
+    limiter.release("middle", 1)
+    advance(clock, 1)
+    assert(limiter.tryAcquire("newest", 1))
+    limiter.release("newest", 1)
+    assertEquals(limiter.trackedCallers, 3)
+
+    // A fourth arrival displaces the least recently seen, and the set stays at the cap.
+    advance(clock, 1)
+    assert(limiter.tryAcquire("arrival", 1))
+    assertEquals(limiter.trackedCallers, 3)
+    assert(!limiter.isTracked("oldest"))
+    assert(limiter.isTracked("middle"))
+    assert(limiter.isTracked("newest"))
+    assert(limiter.isTracked("arrival"))
+  }
+
+  test("a caller holding permits is never evicted") {
+    val clock = new ManualClock()
+    val limiter = newLimiter(100, clock, maxTrackedCallers = 2)
+
+    // "holder" is the least recently seen by a wide margin, but its permits are still out.
+    assert(limiter.tryAcquire("holder", 10))
+    advance(clock, 60)
+    assert(limiter.tryAcquire("other", 1))
+    limiter.release("other", 1)
+
+    // Room is made from the idle caller instead, and the set is allowed past the cap only while
+    // every member is holding something.
+    advance(clock, 1)
+    assert(limiter.tryAcquire("arrival", 1))
+    assert(limiter.isTracked("holder"))
+
+    // The holder's permits come back, which is only possible because its state survived.
+    limiter.release("holder", 10)
+    assertEquals(limiter.usedPermits, 1)
+  }
+
+  test("permits are returned in full when many callers churn past the cap") {
+    val clock = new ManualClock()
+    val budget = 1000
+    val limiter = newLimiter(budget, clock, maxTrackedCallers = 6)
+
+    // Far more callers than slots, each acquiring and releasing in strict pairs. Every permit has
+    // to come back: an evicted caller must never be one that still holds something.
+    (1 to 20000).foreach { i =>
+      val key = s"caller-${i % 40}"
+      if (limiter.tryAcquire(key, 1 + (i % 3))) limiter.release(key, 1 + (i % 3))
+      if (i % 500 == 0) advance(clock, 1)
+    }
+    assertEquals(limiter.usedPermits, 0)
+  }
+
+  test("an evicted caller does not hand its demerit to the next arrival") {
+    val clock = new ManualClock()
+    val limiter = newLimiter(100, clock, maxTrackedCallers = 2)
+
+    // Drive one caller well over the penalty threshold, then let it go quiet.
+    assert(limiter.tryAcquire("hog", 100))
+    (1 to 20).foreach(_ => assert(!limiter.tryAcquire("hog", 1)))
+    limiter.release("hog", 100)
+    advance(clock, 6)
+
+    // An unfamiliar caller arriving into a bucket with nothing held gets the whole budget, rather
+    // than inheriting a penalty from the caller whose slot it took.
+    assert(limiter.tryAcquire("filler", 1))
+    limiter.release("filler", 1)
+    advance(clock, 1)
+    assert(limiter.tryAcquire("innocent", 100))
+    assertEquals(limiter.usedPermits, 100)
+  }
+
+  test("a hog cannot shed its penalty by being evicted") {
+    val clock = new ManualClock()
+    val limiter = newLimiter(100, clock, maxTrackedCallers = 2)
+
+    // The hog keeps arriving, so it is never the least recently seen and never the eviction
+    // candidate however many other callers churn through the remaining slot.
+    assert(limiter.tryAcquire("hog", 100))
+    (1 to 20).foreach(_ => assert(!limiter.tryAcquire("hog", 1)))
+    (1 to 50).foreach { i =>
+      assert(!limiter.tryAcquire("hog", 1))
+      val key = s"churn-$i"
+      if (limiter.tryAcquire(key, 1)) limiter.release(key, 1)
+    }
+    assert(limiter.isTracked("hog"))
+
+    // Still penalized: a permit frees up and the hog cannot take it back.
+    limiter.release("hog", 1)
+    assert(!limiter.tryAcquire("hog", 1))
   }
 }


### PR DESCRIPTION
Callers seen past `max-tracked-callers` shared a single overflow state. Pooling identities onto one mutable state has no clean way in or out of the pool, and four faults followed from that:

  - A caller promoted out of the pool got a fresh state, so a hog shed the penalty it had earned there while the demerit stayed behind to floor whichever caller arrived next.
  - A caller was pinned to the pool for as long as it held any permit, because a release could otherwise not find its permits, so a service with sustained concurrency was never promoted even with every slot free.
  - Pool members could not restrain each other, since a caller is excluded from its own contention test and they were all one caller.
  - A denial by any member penalized all of them.

Give every caller a state of its own and make room by forgetting the least recently seen caller that holds no permits. A caller that is hammering is by definition recently seen, so it is never the one evicted and cannot shed a penalty by rotating identities; a caller quiet enough to be evicted has a demerit that has already decayed or is about to. An evicted caller loses only history it no longer needs, and re-registers on its next request.

A caller holding permits is never evicted, since forgetting it would lose the permits it has yet to return. The cap is therefore a target rather than a hard ceiling, with the set bounded by the greater of the cap and the budget, because a holder holds at least one permit.

This removes the shared state, the map of who holds what against it, and the hand-written copy of the scan bookkeeping that applied to it, along with the class of bug that came from a release having to work out which of two states held a caller's permits.