### PR TITLE
core: render and or chains iteratively

### DIFF
--- a/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
+++ b/atlas-core/src/main/scala/com/netflix/atlas/core/model/Query.scala
@@ -166,9 +166,10 @@ object Query {
     * exponentially with the number of operators being distributed. The limit is there to fail
     * fast rather than do an unreasonable amount of work for a small input. A scan of the
     * expressions in use found a maximum of around 12k clauses, so this leaves a good deal of
-    * room for legitimate queries.
+    * room for legitimate queries. Exposed so callers that reason about the longest chain a
+    * normal form can produce do not have to duplicate the value.
     */
-  private final val maxNormalFormClauses = 100_000
+  private[model] val maxNormalFormClauses: Int = 100_000
 
   /**
     * Check the size of a combined clause list before computing it. Every case that combines
@@ -189,6 +190,77 @@ object Query {
   private def concat(qs1: List[Query], qs2: List[Query]): List[Query] = {
     checkClauseLimit(qs1.size.toLong + qs2.size)
     qs1 ::: qs2
+  }
+
+  /**
+    * Append a chain of `And` or `Or` sub-queries nested to the left. Conversion to a normal
+    * form reduces the clauses into a chain of one operator, and that chain can be as long as
+    * the clause limit allows, so it is walked iteratively. Recursing once per level would
+    * overflow the stack well before the limit is reached.
+    *
+    * The sub-queries are passed in rather than the operator itself, and the caller states which
+    * operator it is. That keeps the walk from ever appending the node it was called for, which
+    * would recurse back into this method.
+    *
+    * Only the operator of the caller is followed. A sub-query using the other operator is
+    * appended as a unit and starts a new chain, so the depth of the recursion is the number of
+    * times the two alternate rather than the length of either chain. A chain nested to the
+    * right is not flattened either, the normal forms do not produce that shape.
+    */
+  private def appendChain(
+    builder: java.lang.StringBuilder,
+    q1: Query,
+    q2: Query,
+    isAnd: Boolean
+  ): Unit = {
+    val token = if (isAnd) ",:and" else ",:or"
+
+    // The sub-queries on the right are appended in the opposite order to the one they are found
+    // in when walking down the left side, so they have to be held somewhere. Count the links
+    // first, which needs no storage, then fill an array of exactly that size. A chain can be as
+    // long as the clause limit allows, so this is one allocation rather than one per link.
+    var length = 1
+    var node: Query = q1
+    var counting = true
+    while (counting) {
+      node match {
+        case And(a, _) if isAnd => length += 1; node = a
+        case Or(a, _) if !isAnd => length += 1; node = a
+        case _                  => counting = false
+      }
+    }
+
+    if (length == 1) {
+      // A single operator, the common case, does not need the array at all.
+      q1.append(builder)
+      builder.append(',')
+      q2.append(builder)
+      builder.append(token)
+    } else {
+      // Both loops stop on the same condition, so the index cannot run past the start of the
+      // array. If they ever disagree it fails here rather than leaving an entry unset.
+      val rights = new Array[Query](length)
+      var i = length - 1
+      rights(i) = q2
+      node = q1
+      var filling = true
+      while (filling) {
+        node match {
+          case And(a, b) if isAnd => i -= 1; rights(i) = b; node = a
+          case Or(a, b) if !isAnd => i -= 1; rights(i) = b; node = a
+          case _                  => filling = false
+        }
+      }
+
+      node.append(builder)
+      i = 0
+      while (i < length) {
+        builder.append(',')
+        rights(i).append(builder)
+        builder.append(token)
+        i += 1
+      }
+    }
   }
 
   private def crossOr(qs1: List[Query], qs2: List[Query]): List[Query] = {
@@ -530,7 +602,7 @@ object Query {
     def labelString: String = s"(${q1.labelString}) and (${q2.labelString})"
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, q1, q2, Interpreter.WordToken(":and"))
+      appendChain(builder, q1, q2, isAnd = true)
     }
   }
 
@@ -548,7 +620,7 @@ object Query {
     def labelString: String = s"(${q1.labelString}) or (${q2.labelString})"
 
     override def append(builder: java.lang.StringBuilder): Unit = {
-      Interpreter.append(builder, q1, q2, Interpreter.WordToken(":or"))
+      appendChain(builder, q1, q2, isAnd = false)
     }
   }
 

--- a/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
+++ b/atlas-core/src/test/scala/com/netflix/atlas/core/model/QuerySuite.scala
@@ -15,12 +15,15 @@
  */
 package com.netflix.atlas.core.model
 
+import com.netflix.atlas.core.stacklang.Interpreter
 import com.netflix.atlas.core.util.SortedTagMap
 import munit.FunSuite
 
 class QuerySuite extends FunSuite {
 
   import com.netflix.atlas.core.model.Query.*
+
+  private val interpreter = Interpreter(QueryVocabulary.allWords)
 
   def matches(q: Query, tags: Map[String, String]): Boolean = {
     val result = q.matches(tags)
@@ -714,5 +717,86 @@ class QuerySuite extends FunSuite {
     val in = (i: Int) => In(s"k$i", List("a", "b", "c", "d", "e"))
     val q = (1 until 4).foldLeft[Query](in(0))((acc, i) => And(acc, in(i)))
     assertEquals(Query.expandInClauses(q).size, 625)
+  }
+
+  private def leaf(i: Int): Query = Equal("k", s"v$i")
+
+  /** Chain of `n` sub-queries nested to the left, the shape produced by `dnf` and `cnf`. */
+  private def chain(n: Int, op: (Query, Query) => Query): Query = {
+    (1 until n).foldLeft(leaf(0))((acc, i) => op(acc, leaf(i)))
+  }
+
+  /** Chain of `n` sub-queries nested to the right. */
+  private def rightChain(n: Int, op: (Query, Query) => Query): Query = {
+    (0 until n - 1).foldRight(leaf(n - 1))((i, acc) => op(leaf(i), acc))
+  }
+
+  /** Chain of `n` sub-queries nested to the left, alternating between the two operators. */
+  private def alternatingChain(n: Int): Query = {
+    (1 until n).foldLeft(leaf(0)) { (acc, i) =>
+      if (i % 2 == 0) And(acc, leaf(i)) else Or(acc, leaf(i))
+    }
+  }
+
+  /** Expected rendering of `chain(n, op)` where the operator is written as `token`. */
+  private def expectedChain(n: Int, token: String): String = {
+    val builder = new java.lang.StringBuilder
+    builder.append("k,v0,:eq")
+    (1 until n).foreach { i =>
+      builder.append(",k,v").append(i).append(",:eq,").append(token)
+    }
+    builder.toString
+  }
+
+  test("toString of a long or chain") {
+    // A query is allowed to expand to `Query.maxNormalFormClauses`, and `dnf` reduces the
+    // clauses into a chain nested to the left, so rendering has to handle a chain that long.
+    val q = chain(maxNormalFormClauses, Or.apply)
+    assertEquals(q.toString, expectedChain(maxNormalFormClauses, ":or"))
+  }
+
+  test("toString of a long and chain") {
+    val q = chain(maxNormalFormClauses, And.apply)
+    assertEquals(q.toString, expectedChain(maxNormalFormClauses, ":and"))
+  }
+
+  test("toString of a chain matches the recursive rendering") {
+    // The chains are short enough to render either way, so the iterative walk can be checked
+    // against the straightforward definition. Only the operator of the node being rendered is
+    // walked iteratively, so chains nested to the right and chains that alternate between the
+    // operators are covered as well.
+    val ops = List[(Query, Query) => Query](Or.apply, And.apply)
+    val queries = ops.flatMap(op => List(chain(64, op), rightChain(64, op))) :+ alternatingChain(64)
+    queries.foreach { q =>
+      val expected = new java.lang.StringBuilder
+      def recurse(sub: Query): Unit = sub match {
+        case Or(a, b)  => recurse(a); expected.append(','); recurse(b); expected.append(",:or")
+        case And(a, b) => recurse(a); expected.append(','); recurse(b); expected.append(",:and")
+        case other     => other.append(expected)
+      }
+      recurse(q)
+      assertEquals(q.toString, expected.toString)
+      // `exprString` is documented as executable by the interpreter, so it has to round trip.
+      assertEquals(interpreter.execute(q.toString).stack, List[Any](q))
+    }
+  }
+
+  test("toString of alternating and or nesting") {
+    // Chains of one operator interrupted by the other must still round trip.
+    val q = And(Or(Equal("a", "1"), Equal("b", "2")), Or(Equal("c", "3"), Equal("d", "4")))
+    assertEquals(q.toString, "a,1,:eq,b,2,:eq,:or,c,3,:eq,d,4,:eq,:or,:and")
+    assertEquals(interpreter.execute(q.toString).stack, List[Any](q))
+  }
+
+  test("toString of a chain with a sub-query at the head") {
+    // The walk down the left side of a chain stops on the first sub-query using the other
+    // operator, so the head of the chain is not always a leaf.
+    val q1 = And(And(Or(Equal("a", "1"), Equal("b", "2")), Equal("c", "3")), Equal("d", "4"))
+    assertEquals(q1.toString, "a,1,:eq,b,2,:eq,:or,c,3,:eq,:and,d,4,:eq,:and")
+    assertEquals(interpreter.execute(q1.toString).stack, List[Any](q1))
+
+    val q2 = Or(Or(And(Equal("a", "1"), Equal("b", "2")), Equal("c", "3")), Equal("d", "4"))
+    assertEquals(q2.toString, "a,1,:eq,b,2,:eq,:and,c,3,:eq,:or,d,4,:eq,:or")
+    assertEquals(interpreter.execute(q2.toString).stack, List[Any](q2))
   }
 }


### PR DESCRIPTION
`And` and `Or` appended the string form by recursing into each sub-query, so the depth of the recursion was the depth of the tree. Converting a query to a normal form reduces the clauses into a chain of one operator nested to the left, and that chain can be as long as the clause limit allows, so rendering the result of `dnf` or `cnf` could exhaust the stack. The depth at which that happens depends on the stack size of the thread, a chain of a few hundred is enough on a small stack.

Walk the chain iteratively instead. Only the operator of the root is followed, so a sub-query using the other operator is appended as a unit and starts a new chain, and the depth of the recursion becomes the number of times the two alternate.

Output is unchanged. Checked against the previous definition for the expressions in use, both as written and after conversion to disjunctive normal form.