### PR TITLE
pekko: add agent facing service doc

### DIFF
--- a/atlas-pekko/src/main/resources/reference.conf
+++ b/atlas-pekko/src/main/resources/reference.conf
@@ -175,6 +175,25 @@ atlas.pekko {
     ]
   }
 
+  # Pointer to an agent facing document describing how to use the service. If a document is
+  # available, then a `Link` header with a relation type of `service-doc` is added to all
+  # responses so a client that has never seen the API has a single place to look. The document
+  # itself should be short and task oriented: what the API is for, the few endpoints that
+  # matter, worked examples, and the cost model.
+  service-doc {
+    # Resource in the classpath with the document to serve at `/.well-known/llms.txt` and the
+    # `/llms.txt` alias, for example `www/llms.txt`. Empty, the default, means there is no
+    # document: the paths are not mapped and no link header gets added. If the configured
+    # resource is not present in the classpath, then it is treated the same as if it were
+    # empty.
+    resource = ""
+
+    # Summary of what is at the other end of the link. This is what makes a client decide the
+    # fetch is worth doing, so it should name the contents rather than just say "docs". Should
+    # be set along with the resource above.
+    title = ""
+  }
+
   # Name of the actor system
   name = "atlas"
 

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/RequestHandler.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/RequestHandler.scala
@@ -114,6 +114,12 @@ object RequestHandler extends StrictLogging {
         .distinct
     }
 
+    // Lazy for the same reason as `requestAuthenticator` below: it resolves a classpath resource
+    // using the thread context class loader, so it must not be built eagerly for the
+    // `defaultSettings` singleton where both the config source and the current thread may not be
+    // the ones used when the routes are actually wired.
+    lazy val serviceDoc: ServiceDoc = ServiceDoc(config)
+
     val corsEnabled: Boolean = {
       config.getBoolean("atlas.pekko.request-handler.cors")
     }
@@ -173,7 +179,11 @@ object RequestHandler extends StrictLogging {
     // Placing the authenticator here, inside the exception/rejection handling, the access log, and
     // the CORS wrapper below, ensures its rejections are rendered by the standard error handling,
     // included in the access log, and carry CORS headers.
-    val finalRoutes = ok ~ settings.requestAuthenticator(route)
+    // Serve the agent facing service doc here rather than from an endpoint class so that the
+    // location advertised by the link header below is always mapped, whatever set of endpoints
+    // is configured. It is inside the authenticator so access to it is treated the same as any
+    // other route, and after the user routes so that it cannot shadow a configured endpoint.
+    val finalRoutes = ok ~ settings.requestAuthenticator(route ~ settings.serviceDoc.routes)
 
     // Automatically deal with compression
     val gzip =
@@ -199,11 +209,19 @@ object RequestHandler extends StrictLogging {
       else
         accessLog(settings.diagnosticHeaders) { close }
 
+    // Point clients at the agent facing service doc. Applied outside the access log so this
+    // fixed header is not recorded on every log entry, and as a default header so a route that
+    // sets its own `Link` header takes precedence.
+    val serviceDoc = settings.serviceDoc.linkHeader match {
+      case Some(h) => respondWithDefaultHeader(h) { log }
+      case None    => log
+    }
+
     // Add CORS headers to all responses
     if (settings.corsEnabled)
-      cors(settings.corsHostPatterns) { log }
+      cors(settings.corsHostPatterns) { serviceDoc }
     else
-      log
+      serviceDoc
   }
 
   def errorResponse(t: Throwable): HttpResponse = {

--- a/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/ServiceDoc.scala
+++ b/atlas-pekko/src/main/scala/com/netflix/atlas/pekko/ServiceDoc.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.pekko
+
+import com.typesafe.config.Config
+import org.apache.pekko.http.scaladsl.model.ContentTypes
+import org.apache.pekko.http.scaladsl.model.Uri
+import org.apache.pekko.http.scaladsl.model.headers.Link
+import org.apache.pekko.http.scaladsl.model.headers.LinkParams
+import org.apache.pekko.http.scaladsl.model.headers.LinkValue
+import org.apache.pekko.http.scaladsl.server.Directives.*
+import org.apache.pekko.http.scaladsl.server.PathMatcher
+import org.apache.pekko.http.scaladsl.server.Route
+
+/**
+  * Agent facing document describing how to use the service. If a document is available, then
+  * it is served at the well-known location and a `Link` header with a relation type of
+  * `service-doc` is added to all responses so a client that has never seen the API has a
+  * single place to look.
+  *
+  * The document and the header are handled together here so that the advertised location and
+  * the location that is actually served cannot drift apart.
+  *
+  * @param title
+  *     Human readable summary of what is at the other end of the link. This is what makes a
+  *     client decide the fetch is worthwhile, so it should name the contents rather than just
+  *     say "docs".
+  * @param resource
+  *     Classpath resource with the document to serve. Empty if there is no document, in which
+  *     case nothing is served and no header will get added.
+  * @param classLoader
+  *     Class loader used to look up and serve the document. It is captured here rather than
+  *     resolved when the route runs so that the loader used to check whether the resource is
+  *     available is the same one used to serve it.
+  */
+case class ServiceDoc(title: String, resource: Option[String], classLoader: ClassLoader) {
+
+  /** Header to add to responses pointing at the document, if there is one. */
+  val linkHeader: Option[Link] = resource.map { _ =>
+    val rel = LinkParams.rel("service-doc")
+    val uri = Uri(ServiceDoc.wellKnownPath)
+    val safeTitle = ServiceDoc.headerSafeTitle(title)
+    val value =
+      if (safeTitle.isEmpty) LinkValue(uri, rel)
+      else LinkValue(uri, rel, LinkParams.title(safeTitle))
+    Link(value)
+  }
+
+  /**
+    * Route serving the document at the well-known location and the `llms.txt` alias. If there
+    * is no document available, then the paths are not mapped and will result in the usual not
+    * found response.
+    */
+  val routes: Route = resource.fold[Route](reject) { r =>
+    (ServiceDoc.pathMatcher(ServiceDoc.wellKnownPath) |
+      ServiceDoc.pathMatcher(ServiceDoc.aliasPath)) {
+      getFromResource(r, ContentTypes.`text/plain(UTF-8)`, classLoader)
+    }
+  }
+}
+
+object ServiceDoc {
+
+  /** Config block used to configure the document. */
+  private val configPath = "atlas.pekko.service-doc"
+
+  /**
+    * Location for the document, using the well-known URI prefix from
+    * [[https://www.rfc-editor.org/rfc/rfc8615.html RFC 8615]]. Note that `llms.txt` is not a
+    * registered well-known URI, it is an emerging convention, so [[aliasPath]] is served as
+    * well.
+    */
+  val wellKnownPath: String = "/.well-known/llms.txt"
+
+  /** Alias for [[wellKnownPath]] following the emerging `llms.txt` convention. */
+  val aliasPath: String = "/llms.txt"
+
+  /** Class loader used to look up and serve the document resource. */
+  def defaultClassLoader: ClassLoader = {
+    val cl = Thread.currentThread().getContextClassLoader
+    if (cl != null) cl else classOf[ServiceDoc].getClassLoader
+  }
+
+  private def pathMatcher(path: String) = {
+    rawPathPrefix(PathMatcher(Uri.Path(path), ())) & pathEnd
+  }
+
+  /**
+    * Make the title safe to render as the `title` parameter of the `Link` header. The value is
+    * rendered into a quoted string without any escaping, so a raw quote or backslash would
+    * produce a malformed header and a control character would cause the whole header to be
+    * dropped while rendering the response.
+    */
+  private[pekko] def headerSafeTitle(title: String): String = {
+    val builder = new StringBuilder(title.length)
+    title.foreach {
+      case c if Character.isISOControl(c) => // Drop control characters
+      case c if c == '"' || c == '\\'     => builder.append('\\').append(c)
+      case c                              => builder.append(c)
+    }
+    builder.toString()
+  }
+
+  /**
+    * Create the service doc settings based on the `atlas.pekko.service-doc` config block. If
+    * the configured resource is not present in the classpath, then it will not be served and
+    * no link header will get used.
+    */
+  def apply(config: Config, classLoader: ClassLoader = defaultClassLoader): ServiceDoc = {
+    val cfg = config.getConfig(configPath)
+    val resource = cfg.getString("resource")
+    val available = resource.nonEmpty && classLoader.getResource(resource) != null
+    ServiceDoc(cfg.getString("title"), if (available) Some(resource) else None, classLoader)
+  }
+}

--- a/atlas-pekko/src/test/resources/www/llms.txt
+++ b/atlas-pekko/src/test/resources/www/llms.txt
@@ -1,0 +1,3 @@
+# Test Service
+
+Agent facing document used by the unit tests.

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/RequestAuthenticatorSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/RequestAuthenticatorSuite.scala
@@ -58,7 +58,11 @@ class RequestAuthenticatorSuite extends MUnitRouteSuite {
       .exists(_.name() == "ipc.server.call")
   }
 
-  private def configWith(authenticator: Option[String], accessLog: Boolean = false): Config = {
+  private def configWith(
+    authenticator: Option[String],
+    accessLog: Boolean = false,
+    docResource: String = ""
+  ): Config = {
     val auth = authenticator.fold("")(c => s"""authenticator = "$c"""")
     ConfigFactory.parseString(s"""
         |atlas.pekko.api-endpoints = []
@@ -70,6 +74,10 @@ class RequestAuthenticatorSuite extends MUnitRouteSuite {
         |  access-log = $accessLog
         |  close-probability = 0.0
         |  $auth
+        |}
+        |atlas.pekko.service-doc {
+        |  resource = "$docResource"
+        |  title = ""
         |}
       """.stripMargin)
   }
@@ -164,6 +172,18 @@ class RequestAuthenticatorSuite extends MUnitRouteSuite {
     val route = RequestHandler.standardOptions(complete("secret"), settings)
     Get("/ok") ~> route ~> check {
       assertEquals(response.status, StatusCodes.OK)
+    }
+  }
+
+  test("rejecting authenticator: service doc is not exempt") {
+    val cls = classOf[RejectingAuthenticator].getName
+    val settings = RequestHandler.Settings(configWith(Some(cls), docResource = "www/llms.txt"))
+    val route = RequestHandler.standardOptions(complete("secret"), settings)
+    Get(ServiceDoc.wellKnownPath) ~> route ~> check {
+      // The link header proves the doc is enabled for this config, so the rejection below is
+      // coming from the authenticator rather than from an unmapped path.
+      assert(response.headers.exists(_.is("link")))
+      assertEquals(response.status, StatusCodes.Forbidden)
     }
   }
 

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/RequestHandlerNoCompressionSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/RequestHandlerNoCompressionSuite.scala
@@ -50,6 +50,10 @@ class RequestHandlerNoCompressionSuite extends MUnitRouteSuite {
       |  access-log = false
       |  close-probability = 0.0
       |}
+      |atlas.pekko.service-doc {
+      |  resource = ""
+      |  title = ""
+      |}
     """.stripMargin
   )
 

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/RequestHandlerSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/RequestHandlerSuite.scala
@@ -55,6 +55,10 @@ class RequestHandlerSuite extends MUnitRouteSuite {
       |  access-log = true
       |  close-probability = 0.0
       |}
+      |atlas.pekko.service-doc {
+      |  resource = "www/llms.txt"
+      |  title = "Test service guide"
+      |}
     """.stripMargin
   )
 
@@ -78,6 +82,23 @@ class RequestHandlerSuite extends MUnitRouteSuite {
   test("/ok") {
     Get("/ok") ~> routes ~> check {
       assertEquals(response.status, StatusCodes.OK)
+    }
+  }
+
+  test("service doc link header") {
+    Get("/not-found") ~> routes ~> check {
+      val link = response.headers.find(_.is("link")).map(_.value)
+      assertEquals(
+        link,
+        Some("</.well-known/llms.txt>; rel=service-doc; title=\"Test service guide\"")
+      )
+    }
+  }
+
+  test("service doc served at advertised location") {
+    Get("/.well-known/llms.txt") ~> routes ~> check {
+      assertEquals(response.status, StatusCodes.OK)
+      assert(responseAs[String].contains("Agent facing document"))
     }
   }
 
@@ -138,7 +159,9 @@ class RequestHandlerSuite extends MUnitRouteSuite {
     val header = RawHeader("Origin", origin)
     Get("/ok").addHeader(header) ~> routes ~> check {
       assertEquals(response.status, StatusCodes.OK)
-      assertEquals(response.headers, List(RawHeader("test", "12345")))
+      // The service doc link is present on every response, including this one
+      val headers = response.headers.filterNot(_.is("link"))
+      assertEquals(headers, List(RawHeader("test", "12345")))
     }
   }
 

--- a/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/ServiceDocSuite.scala
+++ b/atlas-pekko/src/test/scala/com/netflix/atlas/pekko/ServiceDocSuite.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.pekko
+
+import com.netflix.atlas.pekko.testkit.MUnitRouteSuite
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+
+class ServiceDocSuite extends MUnitRouteSuite {
+
+  private def config(overrides: String): Config = {
+    ConfigFactory.parseString(overrides).withFallback(ConfigFactory.load()).resolve()
+  }
+
+  // Config for the document that is available in the test resources.
+  private def enabled(title: String = "Test service guide"): Config = {
+    config(s"""
+        |atlas.pekko.service-doc.resource = "www/llms.txt"
+        |atlas.pekko.service-doc.title = "$title"
+      """.stripMargin)
+  }
+
+  test("disabled by default") {
+    val doc = ServiceDoc(config(""))
+    assertEquals(doc.resource, None)
+    assertEquals(doc.linkHeader, None)
+  }
+
+  test("link header for available document") {
+    val doc = ServiceDoc(enabled())
+    assertEquals(doc.resource, Some("www/llms.txt"))
+    assertEquals(
+      doc.linkHeader.map(_.value),
+      Some("</.well-known/llms.txt>; rel=service-doc; title=\"Test service guide\"")
+    )
+  }
+
+  test("missing resource, no link header") {
+    val doc = ServiceDoc(config("atlas.pekko.service-doc.resource = \"www/missing.txt\""))
+    assertEquals(doc.resource, None)
+    assertEquals(doc.linkHeader, None)
+  }
+
+  test("disabled, no link header") {
+    val doc = ServiceDoc(config("atlas.pekko.service-doc.resource = \"\""))
+    assertEquals(doc.resource, None)
+    assertEquals(doc.linkHeader, None)
+  }
+
+  test("quotes and backslashes in the title are escaped") {
+    val doc = ServiceDoc(enabled("""a \"b\" c\\d"""))
+    assertEquals(
+      doc.linkHeader.map(_.value),
+      Some("</.well-known/llms.txt>; rel=service-doc; title=\"a \\\"b\\\" c\\\\d\"")
+    )
+  }
+
+  test("control characters in the title are dropped") {
+    val doc = ServiceDoc(enabled("""a\r\nX-Injected: yes"""))
+    assertEquals(
+      doc.linkHeader.map(_.value),
+      Some("</.well-known/llms.txt>; rel=service-doc; title=\"aX-Injected: yes\"")
+    )
+  }
+
+  test("empty title omits the parameter") {
+    val doc = ServiceDoc(enabled(""))
+    assertEquals(doc.linkHeader.map(_.value), Some("</.well-known/llms.txt>; rel=service-doc"))
+  }
+
+  test("document served at the well-known path") {
+    val doc = ServiceDoc(enabled())
+    Get(ServiceDoc.wellKnownPath) ~> doc.routes ~> check {
+      assertEquals(response.status, StatusCodes.OK)
+      assert(responseAs[String].contains("Agent facing document"))
+    }
+  }
+
+  test("document served at the alias path") {
+    val doc = ServiceDoc(enabled())
+    Get(ServiceDoc.aliasPath) ~> doc.routes ~> check {
+      assertEquals(response.status, StatusCodes.OK)
+      assert(responseAs[String].contains("Agent facing document"))
+    }
+  }
+
+  test("paths are not mapped if there is no document") {
+    val doc = ServiceDoc(config("atlas.pekko.service-doc.resource = \"\""))
+    Get(ServiceDoc.wellKnownPath) ~> doc.routes ~> check {
+      assert(!handled)
+    }
+  }
+}


### PR DESCRIPTION
Adds a `Link` header with a relation type of `service-doc` to all responses pointing at an agent facing document, and serves that document at the well-known `/.well-known/llms.txt` location along with the `/llms.txt` alias. The intent is to give a client that has never seen the API a single place to look rather than having it probe endpoints to figure out what is available.

The header and the route are both handled by `ServiceDoc` so the advertised location and the location that is actually served cannot drift apart. The route is mounted in `RequestHandler.standardOptions` rather than in an endpoint class so the advertised path is mapped whatever set of endpoints is configured, and it is inside the request authenticator so access to it is treated the same as any other route.

Disabled by default: the document is only served, and the header only added, if `atlas.pekko.service-doc.resource` is set and present in the classpath.