### PR TITLE
core: reduce bitmap churn in query eval

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndex.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndex.scala
@@ -249,8 +249,11 @@ class RoaringTagIndex[T <: TaggedItem](items: Array[T], stats: IndexStats) exten
     * OWNERSHIP: the returned bitmap must be treated as READ-ONLY. For some queries it
     * is a shared reference into the index (e.g. the stored bitmap for an exact tag
     * match, or `all`), and mutating it would corrupt the index for every later query.
-    * Callers that need to mutate the result (in-place `and`/`or`, offset removal) must
-    * obtain an owned copy via [[findOwned]].
+    * The combinators (`and`, `or`, `andNot`) never mutate a bitmap that could be shared
+    * with the index, so they can consume this directly. Their own result is always
+    * freshly allocated, which is what lets `or` fold a chain into the accumulator
+    * returned by a nested `or`. Callers that need to mutate the result (offset removal
+    * in [[findItems]]) must obtain a copy via [[findOwned]].
     *
     * Offset is NOT applied here. Removing a fixed prefix range commutes with
     * and/or/andNot, so it is applied once on the final set at the top-level entry
@@ -280,17 +283,20 @@ class RoaringTagIndex[T <: TaggedItem](items: Array[T], stats: IndexStats) exten
     * cases that [[findReadOnly]] can answer with a shared index bitmap need a copy;
     * every other case already produces a freshly-allocated set.
     *
-    * MAINTENANCE: the shared-returning leaves are exactly `Equal` (`vidx.get`),
-    * `HasKey` (`keyIndex.get`), and `True` (`all`). If a new leaf is added that
-    * returns a stored index bitmap rather than a fresh one, it MUST be added to the
-    * match below, or using it as the left operand of `and`/`or` will corrupt the
-    * index. (See the "ownership" tests in RoaringTagIndexSuite.)
+    * MAINTENANCE: the shared-returning leaves are `Equal` (`vidx.get`), `HasKey`
+    * (`keyIndex.get`), `True` (`all`), and `In`/`PatternQuery` when exactly one value
+    * matches (see `UnionAccumulator`). If a new leaf is added that returns a stored
+    * index bitmap rather than a fresh one, it MUST be added to the match below, or
+    * mutating the result will corrupt the index. (See the "ownership" tests in
+    * RoaringTagIndexSuite.)
     */
   private def findOwned(query: Query): RoaringBitmap = {
     import com.netflix.atlas.core.model.Query.*
     query match {
-      case _: Equal | _: HasKey | True => ownedCopy(findReadOnly(query))
-      case _                           => findReadOnly(query)
+      case _: Equal | _: HasKey | _: In | _: PatternQuery | True =>
+        ownedCopy(findReadOnly(query))
+      case _ =>
+        findReadOnly(query)
     }
   }
 
@@ -312,20 +318,54 @@ class RoaringTagIndex[T <: TaggedItem](items: Array[T], stats: IndexStats) exten
   }
 
   private def and(q1: Query, q2: Query): RoaringBitmap = {
-    val s1 = findOwned(q1) // mutated in place below, so must be owned
-    if (s1.isEmpty) s1
-    else {
-      // Short circuit, only perform second query if s1 is not empty. `and` only reads
-      // s2, so a shared bitmap is fine here -- no copy needed.
-      s1.and(findReadOnly(q2))
-      s1
+    import com.netflix.atlas.core.model.Query.*
+    // A negated operand does not need to be materialized against the full set. Since
+    // `s1 AND NOT(q)` is `s1 \ q` and s1 is a subset of `all`, the andNot can be done
+    // directly against the sub-query. This avoids converting the run containers in
+    // `all` into bitmap containers just to throw most of the result away.
+    q1 match {
+      case Not(q) => andNot(q2, q)
+      case _      =>
+        q2 match {
+          case Not(q) => andNot(q1, q)
+          case _      =>
+            val s1 = findReadOnly(q1)
+            // Short circuit, only perform second query if s1 is not empty. Static `and`
+            // reads both operands and allocates just the intersection, which is
+            // typically much smaller than a copy of s1.
+            if (s1.isEmpty) new RoaringBitmap() else RoaringBitmap.and(s1, findReadOnly(q2))
+        }
     }
   }
 
+  /** Compute `q1 AND NOT(q2)` without materializing the complement of `q2`. */
+  private def andNot(q1: Query, q2: Query): RoaringBitmap = {
+    val s1 = findReadOnly(q1)
+    if (s1.isEmpty) new RoaringBitmap() else diff(s1, findReadOnly(q2))
+  }
+
   private def or(q1: Query, q2: Query): RoaringBitmap = {
-    val s1 = findOwned(q1)
-    s1.or(findReadOnly(q2)) // s2 only read, shared is fine
-    s1
+    import com.netflix.atlas.core.model.Query.*
+    // A nested `Or` has already allocated a fresh accumulator (see below), so the union
+    // can be folded into it. Without this, a chain such as `Or(Or(Or(a, b), c), d)` --
+    // the shape produced by expanding `:in` and by query normalization -- would copy the
+    // growing result at every level, making the chain quadratic in the result size.
+    q1 match {
+      case _: Or =>
+        val s1 = findReadOnly(q1)
+        s1.or(findReadOnly(q2))
+        s1
+      case _ =>
+        q2 match {
+          case _: Or =>
+            val s2 = findReadOnly(q2)
+            s2.or(findReadOnly(q1))
+            s2
+          case _ =>
+            // Static `or` reads both operands, so a shared bitmap from a leaf is fine.
+            RoaringBitmap.or(findReadOnly(q1), findReadOnly(q2))
+        }
+    }
   }
 
   private def equal(k: String, v: String): RoaringBitmap = {
@@ -395,15 +435,12 @@ class RoaringTagIndex[T <: TaggedItem](items: Array[T], stats: IndexStats) exten
     val vidx = itemIndex.get(kp)
     if (vidx == null) new RoaringBitmap()
     else {
-      val set = new LazyOrBitmap()
+      val set = new UnionAccumulator
       vs.foreach { v =>
         val vp = valueMap.get(v, -1)
-        val matchSet = vidx.get(vp)
-        if (matchSet != null)
-          set.naivelazyor(matchSet)
+        set.add(vidx.get(vp))
       }
-      set.repairAfterLazy()
-      set
+      set.result()
     }
   }
 
@@ -412,7 +449,7 @@ class RoaringTagIndex[T <: TaggedItem](items: Array[T], stats: IndexStats) exten
     val vidx = itemIndex.get(kp)
     if (vidx == null) new RoaringBitmap()
     else {
-      val set = new LazyOrBitmap()
+      val set = new UnionAccumulator
       val prefix = q.pattern.prefix()
       if (prefix != null) {
         val vp = findOffset(values, prefix, 0)
@@ -425,18 +462,17 @@ class RoaringTagIndex[T <: TaggedItem](items: Array[T], stats: IndexStats) exten
         ) {
           val v = tagValue(tagIndex(i))
           if (q.check(values(v))) {
-            set.naivelazyor(vidx.get(v))
+            set.add(vidx.get(v))
           }
           i += 1
         }
       } else {
         vidx.foreach { (v, items) =>
           if (q.check(values(v)))
-            set.naivelazyor(items)
+            set.add(items)
         }
       }
-      set.repairAfterLazy()
-      set
+      set.result()
     }
   }
 
@@ -674,5 +710,46 @@ object RoaringTagIndex {
 
   private[index] def hasNonEmptyIntersection(b1: RoaringBitmap, b2: RoaringBitmap): Boolean = {
     RoaringBitmap.intersects(b1, b2)
+  }
+
+  /**
+    * Accumulator for the union of a set of bitmaps from the index. The lazy or
+    * accumulator is only created once there are at least two sets to combine. For
+    * the common cases of zero or one match that avoids promoting the containers to
+    * bitmap containers and repairing them afterwards.
+    *
+    * Note that with a single match the shared bitmap from the index is returned by
+    * [[result]], so it must be treated as read-only (see `findOwned`).
+    */
+  private[index] class UnionAccumulator {
+
+    private var first: RoaringBitmap = _
+    private var acc: LazyOrBitmap = _
+
+    def add(set: RoaringBitmap): Unit = {
+      if (set != null) {
+        if (acc != null) {
+          acc.naivelazyor(set)
+        } else if (first == null) {
+          first = set
+        } else {
+          acc = new LazyOrBitmap()
+          acc.naivelazyor(first)
+          acc.naivelazyor(set)
+          first = null
+        }
+      }
+    }
+
+    def result(): RoaringBitmap = {
+      if (acc != null) {
+        acc.repairAfterLazy()
+        acc
+      } else if (first != null) {
+        first
+      } else {
+        new RoaringBitmap()
+      }
+    }
   }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/index/RoaringTagIndexSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/index/RoaringTagIndexSuite.scala
@@ -316,11 +316,15 @@ class RoaringTagIndexSuite extends TagIndexSuite {
       .sorted
 
   private val inQuery: Query = Query.In(multiKey, multiVals.take(3))
+
+  // Single match: `in`/`strPattern` short circuit the union and hand back the shared
+  // bitmap stored in the index, so this is the riskiest input for the ownership rules.
+  private val singleValueIn: Query = Query.In(multiKey, List(multiVals.head))
   private val regexQuery: Query = Query.Regex(multiKey, multiVals.head.take(2))
   private val geQuery: Query = Query.GreaterThanEqual(multiKey, multiVals(multiVals.size / 2))
 
   private val leafQueries: List[Query] =
-    Query.True :: inQuery :: regexQuery :: geQuery ::
+    Query.True :: inQuery :: singleValueIn :: regexQuery :: geQuery ::
       sampleKeys.map(Query.HasKey.apply) :::
       sampleTags.map { case (k, v) => Query.Equal(k, v) }
 
@@ -328,10 +332,11 @@ class RoaringTagIndexSuite extends TagIndexSuite {
     val idx = freshIndex()
     val q = Query.Equal(sampleTags.head._1, sampleTags.head._2)
     val before = ids(idx, q)
-    // q is the first operand, evaluated via findOwned (must clone); the in-place
-    // `and` then mutates the accumulator. AND with *different* equality tags so the
-    // intersection is a strict subset -- if the clone is missing, q's stored bitmap
-    // shrinks. Guard against a vacuous setup: require at least one term to shrink q.
+    // q is the first operand and resolves to the bitmap stored in the index. AND with
+    // *different* equality tags so the intersection is a strict subset -- if `and`
+    // ever intersects into its operand rather than allocating a fresh result, q's
+    // stored bitmap shrinks. Guard against a vacuous setup: require at least one term
+    // to shrink q.
     assert(
       sampleTags.tail.exists {
         case (k, v) => ids(idx, Query.And(q, Query.Equal(k, v))).size < before.size
@@ -355,11 +360,20 @@ class RoaringTagIndexSuite extends TagIndexSuite {
       },
       "test setup is vacuous: no OR term grows the first operand"
     )
-    // in-place `or` would add bits to q's stored bitmap if it were not cloned.
+    // An `or` that unioned into its first operand would add bits to q's stored bitmap.
     sampleTags.tail.foreach {
       case (k, v) => idx.findItems(TagQuery(Some(Query.Or(q, Query.Equal(k, v)))))
     }
     assertEquals(ids(idx, q), before, "Equal result changed after OR -> shared bitmap mutated")
+  }
+
+  test("an OR chain matches the equivalent In query") {
+    // `or` folds a chain into the accumulator returned by the nested `or`; this locks
+    // the result against the same query expressed as a single In leaf.
+    val idx = freshIndex()
+    val chained = Query.In(multiKey, multiVals).toOrQuery
+    assert(!chained.isInstanceOf[Query.In], "test setup is vacuous: not an OR chain")
+    assertEquals(ids(idx, chained), ids(idx, Query.In(multiKey, multiVals)))
   }
 
   test("ownership: HasKey/True survive NOT and a deep compound battery") {
@@ -377,10 +391,16 @@ class RoaringTagIndexSuite extends TagIndexSuite {
       Query.And(Query.Not(a), Query.HasKey(sampleKeys.head)),
       Query.And(Query.And(a, Query.HasKey(sampleKeys.head)), b),
       Query.Or(Query.Or(a, b), Query.HasKey(sampleKeys.last)),
-      // Non-Equal leaves as the first (mutated) operand -- locks the invariant that
-      // In/Regex/range return fresh sets and don't need a copy in findOwned.
+      // Non-Equal leaves as operands. In/Regex may return a shared index bitmap when
+      // exactly one value matches, so neither and/or may mutate their operands.
       Query.And(inQuery, Query.HasKey(sampleKeys.head)),
+      Query.And(singleValueIn, Query.HasKey(sampleKeys.head)),
+      Query.Or(singleValueIn, a),
       Query.Or(regexQuery, a),
+      // OR chains: `or` folds into the accumulator of a nested `or`, so the fold must
+      // never start from a leaf's shared bitmap. Cover both nesting directions.
+      Query.Or(Query.Or(singleValueIn, regexQuery), b),
+      Query.Or(a, Query.Or(b, singleValueIn)),
       Query.And(geQuery, Query.HasKey(sampleKeys.head))
     )
     // Run twice to surface progressive corruption (each run would further
@@ -409,6 +429,26 @@ class RoaringTagIndexSuite extends TagIndexSuite {
       idx.findItems(TagQuery(None, limit = Int.MaxValue)).map(_.id),
       before,
       "all changed after offset query -> shared `all` was mutated"
+    )
+  }
+
+  test("ownership: offset query on a single-match In does not corrupt the index") {
+    // `in` returns the shared bitmap when only one value matches, so the offset>0
+    // path (which trims the prefix in place) must copy it first.
+    val idx = freshIndex()
+    val full = idx.findItems(TagQuery(Some(singleValueIn), limit = Int.MaxValue))
+    assert(full.size > 1, "test setup is vacuous: single-value In needs >1 matching item")
+    val before = full.map(_.id)
+    val someId = full(full.size / 2).id.toString
+    (0 until 2).foreach { _ =>
+      val paged =
+        idx.findItems(TagQuery(Some(singleValueIn), offset = someId, limit = Int.MaxValue))
+      assert(paged.size < full.size, "offset did not trim; offset>0 copy path not exercised")
+    }
+    assertEquals(
+      idx.findItems(TagQuery(Some(singleValueIn), limit = Int.MaxValue)).map(_.id),
+      before,
+      "In result changed after offset query -> shared bitmap was mutated"
     )
   }
 

--- a/atlas-jmh/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndexBench.scala
+++ b/atlas-jmh/src/main/scala/com/netflix/atlas/core/index/RoaringTagIndexBench.scala
@@ -96,4 +96,64 @@ class RoaringTagIndexBench {
   def findValuesAllMany(bh: Blackhole): Unit = {
     bh.consume(index.findValues(TagQuery(None, Some("nf.node"))))
   }
+
+  // Query shapes seen in production profiles for the find items path.
+  private val nodes = items.map(_.tags("nf.node")).toList
+
+  private val eqQuery = Query.Equal("nf.app", "atlas_backend")
+
+  private val notQuery =
+    Query.And(eqQuery, Query.Not(Query.Regex("nf.node", "abc")))
+
+  // The common production shape: a selective term AND'd with a negation. The result is
+  // a small subset, so materializing the complement of the negated term against the
+  // full set of items dominates the cost.
+  private val notSelectiveQuery =
+    Query.And(Query.Equal("nf.node", nodes.head), Query.Not(Query.Regex("nf.node", "abc")))
+
+  private val inOneQuery = Query.In("nf.node", nodes.take(1))
+
+  private val inManyQuery = Query.In("nf.node", nodes.take(100))
+
+  private val reQuery = Query.Regex("nf.node", "a")
+
+  private val andQuery = Query.And(eqQuery, Query.Equal("nf.stack", "dev"))
+
+  // Left-nested OR chain, the shape produced by expanding an `:in` query.
+  private val orChainQuery = Query.In("nf.node", nodes.take(100)).toOrQuery
+
+  @Benchmark
+  def findItemsNot(bh: Blackhole): Unit = {
+    bh.consume(index.findItems(TagQuery(Some(notQuery), limit = Integer.MAX_VALUE)))
+  }
+
+  @Benchmark
+  def findItemsNotSelective(bh: Blackhole): Unit = {
+    bh.consume(index.findItems(TagQuery(Some(notSelectiveQuery), limit = Integer.MAX_VALUE)))
+  }
+
+  @Benchmark
+  def findItemsAnd(bh: Blackhole): Unit = {
+    bh.consume(index.findItems(TagQuery(Some(andQuery), limit = Integer.MAX_VALUE)))
+  }
+
+  @Benchmark
+  def findItemsOrChain(bh: Blackhole): Unit = {
+    bh.consume(index.findItems(TagQuery(Some(orChainQuery), limit = Integer.MAX_VALUE)))
+  }
+
+  @Benchmark
+  def findItemsInOne(bh: Blackhole): Unit = {
+    bh.consume(index.findItems(TagQuery(Some(inOneQuery), limit = Integer.MAX_VALUE)))
+  }
+
+  @Benchmark
+  def findItemsInMany(bh: Blackhole): Unit = {
+    bh.consume(index.findItems(TagQuery(Some(inManyQuery), limit = Integer.MAX_VALUE)))
+  }
+
+  @Benchmark
+  def findItemsRegex(bh: Blackhole): Unit = {
+    bh.consume(index.findItems(TagQuery(Some(reQuery), limit = Integer.MAX_VALUE)))
+  }
 }


### PR DESCRIPTION
Profiles of the find items path showed org.roaringbitmap accounting for ~39% of CPU self-time and ~77% of allocated bytes, concentrated in a few sites in RoaringTagIndex.

* Special case a negated operand of `and`. Since every leaf result is a subset of `all`, `s1 AND NOT(q)` is `s1 \ q`, so there is no need to materialize the complement of `q` against `all`. The old form converted every run container in `all` into an 8KB bitmap container just to throw most of the result away.

* Use the static `RoaringBitmap.and`/`or` rather than cloning the first operand and narrowing it in place. Only the result is allocated, which for an intersection is typically much smaller than a copy of the input. A nested `or` is still folded into its accumulator so that chains, such as those produced by expanding `:in`, do not become quadratic.

* Add a fast path for `in` and `strPattern` when zero or one value matches. Previously every call built a lazy or accumulator, promoting each key to a bitmap container and then converting it back in `repairAfterLazy`. With a single match the stored bitmap can be used directly. Since that bitmap is shared with the index, `findOwned` now copies it before the offset path mutates the result.

Benchmark, 10k item synthetic index, throughput and bytes per op:

```
  in, single match     15.1M -> 30.2M ops/s,  192 ->   48 B/op
  eq,:re,:not,:and     2.25M -> 6.42M ops/s, 6000 -> 3000 B/op
  or chain, 100 terms   145k ->  148k ops/s, 3456 -> 3440 B/op
```

Other shapes measured flat. The synthetic index is too small to show the main win, which is avoiding the copy of a multi-million item `all`.