### PR TITLE
webapi: bounds check compact batch decode

### DIFF
--- a/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishPayloads.scala
+++ b/atlas-webapi/src/main/scala/com/netflix/atlas/webapi/PublishPayloads.scala
@@ -41,6 +41,11 @@ object PublishPayloads {
   // could exhaust memory.
   private final val maxArraySize = 100_000
 
+  // Maximum number of tags for a single datapoint in the compact format. The flat key/value
+  // array allocated per datapoint holds twice the tag count, so this is half of `maxArraySize`
+  // to keep that allocation within the overall array limit.
+  private final val maxTagsPerDatapoint = maxArraySize / 2
+
   // Maximum number of tags allowed. This will be used to help pre-size buffers when
   // processing tag data.
   private final val maxPermittedTags = ApiSettings.maxPermittedTags
@@ -262,14 +267,36 @@ object PublishPayloads {
     finally parser.close()
   }
 
-  private def nextArraySize(parser: JsonParser): Int = {
-    val size = nextInt(parser)
-    if (size > maxArraySize) {
+  /**
+    * Read a count from the input and check that it is within the permitted range. The value is
+    * read as a long so that a value outside the range of an int is reported as an invalid count
+    * rather than surfacing as a coercion failure from the parser. The `name` is included in the
+    * message so a rejected payload indicates which count was bad.
+    */
+  private def nextSize(parser: JsonParser, name: String, max: Int = maxArraySize): Int = {
+    val size = nextLong(parser)
+    if (size < 0 || size > max) {
       throw new IllegalArgumentException(
-        s"requested buffer size exceeds limit ($size > $maxArraySize)"
+        s"$name is invalid or exceeds limit ($size, max: $max)"
       )
     }
-    size
+    size.toInt
+  }
+
+  /**
+    * Read an index into the string table and return the corresponding entry. The bound is the
+    * number of entries actually populated for this payload, not the length of the array: the
+    * array is reused across requests on the same thread and may be longer, with stale entries
+    * from a previous payload past `tableSize`.
+    */
+  private def nextTableString(parser: JsonParser, table: Array[String], tableSize: Int): String = {
+    val i = nextInt(parser)
+    if (i < 0 || i >= tableSize) {
+      throw new IllegalArgumentException(
+        s"string table index is out of bounds ($i, size: $tableSize)"
+      )
+    }
+    table(i)
   }
 
   private def getOrCreateStringArray(size: Int): Array[String] = {
@@ -319,7 +346,7 @@ object PublishPayloads {
     val strInterner = Interner.forStrings
 
     requireNextToken(parser, JsonToken.START_ARRAY)
-    val size = nextArraySize(parser)
+    val size = nextSize(parser, "string table size")
     val table = getOrCreateStringArray(size)
     var i = 0
     while (i < size) {
@@ -328,29 +355,30 @@ object PublishPayloads {
       i += 1
     }
 
-    val numDatapointTuples = nextInt(parser)
+    val numDatapointTuples = nextSize(parser, "number of datapoints", Int.MaxValue)
     // `intern` is fixed for the whole batch, so branch once and run a specialized loop rather
     // than re-checking it per datapoint.
-    if (intern) decodeCompactTuplesInterned(parser, table, numDatapointTuples, consumer)
-    else decodeCompactTuplesRaw(parser, table, numDatapointTuples, consumer)
+    if (intern) decodeCompactTuplesInterned(parser, table, size, numDatapointTuples, consumer)
+    else decodeCompactTuplesRaw(parser, table, size, numDatapointTuples, consumer)
   }
 
   private def decodeCompactTuplesRaw(
     parser: JsonParser,
     table: Array[String],
+    tableSize: Int,
     numTuples: Int,
     consumer: PublishConsumer
   ): Unit = {
     var i = 0
     while (i < numTuples) {
       val id = ItemId(nextString(parser))
-      val numTags = nextArraySize(parser)
+      val numTags = nextSize(parser, "tag count", maxTagsPerDatapoint)
       val len = 2 * numTags
       val tagsArray = new Array[String](len)
       var j = 0
       while (j < numTags) {
-        tagsArray(2 * j) = table(nextInt(parser))
-        tagsArray(2 * j + 1) = table(nextInt(parser))
+        tagsArray(2 * j) = nextTableString(parser, table, tableSize)
+        tagsArray(2 * j + 1) = nextTableString(parser, table, tableSize)
         j += 1
       }
       val tags = SortedTagMap.createUnsafe(tagsArray, len)
@@ -364,6 +392,7 @@ object PublishPayloads {
   private def decodeCompactTuplesInterned(
     parser: JsonParser,
     table: Array[String],
+    tableSize: Int,
     numTuples: Int,
     consumer: PublishConsumer
   ): Unit = {
@@ -376,13 +405,13 @@ object PublishPayloads {
     var i = 0
     while (i < numTuples) {
       val id = TaggedItem.internId(ItemId(nextString(parser)), wallTime)
-      val numTags = nextArraySize(parser)
+      val numTags = nextSize(parser, "tag count", maxTagsPerDatapoint)
       val len = 2 * numTags
       val buffer = probe.prepare(len)
       var j = 0
       while (j < numTags) {
-        buffer(2 * j) = table(nextInt(parser))
-        buffer(2 * j + 1) = table(nextInt(parser))
+        buffer(2 * j) = nextTableString(parser, table, tableSize)
+        buffer(2 * j + 1) = nextTableString(parser, table, tableSize)
         j += 1
       }
       val hashCode = SortedTagMap.computeHashCode(buffer, len)

--- a/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishPayloadsSuite.scala
+++ b/atlas-webapi/src/test/scala/com/netflix/atlas/webapi/PublishPayloadsSuite.scala
@@ -28,6 +28,9 @@ class PublishPayloadsSuite extends FunSuite {
 
   private val timestamp = 1636116180000L
 
+  // Valid ItemId for hand-written compact batch payloads, 16 bytes as hex.
+  private val compactId = "0" * 32
+
   private def datapointTuples(n: Int): List[DatapointTuple] = {
     datapoints(n).map(_.toTuple)
   }
@@ -225,6 +228,58 @@ class PublishPayloadsSuite extends FunSuite {
     assert(decoded.head.value.isNaN)
     assertEquals(decoded.head.tags, input.head.tags)
     assertEquals(decoded.tail, input.tail)
+  }
+
+  test("compact batch rejects negative string table size") {
+    val e = intercept[IllegalArgumentException] {
+      PublishPayloads.decodeCompactBatch("[-1,0]")
+    }
+    assert(e.getMessage.contains("invalid or exceeds limit"), e.getMessage)
+  }
+
+  test("compact batch rejects a string table size beyond the range of an int") {
+    val e = intercept[IllegalArgumentException] {
+      PublishPayloads.decodeCompactBatch("[9999999999,0]")
+    }
+    assert(e.getMessage.contains("string table size is invalid"), e.getMessage)
+  }
+
+  test("compact batch rejects negative datapoint count") {
+    val e = intercept[IllegalArgumentException] {
+      PublishPayloads.decodeCompactBatch(s"""[1,"a",-1,"$compactId",1,0,0,1234,1.0]""")
+    }
+    assert(e.getMessage.contains("number of datapoints is invalid"), e.getMessage)
+  }
+
+  test("compact batch rejects negative tag count") {
+    val payload = s"""[1,"a",1,"$compactId",-1,0,1.0]"""
+    val e = intercept[IllegalArgumentException] {
+      PublishPayloads.decodeCompactBatch(payload)
+    }
+    assert(e.getMessage.contains("invalid or exceeds limit"), e.getMessage)
+  }
+
+  test("compact batch rejects string table index past the table size") {
+    val payload = s"""[1,"a",1,"$compactId",1,0,1,1234,1.0]"""
+    val e = intercept[IllegalArgumentException] {
+      PublishPayloads.decodeCompactBatch(payload)
+    }
+    assert(e.getMessage.contains("string table index is out of bounds"), e.getMessage)
+  }
+
+  test("compact batch cannot read stale entries from a reused string table") {
+    // The string table array is cached per thread and only grown, never cleared. A payload
+    // declaring a smaller table must not be able to reach entries left by an earlier payload
+    // decoded on the same thread.
+    val first = s"""[3,"k","secret","z",1,"$compactId",1,0,1,1234,1.0]"""
+    val decoded = PublishPayloads.decodeCompactBatch(first)
+    assertEquals(decoded.head.tags, Map("k" -> "secret"))
+
+    val second = s"""[1,"a",1,"$compactId",1,0,1,1234,1.0]"""
+    val e = intercept[IllegalArgumentException] {
+      PublishPayloads.decodeCompactBatch(second)
+    }
+    assert(e.getMessage.contains("string table index is out of bounds"), e.getMessage)
   }
 
   test("encode and decode empty tuples list") {


### PR DESCRIPTION
Several counts in the compact batch format were read from the payload and used without validation.

Sizes were only checked against an upper limit, not for negative values. A negative string table size skipped the fill loop entirely, and a negative tag count reached `new Array[String](2 * numTags)` as a NegativeArraySizeException. This mirrors the check already done in LwcMessages.parseTags. Counts are now read as a long so a value outside the range of an int is reported as an invalid count rather than a coercion failure from the parser, and the message names the count that was bad. The datapoint count was not checked at all, so a negative value silently produced an empty batch and reported success. The tag count is limited to half of the array limit since the array allocated per datapoint holds twice the tag count.

String table indexes were used to access the table with no validation. The table array is cached per thread and only grown, never cleared, so an index between the declared size and the array length returned an entry left over from a payload decoded earlier on the same thread. A payload declaring a small table could read tag keys and values from a previous request. Bound the index by the declared size rather than the array length.