### PR TITLE
webapi: enforce tags max-limit on query

### DIFF
--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsApi.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/TagsApi.scala
@@ -102,11 +102,11 @@ class TagsApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi {
   private def tagString(ts: List[Tag]): String = ts.map(tagString).mkString("\n")
 
   private def offsetString(limit: Int, vs: List[String]): Option[String] = {
-    if (vs.size < limit) None else Some(vs.last)
+    if (vs.isEmpty || vs.size < limit) None else Some(vs.last)
   }
 
   private def offsetTag(limit: Int, vs: List[Tag]): Option[String] = {
-    if (vs.size < limit) None
+    if (vs.isEmpty || vs.size < limit) None
     else {
       val t = vs.last
       Some(s"${t.key},${t.value}")
@@ -144,7 +144,13 @@ object TagsApi {
 
     require(limit > 0, s"limit must be positive (got $limit)")
 
-    def actualLimit: Int = if (limit > ApiSettings.maxTagLimit) ApiSettings.maxTagLimit else limit
+    /**
+      * Requested limit after applying the configured maximum. Use this rather than `limit`
+      * for anything that reaches the index or the pagination check so the offset header
+      * always agrees with the data that was actually returned. Sampled once per request so
+      * a dynamic config update cannot make those two uses disagree.
+      */
+    val actualLimit: Int = math.min(limit, ApiSettings.maxTagLimit)
 
     def useText: Boolean = format.contains("txt")
 
@@ -161,7 +167,7 @@ object TagsApi {
 
     def toTagQuery(cq: Query): TagQuery = {
       val q = Some(query.fold(cq)(s => Query.And(toQuery(s), cq)))
-      TagQuery(q, key, offset.getOrElse(""), limit)
+      TagQuery(q, key, offset.getOrElse(""), actualLimit)
     }
 
     private def toQuery(s: String): Query = {

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/TagsApiSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/TagsApiSuite.scala
@@ -23,8 +23,10 @@ import com.netflix.atlas.core.db.StaticDatabase
 import com.netflix.atlas.core.index.TagIndex
 import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.EvalContext
+import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.TaggedItem
 import com.netflix.atlas.core.model.TimeSeries
+import com.netflix.atlas.pekko.CallerContext
 import com.netflix.atlas.pekko.RequestHandler
 import com.netflix.atlas.pekko.testkit.MUnitRouteSuite
 
@@ -139,6 +141,25 @@ class TagsApiSuite extends MUnitRouteSuite {
   testGet("/api/v1/tags/name?verbose=1&format=txt") {
     val expected = (0 to 11).map(toTagText).mkString("\n")
     assertEquals(responseAs[String], expected)
+  }
+
+  test("tag query limit is clamped to max-limit") {
+    val req = TagsApi.Request(limit = Integer.MAX_VALUE)
+    assertEquals(req.toTagQuery(Query.True).limit, ApiSettings.maxTagLimit)
+  }
+
+  test("tag query limit is used as is when under max-limit") {
+    val limit = math.max(1, ApiSettings.maxTagLimit - 1)
+    val req = TagsApi.Request(limit = limit)
+    assertEquals(req.toTagQuery(Query.True).limit, limit)
+  }
+
+  test("db request limit is clamped for values lookup") {
+    val req = TagsApi.Request(key = Some("name"), limit = Integer.MAX_VALUE)
+    req.toDbRequest(CallerContext.Anonymous) match {
+      case r: TagsApi.ListValuesRequest => assertEquals(r.q.limit, ApiSettings.maxTagLimit)
+      case r                            => fail(s"unexpected request type: $r")
+    }
   }
 
   test("failure in db actor gets sent back") {


### PR DESCRIPTION
The `limit` param was passed through to the TagQuery unchanged, so `tags.max-limit` only affected whether the pagination header was emitted. A request such as `/api/v1/tags?limit=2000000000` would materialize the full tag list from the index.

Use `actualLimit` for the query, which is already clamped to the configured max and is what the pagination check uses, so both paths agree.

`actualLimit` becomes a val so the max is sampled once per request. It read `ApiSettings.maxTagLimit`, which resolves the dynamic config on every access, so a config update between the two uses could otherwise cap the query while the pagination check used the old value and dropped the offset header. Also guard the offset helpers against an empty result, reachable once the configured max governs the size of the list coming back from the index.