### PR TITLE
Remove obsolete wiki publishing workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,23 +238,9 @@ want to keep up with the churn and potential breakage of using the latest in pro
 
 ### Updating Documentation
 
-The main documentation for using Atlas is on the [GitHub wiki]. This wiki is not directly
-editable for several reasons:
+The Atlas documentation is published at [Atlas documentation] and maintained in the
+[atlas-docs] repository. To contribute changes, update the content in that repository and open
+a pull request there.
 
-1. We have had problems with spammers in the past putting up bogus pages
-2. GitHub does not allow pull requests for the wiki
-3. A number of the tedious steps like including sample graphs and formatting expressions are
-   easier to do with some scripting
-   
-The documentation is kept inline with the code as part of the [atlas-wiki] sub-project. To
-update the documentation, update the content in that sub-project and send in a PR just as you
-would for [contributing code](#contributing-code). Once the PR has been reviewed and merged, then
-one of the project maintainers will need to publish the changes to the wiki repository by
-running:
-
-```
-$ make publish-wiki
-```
-
-[GitHub wiki]: https://github.com/Netflix/atlas/wiki
-[atlas-wiki]: https://github.com/Netflix/atlas/tree/master/atlas-wiki/src/main
+[Atlas documentation]: https://netflix.github.io/atlas-docs/
+[atlas-docs]: https://github.com/Netflix/atlas-docs

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,9 @@ else
 	SBT := cat /dev/null | project/sbt ++${TRAVIS_SCALA_VERSION}
 endif
 
-WIKI_PRG        := atlas-wiki/runMain com.netflix.atlas.wiki.Main
-WIKI_INPUT_DIR  := $(shell pwd)/atlas-wiki/src/main/resources
-WIKI_OUTPUT_DIR := $(shell pwd)/target/atlas.wiki
-
 LAUNCHER_JAR_URL := https://repo1.maven.org/maven2/com/netflix/iep/iep-launcher/6.0.6/iep-launcher-6.0.6.jar
 
-.PHONY: build snapshot release clean format update-wiki publish-wiki
+.PHONY: build snapshot release clean format
 
 build:
 	$(SBT) clean testFull checkLicenseHeaders scalafmtCheckAll
@@ -42,19 +38,6 @@ clean:
 
 format:
 	$(SBT) formatLicenseHeaders scalafmtAll
-
-$(WIKI_OUTPUT_DIR):
-	mkdir -p target
-	git clone git@github.com:Netflix/atlas.wiki.git $(WIKI_OUTPUT_DIR)
-
-update-wiki: $(WIKI_OUTPUT_DIR)
-	cd $(WIKI_OUTPUT_DIR) && git rm -rf *
-	$(SBT) "$(WIKI_PRG) $(WIKI_INPUT_DIR) $(WIKI_OUTPUT_DIR)"
-
-publish-wiki: update-wiki
-	cd $(WIKI_OUTPUT_DIR) && git add * && git status
-	cd $(WIKI_OUTPUT_DIR) && git commit -a -m "update wiki"
-	cd $(WIKI_OUTPUT_DIR) && git push origin master
 
 # Build a single runnable jar. The classpath is extracted from sbt by keeping only
 # .jar entries, which relies on exportJars being set (see project/BuildSettings.scala)


### PR DESCRIPTION
## Summary

- Point documentation contributors to the current `Netflix/atlas-docs` repository.
- Remove the obsolete `atlas-wiki` Make variables and publishing targets.

## Context

PR #1407 removed the `atlas-wiki` subproject after documentation moved to `Netflix/atlas-docs`, but the contributor guide and Makefile still describe and invoke the old wiki workflow. The remaining targets reference a project and input directory that no longer exist.

## Validation

- Ran `git diff --check`.
- Ran `make -n build` to confirm the updated Makefile parses.
- Confirmed no `atlas-wiki`, `WIKI_`, `update-wiki`, or `publish-wiki` references remain.
- Confirmed the published documentation and `Netflix/atlas-docs` links return HTTP 200.
