### PR TITLE
eval: add bounds checking for tag count in LwcMessages.parseTags

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcMessages.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/model/LwcMessages.scala
@@ -35,6 +35,11 @@ import tools.jackson.databind.node.NullNode
   */
 object LwcMessages {
 
+  // Maximum number of tags allowed when parsing. This is used as a sanity
+  // check in case a bad payload comes in with a really large size that
+  // could exhaust memory.
+  private final val maxTags = 100_000
+
   // For reading arbitrary json structures for events
   private val mapper = Json.newMapperBuilder
     .disable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
@@ -408,6 +413,10 @@ object LwcMessages {
   private def parseTags(parser: JsonParser, n: Int): Map[String, String] = {
     if (n == 0) {
       SortedTagMap.empty
+    } else if (n < 0 || n > maxTags) {
+      throw new IllegalArgumentException(
+        s"requested tag count is invalid or exceeds limit ($n, max: $maxTags)"
+      )
     } else {
       val data = new Array[String](2 * n)
       var i = 0

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcMessagesSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/model/LwcMessagesSuite.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.eval.model
 
+import java.io.ByteArrayOutputStream
 import java.util.Random
 import java.util.UUID
 import scala.util.Using
@@ -324,4 +325,42 @@ class LwcMessagesSuite extends FunSuite {
   }
 
   private def randomString: String = UUID.randomUUID().toString
+
+  test("batch: invalid tag count throws IllegalArgumentException") {
+    val baos = new ByteArrayOutputStream()
+    val gen = Json.newSmileGenerator(baos)
+    try {
+      gen.writeStartArray()
+      gen.writeNumber(2) // Datapoint
+      gen.writeNumber(1234567890L)
+      gen.writeString("id")
+      gen.writeNumber(100_001)
+      gen.writeNumber(1.0)
+      gen.writeEndArray()
+    } finally {
+      gen.close()
+    }
+    intercept[IllegalArgumentException] {
+      LwcMessages.parseBatch(ByteString.fromArrayUnsafe(baos.toByteArray))
+    }
+  }
+
+  test("batch: negative tag count throws IllegalArgumentException") {
+    val baos = new ByteArrayOutputStream()
+    val gen = Json.newSmileGenerator(baos)
+    try {
+      gen.writeStartArray()
+      gen.writeNumber(2) // Datapoint
+      gen.writeNumber(1234567890L)
+      gen.writeString("id")
+      gen.writeNumber(-1)
+      gen.writeNumber(1.0)
+      gen.writeEndArray()
+    } finally {
+      gen.close()
+    }
+    intercept[IllegalArgumentException] {
+      LwcMessages.parseBatch(ByteString.fromArrayUnsafe(baos.toByteArray))
+    }
+  }
 }


### PR DESCRIPTION
### Problem
In `LwcMessages.parseTags(parser, n)`, the string array `new Array[String](2 * n)` is allocated directly based on the integer `n` parsed from the incoming Smile payload stream without prior bounds validation.

If a corrupted or malformed payload contains an invalid or excessively large tag count, the JVM attempts to allocate an oversized array, which can lead to an unhandled `OutOfMemoryError` or `NegativeArraySizeException`.

### Solution
Add a defensive bounds check for tag count in `LwcMessages.parseTags` (consistent with the sanity checking pattern in `PublishPayloads.maxArraySize`), ensuring `n` is within `[0, maxTags]` (where `maxTags = 100_000`), and throwing an `IllegalArgumentException` otherwise.

### Changes
1. Added `maxTags` constant in `LwcMessages`.
2. Added validation in `LwcMessages.parseTags` to reject negative or excessive tag counts with `IllegalArgumentException`.
3. Added unit test cases in `LwcMessagesSuite` covering both excessive and negative tag count scenarios.
