### PR TITLE
core: bound normal form conversion

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
@@ -106,7 +106,11 @@ object Query {
     }
   }
 
-  /** Converts the input query into conjunctive normal form. */
+  /**
+    * Converts the input query into conjunctive normal form. Throws an
+    * `IllegalArgumentException` if the normal form would exceed the clause limit, see
+    * `cnfList` for more information.
+    */
   def cnf(query: Query): Query = {
     cnfList(query).reduceLeft { (q1, q2) =>
       Query.And(q1, q2)
@@ -115,20 +119,25 @@ object Query {
 
   /**
     * Converts the input query into a list of sub-queries that should be ANDd
-    * together.
+    * together. Throws an `IllegalArgumentException` if the number of clauses would
+    * exceed `maxNormalFormClauses`.
     */
   def cnfList(query: Query): List[Query] = {
     query match {
-      case And(q1, q2)      => cnfList(q1) ::: cnfList(q2)
+      case And(q1, q2)      => concat(cnfList(q1), cnfList(q2))
       case Or(q1, q2)       => crossOr(cnfList(q1), cnfList(q2))
       case Not(And(q1, q2)) => cnfList(Or(Not(q1), Not(q2)))
-      case Not(Or(q1, q2))  => cnfList(Not(q1)) ::: cnfList(Not(q2))
+      case Not(Or(q1, q2))  => concat(cnfList(Not(q1)), cnfList(Not(q2)))
       case Not(Not(q))      => List(q)
       case q                => List(q)
     }
   }
 
-  /** Converts the input query into disjunctive normal form. */
+  /**
+    * Converts the input query into disjunctive normal form. Throws an
+    * `IllegalArgumentException` if the normal form would exceed the clause limit, see
+    * `dnfList` for more information.
+    */
   def dnf(query: Query): Query = {
     dnfList(query).reduceLeft { (q1, q2) =>
       Query.Or(q1, q2)
@@ -137,24 +146,58 @@ object Query {
 
   /**
     * Converts the input query into a list of sub-queries that should be ORd
-    * together.
+    * together. Throws an `IllegalArgumentException` if the number of clauses would
+    * exceed `maxNormalFormClauses`.
     */
   def dnfList(query: Query): List[Query] = {
     query match {
       case And(q1, q2)      => crossAnd(dnfList(q1), dnfList(q2))
-      case Or(q1, q2)       => dnfList(q1) ::: dnfList(q2)
-      case Not(And(q1, q2)) => dnfList(Not(q1)) ::: dnfList(Not(q2))
+      case Or(q1, q2)       => concat(dnfList(q1), dnfList(q2))
+      case Not(And(q1, q2)) => concat(dnfList(Not(q1)), dnfList(Not(q2)))
       case Not(Or(q1, q2))  => dnfList(And(Not(q1), Not(q2)))
       case Not(Not(q))      => List(q)
       case q                => List(q)
     }
   }
 
+  /**
+    * Maximum number of clauses allowed when converting a query to a normal form. The conversion
+    * distributes one operator over another, so the number of clauses is a product and grows
+    * exponentially with the number of operators being distributed. The limit is there to fail
+    * fast rather than do an unreasonable amount of work for a small input. A scan of the
+    * expressions in use found a maximum of around 12k clauses, so this leaves a good deal of
+    * room for legitimate queries.
+    */
+  private final val maxNormalFormClauses = 100_000
+
+  /**
+    * Check the size of a combined clause list before computing it. Every case that combines
+    * two clause lists is checked, not just the products. A product can only grow past the
+    * limit by going through this check, but so can a sum: each side of a concatenation can be
+    * just under the limit on its own, so checking only the products would allow a query with
+    * a handful of top level disjunctions to produce many times the limit.
+    */
+  private def checkClauseLimit(size: Long): Unit = {
+    if (size > maxNormalFormClauses) {
+      throw new IllegalArgumentException(
+        s"query is too complex, expansion would have at least $size clauses " +
+          s"(max: $maxNormalFormClauses)"
+      )
+    }
+  }
+
+  private def concat(qs1: List[Query], qs2: List[Query]): List[Query] = {
+    checkClauseLimit(qs1.size.toLong + qs2.size)
+    qs1 ::: qs2
+  }
+
   private def crossOr(qs1: List[Query], qs2: List[Query]): List[Query] = {
+    checkClauseLimit(qs1.size.toLong * qs2.size)
     for (q1 <- qs1; q2 <- qs2) yield Or(q1, q2)
   }
 
   private def crossAnd(qs1: List[Query], qs2: List[Query]): List[Query] = {
+    checkClauseLimit(qs1.size.toLong * qs2.size)
     for (q1 <- qs1; q2 <- qs2) yield And(q1, q2)
   }
 
@@ -165,13 +208,25 @@ object Query {
     * In order to avoid a massive combinatorial explosion clauses that have more than `limit`
     * expressions will not be expanded. The default limit is 5. It is somewhat arbitrary, but
     * seems to work well in practice for the current query data sets at Netflix.
+    *
+    * The `limit` only bounds a single `:in` clause. The product across a conjunction of them
+    * is bounded by `maxNormalFormClauses` and will throw an `IllegalArgumentException` rather
+    * than expand. Note that the bound applies to a single call: a caller that expands many
+    * queries, such as the clauses of a `dnfList`, needs to bound the overall result itself.
     */
   def expandInClauses(query: Query, limit: Int = 5): List[Query] = {
     query match {
       case Query.And(q1, q2) =>
+        // Expand each side once rather than re-expanding the right side for every clause of
+        // the left, and check the size of the product before computing it. The per-clause
+        // `limit` bounds a single `:in`, the product across a conjunction of them is what
+        // grows exponentially.
+        val as = expandInClauses(q1, limit)
+        val bs = expandInClauses(q2, limit)
+        checkClauseLimit(as.size.toLong * bs.size)
         for {
-          a <- expandInClauses(q1, limit)
-          b <- expandInClauses(q2, limit)
+          a <- as
+          b <- bs
         } yield {
           Query.And(a, b)
         }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/ExprNormalizerSuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/ExprNormalizerSuite.scala
@@ -174,4 +174,30 @@ class ExprNormalizerSuite extends FunSuite {
       List("name,sps,:eq,:sum,(,nf.cluster,),:by,:approx-distinct-cumulative")
     )
   }
+
+  /**
+    * Query of `n` OR-pairs combined with `:and`. Converting to disjunctive normal form is a
+    * cross product, so the number of clauses is 2^n while the input grows linearly.
+    */
+  private def dnfExpansion(n: Int): String = {
+    val clauses = (0 until n).map(i => s"k$i,a,:eq,k$i,b,:eq,:or")
+    val ands = List.fill(n - 1)(":and")
+    (clauses ++ ands :+ ":sum").mkString(",")
+  }
+
+  test("normalize rejects excessive dnf expansion") {
+    // 2^18 clauses, more than the normal form allows. Check the message, the interpreter
+    // throws IllegalArgumentException for many unrelated reasons.
+    val e = intercept[IllegalArgumentException] {
+      normalize(dnfExpansion(18))
+    }
+    assert(e.getMessage.contains("query is too complex"), e.getMessage)
+  }
+
+  test("normalize allows modest dnf expansion") {
+    // 2^9 clauses ORd together, normalized as usual.
+    val results = normalize(dnfExpansion(9))
+    assertEquals(results.size, 1)
+    assertEquals(results.head.split(",:or", -1).length - 1, 511)
+  }
 }

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
@@ -656,4 +656,63 @@ class QuerySuite extends FunSuite {
     val q = Regex("a", "http:/*")
     assertEquals(q.toString, "a,http\\u003a\\u002f*,:re")
   }
+
+  /** Conjunction of `n` disjunctions, the dnf of which has 2^n clauses. */
+  private def orPairs(n: Int): Query = {
+    val pair = (i: Int) => Or(Equal(s"k$i", "a"), Equal(s"k$i", "b"))
+    (1 until n).foldLeft[Query](pair(0))((acc, i) => And(acc, pair(i)))
+  }
+
+  /** Same shape with the operators swapped, the cnf of which has 2^n clauses. */
+  private def andPairs(n: Int): Query = {
+    val pair = (i: Int) => And(Equal(s"k$i", "a"), Equal(s"k$i", "b"))
+    (1 until n).foldLeft[Query](pair(0))((acc, i) => Or(acc, pair(i)))
+  }
+
+  test("dnfList is bounded") {
+    // 2^14 clauses, above the largest expansion seen for expressions in use and well under
+    // the limit.
+    assertEquals(Query.dnfList(orPairs(14)).size, 16384)
+    intercept[IllegalArgumentException] {
+      Query.dnfList(orPairs(18))
+    }
+  }
+
+  test("dnfList bound applies to disjunctions") {
+    // Each side expands to 2^16 clauses, under the limit on its own. The concatenation is
+    // not a product, but it still has to be bounded or a handful of disjunctions can
+    // produce many times the limit.
+    intercept[IllegalArgumentException] {
+      Query.dnfList(Or(orPairs(16), orPairs(16)))
+    }
+  }
+
+  test("cnfList is bounded") {
+    assertEquals(Query.cnfList(andPairs(14)).size, 16384)
+    intercept[IllegalArgumentException] {
+      Query.cnfList(andPairs(18))
+    }
+  }
+
+  test("cnfList bound applies to conjunctions") {
+    intercept[IllegalArgumentException] {
+      Query.cnfList(And(andPairs(16), andPairs(16)))
+    }
+  }
+
+  test("expandInClauses is bounded") {
+    // Each `:in` is small enough to expand on its own, the product across the conjunction is
+    // what grows: 5^8 clauses.
+    val in = (i: Int) => In(s"k$i", List("a", "b", "c", "d", "e"))
+    val q = (1 until 8).foldLeft[Query](in(0))((acc, i) => And(acc, in(i)))
+    intercept[IllegalArgumentException] {
+      Query.expandInClauses(q)
+    }
+  }
+
+  test("expandInClauses allows expansion up to the limit") {
+    val in = (i: Int) => In(s"k$i", List("a", "b", "c", "d", "e"))
+    val q = (1 until 4).foldLeft[Query](in(0))((acc, i) => And(acc, in(i)))
+    assertEquals(Query.expandInClauses(q).size, 625)
+  }
 }


### PR DESCRIPTION
Converting a query to conjunctive or disjunctive normal form distributes one operator over another, so the number of clauses is a product of the sizes of the two sides and grows exponentially with the number of operators involved. A short query could therefore expand into a very large number of clauses. The same applies to the conjunction case of `expandInClauses`, where the existing limit bounds the values of a single `:in` but not the product across several of them.

Check the size of the product before computing it and fail with an IllegalArgumentException when it would exceed 100k clauses. A scan of the expressions in use found a maximum of around 12k clauses, so there is a good deal of room for legitimate queries. The cases that concatenate clause lists are unchanged, they grow linearly with the size of the query.

Also expand each side of the conjunction in `expandInClauses` once rather than re-expanding the right side for every clause of the left.