### PR TITLE
Harden CORS origin reflection and credential handling for wildcard host patterns

### DIFF
--- a/atlas-pekko/src/main/resources/reference.conf
+++ b/atlas-pekko/src/main/resources/reference.conf
@@ -21,10 +21,11 @@ atlas.pekko {
   ]
 
   # Hosts that are allowed to make cross origin requests
-  # 1. '*' match any host
+  # 1. '*' matches any host (emits Access-Control-Allow-Origin: * without credentials)
   # 2. Starts with '.', indicates a sub-domain, for example `.netflix.com`. The origin must
-  #    end with the exact string.
-  # 3. Otherwise the hostname for the origin must match an entry exactly.
+  #    end with the exact string. (Emits Access-Control-Allow-Credentials: true)
+  # 3. Otherwise the hostname for the origin must match an entry exactly. (Emits
+  #    Access-Control-Allow-Credentials: true)
   #
   # An empty list means that CORS headers will not be added.
   cors-host-patterns = ["*"]

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/Cors.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/Cors.scala
@@ -56,6 +56,27 @@ object Cors {
     }
   }
 
+  /**
+    * Check if the origin is allowed via an explicit pattern (specific host or subdomain,
+    * not a wildcard `*`).
+    *
+    * @param hosts
+    *     Set of host patterns to allow.
+    * @param origin
+    *     Origin value normally extracted from the request headers.
+    * @return
+    *     True if the hostname matches an explicit pattern.
+    */
+  def isExplicitHostAllowed(hosts: List[String], origin: String): Boolean = {
+    try {
+      val originHostname = extractHostname(origin)
+      checkExplicitOrigin(hosts, originHostname)
+    } catch {
+      case _: Exception =>
+        false
+    }
+  }
+
   private def extractHostname(origin: String): String = {
     if (origin.startsWith("http:") || origin.startsWith("https:"))
       Uri(origin).authority.host.address()
@@ -73,5 +94,17 @@ object Cors {
 
   private def checkOrigin(host: String, origin: String): Boolean = {
     (host == "*") || (host.startsWith(".") && origin.endsWith(host)) || (host == origin)
+  }
+
+  @scala.annotation.tailrec
+  private def checkExplicitOrigin(hosts: List[String], origin: String): Boolean = {
+    hosts match {
+      case h :: hs => checkExplicitOrigin(h, origin) || checkExplicitOrigin(hs, origin)
+      case Nil     => false
+    }
+  }
+
+  private def checkExplicitOrigin(host: String, origin: String): Boolean = {
+    (host.startsWith(".") && origin.endsWith(host)) || (host == origin)
   }
 }

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/CustomDirectives.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/CustomDirectives.scala
@@ -198,29 +198,40 @@ object CustomDirectives {
       case None                                                 => pass
       case Some(origin) if !Cors.isOriginAllowed(hosts, origin) => pass
       case Some(origin)                                         =>
-        // '*' doesn't seem to work reliably so use requested origin if provided. If running from
-        // a local file we typically see 'null'.
+        val isExplicit = Cors.isExplicitHostAllowed(hosts, origin)
         val allow =
-          if (origin == "null") HttpOriginRange.`*` else HttpOriginRange(HttpOrigin(origin))
+          if (isExplicit)
+            HttpOriginRange(HttpOrigin(origin))
+          else
+            HttpOriginRange.`*`
 
         // List of headers to ignore for caching. For more details see:
         // https://bugs.chromium.org/p/chromium/issues/detail?id=409090
         // https://www.fastly.com/blog/caching-cors
         val vary = RawHeader("Vary", "Origin")
 
-        // Just allow all methods
-        val headers = List(
+        val allowMethods = `Access-Control-Allow-Methods`(
+          HttpMethods.GET,
+          HttpMethods.PATCH,
+          HttpMethods.POST,
+          HttpMethods.PUT,
+          HttpMethods.DELETE
+        )
+
+        // Per W3C CORS and Fetch specifications, Access-Control-Allow-Credentials must not be true
+        // when Access-Control-Allow-Origin is a wildcard (*). Only emit credentials header for
+        // explicitly allowed origins.
+        val baseHeaders = List(
           `Access-Control-Allow-Origin`.forRange(allow),
-          `Access-Control-Allow-Methods`(
-            HttpMethods.GET,
-            HttpMethods.PATCH,
-            HttpMethods.POST,
-            HttpMethods.PUT,
-            HttpMethods.DELETE
-          ),
-          `Access-Control-Allow-Credentials`(true),
+          allowMethods,
           vary
         )
+
+        val headers =
+          if (isExplicit)
+            `Access-Control-Allow-Credentials`(true) :: baseHeaders
+          else
+            baseHeaders
 
         // If specific headers are requested echo those back
         optionalHeaderValueByName("Access-Control-Request-Headers").flatMap {

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/CorsSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/CorsSuite.scala
@@ -33,4 +33,26 @@ class CorsSuite extends FunSuite {
     val origin = Cors.normalizedOrigin("https://123.45.67.89/")
     assertEquals(origin, None)
   }
+
+  test("isExplicitHostAllowed: explicit matches") {
+    val hosts = List("localhost", ".netflix.com")
+    assert(Cors.isExplicitHostAllowed(hosts, "http://localhost"))
+    assert(Cors.isExplicitHostAllowed(hosts, "https://foo.netflix.com"))
+    assert(Cors.isExplicitHostAllowed(hosts, "https://sub.foo.netflix.com"))
+    assert(!Cors.isExplicitHostAllowed(hosts, "https://foo.netflix.org"))
+    assert(!Cors.isExplicitHostAllowed(hosts, "http://localhost.evil.com"))
+  }
+
+  test("isExplicitHostAllowed: wildcard does not count as explicit") {
+    val hosts = List("*")
+    assert(!Cors.isExplicitHostAllowed(hosts, "http://localhost"))
+    assert(!Cors.isExplicitHostAllowed(hosts, "https://foo.netflix.com"))
+    assert(Cors.isOriginAllowed(hosts, "https://foo.netflix.com"))
+  }
+
+  test("isOriginAllowed: wildcard allows arbitrary origin") {
+    val hosts = List("*")
+    assert(Cors.isOriginAllowed(hosts, "https://example.com"))
+    assert(Cors.isOriginAllowed(hosts, "http://evil.com"))
+  }
 }

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/CustomDirectivesSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/CustomDirectivesSuite.scala
@@ -54,7 +54,7 @@ class CustomDirectivesSuite extends MUnitRouteSuite {
 
     def routes: Route = {
       accessLog(List(zone)) {
-        respondWithCorsHeaders(List("*")) {
+        respondWithCorsHeaders(List("localhost", ".netflix.com")) {
           path("text") {
             get {
               val entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, "text response")
@@ -417,26 +417,85 @@ class CustomDirectivesSuite extends MUnitRouteSuite {
     }
   }
 
-  // Some browsers send this when a request is made from a file off the local filesystem
-  test("cors null origin") {
-    val headers = List(RawHeader("Origin", "null"))
+  test("cors with wildcard hosts") {
+    val wildcardRoute = respondWithCorsHeaders(List("*")) {
+      path("json") {
+        get {
+          val entity = HttpEntity(MediaTypes.`application/json`, "[1,2,3]")
+          complete(HttpResponse(status = StatusCodes.OK, entity = entity))
+        }
+      }
+    }
+
+    val headers = List(Origin(HttpOrigin("http://example.com")))
     val req = HttpRequest(HttpMethods.GET, Uri("/json"), headers)
-    req ~> endpoint.routes ~> check {
-      assert(headers.nonEmpty)
+    req ~> wildcardRoute ~> check {
+      assert(response.headers.nonEmpty)
+      var hasOrigin = false
+      var hasCredentials = false
       response.headers.foreach {
         case `Access-Control-Allow-Origin`(v) =>
           assertEquals("*", v.toString)
+          hasOrigin = true
         case `Access-Control-Allow-Methods`(vs) =>
           assertEquals("GET,PATCH,POST,PUT,DELETE", vs.map(_.name()).mkString(","))
-        case `Access-Control-Allow-Credentials`(v) =>
-          assert(v)
-        case h if h.is("netflix-zone") =>
-          assertEquals(h.value, "us-east-1e")
+        case `Access-Control-Allow-Credentials`(_) =>
+          hasCredentials = true
         case h if h.is("vary") =>
           assertEquals(h.value, "Origin")
         case h =>
           fail(s"unexpected header: $h")
       }
+      assert(hasOrigin)
+      assert(!hasCredentials)
+      val expected = """[1,2,3]"""
+      assertEquals(expected, responseAs[String])
+    }
+  }
+
+  // Some browsers send this when a request is made from a file off the local filesystem
+  test("cors null origin") {
+    val wildcardRoute = respondWithCorsHeaders(List("*")) {
+      path("json") {
+        get {
+          val entity = HttpEntity(MediaTypes.`application/json`, "[1,2,3]")
+          complete(HttpResponse(status = StatusCodes.OK, entity = entity))
+        }
+      }
+    }
+
+    val headers = List(RawHeader("Origin", "null"))
+    val req = HttpRequest(HttpMethods.GET, Uri("/json"), headers)
+    req ~> wildcardRoute ~> check {
+      assert(response.headers.nonEmpty)
+      var hasOrigin = false
+      var hasCredentials = false
+      response.headers.foreach {
+        case `Access-Control-Allow-Origin`(v) =>
+          assertEquals("*", v.toString)
+          hasOrigin = true
+        case `Access-Control-Allow-Methods`(vs) =>
+          assertEquals("GET,PATCH,POST,PUT,DELETE", vs.map(_.name()).mkString(","))
+        case `Access-Control-Allow-Credentials`(_) =>
+          hasCredentials = true
+        case h if h.is("vary") =>
+          assertEquals(h.value, "Origin")
+        case h =>
+          fail(s"unexpected header: $h")
+      }
+      assert(hasOrigin)
+      assert(!hasCredentials)
+      val expected = """[1,2,3]"""
+      assertEquals(expected, responseAs[String])
+    }
+  }
+
+  test("cors with disallowed origin") {
+    val headers = List(Origin(HttpOrigin("http://evil.com")))
+    val req = HttpRequest(HttpMethods.GET, Uri("/json"), headers)
+    req ~> endpoint.routes ~> check {
+      val corsHeaders = response.headers.filter(_.name().toLowerCase.startsWith("access-control-"))
+      assert(corsHeaders.isEmpty)
       val expected = """[1,2,3]"""
       assertEquals(expected, responseAs[String])
     }


### PR DESCRIPTION
### Summary
This PR hardens CORS response handling in \tlas-pekko\ to strictly conform with the W3C CORS and Fetch specifications regarding origin reflection and credentials.

### Problem
Previously, when \cors-host-patterns\ contained \*\, \CustomDirectives.respondWithCorsHeaders\ dynamically reflected arbitrary \Origin\ request headers into \Access-Control-Allow-Origin\ while unconditionally setting \Access-Control-Allow-Credentials: true\.

According to the W3C CORS specification, wildcard / unvalidated origins must not be paired with \Access-Control-Allow-Credentials: true\. Reflecting arbitrary origins with credentials enabled allows cross-origin web applications to make credentialed requests using ambient browser sessions.

### Solution
1. Added \Cors.isExplicitHostAllowed\ to distinguish explicit host/subdomain whitelists from wildcard (\*\) patterns.
2. Updated \CustomDirectives.respondWithCorsHeaders\:
   - When matched via **wildcard (\*\)**: Responds with \Access-Control-Allow-Origin: *\ and omits \Access-Control-Allow-Credentials\.
   - When matched via **explicit host patterns**: Reflects the specific origin and allows \Access-Control-Allow-Credentials: true\.
3. Updated \eference.conf\ comments to document the credential behavior.
4. Added test cases in \CorsSuite\ and \CustomDirectivesSuite\ to verify both wildcard and explicit whitelist behaviors.

### Verification
- \CorsSuite\ (6 passed).
- \CustomDirectivesSuite\ (40 passed).