### PR TITLE
eval: avoid dnf expansion for scope check

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
@@ -202,19 +202,26 @@ object Query {
   }
 
   /**
+    * Default for the maximum number of values an `:in` clause can have and still be expanded
+    * by `expandInClauses`. It is somewhat arbitrary, but seems to work well in practice for the
+    * current query data sets at Netflix. Exposed so callers that reason about which clauses
+    * would be expanded do not have to duplicate the value.
+    */
+  val expandInClausesLimit: Int = 5
+
+  /**
     * Split :in queries into a list of queries using :eq. The query should be normalized ahead
     * of time so it is a string of conjunctions. See `dnfList` for more information.
     *
     * In order to avoid a massive combinatorial explosion clauses that have more than `limit`
-    * expressions will not be expanded. The default limit is 5. It is somewhat arbitrary, but
-    * seems to work well in practice for the current query data sets at Netflix.
+    * expressions will not be expanded. The default is `expandInClausesLimit`.
     *
     * The `limit` only bounds a single `:in` clause. The product across a conjunction of them
     * is bounded by `maxNormalFormClauses` and will throw an `IllegalArgumentException` rather
     * than expand. Note that the bound applies to a single call: a caller that expands many
     * queries, such as the clauses of a `dnfList`, needs to bound the overall result itself.
     */
-  def expandInClauses(query: Query, limit: Int = 5): List[Query] = {
+  def expandInClauses(query: Query, limit: Int = expandInClausesLimit): List[Query] = {
     query match {
       case Query.And(q1, q2) =>
         // Expand each side once rather than re-expanding the right side for every clause of

--- a/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
+++ b/atlas-eval/src/main/scala/com/netflix/atlas/eval/stream/StreamContext.scala
@@ -216,18 +216,38 @@ private[stream] class StreamContext(
   }
 
   private def validateDataExpr(expr: DataExpr): Unit = {
-    Query
-      .dnfList(expr.query)
-      .flatMap(q => Query.expandInClauses(q))
-      .foreach(validateQuery)
-  }
-
-  private def validateQuery(query: Query): Unit = {
-    val keys = Query.exactKeys(query) -- ignoredTagKeys
-    if (keys.isEmpty) {
-      val msg = s"rejected expensive query [$query], narrow the scope to a specific app or name"
+    if (!isScoped(expr.query)) {
+      val msg =
+        s"rejected expensive query [${expr.query}], narrow the scope to a specific app or name"
       throw new IllegalArgumentException(msg)
     }
+  }
+
+  /**
+    * Check that every clause of the disjunctive normal form is scoped by at least one tag key
+    * that is matched exactly and is not in `ignored-tag-keys`.
+    *
+    * Equivalent to expanding the `:in` clauses of each clause of `Query.dnfList` and requiring
+    * `Query.exactKeys` to be non-empty, but neither list is materialized. The expansion is not
+    * needed at all: every expansion of an `:in` produces `:eq` on the same key, so all
+    * expansions of a clause have the same set of exact keys. The disjunctive normal form is
+    * computed structurally by `everyClauseMatches`, since materializing it is exponential in
+    * the number of `:or` clauses.
+    */
+  private[stream] def isScoped(query: Query): Boolean = {
+    everyClauseMatches(query, isScopingLeaf)
+  }
+
+  /**
+    * Leaf queries that scope a clause: the key is matched exactly and is not ignored. An `:in`
+    * with more values than `Query.expandInClausesLimit` would not have been expanded into a set
+    * of `:eq` clauses, so it does not contribute an exact key.
+    */
+  private def isScopingLeaf(query: Query): Boolean = query match {
+    case Query.Equal(k, _) => !ignoredTagKeys.contains(k)
+    case Query.In(k, vs) if vs.lengthCompare(Query.expandInClausesLimit) <= 0 =>
+      !ignoredTagKeys.contains(k)
+    case _ => false
   }
 
   private def restrictsNameAndApp(query: Query): Unit = {
@@ -243,36 +263,45 @@ private[stream] class StreamContext(
     isRestricted(query, AppKeys) && isRestricted(query, NameKeys)
   }
 
-  /**
-    * Check that every clause of the disjunctive normal form is restricted to one of `keys`.
-    *
-    * Equivalent to `Query.dnfList(query).forall(isRestrictedClause(_, keys))`, but computed over
-    * the structure of the query rather than by materializing the DNF, which is exponential in
-    * the number of `:or` clauses. The cases mirror those of `Query.dnfList`: `:or` concatenates
-    * the clause lists, so every branch must be restricted, while `:and` forms the cross product,
-    * where every combined clause is restricted exactly when all clauses of one side are. That
-    * relies on `forall(a) || forall(b)` being the same as checking each pair, which holds since
-    * `dnfList` never returns an empty list.
-    */
-  private def isRestricted(query: Query, keys: Set[String]): Boolean = query match {
-    case Query.Or(q1, q2)           => isRestricted(q1, keys) && isRestricted(q2, keys)
-    case Query.And(q1, q2)          => isRestricted(q1, keys) || isRestricted(q2, keys)
-    case Query.Not(Query.And(a, b)) =>
-      isRestricted(Query.Not(a), keys) && isRestricted(Query.Not(b), keys)
-    case Query.Not(Query.Or(a, b)) =>
-      isRestricted(Query.Not(a), keys) || isRestricted(Query.Not(b), keys)
-    // `dnfList` leaves a double negation as a single clause without normalizing further, so the
-    // inner query is checked as a clause rather than recursively.
-    case Query.Not(Query.Not(q)) => isRestrictedClause(q, keys)
-    case q                       => isRestrictedClause(q, keys)
+  private def isRestricted(query: Query, keys: Set[String]): Boolean = {
+    everyClauseMatches(query, isRestrictingLeaf(keys, _))
   }
 
-  /** Check a single DNF clause, which is a conjunction of leaf queries. */
-  private def isRestrictedClause(query: Query, keys: Set[String]): Boolean = query match {
-    case Query.And(q1, q2) => isRestrictedClause(q1, keys) || isRestrictedClause(q2, keys)
+  /** Leaf queries that restrict a clause to one of `keys`. */
+  private def isRestrictingLeaf(keys: Set[String], query: Query): Boolean = query match {
     case Query.Equal(k, _) => keys.contains(k)
     case Query.In(k, _)    => keys.contains(k)
     case _                 => false
+  }
+
+  /**
+    * Check that every clause of the disjunctive normal form contains a leaf matching `leaf`.
+    *
+    * Equivalent to `Query.dnfList(query).forall(clauseMatches(_, leaf))`, but computed over the
+    * structure of the query rather than by materializing the DNF, which is exponential in the
+    * number of `:or` clauses. The cases mirror those of `Query.dnfList`: `:or` concatenates the
+    * clause lists, so every branch must match, while `:and` forms the cross product, where every
+    * combined clause matches exactly when all clauses of one side do. That relies on
+    * `forall(a) || forall(b)` being the same as checking each pair, which holds since `dnfList`
+    * never returns an empty list.
+    */
+  private def everyClauseMatches(query: Query, leaf: Query => Boolean): Boolean = query match {
+    case Query.Or(q1, q2)           => everyClauseMatches(q1, leaf) && everyClauseMatches(q2, leaf)
+    case Query.And(q1, q2)          => everyClauseMatches(q1, leaf) || everyClauseMatches(q2, leaf)
+    case Query.Not(Query.And(a, b)) =>
+      everyClauseMatches(Query.Not(a), leaf) && everyClauseMatches(Query.Not(b), leaf)
+    case Query.Not(Query.Or(a, b)) =>
+      everyClauseMatches(Query.Not(a), leaf) || everyClauseMatches(Query.Not(b), leaf)
+    // `dnfList` leaves a double negation as a single clause without normalizing further, so the
+    // inner query is checked as a clause rather than recursively.
+    case Query.Not(Query.Not(q)) => clauseMatches(q, leaf)
+    case q                       => clauseMatches(q, leaf)
+  }
+
+  /** Check a single DNF clause, which is a conjunction of leaf queries. */
+  private def clauseMatches(query: Query, leaf: Query => Boolean): Boolean = query match {
+    case Query.And(q1, q2) => clauseMatches(q1, leaf) || clauseMatches(q2, leaf)
+    case q                 => leaf(q)
   }
 
   /**

--- a/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/StreamContextSuite.scala
+++ b/atlas-eval/src/test/scala/com/netflix/atlas/eval/stream/StreamContextSuite.scala
@@ -27,6 +27,7 @@ import com.typesafe.config.ConfigFactory
 import munit.FunSuite
 
 import scala.collection.mutable
+import scala.jdk.CollectionConverters.*
 
 class StreamContextSuite extends FunSuite {
 
@@ -138,13 +139,33 @@ class StreamContextSuite extends FunSuite {
   private lazy val hiResContext: StreamContext = newContext
 
   /** Message for the validation failure, or None if the data source is valid. */
-  private def hiResRejection(query: String): Option[String] = {
+  private def rejection(query: String, step: java.time.Duration): Option[String] = {
     val uri = s"http://localhost/api/v1/graph?q=$query"
-    val ds = new DataSource("hi-res", java.time.Duration.ofSeconds(5), uri)
+    val ds = new DataSource("test", step, uri)
     hiResContext.validateDataSource(ds).failed.toOption.map(_.getMessage)
   }
 
+  private def hiResRejection(query: String): Option[String] =
+    rejection(query, java.time.Duration.ofSeconds(5))
+
   private def hiResIsValid(query: String): Boolean = hiResRejection(query).isEmpty
+
+  /**
+    * Random query used to check the structural checks against the definition based on the
+    * disjunctive normal form.
+    */
+  private def genQuery(random: scala.util.Random, leaves: Vector[Query], depth: Int): Query = {
+    def sub: Query = genQuery(random, leaves, depth - 1)
+    def leaf: Query = leaves(random.nextInt(leaves.size))
+    if (depth == 0) leaf
+    else
+      random.nextInt(4) match {
+        case 0 => Query.And(sub, sub)
+        case 1 => Query.Or(sub, sub)
+        case 2 => Query.Not(sub)
+        case _ => leaf
+      }
+  }
 
   /**
     * Check that the query is rejected by the name and app restriction, not by some other
@@ -194,18 +215,8 @@ class StreamContextSuite extends FunSuite {
       Query.HasKey("name"),
       Query.Regex("name", "c.*")
     )
-    def gen(depth: Int): Query = {
-      if (depth == 0) leaves(random.nextInt(leaves.size))
-      else
-        random.nextInt(4) match {
-          case 0 => Query.And(gen(depth - 1), gen(depth - 1))
-          case 1 => Query.Or(gen(depth - 1), gen(depth - 1))
-          case 2 => Query.Not(gen(depth - 1))
-          case _ => leaves(random.nextInt(leaves.size))
-        }
-    }
     (0 until 2000).foreach { _ =>
-      val q = gen(4)
+      val q = genQuery(random, leaves, 4)
       assertEquals(
         hiResContext.isRestricted(q),
         dnfIsRestricted(q),
@@ -218,12 +229,92 @@ class StreamContextSuite extends FunSuite {
     // The disjunctive normal form for this query has 2^40 clauses, far more than could be
     // materialized. The structural check returns immediately.
     val leaf = (i: Int) => Query.Or(Query.Equal(s"k$i", "a"), Query.Equal(s"k$i", "b"))
-    val ors = (1 until 40).foldLeft[Query](leaf(0))((acc, i) => Query.And(acc, leaf(i)))
+    val ors = bigAnd(leaf)
     assert(!hiResContext.isRestricted(ors))
 
     // Both answers have to be produced structurally, otherwise an implementation that always
     // returned false would pass. Pinning name and nf.app makes the same query restricted.
     val pinned = Query.And(Query.Equal("name", "cpu"), Query.Equal("nf.app", "www"))
     assert(hiResContext.isRestricted(Query.And(pinned, ors)))
+  }
+
+  // The scoping check used to materialize the disjunctive normal form and expand the `:in`
+  // clauses of every clause before looking at the keys. Both are exponential: the dnf in the
+  // number of `:or` clauses, the expansion in the number of `:in` clauses. The tests below pin
+  // the behavior and check it against that definition.
+
+  /** `ignored-tag-keys` from the reference config, also used to build `hiResContext`. */
+  private val ignoredTagKeys = ConfigFactory
+    .load()
+    .getStringList("atlas.eval.stream.ignored-tag-keys")
+    .asScala
+    .toSet
+
+  /** Previous implementation, kept as the reference for the equivalence check. */
+  private def dnfIsScoped(query: Query): Boolean = {
+    Query
+      .dnfList(query)
+      .flatMap(q => Query.expandInClauses(q))
+      .forall(q => (Query.exactKeys(q) -- ignoredTagKeys).nonEmpty)
+  }
+
+  test("scope check rejects data sources that are not scoped") {
+    val step = java.time.Duration.ofMinutes(1)
+    val reason = "narrow the scope to a specific app or name"
+    assertEquals(rejection("name,cpu,:eq,:sum", step), None)
+    assert(rejection("name,foo,:re,:sum", step).exists(_.contains(reason)))
+
+    // An `:in` is only treated as an exact key if it is small enough to be expanded.
+    assertEquals(rejection("nf.app,(,a,b,c,d,e,),:in,:sum", step), None)
+    assert(rejection("nf.app,(,a,b,c,d,e,f,),:in,:sum", step).exists(_.contains(reason)))
+
+    // Ignored keys do not scope a query.
+    assert(ignoredTagKeys.contains("nf.region"))
+    assert(rejection("nf.region,us-east-1,:eq,:sum", step).exists(_.contains(reason)))
+  }
+
+  test("scope check matches the dnf definition for generated queries") {
+    val random = new scala.util.Random(42)
+    val leaves = Vector[Query](
+      Query.Equal("name", "cpu"),
+      Query.Equal("nf.app", "www"),
+      // Ignored keys, an exact match on one of these does not scope the query.
+      Query.Equal("nf.region", "us-east-1"),
+      Query.In("nf.account", List("1", "2")),
+      Query.In("name", List("cpu", "disk")),
+      Query.In("nf.app", List("a", "b", "c", "d", "e")),
+      // Too many values to be expanded, so it does not contribute an exact key.
+      Query.In("nf.app", List("a", "b", "c", "d", "e", "f")),
+      Query.HasKey("name"),
+      Query.Not(Query.Equal("name", "cpu")),
+      Query.Regex("name", "c.*")
+    )
+    (0 until 2000).foreach { _ =>
+      val q = genQuery(random, leaves, 3)
+      assertEquals(hiResContext.isScoped(q), dnfIsScoped(q), s"disagreement for query: $q")
+    }
+  }
+
+  test("scope check is not exponential in the number of or or in clauses") {
+    // The disjunctive normal form for these queries has 2^40 clauses, and each clause of the
+    // first would expand to 5^40 combinations. Neither could be materialized, the structural
+    // check returns immediately.
+    val ins = (i: Int) =>
+      Query.Or(
+        Query.In(s"k$i", List("a", "b", "c", "d", "e")),
+        Query.In(s"j$i", List("a", "b", "c", "d", "e"))
+      )
+    assert(hiResContext.isScoped(bigAnd(ins)))
+
+    // Both answers have to be produced structurally, otherwise an implementation that always
+    // returned true would pass. Ignored keys do not scope the query.
+    val ignored =
+      (i: Int) => Query.Or(Query.Equal("nf.region", s"r$i"), Query.Equal("nf.account", s"a$i"))
+    assert(!hiResContext.isScoped(bigAnd(ignored)))
+  }
+
+  /** Conjunction of 40 sub-queries, so the disjunctive normal form has at least 2^40 clauses. */
+  private def bigAnd(f: Int => Query): Query = {
+    (1 until 40).foldLeft(f(0))((acc, i) => Query.And(acc, f(i)))
   }
 }


### PR DESCRIPTION
`validateDataExpr` materialized the disjunctive normal form of the query and expanded the `:in` clauses of every clause before checking that something in the clause was matched exactly. Both steps are cross products, so the work was exponential in the number of `:or` clauses and again in the number of `:in` clauses being expanded, and the two compose.

Neither is needed. Every expansion of an `:in` clause produces `:eq` on the same key, so all expansions of a clause have the same set of exact keys. The remaining question, whether every clause of the normal form has an exact key, distributes over the structure of the query in the same way as the check for hi-res streams: `:or` concatenates the clause lists so both branches must match, and `:and` forms the cross product, where all combined clauses match exactly when all clauses of one side do.

Both checks now share `everyClauseMatches`, parameterized by the leaf predicate, and the scope check is linear in the size of the query. Also expose the default `:in` expansion limit from `Query` so the scope check does not duplicate the value.

Behavior is unchanged for parseable queries. A test checks the new implementation against the previous definition over a set of generated queries. The rejection message now shows the whole query rather than the clause that failed, matching the hi-res check.