### PR TITLE
pekko: show bucket a shed by the endpoint total

### DIFF
--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/ConcurrencyLimiter.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/ConcurrencyLimiter.scala
@@ -53,6 +53,16 @@ trait ConcurrencyLimiter {
     */
   def release(subKey: String, cost: Int): Unit
 
+  /**
+    * Return permits acquired by [[tryAcquire]] for a request that was shed before it ran, because
+    * some other limit it also had to pass refused it. The permits go back exactly as they would on
+    * [[release]], but the caller is accounted for as having been refused capacity rather than as
+    * having completed, which matters to any limiter whose policy depends on who is being turned
+    * away. The default treats it as a plain release, which is correct for a limiter that keeps no
+    * per-caller state.
+    */
+  def releaseDenied(subKey: String, cost: Int): Unit = release(subKey, cost)
+
   /** Number of permits currently held. Intended for reporting via gauges. */
   def usedPermits: Int
 

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/FairShareLimiter.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/FairShareLimiter.scala
@@ -242,18 +242,43 @@ final class FairShareLimiter(
     }
   }
 
-  override def release(subKey: String, cost: Int): Unit = synchronized {
-    val c = clamp(cost)
-    // Charge the release only up to what the caller actually holds, so a mis-paired or duplicate
-    // release cannot drive `total` below the real usage, which would let the bucket over-admit. A
-    // caller holding permits is never evicted, so its state is always here to be found; a sub-key
-    // that holds nothing is a no-op. The state is left in place so demerit and recency survive
-    // until it is pruned.
+  // Hand back up to what the caller actually holds, and report how much that was. Charging only
+  // what is really held means a mis-paired or duplicate release cannot drive `total` below the real
+  // usage, which would let the bucket over-admit. A caller holding permits is never evicted, so its
+  // state is always here to be found; a sub-key that holds nothing is a no-op. The state is left in
+  // place so demerit and recency survive until it is pruned.
+  private def releaseHeld(subKey: String, cost: Int): Int = {
     val state = callers.getOrElse(subKey, null)
-    if (state != null && state.used > 0) {
-      val released = math.min(state.used, c)
+    if (state == null || state.used == 0) 0
+    else {
+      val released = math.min(state.used, cost)
       state.used -= released
       total = math.max(0, total - released)
+      released
+    }
+  }
+
+  override def release(subKey: String, cost: Int): Unit = synchronized {
+    val _ = releaseHeld(subKey, clamp(cost))
+  }
+
+  override def releaseDenied(subKey: String, cost: Int): Unit = synchronized {
+    if (releaseHeld(subKey, clamp(cost)) > 0) {
+      // The permits came back because the request was refused, not because it ran, so record it as
+      // a denial. Otherwise a caller shed by another limit never accrues demerit however hard it
+      // hammers, and is never counted as wanting capacity, which would leave the others free to
+      // borrow the whole bucket while it waits. Nothing held means nothing was shed, so a
+      // mis-paired call stays the no-op that `release` makes it.
+      val now = clock.monotonicTime()
+      val state = callers(subKey)
+      // Count it as an attempt as well as a denial. The endpoint calls this immediately after the
+      // acquire it is undoing, so this is normally already the case, but the policy reads a denial
+      // as implying an attempt and should not depend on the caller for that.
+      state.lastSeen = now
+      state.demeritValue =
+        math.min(maxDemerit, state.demerit(now, decayPerNano, penaltyNanos) + demeritPerDenial)
+      state.demeritTime = now
+      state.lastDenied = now
     }
   }
 

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/RequestLimiter.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/RequestLimiter.scala
@@ -228,7 +228,10 @@ object RequestLimiter {
         return denied
       }
       if (!total.tryAcquire(subKey, requestCost)) {
-        bucketLimiter.release(subKey, requestCost)
+        // The bucket already admitted this request, so hand the permits back as a denial. A plain
+        // release would look identical to a completed request and hide the shed from the bucket's
+        // own policy.
+        bucketLimiter.releaseDenied(subKey, requestCost)
         deniedTotal.increment()
         return denied
       }

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/ConcurrencyLimiterSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/ConcurrencyLimiterSuite.scala
@@ -81,4 +81,12 @@ class ConcurrencyLimiterSuite extends FunSuite {
   test("maxPermits reflects the configured budget") {
     assertEquals(ConcurrencyLimiter(7).maxPermits, 7)
   }
+
+  test("a limiter with no per-caller state treats a denied release as a plain release") {
+    val limiter = ConcurrencyLimiter(4)
+    assert(limiter.tryAcquire("a", 3))
+    assertEquals(limiter.usedPermits, 3)
+    limiter.releaseDenied("a", 3)
+    assertEquals(limiter.usedPermits, 0)
+  }
 }

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/FairShareLimiterSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/FairShareLimiterSuite.scala
@@ -481,4 +481,54 @@ class FairShareLimiterSuite extends FunSuite {
     limiter.release("hog", 1)
     assert(!limiter.tryAcquire("hog", 1))
   }
+
+  test("a denied release returns the permits and marks the caller as wanting capacity") {
+    val limiter = newLimiter(4, new ManualClock())
+
+    // "a" was admitted by this limiter but shed by another, so its permits come back as a denial.
+    assert(limiter.tryAcquire("a", 1))
+    limiter.releaseDenied("a", 1)
+    assertEquals(limiter.usedPermits, 0)
+
+    // "a" is now waiting, so "b" is held to its share of two rather than borrowing the whole
+    // bucket. A plain release would have left "a" invisible and "b" free to take all four.
+    assert(!limiter.tryAcquire("b", 4))
+    assert(limiter.tryAcquire("b", 2))
+  }
+
+  test("a plain release leaves the caller free to borrow") {
+    val limiter = newLimiter(4, new ManualClock())
+    assert(limiter.tryAcquire("a", 1))
+    limiter.release("a", 1)
+    assert(limiter.tryAcquire("b", 4))
+  }
+
+  test("a denied release accrues demerit, so a caller shed repeatedly becomes a hog") {
+    val clock = new ManualClock()
+    val limiter = newLimiter(100, clock)
+
+    // Shed over and over without backing off. Demerit has to accumulate, or a caller refused by
+    // another limit could hammer indefinitely without ever being contained.
+    (1 to 10).foreach { _ =>
+      assert(limiter.tryAcquire("hammer", 1))
+      limiter.releaseDenied("hammer", 1)
+    }
+    assert(limiter.tryAcquire("victim", 1))
+
+    // Penalized now, so it is held to its floor even though the bucket is nearly empty.
+    assert(!limiter.tryAcquire("hammer", 50))
+  }
+
+  test("a denied release for a caller holding nothing is a no-op") {
+    val limiter = newLimiter(4, new ManualClock())
+    assert(limiter.tryAcquire("a", 2))
+
+    // Nothing was shed, so nothing is recorded and no permits move.
+    limiter.releaseDenied("never-acquired", 4)
+    assertEquals(limiter.usedPermits, 2)
+
+    // "never-acquired" was not marked as wanting capacity, so "a" may still borrow.
+    assert(limiter.tryAcquire("a", 2))
+    assertEquals(limiter.usedPermits, 4)
+  }
 }

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/RequestLimiterSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/RequestLimiterSuite.scala
@@ -283,4 +283,44 @@ class RequestLimiterSuite extends FunSuite {
     // The freed permit is available first-come, including back to the same caller.
     assert(limiter.acquire(graphKey("hog"), 1).isDefined)
   }
+
+  // The endpoint total is consumed entirely by a dedicated caller, so the shared bucket's own
+  // budget is not what refuses requests: the total is.
+  private val totalBoundConfig =
+    """
+      |mode = enforce
+      |endpoints {
+      |  graph {
+      |    total-budget = 100
+      |    default-bucket-budget = 100
+      |    fair-share = true
+      |    caller-budgets {
+      |      vip = 100
+      |    }
+      |  }
+      |}
+      |""".stripMargin
+
+  test("a caller shed by the endpoint total still gets its share of the bucket") {
+    val registry = new DefaultRegistry()
+    val limiter = new RequestLimiter(config(totalBoundConfig), registry)
+
+    // vip fills the endpoint total from its own dedicated bucket.
+    val vip = (1 to 100).flatMap(_ => limiter.acquire(graphKey("vip", "vip"), 1))
+    assertEquals(vip.size, 100)
+
+    // b passes the shared bucket and is refused by the total. The shared bucket has to see that as
+    // a denial, or b is invisible to it and a is free to borrow everything once room appears.
+    assert(limiter.acquire(graphKey("b"), 1).isEmpty)
+    assertEquals(requests(registry, "graph", "denied", "total"), 1L)
+
+    // Room appears. a must be held to its share rather than taking the whole bucket.
+    vip.foreach(_.release())
+    val aHeld = (1 to 100).count(_ => limiter.acquire(graphKey("a"), 1).isDefined)
+    assertEquals(aHeld, 50)
+
+    // ...which leaves the capacity b was waiting for actually available to it.
+    val bHeld = (1 to 50).count(_ => limiter.acquire(graphKey("b"), 1).isDefined)
+    assertEquals(bHeld, 50)
+  }
 }


### PR DESCRIPTION
A request has to pass the bucket limiter and the endpoint total. The bucket is tried first, so when the total is what refuses the request the bucket has already admitted it and the permits are handed back. That release was indistinguishable from a completed request, which disabled both halves of the fair-share policy for the shed caller: it accrued no demerit, so it never became a hog however hard it hammered, and it was never counted as wanting capacity, so the other callers kept a cap of the whole budget and could borrow all of it while it waited. Any endpoint whose dedicated buckets consume enough of the total for it to bind first had fair sharing in name only.

Add `releaseDenied` to ConcurrencyLimiter, defaulting to a plain release since a limiter that keeps no per-caller state cannot care, and have the endpoint use it for the rollback. FairShareLimiter records the caller as having attempted and been refused, exactly as if the bucket had refused it directly.

A shed that hands back nothing records nothing, which keeps a mis-paired call the no-op that `release` already is.