### PR TITLE
eval: avoid dnf expansion for hi-res check

### DIFF
--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -203,13 +203,15 @@ private[stream] class StreamContext(
   }
 
   private def validateStyleExpr(styleExpr: StyleExpr, ds: DataSource): Unit = {
-    styleExpr.expr.dataExprs.foreach(validateDataExpr)
+    // `dataExprs` rebuilds the list on each access, extract it once for both checks.
+    val dataExprs = styleExpr.expr.dataExprs
+    dataExprs.foreach(validateDataExpr)
 
     // For hi-res streams, require more precise scoping that allows us to more efficiently
     // match the data and run it only where needed. This would ideally be applied everywhere,
     // but for backwards compatibility the 1m step is opted out for now.
     if (ds.step.toMillis < 60_000) {
-      styleExpr.expr.dataExprs.foreach(expr => restrictsNameAndApp(expr.query))
+      dataExprs.foreach(expr => restrictsNameAndApp(expr.query))
     }
   }
 
@@ -229,8 +231,7 @@ private[stream] class StreamContext(
   }
 
   private def restrictsNameAndApp(query: Query): Unit = {
-    val dnf = Query.dnfList(query)
-    if (!dnf.forall(isRestricted)) {
+    if (!isRestricted(query)) {
       throw new IllegalArgumentException(
         s"rejected expensive query [$query], hi-res streams " +
           "must restrict name and nf.app with :eq or :in"
@@ -238,12 +239,37 @@ private[stream] class StreamContext(
     }
   }
 
-  private def isRestricted(query: Query): Boolean = {
-    isRestricted(query, Set("nf.app", "nf.cluster", "nf.asg")) && isRestricted(query, Set("name"))
+  private[stream] def isRestricted(query: Query): Boolean = {
+    isRestricted(query, AppKeys) && isRestricted(query, NameKeys)
   }
 
+  /**
+    * Check that every clause of the disjunctive normal form is restricted to one of `keys`.
+    *
+    * Equivalent to `Query.dnfList(query).forall(isRestrictedClause(_, keys))`, but computed over
+    * the structure of the query rather than by materializing the DNF, which is exponential in
+    * the number of `:or` clauses. The cases mirror those of `Query.dnfList`: `:or` concatenates
+    * the clause lists, so every branch must be restricted, while `:and` forms the cross product,
+    * where every combined clause is restricted exactly when all clauses of one side are. That
+    * relies on `forall(a) || forall(b)` being the same as checking each pair, which holds since
+    * `dnfList` never returns an empty list.
+    */
   private def isRestricted(query: Query, keys: Set[String]): Boolean = query match {
-    case Query.And(q1, q2) => isRestricted(q1, keys) || isRestricted(q2, keys)
+    case Query.Or(q1, q2)           => isRestricted(q1, keys) && isRestricted(q2, keys)
+    case Query.And(q1, q2)          => isRestricted(q1, keys) || isRestricted(q2, keys)
+    case Query.Not(Query.And(a, b)) =>
+      isRestricted(Query.Not(a), keys) && isRestricted(Query.Not(b), keys)
+    case Query.Not(Query.Or(a, b)) =>
+      isRestricted(Query.Not(a), keys) || isRestricted(Query.Not(b), keys)
+    // `dnfList` leaves a double negation as a single clause without normalizing further, so the
+    // inner query is checked as a clause rather than recursively.
+    case Query.Not(Query.Not(q)) => isRestrictedClause(q, keys)
+    case q                       => isRestrictedClause(q, keys)
+  }
+
+  /** Check a single DNF clause, which is a conjunction of leaf queries. */
+  private def isRestrictedClause(query: Query, keys: Set[String]): Boolean = query match {
+    case Query.And(q1, q2) => isRestrictedClause(q1, keys) || isRestrictedClause(q2, keys)
     case Query.Equal(k, _) => keys.contains(k)
     case Query.In(k, _)    => keys.contains(k)
     case _                 => false
@@ -333,6 +359,12 @@ private[stream] class StreamContext(
 }
 
 private[stream] object StreamContext {
+
+  /** Keys that are considered to restrict a query to a particular application. */
+  private val AppKeys = Set("nf.app", "nf.cluster", "nf.asg")
+
+  /** Keys that are considered to restrict a query to a particular metric name. */
+  private val NameKeys = Set("name")
 
   /** Per-host data sources and the expression map derived from them, updated together. */
   case class HostState(dataSources: DataSources, dataExprMap: Map[String, List[DataSource]])

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/StreamContextSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/StreamContextSuite.scala
@@ -18,6 +18,7 @@ package com.netflix.atlas.eval.stream
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.model.Uri
 import org.apache.pekko.stream.Materializer
+import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.eval.stream.Evaluator.DataSource
 import com.netflix.atlas.eval.stream.Evaluator.DataSources
 import com.netflix.atlas.json3.JsonSupport
@@ -124,5 +125,105 @@ class StreamContextSuite extends FunSuite {
     logged.clear()
     context.logDatapointsExceeded(0L, expr)
     assertEquals(logged.toList.sorted, List("a", "b"))
+  }
+
+  // Hi-res data sources must restrict name and app. The check used to materialize the
+  // disjunctive normal form, which is exponential in the number of `:or` clauses; it is now
+  // computed over the structure of the query. The tests below pin the behavior and check it
+  // against the previous definition.
+
+  // Validation does not mutate the context, so a single instance can be shared. Creating one
+  // builds the full vocabulary for two interpreters plus a grapher, which is not worth
+  // repeating per assertion.
+  private lazy val hiResContext: StreamContext = newContext
+
+  /** Message for the validation failure, or None if the data source is valid. */
+  private def hiResRejection(query: String): Option[String] = {
+    val uri = s"http://localhost/api/v1/graph?q=$query"
+    val ds = new DataSource("hi-res", java.time.Duration.ofSeconds(5), uri)
+    hiResContext.validateDataSource(ds).failed.toOption.map(_.getMessage)
+  }
+
+  private def hiResIsValid(query: String): Boolean = hiResRejection(query).isEmpty
+
+  /**
+    * Check that the query is rejected by the name and app restriction, not by some other
+    * validation failure such as an unknown backend host or an unsupported operator.
+    */
+  private def assertRejectedAsUnrestricted(query: String): Unit = {
+    val reason = "hi-res streams must restrict name and nf.app with :eq or :in"
+    hiResRejection(query) match {
+      case Some(msg) => assert(msg.contains(reason), s"unexpected rejection reason: $msg")
+      case None      => fail(s"expected query to be rejected: $query")
+    }
+  }
+
+  /** Previous implementation, kept as the reference for the equivalence check. */
+  private def dnfIsRestricted(query: Query): Boolean = {
+    def clause(q: Query, keys: Set[String]): Boolean = q match {
+      case Query.And(q1, q2) => clause(q1, keys) || clause(q2, keys)
+      case Query.Equal(k, _) => keys.contains(k)
+      case Query.In(k, _)    => keys.contains(k)
+      case _                 => false
+    }
+    def restricted(q: Query): Boolean =
+      clause(q, Set("nf.app", "nf.cluster", "nf.asg")) && clause(q, Set("name"))
+    Query.dnfList(query).forall(restricted)
+  }
+
+  test("hi-res query must restrict name and app") {
+    assert(hiResIsValid("name,cpu,:eq,nf.app,www,:eq,:and"))
+    assertRejectedAsUnrestricted("name,cpu,:eq")
+    assertRejectedAsUnrestricted("nf.app,www,:eq")
+  }
+
+  test("hi-res query with or must restrict every branch") {
+    assert(hiResIsValid("name,cpu,:eq,nf.app,www,:eq,:and,name,disk,:eq,nf.app,api,:eq,:and,:or"))
+    assertRejectedAsUnrestricted("name,cpu,:eq,nf.app,www,:eq,:and,name,disk,:eq,:or")
+  }
+
+  test("hi-res check matches the dnf definition for generated queries") {
+    val random = new scala.util.Random(42)
+    val leaves = Vector[Query](
+      Query.Equal("name", "cpu"),
+      Query.Equal("nf.app", "www"),
+      Query.Equal("nf.cluster", "www-main"),
+      Query.Equal("other", "v"),
+      Query.In("name", List("cpu", "disk")),
+      Query.In("nf.app", List("www")),
+      Query.HasKey("name"),
+      Query.Regex("name", "c.*")
+    )
+    def gen(depth: Int): Query = {
+      if (depth == 0) leaves(random.nextInt(leaves.size))
+      else
+        random.nextInt(4) match {
+          case 0 => Query.And(gen(depth - 1), gen(depth - 1))
+          case 1 => Query.Or(gen(depth - 1), gen(depth - 1))
+          case 2 => Query.Not(gen(depth - 1))
+          case _ => leaves(random.nextInt(leaves.size))
+        }
+    }
+    (0 until 2000).foreach { _ =>
+      val q = gen(4)
+      assertEquals(
+        hiResContext.isRestricted(q),
+        dnfIsRestricted(q),
+        s"disagreement for query: $q"
+      )
+    }
+  }
+
+  test("hi-res restriction check is not exponential in the number of or clauses") {
+    // The disjunctive normal form for this query has 2^40 clauses, far more than could be
+    // materialized. The structural check returns immediately.
+    val leaf = (i: Int) => Query.Or(Query.Equal(s"k$i", "a"), Query.Equal(s"k$i", "b"))
+    val ors = (1 until 40).foldLeft[Query](leaf(0))((acc, i) => Query.And(acc, leaf(i)))
+    assert(!hiResContext.isRestricted(ors))
+
+    // Both answers have to be produced structurally, otherwise an implementation that always
+    // returned false would pass. Pinning name and nf.app makes the same query restricted.
+    val pinned = Query.And(Query.Equal("name", "cpu"), Query.Equal("nf.app", "www"))
+    assert(hiResContext.isRestricted(Query.And(pinned, ors)))
   }
 }


### PR DESCRIPTION
`restrictsNameAndApp` materialized the disjunctive normal form of the query and checked that every clause was restricted. The number of clauses is exponential in the number of `:or` operators, so the check could do substantially more work than necessary.

The clauses themselves are not needed, only whether all of them are restricted, and that distributes over the structure of the query: `:or` concatenates the clause lists so both branches must be restricted, and `:and` forms the cross product, where all combined clauses are restricted exactly when all clauses of one side are. The remaining cases mirror those of `Query.dnfList`.

Behavior is unchanged. A test checks the new implementation against the previous definition over a set of generated queries.